### PR TITLE
[codex] Add reusable safe filesystem primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+coverage/
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Lower-level primitives are available from named subpaths:
 import { root } from "@openclaw/fs-safe/root";
 import { isPathInside } from "@openclaw/fs-safe/path";
 import { FsSafeError } from "@openclaw/fs-safe/errors";
+import { pathExists } from "@openclaw/fs-safe/fs";
 import { readJsonFile, readJsonFileStrict, writeJsonAtomic } from "@openclaw/fs-safe/json";
 import { replaceFileAtomic, movePathWithCopyFallback } from "@openclaw/fs-safe/atomic";
 import { createPrivateTempWorkspace, createTempFileTarget } from "@openclaw/fs-safe/temp";
@@ -133,12 +134,15 @@ The public surface is intentionally organized by job, not by implementation deta
 - `/path` exposes canonical path checks and scoped path helpers
 - `/json`, `/atomic`, `/temp`, and `/archive` expose focused building blocks for code that already has
   a trusted absolute path
+- `/fs` exposes small generic filesystem predicates such as `pathExists()`
 - `/errors` provides the canonical `FsSafeError` type for downstream `instanceof` checks
-- `/internal/*` is reserved for helper processes and tests, not general application imports
+- `/internal/*` is exported only for OpenClaw helper-process shims and tests; treat it as a reserved,
+  unsupported surface
 
 When two helpers have different failure semantics, the name says so. For example, `readJsonFile()`
 returns `null` on missing or invalid JSON for legacy state files, while `readJsonFileStrict()` throws
 for install manifests and other inputs where parse failure should stop the operation.
+`pathExists()` follows `fs.stat()` semantics, so broken symlinks return false.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,150 @@
+# @openclaw/fs-safe
+
+Race-resistant root-bounded filesystem primitives for Node.js.
+
+The package is for code that must operate on caller-controlled paths without letting symlinks,
+`..` traversal, hardlinks, path aliases, or rename races escape a configured root.
+
+## Motivation
+
+Most Node filesystem helpers make path handling convenient, but they do not give you a reusable
+security boundary. A check like `path.resolve(root, input).startsWith(root)` only validates a string
+snapshot. It does not pin the opened file, defend against symlink swaps between check and use, reject
+hardlinked aliases, or verify that a write still landed on the intended file after a rename.
+
+OpenClaw has many places where an agent, plugin, archive, upload, or config file can supply a path.
+Each call site used to carry its own mix of "within root" checks, temp-file conventions, JSON helpers,
+archive extraction limits, and symlink policy. That made the product harder to audit: small differences
+in helper behavior mattered, and fixing one surface did not automatically improve the others.
+
+`@openclaw/fs-safe` packages those patterns as one small set of primitives:
+
+- define a trusted root once with `root()`, then use relative paths for reads, writes, moves, copies,
+  directory creation, and removal
+- choose explicit policies for hardlinks and symlinks instead of threading boolean flags through every
+  call site
+- use pinned/opened file identity checks where Node exposes enough platform support
+- use sibling-temp and atomic-replace helpers for writes that should not leave partially written files
+- extract archives with entry-count and byte limits, traversal checks, and symlink-safe staging
+
+This is not a full sandbox and it does not replace OS permissions, containers, or process isolation.
+It is a library-level guardrail for the common case where trusted application code must safely touch
+untrusted paths inside a directory it owns.
+
+## Install
+
+```sh
+pnpm add @openclaw/fs-safe
+```
+
+## API
+
+```ts
+import { openRootFile, openPinnedFileSync, safeFileURLToPath, root } from "@openclaw/fs-safe";
+
+const fs = await root("/safe/workspace", {
+  hardlinks: "reject",
+  nonBlockingRead: true,
+  mkdir: true,
+});
+
+await fs.write("notes/today.txt", "hello\n");
+await fs.create("notes/README.md", "seed\n");
+const text = await fs.readText("notes/today.txt");
+const config = await fs.readJson("config.json");
+await fs.copyFrom("/tmp/upload.png", "uploads/upload.png");
+await fs.move("notes/today.txt", "notes/archive/today.txt");
+```
+
+Use `read()` and `open()` when you need metadata or a `FileHandle`:
+
+```ts
+const { buffer, realPath, stat } = await fs.read("notes/today.txt");
+const opened = await fs.open("notes/today.txt");
+```
+
+Lower-level primitives are available from named subpaths:
+
+```ts
+import { root } from "@openclaw/fs-safe/root";
+import { isPathInside } from "@openclaw/fs-safe/path";
+import { FsSafeError } from "@openclaw/fs-safe/errors";
+import { readJsonFile, readJsonFileStrict, writeJsonAtomic } from "@openclaw/fs-safe/json";
+import { replaceFileAtomic, movePathWithCopyFallback } from "@openclaw/fs-safe/atomic";
+import { createPrivateTempWorkspace, createTempFileTarget } from "@openclaw/fs-safe/temp";
+import { extractArchive } from "@openclaw/fs-safe/archive";
+```
+
+`readJsonFile()` returns `null` when the file cannot be read or parsed.
+`readJsonFileStrict()` throws read and parse errors.
+
+Archive extraction keeps ZIP/TAR handling behind one API and exposes lower-level preflight helpers for
+callers that need to enforce the same limits before doing custom work:
+
+```ts
+import { extractArchive, resolveArchiveKind } from "@openclaw/fs-safe/archive";
+
+const kind = resolveArchiveKind(uploadPath);
+if (!kind) {
+  throw new Error(`unsupported archive: ${uploadPath}`);
+}
+await extractArchive({
+  archivePath: uploadPath,
+  destDir: "/safe/workspace/plugin",
+  kind,
+  timeoutMs: 15_000,
+  limits: {
+    maxArchiveBytes: 256 * 1024 * 1024,
+    maxEntries: 50_000,
+  },
+});
+```
+
+`replaceFileAtomic()` and `replaceFileAtomicSync()` write a sibling temp file and
+then replace the destination. They support rename retry/fallback behavior,
+existing-mode preservation, optional temp-file and parent-directory fsync,
+injected filesystem ops for tests, and a `beforeRename` hook for backup/observer
+workflows. `writeSiblingTempFile()` covers stream/download producers that need
+to decide the final sibling path after writing a temp file.
+
+```ts
+import { pathScope } from "@openclaw/fs-safe";
+
+const uploads = pathScope("/safe/uploads", { label: "uploads directory" });
+const files = await uploads.files(["photo.jpg"]);
+const target = await uploads.writable("report.pdf");
+```
+
+## Safety Model
+
+- root-bounded APIs resolve paths against a configured root and reject canonical escapes
+- reads open with `O_NOFOLLOW` where available and verify fd/path identity before returning
+- writes use pinned parent-directory helpers and atomic replacement on POSIX, with verified post-write identity
+- remove and mkdir use fd-relative Python syscalls on POSIX, with legacy fallback when the helper cannot spawn
+- archive extraction rejects traversal paths and blocked link types, enforces entry and byte budgets,
+  and merges through the same safe-open boundary checks used by direct writes
+- optional internal subpath exports expose pinned helper modules used by OpenClaw tests
+
+## Design Notes
+
+The public surface is intentionally organized by job, not by implementation detail:
+
+- `root()` and `SafeRoot` are the preferred API for application code
+- `/path` exposes canonical path checks and scoped path helpers
+- `/json`, `/atomic`, `/temp`, and `/archive` expose focused building blocks for code that already has
+  a trusted absolute path
+- `/errors` provides the canonical `FsSafeError` type for downstream `instanceof` checks
+- `/internal/*` is reserved for helper processes and tests, not general application imports
+
+When two helpers have different failure semantics, the name says so. For example, `readJsonFile()`
+returns `null` on missing or invalid JSON for legacy state files, while `readJsonFileStrict()` throws
+for install manifests and other inputs where parse failure should stop the operation.
+
+## Limitations
+
+- Windows support uses the safest Node-level behavior available, but some fd-relative POSIX hardening is
+  unavailable there.
+- Hardlink rejection depends on platform metadata and should be treated as a defense-in-depth policy,
+  not an authorization model.
+- The package does not sanitize file contents or validate archive payload semantics beyond filesystem
+  safety constraints.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,14 @@
       "types": "./dist/json.d.ts",
       "default": "./dist/json.js"
     },
+    "./fs": {
+      "types": "./dist/fs.d.ts",
+      "default": "./dist/fs.js"
+    },
+    "./timing": {
+      "types": "./dist/timing.d.ts",
+      "default": "./dist/timing.js"
+    },
     "./temp": {
       "types": "./dist/temp.d.ts",
       "default": "./dist/temp.js"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "@openclaw/fs-safe",
+  "version": "0.0.0",
+  "description": "Race-resistant root-bounded filesystem primitives for Node.js.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/fs-safe.git"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./root": {
+      "types": "./dist/root.d.ts",
+      "default": "./dist/root.js"
+    },
+    "./path": {
+      "types": "./dist/path.d.ts",
+      "default": "./dist/path.js"
+    },
+    "./json": {
+      "types": "./dist/json.d.ts",
+      "default": "./dist/json.js"
+    },
+    "./temp": {
+      "types": "./dist/temp.d.ts",
+      "default": "./dist/temp.js"
+    },
+    "./atomic": {
+      "types": "./dist/atomic.d.ts",
+      "default": "./dist/atomic.js"
+    },
+    "./archive": {
+      "types": "./dist/archive.d.ts",
+      "default": "./dist/archive.js"
+    },
+    "./errors": {
+      "types": "./dist/errors.d.ts",
+      "default": "./dist/errors.js"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
+    },
+    "./test-hooks": {
+      "types": "./dist/test-hooks.d.ts",
+      "default": "./dist/test-hooks.js"
+    },
+    "./internal/pinned-open": {
+      "types": "./dist/pinned-open.d.ts",
+      "default": "./dist/pinned-open.js"
+    },
+    "./internal/pinned-path": {
+      "types": "./dist/pinned-path.d.ts",
+      "default": "./dist/pinned-path.js"
+    },
+    "./internal/pinned-write": {
+      "types": "./dist/pinned-write.d.ts",
+      "default": "./dist/pinned-write.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepack": "pnpm build",
+    "test": "vitest run",
+    "check": "pnpm build && pnpm test"
+  },
+  "dependencies": {
+    "jszip": "^3.10.1",
+    "tar": "7.5.13"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.19",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.4"
+  },
+  "engines": {
+    "node": ">=20.11"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1159 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
+      tar:
+        specifier: 7.5.13
+        version: 7.5.13
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.19
+        version: 22.19.17
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.4
+        version: 3.2.4(@types/node@22.19.17)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  chownr@3.0.0: {}
+
+  core-util-is@1.0.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  immediate@3.0.6: {}
+
+  inherits@2.0.4: {}
+
+  isarray@1.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  pako@1.0.11: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.13:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  process-nextick-args@2.0.1: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  safe-buffer@5.1.2: {}
+
+  setimmediate@1.0.5: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  util-deprecate@1.0.2: {}
+
+  vite-node@3.2.4(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.2(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.19.17):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@22.19.17)
+      vite-node: 3.2.4(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  yallist@5.0.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/src/absolute-path.ts
+++ b/src/absolute-path.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { FsSafeError } from "./errors.js";
+
+export type AbsolutePathSymlinkPolicy = "reject" | "follow";
+
+export type ResolvedAbsolutePath = {
+  path: string;
+  canonicalPath: string;
+};
+
+export type ResolvedWritableAbsolutePath = ResolvedAbsolutePath & {
+  parentDir: string;
+  parentExists: boolean;
+};
+
+export function assertAbsolutePathInput(filePath: string): string {
+  if (!filePath) {
+    throw new FsSafeError("invalid-path", "path is required");
+  }
+  if (filePath.includes("\0")) {
+    throw new FsSafeError("invalid-path", "path must not contain NUL bytes");
+  }
+  if (!path.isAbsolute(filePath)) {
+    throw new FsSafeError("invalid-path", "path must be absolute");
+  }
+  return path.normalize(filePath);
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function findExistingAncestor(filePath: string): Promise<string | null> {
+  let current = path.resolve(filePath);
+  while (true) {
+    try {
+      await fs.lstat(current);
+      return current;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+export async function canonicalPathFromExistingAncestor(filePath: string): Promise<string> {
+  const ancestor = await findExistingAncestor(filePath);
+  if (!ancestor) {
+    return path.resolve(filePath);
+  }
+  let canonicalAncestor = ancestor;
+  try {
+    canonicalAncestor = await fs.realpath(ancestor);
+  } catch {
+    // Keep lexical path when the existing ancestor cannot be canonicalized.
+  }
+  const relative = path.relative(ancestor, filePath);
+  return relative ? path.join(canonicalAncestor, relative) : canonicalAncestor;
+}
+
+export async function resolveAbsolutePathForRead(
+  filePath: string,
+  options: { symlinks?: AbsolutePathSymlinkPolicy } = {},
+): Promise<ResolvedAbsolutePath> {
+  const normalized = assertAbsolutePathInput(filePath);
+  let canonicalPath: string;
+  try {
+    canonicalPath = await fs.realpath(normalized);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new FsSafeError("not-found", "path not found", { cause: err });
+    }
+    throw err;
+  }
+  if ((options.symlinks ?? "reject") === "reject" && canonicalPath !== normalized) {
+    throw new FsSafeError("symlink", "path traverses a symlink", { cause: { canonicalPath } });
+  }
+  return { path: normalized, canonicalPath };
+}
+
+export async function resolveAbsolutePathForWrite(
+  filePath: string,
+  options: { symlinks?: AbsolutePathSymlinkPolicy } = {},
+): Promise<ResolvedWritableAbsolutePath> {
+  const normalized = assertAbsolutePathInput(filePath);
+  const parentDir = path.dirname(normalized);
+  const parentExists = await pathExists(parentDir);
+  if ((options.symlinks ?? "reject") === "reject") {
+    const ancestor = await findExistingAncestor(parentDir);
+    if (ancestor) {
+      const canonicalAncestor = await fs.realpath(ancestor).catch(() => ancestor);
+      if (canonicalAncestor !== ancestor) {
+        const canonicalPath = path.join(canonicalAncestor, path.relative(ancestor, normalized));
+        throw new FsSafeError("symlink", "path traverses a symlink", {
+          cause: { canonicalPath },
+        });
+      }
+    }
+  }
+  return {
+    path: normalized,
+    canonicalPath: await canonicalPathFromExistingAncestor(normalized),
+    parentDir,
+    parentExists,
+  };
+}

--- a/src/archive-entry.ts
+++ b/src/archive-entry.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+import { resolveSafeBaseDir } from "./path.js";
+
+export function isWindowsDrivePath(value: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(value);
+}
+
+export function normalizeArchiveEntryPath(raw: string): string {
+  return raw.replaceAll("\\", "/");
+}
+
+export function validateArchiveEntryPath(
+  entryPath: string,
+  params?: { escapeLabel?: string },
+): void {
+  if (!entryPath || entryPath === "." || entryPath === "./") {
+    return;
+  }
+  if (isWindowsDrivePath(entryPath)) {
+    throw new Error(`archive entry uses a drive path: ${entryPath}`);
+  }
+  const normalized = path.posix.normalize(normalizeArchiveEntryPath(entryPath));
+  const escapeLabel = params?.escapeLabel ?? "destination";
+  if (normalized === ".." || normalized.startsWith("../")) {
+    throw new Error(`archive entry escapes ${escapeLabel}: ${entryPath}`);
+  }
+  if (path.posix.isAbsolute(normalized) || normalized.startsWith("//")) {
+    throw new Error(`archive entry is absolute: ${entryPath}`);
+  }
+}
+
+export function stripArchivePath(entryPath: string, stripComponents: number): string | null {
+  const raw = normalizeArchiveEntryPath(entryPath);
+  if (!raw || raw === "." || raw === "./") {
+    return null;
+  }
+
+  const parts = raw.split("/").filter((part) => part.length > 0 && part !== ".");
+  const strip = Math.max(0, Math.floor(stripComponents));
+  const stripped = strip === 0 ? parts.join("/") : parts.slice(strip).join("/");
+  const result = path.posix.normalize(stripped);
+  if (!result || result === "." || result === "./") {
+    return null;
+  }
+  return result;
+}
+
+export function resolveArchiveOutputPath(params: {
+  rootDir: string;
+  relPath: string;
+  originalPath: string;
+  escapeLabel?: string;
+}): string {
+  const safeBase = resolveSafeBaseDir(params.rootDir);
+  const outPath = path.resolve(params.rootDir, params.relPath);
+  const escapeLabel = params.escapeLabel ?? "destination";
+  if (!outPath.startsWith(safeBase)) {
+    throw new Error(`archive entry escapes ${escapeLabel}: ${params.originalPath}`);
+  }
+  return outPath;
+}

--- a/src/archive-kind.ts
+++ b/src/archive-kind.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { normalizeLowercaseStringOrEmpty } from "./string-coerce.js";
+
+export type ArchiveKind = "tar" | "zip";
+
+const TAR_SUFFIXES = [".tgz", ".tar.gz", ".tar"];
+
+export function resolveArchiveKind(filePath: string): ArchiveKind | null {
+  const lower = normalizeLowercaseStringOrEmpty(filePath);
+  if (lower.endsWith(".zip")) {
+    return "zip";
+  }
+  if (TAR_SUFFIXES.some((suffix) => lower.endsWith(suffix))) {
+    return "tar";
+  }
+  return null;
+}
+
+type ResolvePackedRootDirOptions = {
+  rootMarkers?: string[];
+};
+
+async function hasPackedRootMarker(extractDir: string, rootMarkers: string[]): Promise<boolean> {
+  for (const marker of rootMarkers) {
+    const trimmed = marker.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      await fs.stat(path.join(extractDir, trimmed));
+      return true;
+    } catch {
+      // ignore
+    }
+  }
+  return false;
+}
+
+export async function resolvePackedRootDir(
+  extractDir: string,
+  options?: ResolvePackedRootDirOptions,
+): Promise<string> {
+  const direct = path.join(extractDir, "package");
+  try {
+    const stat = await fs.stat(direct);
+    if (stat.isDirectory()) {
+      return direct;
+    }
+  } catch {
+    // ignore
+  }
+
+  if ((options?.rootMarkers?.length ?? 0) > 0) {
+    const hasMarker = await hasPackedRootMarker(extractDir, options?.rootMarkers ?? []);
+    if (hasMarker) {
+      return extractDir;
+    }
+  }
+
+  const entries = await fs.readdir(extractDir, { withFileTypes: true });
+  const dirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  if (dirs.length !== 1) {
+    throw new Error(`unexpected archive layout (dirs: ${dirs.join(", ")})`);
+  }
+  const onlyDir = dirs[0];
+  if (!onlyDir) {
+    throw new Error("unexpected archive layout (no package dir found)");
+  }
+  return path.join(extractDir, onlyDir);
+}

--- a/src/archive-limits.ts
+++ b/src/archive-limits.ts
@@ -1,0 +1,133 @@
+import { Transform } from "node:stream";
+
+export type ArchiveExtractLimits = {
+  /**
+   * Max archive file bytes (compressed).
+   */
+  maxArchiveBytes?: number;
+  /** Max number of extracted entries (files + dirs). */
+  maxEntries?: number;
+  /** Max extracted bytes (sum of all files). */
+  maxExtractedBytes?: number;
+  /** Max extracted bytes for a single file entry. */
+  maxEntryBytes?: number;
+};
+
+export const DEFAULT_MAX_ARCHIVE_BYTES_ZIP = 256 * 1024 * 1024;
+export const DEFAULT_MAX_ENTRIES = 50_000;
+export const DEFAULT_MAX_EXTRACTED_BYTES = 512 * 1024 * 1024;
+export const DEFAULT_MAX_ENTRY_BYTES = 256 * 1024 * 1024;
+
+export const ARCHIVE_LIMIT_ERROR_CODE = {
+  ARCHIVE_SIZE_EXCEEDS_LIMIT: "archive-size-exceeds-limit",
+  ENTRY_COUNT_EXCEEDS_LIMIT: "archive-entry-count-exceeds-limit",
+  ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT: "archive-entry-extracted-size-exceeds-limit",
+  EXTRACTED_SIZE_EXCEEDS_LIMIT: "archive-extracted-size-exceeds-limit",
+} as const;
+
+export type ArchiveLimitErrorCode =
+  (typeof ARCHIVE_LIMIT_ERROR_CODE)[keyof typeof ARCHIVE_LIMIT_ERROR_CODE];
+
+const ARCHIVE_LIMIT_ERROR_MESSAGE = {
+  [ARCHIVE_LIMIT_ERROR_CODE.ARCHIVE_SIZE_EXCEEDS_LIMIT]: "archive size exceeds limit",
+  [ARCHIVE_LIMIT_ERROR_CODE.ENTRY_COUNT_EXCEEDS_LIMIT]: "archive entry count exceeds limit",
+  [ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT]:
+    "archive entry extracted size exceeds limit",
+  [ARCHIVE_LIMIT_ERROR_CODE.EXTRACTED_SIZE_EXCEEDS_LIMIT]: "archive extracted size exceeds limit",
+} as const satisfies Record<ArchiveLimitErrorCode, string>;
+
+export class ArchiveLimitError extends Error {
+  readonly code: ArchiveLimitErrorCode;
+
+  constructor(code: ArchiveLimitErrorCode) {
+    super(ARCHIVE_LIMIT_ERROR_MESSAGE[code]);
+    this.name = "ArchiveLimitError";
+    this.code = code;
+  }
+}
+
+export type ResolvedArchiveExtractLimits = Required<ArchiveExtractLimits>;
+
+function clampLimit(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const v = Math.floor(value);
+  return v > 0 ? v : undefined;
+}
+
+export function resolveExtractLimits(
+  limits?: ArchiveExtractLimits,
+): ResolvedArchiveExtractLimits {
+  // Defaults: defensive, but should not break normal installs.
+  return {
+    maxArchiveBytes: clampLimit(limits?.maxArchiveBytes) ?? DEFAULT_MAX_ARCHIVE_BYTES_ZIP,
+    maxEntries: clampLimit(limits?.maxEntries) ?? DEFAULT_MAX_ENTRIES,
+    maxExtractedBytes: clampLimit(limits?.maxExtractedBytes) ?? DEFAULT_MAX_EXTRACTED_BYTES,
+    maxEntryBytes: clampLimit(limits?.maxEntryBytes) ?? DEFAULT_MAX_ENTRY_BYTES,
+  };
+}
+
+export function assertArchiveEntryCountWithinLimit(
+  entryCount: number,
+  limits: ResolvedArchiveExtractLimits,
+) {
+  if (entryCount > limits.maxEntries) {
+    throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ENTRY_COUNT_EXCEEDS_LIMIT);
+  }
+}
+
+export function createByteBudgetTracker(limits: ResolvedArchiveExtractLimits): {
+  startEntry: () => void;
+  addBytes: (bytes: number) => void;
+  addEntrySize: (size: number) => void;
+} {
+  let entryBytes = 0;
+  let extractedBytes = 0;
+
+  const addBytes = (bytes: number) => {
+    const b = Math.max(0, Math.floor(bytes));
+    if (b === 0) {
+      return;
+    }
+    entryBytes += b;
+    if (entryBytes > limits.maxEntryBytes) {
+      throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT);
+    }
+    extractedBytes += b;
+    if (extractedBytes > limits.maxExtractedBytes) {
+      throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.EXTRACTED_SIZE_EXCEEDS_LIMIT);
+    }
+  };
+
+  return {
+    startEntry() {
+      entryBytes = 0;
+    },
+    addBytes,
+    addEntrySize(size: number) {
+      const s = Math.max(0, Math.floor(size));
+      if (s > limits.maxEntryBytes) {
+        throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT);
+      }
+      // Tar budgets are based on the header-declared size.
+      addBytes(s);
+    },
+  };
+}
+
+export function createExtractBudgetTransform(params: {
+  onChunkBytes: (bytes: number) => void;
+}): Transform {
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      try {
+        const buf = chunk instanceof Buffer ? chunk : Buffer.from(chunk as Uint8Array);
+        params.onChunkBytes(buf.byteLength);
+        callback(null, buf);
+      } catch (err) {
+        callback(err instanceof Error ? err : new Error(String(err)));
+      }
+    },
+  });
+}

--- a/src/archive-staging.ts
+++ b/src/archive-staging.ts
@@ -1,0 +1,217 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { root } from "./root.js";
+import { isNotFoundPathError, isPathInside } from "./path.js";
+
+const ERROR_ARCHIVE_ENTRY_TRAVERSES_SYMLINK = "archive entry traverses symlink in destination";
+
+export type ArchiveSecurityErrorCode =
+  | "destination-not-directory"
+  | "destination-symlink"
+  | "destination-symlink-traversal";
+
+export class ArchiveSecurityError extends Error {
+  code: ArchiveSecurityErrorCode;
+
+  constructor(code: ArchiveSecurityErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.code = code;
+    this.name = "ArchiveSecurityError";
+  }
+}
+
+function symlinkTraversalError(originalPath: string): ArchiveSecurityError {
+  return new ArchiveSecurityError(
+    "destination-symlink-traversal",
+    `${ERROR_ARCHIVE_ENTRY_TRAVERSES_SYMLINK}: ${originalPath}`,
+  );
+}
+
+export async function prepareArchiveDestinationDir(destDir: string): Promise<string> {
+  const stat = await fs.lstat(destDir);
+  if (stat.isSymbolicLink()) {
+    throw new ArchiveSecurityError("destination-symlink", "archive destination is a symlink");
+  }
+  if (!stat.isDirectory()) {
+    throw new ArchiveSecurityError(
+      "destination-not-directory",
+      "archive destination is not a directory",
+    );
+  }
+  return await fs.realpath(destDir);
+}
+
+async function assertNoSymlinkTraversal(params: {
+  rootDir: string;
+  relPath: string;
+  originalPath: string;
+}): Promise<void> {
+  const parts = params.relPath.split(/[\\/]+/).filter(Boolean);
+  let current = path.resolve(params.rootDir);
+  for (const part of parts) {
+    current = path.join(current, part);
+    let stat: Awaited<ReturnType<typeof fs.lstat>>;
+    try {
+      stat = await fs.lstat(current);
+    } catch (err) {
+      if (isNotFoundPathError(err)) {
+        continue;
+      }
+      throw err;
+    }
+    if (stat.isSymbolicLink()) {
+      throw symlinkTraversalError(params.originalPath);
+    }
+  }
+}
+
+async function assertResolvedInsideDestination(params: {
+  destinationRealDir: string;
+  targetPath: string;
+  originalPath: string;
+}): Promise<void> {
+  let resolved: string;
+  try {
+    resolved = await fs.realpath(params.targetPath);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      return;
+    }
+    throw err;
+  }
+  if (!isPathInside(params.destinationRealDir, resolved)) {
+    throw symlinkTraversalError(params.originalPath);
+  }
+}
+
+export async function prepareArchiveOutputPath(params: {
+  destinationDir: string;
+  destinationRealDir: string;
+  relPath: string;
+  outPath: string;
+  originalPath: string;
+  isDirectory: boolean;
+}): Promise<void> {
+  await assertNoSymlinkTraversal({
+    rootDir: params.destinationDir,
+    relPath: params.relPath,
+    originalPath: params.originalPath,
+  });
+
+  if (params.isDirectory) {
+    await fs.mkdir(params.outPath, { recursive: true });
+    await assertResolvedInsideDestination({
+      destinationRealDir: params.destinationRealDir,
+      targetPath: params.outPath,
+      originalPath: params.originalPath,
+    });
+    return;
+  }
+
+  const parentDir = path.dirname(params.outPath);
+  await fs.mkdir(parentDir, { recursive: true });
+  await assertResolvedInsideDestination({
+    destinationRealDir: params.destinationRealDir,
+    targetPath: parentDir,
+    originalPath: params.originalPath,
+  });
+}
+
+async function applyStagedEntryMode(params: {
+  destinationRealDir: string;
+  relPath: string;
+  mode: number;
+  originalPath: string;
+}): Promise<void> {
+  const destinationPath = path.join(params.destinationRealDir, params.relPath);
+  await assertResolvedInsideDestination({
+    destinationRealDir: params.destinationRealDir,
+    targetPath: destinationPath,
+    originalPath: params.originalPath,
+  });
+  if (params.mode !== 0) {
+    await fs.chmod(destinationPath, params.mode).catch(() => undefined);
+  }
+}
+
+export async function withStagedArchiveDestination<T>(params: {
+  destinationRealDir: string;
+  stagingDirPrefix?: string;
+  run: (stagingDir: string) => Promise<T>;
+}): Promise<T> {
+  const stagingDir = await fs.mkdtemp(
+    path.join(params.destinationRealDir, params.stagingDirPrefix ?? ".fs-safe-archive-"),
+  );
+  try {
+    return await params.run(stagingDir);
+  } finally {
+    await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+export async function mergeExtractedTreeIntoDestination(params: {
+  sourceDir: string;
+  destinationDir: string;
+  destinationRealDir: string;
+}): Promise<void> {
+  const targetRoot = await root(params.destinationRealDir);
+  const walk = async (currentSourceDir: string): Promise<void> => {
+    const entries = await fs.readdir(currentSourceDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const sourcePath = path.join(currentSourceDir, entry.name);
+      const relPath = path.relative(params.sourceDir, sourcePath);
+      const originalPath = relPath.split(path.sep).join("/");
+      const destinationPath = path.join(params.destinationDir, relPath);
+      const sourceStat = await fs.lstat(sourcePath);
+
+      if (sourceStat.isSymbolicLink()) {
+        throw symlinkTraversalError(originalPath);
+      }
+
+      if (sourceStat.isDirectory()) {
+        await prepareArchiveOutputPath({
+          destinationDir: params.destinationDir,
+          destinationRealDir: params.destinationRealDir,
+          relPath,
+          outPath: destinationPath,
+          originalPath,
+          isDirectory: true,
+        });
+        await walk(sourcePath);
+        await applyStagedEntryMode({
+          destinationRealDir: params.destinationRealDir,
+          relPath,
+          mode: sourceStat.mode & 0o777,
+          originalPath,
+        });
+        continue;
+      }
+
+      if (!sourceStat.isFile()) {
+        throw new Error(`archive staging contains unsupported entry: ${originalPath}`);
+      }
+
+      await prepareArchiveOutputPath({
+        destinationDir: params.destinationDir,
+        destinationRealDir: params.destinationRealDir,
+        relPath,
+        outPath: destinationPath,
+        originalPath,
+        isDirectory: false,
+      });
+      await targetRoot.copyFrom(sourcePath, relPath, { mkdir: true });
+      await applyStagedEntryMode({
+        destinationRealDir: params.destinationRealDir,
+        relPath,
+        mode: sourceStat.mode & 0o777,
+        originalPath,
+      });
+    }
+  };
+
+  await walk(params.sourceDir);
+}
+
+export function createArchiveSymlinkTraversalError(originalPath: string): ArchiveSecurityError {
+  return symlinkTraversalError(originalPath);
+}

--- a/src/archive-tar.ts
+++ b/src/archive-tar.ts
@@ -1,0 +1,78 @@
+import {
+  resolveArchiveOutputPath,
+  stripArchivePath,
+  validateArchiveEntryPath,
+} from "./archive-entry.js";
+import {
+  assertArchiveEntryCountWithinLimit,
+  createByteBudgetTracker,
+  resolveExtractLimits,
+  type ArchiveExtractLimits,
+} from "./archive-limits.js";
+
+export type TarEntryInfo = { path: string; type: string; size: number };
+
+const BLOCKED_TAR_ENTRY_TYPES = new Set([
+  "SymbolicLink",
+  "Link",
+  "BlockDevice",
+  "CharacterDevice",
+  "FIFO",
+  "Socket",
+]);
+
+export function readTarEntryInfo(entry: unknown): TarEntryInfo {
+  const p =
+    typeof entry === "object" && entry !== null && "path" in entry
+      ? String((entry as { path: unknown }).path)
+      : "";
+  const t =
+    typeof entry === "object" && entry !== null && "type" in entry
+      ? String((entry as { type: unknown }).type)
+      : "";
+  const s =
+    typeof entry === "object" &&
+    entry !== null &&
+    "size" in entry &&
+    typeof (entry as { size?: unknown }).size === "number" &&
+    Number.isFinite((entry as { size: number }).size)
+      ? Math.max(0, Math.floor((entry as { size: number }).size))
+      : 0;
+  return { path: p, type: t, size: s };
+}
+
+export function createTarEntryPreflightChecker(params: {
+  rootDir: string;
+  stripComponents?: number;
+  limits?: ArchiveExtractLimits;
+  escapeLabel?: string;
+}): (entry: TarEntryInfo) => void {
+  const strip = Math.max(0, Math.floor(params.stripComponents ?? 0));
+  const limits = resolveExtractLimits(params.limits);
+  let entryCount = 0;
+  const budget = createByteBudgetTracker(limits);
+
+  return (entry: TarEntryInfo) => {
+    validateArchiveEntryPath(entry.path, { escapeLabel: params.escapeLabel });
+
+    const relPath = stripArchivePath(entry.path, strip);
+    if (!relPath) {
+      return;
+    }
+    validateArchiveEntryPath(relPath, { escapeLabel: params.escapeLabel });
+    resolveArchiveOutputPath({
+      rootDir: params.rootDir,
+      relPath,
+      originalPath: entry.path,
+      escapeLabel: params.escapeLabel,
+    });
+
+    if (BLOCKED_TAR_ENTRY_TYPES.has(entry.type)) {
+      throw new Error(`tar entry is a link: ${entry.path}`);
+    }
+
+    entryCount += 1;
+    assertArchiveEntryCountWithinLimit(entryCount, limits);
+    budget.addEntrySize(entry.size);
+  };
+}

--- a/src/archive-utils.ts
+++ b/src/archive-utils.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs/promises";
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+export async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/archive-zip-preflight.ts
+++ b/src/archive-zip-preflight.ts
@@ -1,0 +1,206 @@
+import JSZip from "jszip";
+import {
+  ARCHIVE_LIMIT_ERROR_CODE,
+  ArchiveLimitError,
+  assertArchiveEntryCountWithinLimit,
+  resolveExtractLimits,
+  type ArchiveExtractLimits,
+} from "./archive-limits.js";
+
+const ZIP_EOCD_SIGNATURE = 0x06054b50;
+const ZIP64_EOCD_SIGNATURE = 0x06064b50;
+const ZIP64_EOCD_LOCATOR_SIGNATURE = 0x07064b50;
+const ZIP_EOCD_MIN_BYTES = 22;
+const ZIP_EOCD_MAX_COMMENT_BYTES = 0xffff;
+const ZIP64_ENTRY_COUNT_SENTINEL = 0xffff;
+const ZIP64_UINT32_SENTINEL = 0xffffffff;
+const ZIP_CENTRAL_FILE_HEADER_SIGNATURE = 0x02014b50;
+const ZIP_CENTRAL_FILE_HEADER_MIN_BYTES = 46;
+const ZIP_CENTRAL_FILE_HEADER_NAME_LENGTH_OFFSET = 28;
+const ZIP_CENTRAL_FILE_HEADER_EXTRA_LENGTH_OFFSET = 30;
+const ZIP_CENTRAL_FILE_HEADER_COMMENT_LENGTH_OFFSET = 32;
+const ZIP_EOCD_TOTAL_ENTRIES_OFFSET = 10;
+const ZIP_EOCD_CENTRAL_DIRECTORY_SIZE_OFFSET = 12;
+const ZIP_EOCD_CENTRAL_DIRECTORY_OFFSET_OFFSET = 16;
+const ZIP_EOCD_COMMENT_LENGTH_OFFSET = 20;
+const ZIP64_EOCD_LOCATOR_BYTES = 20;
+const ZIP64_EOCD_OFFSET_OFFSET = 8;
+const ZIP64_EOCD_TOTAL_ENTRIES_OFFSET = 32;
+const ZIP64_EOCD_CENTRAL_DIRECTORY_SIZE_OFFSET = 40;
+const ZIP64_EOCD_CENTRAL_DIRECTORY_OFFSET_OFFSET = 48;
+
+function asBufferView(buffer: Buffer | Uint8Array): Buffer {
+  if (Buffer.isBuffer(buffer)) {
+    return buffer;
+  }
+  return Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+}
+
+function readSafeUInt64LE(buffer: Buffer, offset: number): number {
+  const value = buffer.readBigUInt64LE(offset);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  return Number(value);
+}
+
+function findZipEndOfCentralDirectory(buffer: Buffer): number {
+  if (buffer.byteLength < ZIP_EOCD_MIN_BYTES) {
+    return -1;
+  }
+  const minOffset = Math.max(
+    0,
+    buffer.byteLength - ZIP_EOCD_MIN_BYTES - ZIP_EOCD_MAX_COMMENT_BYTES,
+  );
+  for (let offset = buffer.byteLength - ZIP_EOCD_MIN_BYTES; offset >= minOffset; offset -= 1) {
+    if (buffer.readUInt32LE(offset) !== ZIP_EOCD_SIGNATURE) {
+      continue;
+    }
+    const commentLength = buffer.readUInt16LE(offset + ZIP_EOCD_COMMENT_LENGTH_OFFSET);
+    if (offset + ZIP_EOCD_MIN_BYTES + commentLength === buffer.byteLength) {
+      return offset;
+    }
+  }
+  return -1;
+}
+
+type ZipCentralDirectoryInfo = {
+  declaredEntryCount: number;
+  centralDirectoryOffset: number;
+  centralDirectorySize: number;
+  endOfCentralDirectoryOffset: number;
+};
+
+function readZip64CentralDirectoryInfo(
+  buffer: Buffer,
+  eocdOffset: number,
+): ZipCentralDirectoryInfo | null {
+  const locatorOffset = eocdOffset - ZIP64_EOCD_LOCATOR_BYTES;
+  if (locatorOffset < 0 || buffer.readUInt32LE(locatorOffset) !== ZIP64_EOCD_LOCATOR_SIGNATURE) {
+    return null;
+  }
+  const zip64EocdOffset = readSafeUInt64LE(buffer, locatorOffset + ZIP64_EOCD_OFFSET_OFFSET);
+  if (
+    zip64EocdOffset < 0 ||
+    zip64EocdOffset + ZIP64_EOCD_CENTRAL_DIRECTORY_OFFSET_OFFSET + 8 > buffer.byteLength ||
+    buffer.readUInt32LE(zip64EocdOffset) !== ZIP64_EOCD_SIGNATURE
+  ) {
+    return null;
+  }
+  return {
+    declaredEntryCount: readSafeUInt64LE(buffer, zip64EocdOffset + ZIP64_EOCD_TOTAL_ENTRIES_OFFSET),
+    centralDirectorySize: readSafeUInt64LE(
+      buffer,
+      zip64EocdOffset + ZIP64_EOCD_CENTRAL_DIRECTORY_SIZE_OFFSET,
+    ),
+    centralDirectoryOffset: readSafeUInt64LE(
+      buffer,
+      zip64EocdOffset + ZIP64_EOCD_CENTRAL_DIRECTORY_OFFSET_OFFSET,
+    ),
+    endOfCentralDirectoryOffset: eocdOffset,
+  };
+}
+
+function readZipCentralDirectoryInfo(buffer: Buffer): ZipCentralDirectoryInfo | null {
+  const eocdOffset = findZipEndOfCentralDirectory(buffer);
+  if (eocdOffset < 0) {
+    return null;
+  }
+  const declaredEntryCount = buffer.readUInt16LE(eocdOffset + ZIP_EOCD_TOTAL_ENTRIES_OFFSET);
+  const centralDirectorySize = buffer.readUInt32LE(
+    eocdOffset + ZIP_EOCD_CENTRAL_DIRECTORY_SIZE_OFFSET,
+  );
+  const centralDirectoryOffset = buffer.readUInt32LE(
+    eocdOffset + ZIP_EOCD_CENTRAL_DIRECTORY_OFFSET_OFFSET,
+  );
+  const usesZip64 =
+    declaredEntryCount === ZIP64_ENTRY_COUNT_SENTINEL ||
+    centralDirectorySize === ZIP64_UINT32_SENTINEL ||
+    centralDirectoryOffset === ZIP64_UINT32_SENTINEL;
+  if (usesZip64) {
+    return (
+      readZip64CentralDirectoryInfo(buffer, eocdOffset) ?? {
+        declaredEntryCount,
+        centralDirectoryOffset,
+        centralDirectorySize,
+        endOfCentralDirectoryOffset: eocdOffset,
+      }
+    );
+  }
+  return {
+    declaredEntryCount,
+    centralDirectoryOffset,
+    centralDirectorySize,
+    endOfCentralDirectoryOffset: eocdOffset,
+  };
+}
+
+function countZipCentralDirectoryHeaders(
+  buffer: Buffer,
+  info: ZipCentralDirectoryInfo,
+): number | null {
+  const start = info.centralDirectoryOffset;
+  const declaredEnd = start + info.centralDirectorySize;
+  const scanEnd = info.endOfCentralDirectoryOffset;
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(declaredEnd) ||
+    !Number.isSafeInteger(scanEnd) ||
+    start < 0 ||
+    declaredEnd < start ||
+    scanEnd < start ||
+    scanEnd > buffer.byteLength
+  ) {
+    return null;
+  }
+  let offset = start;
+  let count = 0;
+  while (offset < scanEnd) {
+    if (scanEnd - offset < ZIP_CENTRAL_FILE_HEADER_MIN_BYTES) {
+      break;
+    }
+    if (buffer.readUInt32LE(offset) !== ZIP_CENTRAL_FILE_HEADER_SIGNATURE) {
+      break;
+    }
+    const nameLength = buffer.readUInt16LE(offset + ZIP_CENTRAL_FILE_HEADER_NAME_LENGTH_OFFSET);
+    const extraLength = buffer.readUInt16LE(offset + ZIP_CENTRAL_FILE_HEADER_EXTRA_LENGTH_OFFSET);
+    const commentLength = buffer.readUInt16LE(
+      offset + ZIP_CENTRAL_FILE_HEADER_COMMENT_LENGTH_OFFSET,
+    );
+    const nextOffset =
+      offset + ZIP_CENTRAL_FILE_HEADER_MIN_BYTES + nameLength + extraLength + commentLength;
+    if (nextOffset <= offset || nextOffset > scanEnd) {
+      return null;
+    }
+    count += 1;
+    offset = nextOffset;
+  }
+  return count > 0 || info.declaredEntryCount === 0 ? count : null;
+}
+
+export function readZipCentralDirectoryEntryCount(buffer: Buffer | Uint8Array): number | null {
+  const view = asBufferView(buffer);
+  const info = readZipCentralDirectoryInfo(view);
+  if (!info) {
+    return null;
+  }
+  const countedEntryCount = countZipCentralDirectoryHeaders(view, info);
+  return countedEntryCount === null
+    ? info.declaredEntryCount
+    : Math.max(info.declaredEntryCount, countedEntryCount);
+}
+
+export async function loadZipArchiveWithPreflight(
+  buffer: Buffer | Uint8Array,
+  limits?: ArchiveExtractLimits,
+): Promise<JSZip> {
+  const resolvedLimits = resolveExtractLimits(limits);
+  if (buffer.byteLength > resolvedLimits.maxArchiveBytes) {
+    throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ARCHIVE_SIZE_EXCEEDS_LIMIT);
+  }
+  const entryCount = readZipCentralDirectoryEntryCount(buffer);
+  if (entryCount !== null) {
+    assertArchiveEntryCountWithinLimit(entryCount, resolvedLimits);
+  }
+  return await JSZip.loadAsync(buffer);
+}

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -34,12 +34,12 @@ import {
   readTarEntryInfo,
   type TarEntryInfo,
 } from "./archive-tar.js";
-import { withTimeout } from "./archive-utils.js";
 import { loadZipArchiveWithPreflight } from "./archive-zip-preflight.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { FsSafeError } from "./errors.js";
 import { root } from "./root.js";
 import { isNotFoundPathError } from "./path.js";
+import { withTimeout } from "./timing.js";
 
 export type ArchiveLogger = {
   info?: (message: string) => void;
@@ -66,7 +66,6 @@ export {
   withStagedArchiveDestination,
 } from "./archive-staging.js";
 export { createTarEntryPreflightChecker, type TarEntryInfo } from "./archive-tar.js";
-export { fileExists, withTimeout } from "./archive-utils.js";
 export {
   loadZipArchiveWithPreflight,
   readZipCentralDirectoryEntryCount,

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -1,0 +1,419 @@
+import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import type { Stats } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import * as tar from "tar";
+import {
+  resolveArchiveOutputPath,
+  stripArchivePath,
+  validateArchiveEntryPath,
+} from "./archive-entry.js";
+import {
+  ARCHIVE_LIMIT_ERROR_CODE,
+  ArchiveLimitError,
+  assertArchiveEntryCountWithinLimit,
+  createByteBudgetTracker,
+  createExtractBudgetTransform,
+  resolveExtractLimits,
+  type ArchiveExtractLimits,
+} from "./archive-limits.js";
+import { resolveArchiveKind, type ArchiveKind } from "./archive-kind.js";
+import {
+  createArchiveSymlinkTraversalError,
+  mergeExtractedTreeIntoDestination,
+  prepareArchiveDestinationDir,
+  prepareArchiveOutputPath,
+  withStagedArchiveDestination,
+} from "./archive-staging.js";
+import {
+  createTarEntryPreflightChecker,
+  readTarEntryInfo,
+  type TarEntryInfo,
+} from "./archive-tar.js";
+import { withTimeout } from "./archive-utils.js";
+import { loadZipArchiveWithPreflight } from "./archive-zip-preflight.js";
+import { sameFileIdentity } from "./file-identity.js";
+import { FsSafeError } from "./errors.js";
+import { root } from "./root.js";
+import { isNotFoundPathError } from "./path.js";
+
+export type ArchiveLogger = {
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+};
+
+export { resolveArchiveKind, resolvePackedRootDir, type ArchiveKind } from "./archive-kind.js";
+export {
+  ARCHIVE_LIMIT_ERROR_CODE,
+  ArchiveLimitError,
+  DEFAULT_MAX_ARCHIVE_BYTES_ZIP,
+  DEFAULT_MAX_ENTRIES,
+  DEFAULT_MAX_EXTRACTED_BYTES,
+  DEFAULT_MAX_ENTRY_BYTES,
+  type ArchiveExtractLimits,
+  type ArchiveLimitErrorCode,
+} from "./archive-limits.js";
+export { ArchiveSecurityError, type ArchiveSecurityErrorCode } from "./archive-staging.js";
+export {
+  createArchiveSymlinkTraversalError,
+  mergeExtractedTreeIntoDestination,
+  prepareArchiveDestinationDir,
+  prepareArchiveOutputPath,
+  withStagedArchiveDestination,
+} from "./archive-staging.js";
+export { createTarEntryPreflightChecker, type TarEntryInfo } from "./archive-tar.js";
+export { fileExists, withTimeout } from "./archive-utils.js";
+export {
+  loadZipArchiveWithPreflight,
+  readZipCentralDirectoryEntryCount,
+} from "./archive-zip-preflight.js";
+
+const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsConstants;
+const OPEN_WRITE_CREATE_FLAGS =
+  fsConstants.O_WRONLY |
+  fsConstants.O_CREAT |
+  fsConstants.O_EXCL |
+  (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+
+function symlinkTraversalError(originalPath: string) {
+  return createArchiveSymlinkTraversalError(originalPath);
+}
+
+type OpenZipOutputFileResult = {
+  handle: FileHandle;
+  createdForWrite: boolean;
+  realPath: string;
+  stat: Stats;
+};
+
+async function openZipOutputFile(params: {
+  relPath: string;
+  originalPath: string;
+  destinationRealDir: string;
+}): Promise<OpenZipOutputFileResult> {
+  try {
+    const targetRoot = await root(params.destinationRealDir);
+    return await targetRoot.openWritable(params.relPath, {
+      mkdir: false,
+      mode: 0o666,
+    });
+  } catch (err) {
+    if (
+      err instanceof FsSafeError &&
+      (err.code === "invalid-path" ||
+        err.code === "outside-workspace" ||
+        err.code === "path-mismatch")
+    ) {
+      throw symlinkTraversalError(params.originalPath);
+    }
+    throw err;
+  }
+}
+
+async function cleanupPartialRegularFile(filePath: string): Promise<void> {
+  let stat: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    stat = await fs.lstat(filePath);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      return;
+    }
+    throw err;
+  }
+  if (stat.isFile()) {
+    await fs.unlink(filePath).catch(() => undefined);
+  }
+}
+
+function buildArchiveAtomicTempPath(targetPath: string): string {
+  return path.join(
+    path.dirname(targetPath),
+    `.${path.basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+}
+
+async function verifyZipWriteResult(params: {
+  destinationRealDir: string;
+  relPath: string;
+  expectedStat: Stats;
+}): Promise<string> {
+  const targetRoot = await root(params.destinationRealDir);
+  const opened = await targetRoot.open(params.relPath, {
+    hardlinks: "reject",
+  });
+  try {
+    if (!sameFileIdentity(opened.stat, params.expectedStat)) {
+      throw new FsSafeError("path-mismatch", "path changed during zip extract");
+    }
+    return opened.realPath;
+  } finally {
+    await opened.handle.close().catch(() => undefined);
+  }
+}
+
+type ZipEntry = {
+  name: string;
+  dir: boolean;
+  unixPermissions?: number;
+  nodeStream?: () => NodeJS.ReadableStream;
+  async: (type: "nodebuffer") => Promise<Buffer>;
+};
+
+type ZipExtractBudget = ReturnType<typeof createByteBudgetTracker>;
+
+async function readZipEntryStream(entry: ZipEntry): Promise<NodeJS.ReadableStream> {
+  if (typeof entry.nodeStream === "function") {
+    return entry.nodeStream();
+  }
+  // Old JSZip: fall back to buffering, but still extract via a stream.
+  const buf = await entry.async("nodebuffer");
+  return Readable.from(buf);
+}
+
+function resolveZipOutputPath(params: {
+  entryPath: string;
+  strip: number;
+  destinationDir: string;
+}): { relPath: string; outPath: string } | null {
+  validateArchiveEntryPath(params.entryPath);
+  const relPath = stripArchivePath(params.entryPath, params.strip);
+  if (!relPath) {
+    return null;
+  }
+  validateArchiveEntryPath(relPath);
+  return {
+    relPath,
+    outPath: resolveArchiveOutputPath({
+      rootDir: params.destinationDir,
+      relPath,
+      originalPath: params.entryPath,
+    }),
+  };
+}
+
+async function prepareZipOutputPath(params: {
+  destinationDir: string;
+  destinationRealDir: string;
+  relPath: string;
+  outPath: string;
+  originalPath: string;
+  isDirectory: boolean;
+}): Promise<void> {
+  await prepareArchiveOutputPath(params);
+}
+
+async function writeZipFileEntry(params: {
+  entry: ZipEntry;
+  relPath: string;
+  destinationRealDir: string;
+  budget: ZipExtractBudget;
+}): Promise<void> {
+  const opened = await openZipOutputFile({
+    relPath: params.relPath,
+    originalPath: params.entry.name,
+    destinationRealDir: params.destinationRealDir,
+  });
+  params.budget.startEntry();
+  const readable = await readZipEntryStream(params.entry);
+  const destinationPath = opened.realPath;
+  const targetMode = opened.stat.mode & 0o777;
+  await opened.handle.close().catch(() => undefined);
+
+  let tempHandle: FileHandle | null = null;
+  let tempPath: string | null = null;
+  let tempStat: Stats | null = null;
+  let handleClosedByStream = false;
+
+  try {
+    tempPath = buildArchiveAtomicTempPath(destinationPath);
+    tempHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, targetMode || 0o666);
+    const writable = tempHandle.createWriteStream();
+    writable.once("close", () => {
+      handleClosedByStream = true;
+    });
+
+    await pipeline(
+      readable,
+      createExtractBudgetTransform({ onChunkBytes: params.budget.addBytes }),
+      writable,
+    );
+    tempStat = await fs.stat(tempPath);
+    if (!tempStat) {
+      throw new Error("zip temp write did not produce file metadata");
+    }
+    if (!handleClosedByStream) {
+      await tempHandle.close().catch(() => undefined);
+      handleClosedByStream = true;
+    }
+    tempHandle = null;
+    await fs.rename(tempPath, destinationPath);
+    tempPath = null;
+    const verifiedPath = await verifyZipWriteResult({
+      destinationRealDir: params.destinationRealDir,
+      relPath: params.relPath,
+      expectedStat: tempStat,
+    });
+
+    // Best-effort permission restore for zip entries created on unix.
+    if (typeof params.entry.unixPermissions === "number") {
+      const mode = params.entry.unixPermissions & 0o777;
+      if (mode !== 0) {
+        await fs.chmod(verifiedPath, mode).catch(() => undefined);
+      }
+    }
+  } catch (err) {
+    if (tempPath) {
+      await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    } else {
+      await cleanupPartialRegularFile(destinationPath).catch(() => undefined);
+    }
+    if (err instanceof FsSafeError) {
+      throw symlinkTraversalError(params.entry.name);
+    }
+    throw err;
+  } finally {
+    if (tempHandle && !handleClosedByStream) {
+      await tempHandle.close().catch(() => undefined);
+    }
+  }
+}
+
+async function extractZip(params: {
+  archivePath: string;
+  destDir: string;
+  stripComponents?: number;
+  limits?: ArchiveExtractLimits;
+}): Promise<void> {
+  const limits = resolveExtractLimits(params.limits);
+  const destinationRealDir = await prepareArchiveDestinationDir(params.destDir);
+  const stat = await fs.stat(params.archivePath);
+  if (stat.size > limits.maxArchiveBytes) {
+    throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ARCHIVE_SIZE_EXCEEDS_LIMIT);
+  }
+
+  const buffer = await fs.readFile(params.archivePath);
+  const zip = await loadZipArchiveWithPreflight(buffer, limits);
+  const entries = Object.values(zip.files) as ZipEntry[];
+  const strip = Math.max(0, Math.floor(params.stripComponents ?? 0));
+
+  assertArchiveEntryCountWithinLimit(entries.length, limits);
+
+  const budget = createByteBudgetTracker(limits);
+
+  for (const entry of entries) {
+    const output = resolveZipOutputPath({
+      entryPath: entry.name,
+      strip,
+      destinationDir: params.destDir,
+    });
+    if (!output) {
+      continue;
+    }
+
+    await prepareZipOutputPath({
+      destinationDir: params.destDir,
+      destinationRealDir,
+      relPath: output.relPath,
+      outPath: output.outPath,
+      originalPath: entry.name,
+      isDirectory: entry.dir,
+    });
+    if (entry.dir) {
+      continue;
+    }
+
+    await writeZipFileEntry({
+      entry,
+      relPath: output.relPath,
+      destinationRealDir,
+      budget,
+    });
+  }
+}
+
+export async function extractArchive(params: {
+  archivePath: string;
+  destDir: string;
+  timeoutMs: number;
+  kind?: ArchiveKind;
+  stripComponents?: number;
+  tarGzip?: boolean;
+  limits?: ArchiveExtractLimits;
+  logger?: ArchiveLogger;
+}): Promise<void> {
+  const kind = params.kind ?? resolveArchiveKind(params.archivePath);
+  if (!kind) {
+    throw new Error(`unsupported archive: ${params.archivePath}`);
+  }
+
+  const label = kind === "zip" ? "extract zip" : "extract tar";
+  if (kind === "tar") {
+    await withTimeout(
+      (async () => {
+        const limits = resolveExtractLimits(params.limits);
+        const stat = await fs.stat(params.archivePath);
+        if (stat.size > limits.maxArchiveBytes) {
+          throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ARCHIVE_SIZE_EXCEEDS_LIMIT);
+        }
+
+        const destinationRealDir = await prepareArchiveDestinationDir(params.destDir);
+        await withStagedArchiveDestination({
+          destinationRealDir,
+          run: async (stagingDir) => {
+            const checkTarEntrySafety = createTarEntryPreflightChecker({
+              rootDir: destinationRealDir,
+              stripComponents: params.stripComponents,
+              limits,
+            });
+            // A canonical cwd is not enough here: tar can still follow
+            // pre-existing child symlinks in the live destination tree.
+            // Extract into a private staging dir first, then merge through
+            // the same safe-open boundary checks used by direct file writes.
+            await tar.x({
+              file: params.archivePath,
+              cwd: stagingDir,
+              strip: Math.max(0, Math.floor(params.stripComponents ?? 0)),
+              gzip: params.tarGzip,
+              preservePaths: false,
+              strict: true,
+              onReadEntry(entry) {
+                try {
+                  checkTarEntrySafety(readTarEntryInfo(entry));
+                } catch (err) {
+                  const error = err instanceof Error ? err : new Error(String(err));
+                  // Node's EventEmitter calls listeners with `this` bound to the
+                  // emitter (tar.Unpack), which exposes Parser.abort().
+                  const emitter = this as unknown as { abort?: (error: Error) => void };
+                  emitter.abort?.(error);
+                }
+              },
+            });
+            await mergeExtractedTreeIntoDestination({
+              sourceDir: stagingDir,
+              destinationDir: destinationRealDir,
+              destinationRealDir,
+            });
+          },
+        });
+      })(),
+      params.timeoutMs,
+      label,
+    );
+    return;
+  }
+
+  await withTimeout(
+    extractZip({
+      archivePath: params.archivePath,
+      destDir: params.destDir,
+      stripComponents: params.stripComponents,
+      limits: params.limits,
+    }),
+    params.timeoutMs,
+    label,
+  );
+}

--- a/src/atomic.ts
+++ b/src/atomic.ts
@@ -1,0 +1,11 @@
+export {
+  replaceFileAtomic,
+  replaceFileAtomicSync,
+  type ReplaceFileAtomicFileSystem,
+  type ReplaceFileAtomicOptions,
+  type ReplaceFileAtomicResult,
+  type ReplaceFileAtomicSyncFileSystem,
+  type ReplaceFileAtomicSyncOptions,
+} from "./replace-file.js";
+export { replaceDirectoryStaged, type ReplaceDirectoryStagedOptions } from "./replace-directory.js";
+export { movePathWithCopyFallback, type MovePathWithCopyFallbackOptions } from "./move-path.js";

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,28 @@
+export type FsSafeErrorCode =
+  | "already-exists"
+  | "hardlink"
+  | "helper-failed"
+  | "helper-unavailable"
+  | "invalid-path"
+  | "not-empty"
+  | "not-file"
+  | "not-found"
+  | "not-removable"
+  | "outside-workspace"
+  | "path-alias"
+  | "path-mismatch"
+  | "symlink"
+  | "too-large"
+  | "unsupported-platform";
+
+export class FsSafeError extends Error {
+  readonly code: FsSafeErrorCode;
+  readonly cause?: unknown;
+
+  constructor(code: FsSafeErrorCode, message: string, options: { cause?: unknown } = {}) {
+    super(message, options);
+    this.name = "FsSafeError";
+    this.code = code;
+    this.cause = options.cause;
+  }
+}

--- a/src/file-identity.ts
+++ b/src/file-identity.ts
@@ -1,0 +1,25 @@
+export type FileIdentityStat = {
+  dev: number | bigint;
+  ino: number | bigint;
+};
+
+function isZero(value: number | bigint): boolean {
+  return value === 0 || value === 0n;
+}
+
+export function sameFileIdentity(
+  left: FileIdentityStat,
+  right: FileIdentityStat,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (left.ino !== right.ino) {
+    return false;
+  }
+
+  // On Windows, path-based stat calls can report dev=0 while fd-based stat
+  // reports a real volume serial; treat either-side dev=0 as "unknown device".
+  if (left.dev === right.dev) {
+    return true;
+  }
+  return platform === "win32" && (isZero(left.dev) || isZero(right.dev));
+}

--- a/src/file-url.ts
+++ b/src/file-url.ts
@@ -1,0 +1,1 @@
+export * from "./local-file-access.js";

--- a/src/filename.ts
+++ b/src/filename.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+
+export function sanitizeUntrustedFileName(fileName: string, fallbackName: string): string {
+  const trimmed = typeof fileName === "string" ? fileName.trim() : "";
+  if (!trimmed) {
+    return fallbackName;
+  }
+  let base = path.posix.basename(trimmed);
+  base = path.win32.basename(base);
+  let cleaned = "";
+  for (let i = 0; i < base.length; i++) {
+    const code = base.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) {
+      continue;
+    }
+    cleaned += base[i];
+  }
+  base = cleaned.trim();
+  if (!base || base === "." || base === "..") {
+    return fallbackName;
+  }
+  if (base.length > 200) {
+    base = base.slice(0, 200);
+  }
+  return base;
+}

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,0 +1,16 @@
+import fs from "node:fs/promises";
+
+/**
+ * Returns true when `fs.stat()` can stat the path.
+ *
+ * This follows stat semantics: broken symlinks return false, while symlinks to
+ * existing targets return true.
+ */
+export async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/home-dir.ts
+++ b/src/home-dir.ts
@@ -1,0 +1,144 @@
+import os from "node:os";
+import path from "node:path";
+import { normalizeOptionalString } from "./string-coerce.js";
+
+function normalize(value: string | undefined): string | undefined {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed === "undefined" || trimmed === "null") {
+    return undefined;
+  }
+  return trimmed;
+}
+
+export function resolveEffectiveHomeDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string | undefined {
+  const raw = resolveRawHomeDir(env, homedir);
+  return raw ? path.resolve(raw) : undefined;
+}
+
+export function resolveOsHomeDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string | undefined {
+  const raw = resolveRawOsHomeDir(env, homedir);
+  return raw ? path.resolve(raw) : undefined;
+}
+
+function resolveRawHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): string | undefined {
+  const explicitHome = normalize(env.OPENCLAW_HOME);
+  if (explicitHome) {
+    if (explicitHome === "~" || explicitHome.startsWith("~/") || explicitHome.startsWith("~\\")) {
+      const fallbackHome = resolveRawOsHomeDir(env, homedir);
+      if (fallbackHome) {
+        return explicitHome.replace(/^~(?=$|[\\/])/, fallbackHome);
+      }
+      return undefined;
+    }
+    return explicitHome;
+  }
+
+  return resolveRawOsHomeDir(env, homedir);
+}
+
+function resolveRawOsHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): string | undefined {
+  const envHome = normalize(env.HOME);
+  if (envHome) {
+    return envHome;
+  }
+  const userProfile = normalize(env.USERPROFILE);
+  if (userProfile) {
+    return userProfile;
+  }
+  return normalizeSafe(homedir);
+}
+
+function normalizeSafe(homedir: () => string): string | undefined {
+  try {
+    return normalize(homedir());
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveRequiredHomeDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
+  return resolveEffectiveHomeDir(env, homedir) ?? path.resolve(process.cwd());
+}
+
+export function resolveRequiredOsHomeDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
+  return resolveOsHomeDir(env, homedir) ?? path.resolve(process.cwd());
+}
+
+export function expandHomePrefix(
+  input: string,
+  opts?: {
+    home?: string;
+    env?: NodeJS.ProcessEnv;
+    homedir?: () => string;
+  },
+): string {
+  if (!input.startsWith("~")) {
+    return input;
+  }
+  const home =
+    normalize(opts?.home) ??
+    resolveEffectiveHomeDir(opts?.env ?? process.env, opts?.homedir ?? os.homedir);
+  if (!home) {
+    return input;
+  }
+  return input.replace(/^~(?=$|[\\/])/, home);
+}
+
+export function resolveHomeRelativePath(
+  input: string,
+  opts?: {
+    env?: NodeJS.ProcessEnv;
+    homedir?: () => string;
+  },
+): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("~")) {
+    const expanded = expandHomePrefix(trimmed, {
+      home: resolveRequiredHomeDir(opts?.env ?? process.env, opts?.homedir ?? os.homedir),
+      env: opts?.env,
+      homedir: opts?.homedir,
+    });
+    return path.resolve(expanded);
+  }
+  return path.resolve(trimmed);
+}
+
+export function resolveOsHomeRelativePath(
+  input: string,
+  opts?: {
+    env?: NodeJS.ProcessEnv;
+    homedir?: () => string;
+  },
+): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed.startsWith("~")) {
+    const expanded = expandHomePrefix(trimmed, {
+      home: resolveRequiredOsHomeDir(opts?.env ?? process.env, opts?.homedir ?? os.homedir),
+      env: opts?.env,
+      homedir: opts?.homedir,
+    });
+    return path.resolve(expanded);
+  }
+  return path.resolve(trimmed);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,166 @@
+export { FsSafeError, type FsSafeErrorCode } from "./errors.js";
+export {
+  isWindowsDrivePath,
+  normalizeArchiveEntryPath,
+  resolveArchiveOutputPath,
+  stripArchivePath,
+  validateArchiveEntryPath,
+} from "./archive-entry.js";
+export {
+  DEFAULT_SECRET_FILE_MAX_BYTES,
+  PRIVATE_SECRET_DIR_MODE,
+  PRIVATE_SECRET_FILE_MODE,
+  loadSecretFileSync,
+  readSecretFileSync,
+  tryReadSecretFileSync,
+  writePrivateSecretFileAtomic,
+  type SecretFileReadOptions,
+  type SecretFileReadResult,
+} from "./secret-file.js";
+export {
+  ROOT_PATH_ALIAS_POLICIES,
+  resolvePathViaExistingAncestorSync,
+  resolveRootPath,
+  resolveRootPathSync,
+  type ResolvedRootPath,
+  type RootPathAliasPolicy,
+} from "./root-path.js";
+export * from "./root-paths.js";
+export {
+  canUseRootFileOpen,
+  matchRootFileOpenFailure,
+  openRootFile,
+  openRootFileSync,
+  type RootFileOpenFailure,
+  type RootFileOpenFailureReason,
+  type RootFileOpenResult,
+  type OpenRootFileParams,
+  type OpenRootFileSyncParams,
+} from "./root-file.js";
+export { sameFileIdentity, type FileIdentityStat } from "./file-identity.js";
+export {
+  openPinnedFileSync,
+  type PinnedOpenSyncAllowedType,
+  type PinnedOpenSyncFailureReason,
+  type PinnedOpenSyncFs,
+  type PinnedOpenSyncResult,
+} from "./pinned-open.js";
+export {
+  assertNoWindowsNetworkPath,
+  basenameFromMediaSource,
+  hasEncodedFileUrlSeparator,
+  isWindowsNetworkPath,
+  safeFileURLToPath,
+  trySafeFileURLToPath,
+} from "./local-file-access.js";
+export {
+  isPathInside,
+  isPathInsideWithRealpath,
+  isWithinDir,
+  resolveSafeBaseDir,
+  safeRealpathSync,
+  safeStatSync,
+} from "./path.js";
+export {
+  assertNoHardlinkedFinalPath,
+  assertNoPathAliasEscape,
+  PATH_ALIAS_POLICIES,
+  type PathAliasPolicy,
+} from "./path-policy.js";
+export {
+  pathScope,
+  type PathScope,
+  type PathScopeOptions,
+  type PathScopeResolveOptions,
+} from "./path-scope.js";
+export { formatPosixMode } from "./mode.js";
+export {
+  assertCanonicalPathWithinBase,
+  resolveSafeInstallDir,
+  safeDirName,
+  safePathSegmentHashed,
+} from "./install-path.js";
+export { sanitizeUntrustedFileName } from "./filename.js";
+export {
+  JsonFileReadError,
+  createAsyncLock,
+  loadJsonFile,
+  readDurableJsonFile,
+  readJsonFile,
+  readJsonFileSync,
+  readJsonFileStrict,
+  saveJsonFile,
+  writeJsonAtomic,
+  writeTextAtomic,
+} from "./json.js";
+export {
+  privateFileStore,
+  writePrivateJsonAtomic,
+  writePrivateJsonAtomicSync,
+  writePrivateTextAtomic,
+  writePrivateTextAtomicSync,
+  type PrivateFileStore,
+} from "./private-file-store.js";
+export { readRegularFile, statRegularFile, type RegularFileStatResult } from "./regular-file.js";
+export * from "./atomic.js";
+export * from "./temp.js";
+export {
+  assertNoSymlinkParents,
+  assertNoSymlinkParentsSync,
+  type AssertNoSymlinkParentsOptions,
+} from "./symlink-parents.js";
+export {
+  assertAbsolutePathInput,
+  canonicalPathFromExistingAncestor,
+  findExistingAncestor,
+  resolveAbsolutePathForRead,
+  resolveAbsolutePathForWrite,
+  type AbsolutePathSymlinkPolicy,
+  type ResolvedAbsolutePath,
+  type ResolvedWritableAbsolutePath,
+} from "./absolute-path.js";
+export {
+  createSidecarLockManager,
+  type SidecarLockAcquireOptions,
+  type SidecarLockHandle,
+  type SidecarLockHeldEntry,
+  type SidecarLockRetryOptions,
+} from "./sidecar-lock.js";
+export { movePathToTrash, type MovePathToTrashOptions } from "./trash.js";
+export {
+  ARCHIVE_LIMIT_ERROR_CODE,
+  ArchiveLimitError,
+  ArchiveSecurityError,
+  DEFAULT_MAX_ARCHIVE_BYTES_ZIP,
+  DEFAULT_MAX_ENTRIES,
+  DEFAULT_MAX_EXTRACTED_BYTES,
+  DEFAULT_MAX_ENTRY_BYTES,
+  createArchiveSymlinkTraversalError,
+  createTarEntryPreflightChecker,
+  extractArchive,
+  fileExists,
+  loadZipArchiveWithPreflight,
+  mergeExtractedTreeIntoDestination,
+  prepareArchiveDestinationDir,
+  prepareArchiveOutputPath,
+  readZipCentralDirectoryEntryCount,
+  resolveArchiveKind,
+  resolvePackedRootDir,
+  withStagedArchiveDestination,
+  withTimeout,
+  type ArchiveExtractLimits,
+  type ArchiveKind,
+  type ArchiveLimitErrorCode,
+  type ArchiveLogger,
+  type ArchiveSecurityErrorCode,
+  type TarEntryInfo,
+} from "./archive.js";
+export type {
+  BasePathOptions,
+  FastPathMode,
+  SafeDirEntry,
+  SafeEncoding,
+  SafePathStat,
+} from "./types.js";
+
+export * from "./root.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,8 @@ export {
   type SidecarLockHeldEntry,
   type SidecarLockRetryOptions,
 } from "./sidecar-lock.js";
+export { pathExists } from "./fs.js";
+export { withTimeout } from "./timing.js";
 export { movePathToTrash, type MovePathToTrashOptions } from "./trash.js";
 export {
   ARCHIVE_LIMIT_ERROR_CODE,
@@ -138,7 +140,6 @@ export {
   createArchiveSymlinkTraversalError,
   createTarEntryPreflightChecker,
   extractArchive,
-  fileExists,
   loadZipArchiveWithPreflight,
   mergeExtractedTreeIntoDestination,
   prepareArchiveDestinationDir,
@@ -147,7 +148,6 @@ export {
   resolveArchiveKind,
   resolvePackedRootDir,
   withStagedArchiveDestination,
-  withTimeout,
   type ArchiveExtractLimits,
   type ArchiveKind,
   type ArchiveLimitErrorCode,

--- a/src/install-path.ts
+++ b/src/install-path.ts
@@ -1,0 +1,114 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isPathInside } from "./path.js";
+
+export function safeDirName(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  return trimmed.replaceAll("/", "__").replaceAll("\\", "__");
+}
+
+export function safePathSegmentHashed(input: string): string {
+  const trimmed = input.trim();
+  const base = trimmed
+    .replaceAll(/[\\/]/g, "-")
+    .replaceAll(/[^a-zA-Z0-9._-]/g, "-")
+    .replaceAll(/-+/g, "-")
+    .replaceAll(/^-+/g, "")
+    .replaceAll(/-+$/g, "");
+
+  const normalized = base.length > 0 ? base : "skill";
+  const safe = normalized === "." || normalized === ".." ? "skill" : normalized;
+
+  const hash = createHash("sha256").update(trimmed).digest("hex").slice(0, 10);
+
+  if (safe !== trimmed) {
+    const prefix = safe.length > 50 ? safe.slice(0, 50) : safe;
+    return `${prefix}-${hash}`;
+  }
+  if (safe.length > 60) {
+    return `${safe.slice(0, 50)}-${hash}`;
+  }
+  return safe;
+}
+
+export function resolveSafeInstallDir(params: {
+  baseDir: string;
+  id: string;
+  invalidNameMessage: string;
+  nameEncoder?: (id: string) => string;
+}): { ok: true; path: string } | { ok: false; error: string } {
+  const encodedName = (params.nameEncoder ?? safeDirName)(params.id);
+  const targetDir = path.join(params.baseDir, encodedName);
+  const resolvedBase = path.resolve(params.baseDir);
+  const resolvedTarget = path.resolve(targetDir);
+  const relative = path.relative(resolvedBase, resolvedTarget);
+  if (
+    !relative ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    return { ok: false, error: params.invalidNameMessage };
+  }
+  return { ok: true, path: targetDir };
+}
+
+export async function assertCanonicalPathWithinBase(params: {
+  baseDir: string;
+  candidatePath: string;
+  boundaryLabel: string;
+}): Promise<void> {
+  const baseDir = path.resolve(params.baseDir);
+  const candidatePath = path.resolve(params.candidatePath);
+  if (!isPathInside(baseDir, candidatePath)) {
+    throw new Error(`Invalid path: must stay within ${params.boundaryLabel}`);
+  }
+
+  const baseLstat = await fs.lstat(baseDir);
+  if (baseLstat.isSymbolicLink()) {
+    const baseStat = await fs.stat(baseDir);
+    if (!baseStat.isDirectory()) {
+      throw new Error(
+        `Invalid ${params.boundaryLabel}: base directory must resolve to a directory`,
+      );
+    }
+  } else if (!baseLstat.isDirectory()) {
+    throw new Error(`Invalid ${params.boundaryLabel}: base directory must be a directory`);
+  }
+  const baseRealPath = await fs.realpath(baseDir);
+
+  const validateDirectory = async (dirPath: string): Promise<void> => {
+    const resolvedDirPath = path.resolve(dirPath);
+    const dirLstat = await fs.lstat(dirPath);
+    if (dirLstat.isSymbolicLink()) {
+      if (resolvedDirPath !== baseDir) {
+        throw new Error(`Invalid path: must stay within ${params.boundaryLabel}`);
+      }
+      const dirStat = await fs.stat(dirPath);
+      if (!dirStat.isDirectory()) {
+        throw new Error(`Invalid path: must stay within ${params.boundaryLabel}`);
+      }
+    } else if (!dirLstat.isDirectory()) {
+      throw new Error(`Invalid path: must stay within ${params.boundaryLabel}`);
+    }
+    const dirRealPath = await fs.realpath(dirPath);
+    if (!isPathInside(baseRealPath, dirRealPath)) {
+      throw new Error(`Invalid path: must stay within ${params.boundaryLabel}`);
+    }
+  };
+
+  try {
+    await validateDirectory(candidatePath);
+    return;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code !== "ENOENT") {
+      throw err;
+    }
+  }
+  await validateDirectory(path.dirname(candidatePath));
+}

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,0 +1,291 @@
+import { randomUUID } from "node:crypto";
+import fsSync, { readFileSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const JSON_FILE_MODE = 0o600;
+const JSON_DIR_MODE = 0o700;
+
+function getErrorCode(err: unknown): string | undefined {
+  return err instanceof Error ? (err as NodeJS.ErrnoException).code : undefined;
+}
+
+function trySetSecureMode(pathname: string) {
+  try {
+    fsSync.chmodSync(pathname, JSON_FILE_MODE);
+  } catch {
+    // best-effort on platforms without chmod support
+  }
+}
+
+function trySyncDirectory(pathname: string) {
+  let fd: number | undefined;
+  try {
+    fd = fsSync.openSync(path.dirname(pathname), "r");
+    fsSync.fsyncSync(fd);
+  } catch {
+    // best-effort; some platforms/filesystems do not support syncing directories.
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fsSync.closeSync(fd);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+}
+
+function readSymlinkTargetPath(linkPath: string): string {
+  const target = fsSync.readlinkSync(linkPath);
+  return path.resolve(path.dirname(linkPath), target);
+}
+
+function resolveJsonWriteTarget(pathname: string): { targetPath: string; followsSymlink: boolean } {
+  let currentPath = pathname;
+  const visited = new Set<string>();
+  let followsSymlink = false;
+
+  for (;;) {
+    let stat: fsSync.Stats;
+    try {
+      stat = fsSync.lstatSync(currentPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      return { targetPath: currentPath, followsSymlink };
+    }
+
+    if (!stat.isSymbolicLink()) {
+      return { targetPath: currentPath, followsSymlink };
+    }
+
+    if (visited.has(currentPath)) {
+      const err = new Error(
+        `Too many symlink levels while resolving ${pathname}`,
+      ) as NodeJS.ErrnoException;
+      err.code = "ELOOP";
+      throw err;
+    }
+
+    visited.add(currentPath);
+    followsSymlink = true;
+    currentPath = readSymlinkTargetPath(currentPath);
+  }
+}
+
+function renameJsonFileWithFallback(tmpPath: string, pathname: string) {
+  try {
+    fsSync.renameSync(tmpPath, pathname);
+    return;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EPERM" || code === "EEXIST") {
+      fsSync.copyFileSync(tmpPath, pathname);
+      fsSync.rmSync(tmpPath, { force: true });
+      return;
+    }
+    throw error;
+  }
+}
+
+function writeTempJsonFile(pathname: string, payload: string) {
+  const fd = fsSync.openSync(pathname, "w", JSON_FILE_MODE);
+  try {
+    fsSync.writeFileSync(fd, payload, "utf8");
+    fsSync.fsyncSync(fd);
+  } finally {
+    fsSync.closeSync(fd);
+  }
+}
+
+export function loadJsonFile<T = unknown>(pathname: string): T | undefined {
+  try {
+    const raw = fsSync.readFileSync(pathname, "utf8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveJsonFile(pathname: string, data: unknown) {
+  const { targetPath, followsSymlink } = resolveJsonWriteTarget(pathname);
+  const tmpPath = `${targetPath}.${randomUUID()}.tmp`;
+  const payload = `${JSON.stringify(data, null, 2)}\n`;
+
+  if (!followsSymlink) {
+    fsSync.mkdirSync(path.dirname(targetPath), { recursive: true, mode: JSON_DIR_MODE });
+  }
+  try {
+    writeTempJsonFile(tmpPath, payload);
+    trySetSecureMode(tmpPath);
+    renameJsonFileWithFallback(tmpPath, targetPath);
+    trySetSecureMode(targetPath);
+    trySyncDirectory(targetPath);
+  } finally {
+    try {
+      fsSync.rmSync(tmpPath, { force: true });
+    } catch {
+      // best-effort cleanup when rename does not happen
+    }
+  }
+}
+
+export class JsonFileReadError extends Error {
+  readonly filePath: string;
+  readonly reason: "read" | "parse";
+
+  constructor(filePath: string, reason: "read" | "parse", cause: unknown) {
+    super(`Failed to ${reason} JSON file: ${filePath}`, { cause });
+    this.name = "JsonFileReadError";
+    this.filePath = filePath;
+    this.reason = reason;
+  }
+}
+
+async function replaceFileWithWindowsFallback(tempPath: string, filePath: string, mode: number) {
+  try {
+    await fs.rename(tempPath, filePath);
+    return;
+  } catch (err) {
+    const code = getErrorCode(err);
+    if (process.platform !== "win32" || (code !== "EPERM" && code !== "EEXIST")) {
+      throw err;
+    }
+  }
+
+  const existing = await fs.lstat(filePath).catch(() => null);
+  if (existing?.isSymbolicLink()) {
+    await fs.rm(filePath, { force: true });
+    await fs.rename(tempPath, filePath);
+    return;
+  }
+
+  await fs.copyFile(tempPath, filePath);
+  try {
+    await fs.chmod(filePath, mode);
+  } catch {
+    // best-effort; ignore on platforms without chmod
+  }
+  await fs.rm(tempPath, { force: true }).catch(() => undefined);
+}
+
+export async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function readJsonFileStrict<T>(filePath: string): Promise<T> {
+  const raw = await fs.readFile(filePath, "utf8");
+  return JSON.parse(raw) as T;
+}
+
+export async function readDurableJsonFile<T>(filePath: string): Promise<T | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if (getErrorCode(err) === "ENOENT") {
+      return null;
+    }
+    throw new JsonFileReadError(filePath, "read", err);
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new JsonFileReadError(filePath, "parse", err);
+  }
+}
+
+export function readJsonFileSync(filePath: string): unknown {
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeJsonAtomic(
+  filePath: string,
+  value: unknown,
+  options?: { mode?: number; trailingNewline?: boolean; ensureDirMode?: number },
+) {
+  const text = JSON.stringify(value, null, 2);
+  await writeTextAtomic(filePath, text, {
+    mode: options?.mode,
+    ensureDirMode: options?.ensureDirMode,
+    appendTrailingNewline: options?.trailingNewline,
+  });
+}
+
+export async function writeTextAtomic(
+  filePath: string,
+  content: string,
+  options?: { mode?: number; ensureDirMode?: number; appendTrailingNewline?: boolean },
+) {
+  const mode = options?.mode ?? 0o600;
+  const payload =
+    options?.appendTrailingNewline && !content.endsWith("\n") ? `${content}\n` : content;
+  const mkdirOptions: { recursive: true; mode?: number } = { recursive: true };
+  if (typeof options?.ensureDirMode === "number") {
+    mkdirOptions.mode = options.ensureDirMode;
+  }
+  await fs.mkdir(path.dirname(filePath), mkdirOptions);
+  const parentDir = path.dirname(filePath);
+  const tmp = `${filePath}.${randomUUID()}.tmp`;
+  try {
+    const tmpHandle = await fs.open(tmp, "w", mode);
+    try {
+      await tmpHandle.writeFile(payload, { encoding: "utf8" });
+      await tmpHandle.sync();
+    } finally {
+      await tmpHandle.close().catch(() => undefined);
+    }
+    try {
+      await fs.chmod(tmp, mode);
+    } catch {
+      // best-effort; ignore on platforms without chmod
+    }
+    await replaceFileWithWindowsFallback(tmp, filePath, mode);
+    try {
+      const dirHandle = await fs.open(parentDir, "r");
+      try {
+        await dirHandle.sync();
+      } finally {
+        await dirHandle.close().catch(() => undefined);
+      }
+    } catch {
+      // best-effort; some platforms/filesystems do not support syncing directories.
+    }
+    try {
+      await fs.chmod(filePath, mode);
+    } catch {
+      // best-effort; ignore on platforms without chmod
+    }
+  } finally {
+    await fs.rm(tmp, { force: true }).catch(() => undefined);
+  }
+}
+
+export function createAsyncLock() {
+  let lock: Promise<void> = Promise.resolve();
+  return async function withLock<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = lock;
+    let release: (() => void) | undefined;
+    lock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await prev;
+    try {
+      return await fn();
+    } finally {
+      release?.();
+    }
+  };
+}

--- a/src/local-file-access.ts
+++ b/src/local-file-access.ts
@@ -1,0 +1,75 @@
+import path from "node:path";
+import { fileURLToPath, URL } from "node:url";
+import { normalizeLowercaseStringOrEmpty } from "./string-coerce.js";
+
+const ENCODED_FILE_URL_SEPARATOR_RE = /%(?:2f|5c)/i;
+
+function isLocalFileUrlHost(hostname: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(hostname);
+  return normalized === "" || normalized === "localhost";
+}
+
+export function hasEncodedFileUrlSeparator(pathname: string): boolean {
+  return ENCODED_FILE_URL_SEPARATOR_RE.test(pathname);
+}
+
+export function isWindowsNetworkPath(filePath: string): boolean {
+  if (process.platform !== "win32") {
+    return false;
+  }
+  const normalized = filePath.replace(/\//g, "\\");
+  return normalized.startsWith("\\\\?\\UNC\\") || normalized.startsWith("\\\\");
+}
+
+export function assertNoWindowsNetworkPath(filePath: string, label = "Path"): void {
+  if (isWindowsNetworkPath(filePath)) {
+    throw new Error(`${label} cannot use Windows network paths: ${filePath}`);
+  }
+}
+
+export function safeFileURLToPath(fileUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(fileUrl);
+  } catch {
+    throw new Error(`Invalid file:// URL: ${fileUrl}`);
+  }
+  if (parsed.protocol !== "file:") {
+    throw new Error(`Invalid file:// URL: ${fileUrl}`);
+  }
+  if (!isLocalFileUrlHost(parsed.hostname)) {
+    throw new Error(`file:// URLs with remote hosts are not allowed: ${fileUrl}`);
+  }
+  if (hasEncodedFileUrlSeparator(parsed.pathname)) {
+    throw new Error(`file:// URLs cannot encode path separators: ${fileUrl}`);
+  }
+  const filePath = fileURLToPath(parsed);
+  assertNoWindowsNetworkPath(filePath, "Local file URL");
+  return filePath;
+}
+
+export function trySafeFileURLToPath(fileUrl: string): string | undefined {
+  try {
+    return safeFileURLToPath(fileUrl);
+  } catch {
+    return undefined;
+  }
+}
+
+export function basenameFromMediaSource(source?: string): string | undefined {
+  if (!source) {
+    return undefined;
+  }
+  if (source.startsWith("file://")) {
+    const filePath = trySafeFileURLToPath(source);
+    return filePath ? path.basename(filePath) || undefined : undefined;
+  }
+  if (/^https?:\/\//i.test(source)) {
+    try {
+      return path.basename(new URL(source).pathname) || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return path.basename(source) || undefined;
+}

--- a/src/mode.ts
+++ b/src/mode.ts
@@ -1,0 +1,3 @@
+export function formatPosixMode(mode: number): string {
+  return (mode & 0o777).toString(8).padStart(3, "0");
+}

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs/promises";
+
+export type MovePathWithCopyFallbackOptions = {
+  from: string;
+  to: string;
+};
+
+export async function movePathWithCopyFallback(
+  options: MovePathWithCopyFallbackOptions,
+): Promise<void> {
+  try {
+    await fs.rename(options.from, options.to);
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | null)?.code !== "EXDEV") {
+      throw error;
+    }
+  }
+  await fs.cp(options.from, options.to, {
+    recursive: true,
+    force: true,
+    dereference: false,
+  });
+  await fs.rm(options.from, { recursive: true, force: true });
+}

--- a/src/path-policy.ts
+++ b/src/path-policy.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import {
+  ROOT_PATH_ALIAS_POLICIES,
+  resolveRootPath,
+  type RootPathAliasPolicy,
+} from "./root-path.js";
+import { isNotFoundPathError } from "./path.js";
+
+export type PathAliasPolicy = RootPathAliasPolicy;
+
+export const PATH_ALIAS_POLICIES = ROOT_PATH_ALIAS_POLICIES;
+
+export async function assertNoPathAliasEscape(params: {
+  absolutePath: string;
+  rootPath: string;
+  boundaryLabel: string;
+  policy?: PathAliasPolicy;
+}): Promise<void> {
+  const resolved = await resolveRootPath({
+    absolutePath: params.absolutePath,
+    rootPath: params.rootPath,
+    boundaryLabel: params.boundaryLabel,
+    policy: params.policy,
+  });
+  const allowFinalSymlink = params.policy?.allowFinalSymlinkForUnlink === true;
+  if (allowFinalSymlink && resolved.kind === "symlink") {
+    return;
+  }
+  await assertNoHardlinkedFinalPath({
+    filePath: resolved.absolutePath,
+    root: resolved.rootPath,
+    boundaryLabel: params.boundaryLabel,
+    allowFinalHardlinkForUnlink: params.policy?.allowFinalHardlinkForUnlink,
+  });
+}
+
+export async function assertNoHardlinkedFinalPath(params: {
+  filePath: string;
+  root: string;
+  boundaryLabel: string;
+  allowFinalHardlinkForUnlink?: boolean;
+}): Promise<void> {
+  if (params.allowFinalHardlinkForUnlink) {
+    return;
+  }
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(params.filePath);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      return;
+    }
+    throw err;
+  }
+  if (!stat.isFile()) {
+    return;
+  }
+  if (stat.nlink > 1) {
+    throw new Error(
+      `Hardlinked path is not allowed under ${params.boundaryLabel} (${shortPath(params.root)}): ${shortPath(params.filePath)}`,
+    );
+  }
+}
+
+function shortPath(value: string) {
+  if (value.startsWith(os.homedir())) {
+    return `~${value.slice(os.homedir().length)}`;
+  }
+  return value;
+}

--- a/src/path-scope.ts
+++ b/src/path-scope.ts
@@ -1,0 +1,6 @@
+export {
+  pathScope,
+  type PathScope,
+  type PathScopeOptions,
+  type PathScopeResolveOptions,
+} from "./root-paths.js";

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { FsSafeError } from "./errors.js";
+import { normalizeLowercaseStringOrEmpty } from "./string-coerce.js";
+
+const NOT_FOUND_CODES = new Set(["ENOENT", "ENOTDIR"]);
+const SYMLINK_OPEN_CODES = new Set(["ELOOP", "EINVAL", "ENOTSUP"]);
+const PARENT_SEGMENT_PREFIX = /^\.\.(?:[\\/]|$)/u;
+const POSIX_SEPARATOR_CHAR_CODE = 0x2f;
+
+export function normalizeWindowsPathForComparison(input: string): string {
+  let normalized = path.win32.normalize(input);
+  if (normalized.startsWith("\\\\?\\")) {
+    normalized = normalized.slice(4);
+    if (normalized.toUpperCase().startsWith("UNC\\")) {
+      normalized = `\\\\${normalized.slice(4)}`;
+    }
+  }
+  return normalizeLowercaseStringOrEmpty(normalized.replaceAll("/", "\\"));
+}
+
+export function isNodeError(value: unknown): value is NodeJS.ErrnoException {
+  return Boolean(
+    value && typeof value === "object" && "code" in (value as Record<string, unknown>),
+  );
+}
+
+export function hasNodeErrorCode(value: unknown, code: string): boolean {
+  return isNodeError(value) && value.code === code;
+}
+
+export function isNotFoundPathError(value: unknown): boolean {
+  return isNodeError(value) && typeof value.code === "string" && NOT_FOUND_CODES.has(value.code);
+}
+
+export function isSymlinkOpenError(value: unknown): boolean {
+  return isNodeError(value) && typeof value.code === "string" && SYMLINK_OPEN_CODES.has(value.code);
+}
+
+export function isPathInside(root: string, target: string): boolean {
+  if (process.platform === "win32") {
+    const rootForCompare = normalizeWindowsPathForComparison(path.win32.resolve(root));
+    const targetForCompare = normalizeWindowsPathForComparison(path.win32.resolve(target));
+    const relative = path.win32.relative(rootForCompare, targetForCompare);
+    return (
+      relative === "" || (!PARENT_SEGMENT_PREFIX.test(relative) && !path.win32.isAbsolute(relative))
+    );
+  }
+
+  if (
+    root.length > 0 &&
+    root.charCodeAt(0) === POSIX_SEPARATOR_CHAR_CODE &&
+    target.length >= root.length &&
+    target.charCodeAt(0) === POSIX_SEPARATOR_CHAR_CODE &&
+    !target.includes("/..") &&
+    (target === root ||
+      (target.startsWith(root) && target.charCodeAt(root.length) === POSIX_SEPARATOR_CHAR_CODE))
+  ) {
+    return true;
+  }
+
+  const resolvedRoot = path.resolve(root);
+  const resolvedTarget = path.resolve(target);
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  return relative === "" || (!PARENT_SEGMENT_PREFIX.test(relative) && !path.isAbsolute(relative));
+}
+
+export function resolveSafeBaseDir(rootDir: string): string {
+  const resolved = path.resolve(rootDir);
+  return resolved.endsWith(path.sep) ? resolved : `${resolved}${path.sep}`;
+}
+
+export function isWithinDir(rootDir: string, targetPath: string): boolean {
+  return isPathInside(rootDir, targetPath);
+}
+
+export function safeRealpathSync(targetPath: string, cache?: Map<string, string>): string | null {
+  const cached = cache?.get(targetPath);
+  if (cached) {
+    return cached;
+  }
+  try {
+    const resolved = fs.realpathSync(targetPath);
+    cache?.set(targetPath, resolved);
+    cache?.set(resolved, resolved);
+    return resolved;
+  } catch {
+    return null;
+  }
+}
+
+export function isPathInsideWithRealpath(
+  basePath: string,
+  candidatePath: string,
+  opts?: { requireRealpath?: boolean; cache?: Map<string, string> },
+): boolean {
+  if (!isPathInside(basePath, candidatePath)) {
+    return false;
+  }
+  const baseReal = safeRealpathSync(basePath, opts?.cache);
+  const candidateReal = safeRealpathSync(candidatePath, opts?.cache);
+  if (!baseReal || !candidateReal) {
+    return opts?.requireRealpath === false;
+  }
+  return isPathInside(baseReal, candidateReal);
+}
+
+export function safeStatSync(targetPath: string): fs.Stats | null {
+  try {
+    return fs.statSync(targetPath);
+  } catch {
+    return null;
+  }
+}
+
+export function splitSafeRelativePath(relativePath: string): string[] {
+  if (relativePath.length === 0 || relativePath === ".") {
+    return [];
+  }
+  if (relativePath.includes("\0")) {
+    throw new FsSafeError("invalid-path", "relative path contains a NUL byte");
+  }
+  if (relativePath.includes("\\")) {
+    throw new FsSafeError("invalid-path", "relative path must use forward slashes");
+  }
+  if (
+    path.posix.isAbsolute(relativePath) ||
+    path.win32.isAbsolute(relativePath) ||
+    relativePath.startsWith("//")
+  ) {
+    throw new FsSafeError("invalid-path", "relative path must not be absolute");
+  }
+
+  const segments = relativePath.split("/").filter((segment) => segment.length > 0 && segment !== ".");
+  for (const segment of segments) {
+    if (segment === "..") {
+      throw new FsSafeError("invalid-path", "relative path must not contain '..'");
+    }
+  }
+  return segments;
+}
+
+export function resolveSafeRelativePath(rootDir: string, relativePath: string): string {
+  const root = path.resolve(rootDir);
+  const target = path.resolve(root, ...splitSafeRelativePath(relativePath));
+  if (target !== root && !target.startsWith(root + path.sep)) {
+    throw new FsSafeError("outside-workspace", "relative path escapes root");
+  }
+  return target;
+}

--- a/src/pinned-helper.ts
+++ b/src/pinned-helper.ts
@@ -1,0 +1,446 @@
+import { spawn } from "node:child_process";
+import fsSync from "node:fs";
+
+import { FsSafeError } from "./errors.js";
+import { splitSafeRelativePath } from "./path.js";
+import type { SafeDirEntry, SafePathStat } from "./types.js";
+
+const PINNED_HELPER_SOURCE = String.raw`
+import base64
+import errno
+import json
+import os
+import stat
+import sys
+import tempfile
+
+operation = sys.argv[1]
+root_path = sys.argv[2]
+payload = json.loads(sys.stdin.read() or "{}")
+
+DIR_FLAGS = os.O_RDONLY
+if hasattr(os, "O_DIRECTORY"):
+    DIR_FLAGS |= os.O_DIRECTORY
+if hasattr(os, "O_NOFOLLOW"):
+    DIR_FLAGS |= os.O_NOFOLLOW
+READ_FLAGS = os.O_RDONLY
+if hasattr(os, "O_NOFOLLOW"):
+    READ_FLAGS |= os.O_NOFOLLOW
+WRITE_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+if hasattr(os, "O_NOFOLLOW"):
+    WRITE_FLAGS |= os.O_NOFOLLOW
+
+def fail(code, message):
+    print(json.dumps({"ok": False, "code": code, "message": message}), file=sys.stderr)
+    sys.exit(1)
+
+def split_relative(value):
+    if value in ("", "."):
+        return []
+    if "\x00" in value or "\\" in value or value.startswith("/") or value.startswith("//"):
+        raise OSError(errno.EPERM, "invalid relative path")
+    parts = [part for part in value.split("/") if part and part != "."]
+    for part in parts:
+        if part == "..":
+            raise OSError(errno.EPERM, "path traversal is not allowed")
+    return parts
+
+def open_dir(path_value, dir_fd=None):
+    return os.open(path_value, DIR_FLAGS, dir_fd=dir_fd)
+
+def walk_dir(root_fd, segments, mkdir_enabled=False):
+    current_fd = os.dup(root_fd)
+    try:
+        for segment in segments:
+            try:
+                next_fd = open_dir(segment, dir_fd=current_fd)
+            except FileNotFoundError:
+                if not mkdir_enabled:
+                    raise
+                os.mkdir(segment, 0o777, dir_fd=current_fd)
+                next_fd = open_dir(segment, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except Exception:
+        os.close(current_fd)
+        raise
+
+def parent_and_basename(root_fd, relative):
+    segments = split_relative(relative)
+    if not segments:
+        raise OSError(errno.EPERM, "operation requires a non-root path")
+    parent_fd = walk_dir(root_fd, segments[:-1])
+    return parent_fd, segments[-1]
+
+def encode_stat(st):
+    mode = st.st_mode
+    return {
+        "dev": st.st_dev,
+        "gid": st.st_gid,
+        "ino": st.st_ino,
+        "isDirectory": stat.S_ISDIR(mode),
+        "isFile": stat.S_ISREG(mode),
+        "isSymbolicLink": stat.S_ISLNK(mode),
+        "mode": mode,
+        "mtimeMs": st.st_mtime * 1000,
+        "nlink": st.st_nlink,
+        "size": st.st_size,
+        "uid": st.st_uid,
+    }
+
+def reject_unsafe_endpoint(st):
+    mode = st.st_mode
+    if stat.S_ISLNK(mode):
+        raise OSError(errno.ELOOP, "symlink endpoint is not allowed")
+    if stat.S_ISREG(mode) and st.st_nlink > 1:
+        raise OSError(errno.EPERM, "hardlinked file endpoint is not allowed")
+
+def stat_path(root_fd, relative):
+    segments = split_relative(relative)
+    if not segments:
+        return encode_stat(os.fstat(root_fd))
+    parent_fd, basename = parent_and_basename(root_fd, relative)
+    try:
+        st = os.lstat(basename, dir_fd=parent_fd)
+        if payload.get("rejectSymlink", True) and stat.S_ISLNK(st.st_mode):
+            raise OSError(errno.ELOOP, "symlink endpoint is not allowed")
+        return encode_stat(st)
+    finally:
+        os.close(parent_fd)
+
+def readdir_path(root_fd, relative):
+    dir_fd = walk_dir(root_fd, split_relative(relative))
+    try:
+        names = sorted(os.listdir(dir_fd))
+        if not payload.get("withFileTypes", False):
+            return names
+        entries = []
+        for name in names:
+            st = os.lstat(name, dir_fd=dir_fd)
+            entry = encode_stat(st)
+            entry["name"] = name
+            entries.append(entry)
+        return entries
+    finally:
+        os.close(dir_fd)
+
+def mkdirp_path(root_fd, relative):
+    dir_fd = walk_dir(root_fd, split_relative(relative), mkdir_enabled=True)
+    os.close(dir_fd)
+    return None
+
+def remove_tree(parent_fd, basename):
+    st = os.lstat(basename, dir_fd=parent_fd)
+    if stat.S_ISDIR(st.st_mode) and not stat.S_ISLNK(st.st_mode):
+        dir_fd = open_dir(basename, dir_fd=parent_fd)
+        try:
+            for child in os.listdir(dir_fd):
+                remove_tree(dir_fd, child)
+        finally:
+            os.close(dir_fd)
+        os.rmdir(basename, dir_fd=parent_fd)
+    else:
+        os.unlink(basename, dir_fd=parent_fd)
+
+def remove_path(root_fd, relative):
+    parent_fd, basename = parent_and_basename(root_fd, relative)
+    try:
+        try:
+            st = os.lstat(basename, dir_fd=parent_fd)
+        except FileNotFoundError:
+            if payload.get("force", True):
+                return None
+            raise
+        if stat.S_ISDIR(st.st_mode) and not stat.S_ISLNK(st.st_mode):
+            if payload.get("recursive", False):
+                remove_tree(parent_fd, basename)
+            else:
+                os.rmdir(basename, dir_fd=parent_fd)
+        else:
+            os.unlink(basename, dir_fd=parent_fd)
+        return None
+    finally:
+        os.close(parent_fd)
+
+def read_path(root_fd, relative):
+    parent_fd, basename = parent_and_basename(root_fd, relative)
+    try:
+        fd = os.open(basename, READ_FLAGS, dir_fd=parent_fd)
+        try:
+            st = os.fstat(fd)
+            reject_unsafe_endpoint(st)
+            if not stat.S_ISREG(st.st_mode):
+                raise OSError(errno.EPERM, "only regular files can be read")
+            chunks = []
+            while True:
+                chunk = os.read(fd, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            return {"base64": base64.b64encode(b"".join(chunks)).decode("ascii"), "stat": encode_stat(st)}
+        finally:
+            os.close(fd)
+    finally:
+        os.close(parent_fd)
+
+def write_path(root_fd, relative):
+    parent_fd, basename = parent_and_basename(root_fd, relative)
+    data = base64.b64decode(payload.get("base64", ""))
+    overwrite = payload.get("overwrite", True)
+    try:
+        if not overwrite:
+            try:
+                os.lstat(basename, dir_fd=parent_fd)
+                raise FileExistsError(errno.EEXIST, "destination exists", basename)
+            except FileNotFoundError:
+                pass
+        prefix = ".fs-safe-" + basename.replace("/", "_") + "-"
+        temp_name = None
+        fd = None
+        try:
+            for _ in range(32):
+                candidate = prefix + next(tempfile._get_candidate_names())
+                try:
+                    fd = os.open(candidate, WRITE_FLAGS, 0o600, dir_fd=parent_fd)
+                    temp_name = candidate
+                    break
+                except FileExistsError:
+                    continue
+            if fd is None or temp_name is None:
+                raise FileExistsError(errno.EEXIST, "could not allocate temp file")
+            os.write(fd, data)
+            os.fsync(fd)
+            os.close(fd)
+            fd = None
+            os.replace(temp_name, basename, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            os.fsync(parent_fd)
+            return None
+        finally:
+            if fd is not None:
+                os.close(fd)
+            if temp_name is not None:
+                try:
+                    os.unlink(temp_name, dir_fd=parent_fd)
+                except FileNotFoundError:
+                    pass
+    finally:
+        os.close(parent_fd)
+
+def rename_path(root_fd):
+    from_parent_fd, from_base = parent_and_basename(root_fd, payload["from"])
+    to_parent_fd, to_base = parent_and_basename(root_fd, payload["to"])
+    try:
+        from_stat = os.lstat(from_base, dir_fd=from_parent_fd)
+        reject_unsafe_endpoint(from_stat)
+        if not payload.get("overwrite", True):
+            try:
+                os.lstat(to_base, dir_fd=to_parent_fd)
+                raise FileExistsError(errno.EEXIST, "destination exists", to_base)
+            except FileNotFoundError:
+                pass
+        os.rename(from_base, to_base, src_dir_fd=from_parent_fd, dst_dir_fd=to_parent_fd)
+        os.fsync(from_parent_fd)
+        if from_parent_fd != to_parent_fd:
+            os.fsync(to_parent_fd)
+        return None
+    finally:
+        os.close(from_parent_fd)
+        os.close(to_parent_fd)
+
+try:
+    root_fd = open_dir(root_path)
+    try:
+        relative = payload.get("relativePath", "")
+        if operation == "stat":
+            result = stat_path(root_fd, relative)
+        elif operation == "readdir":
+            result = readdir_path(root_fd, relative)
+        elif operation == "mkdirp":
+            result = mkdirp_path(root_fd, relative)
+        elif operation == "remove":
+            result = remove_path(root_fd, relative)
+        elif operation == "read":
+            result = read_path(root_fd, relative)
+        elif operation == "write":
+            result = write_path(root_fd, relative)
+        elif operation == "rename":
+            result = rename_path(root_fd)
+        else:
+            raise RuntimeError("unknown operation: " + operation)
+        print(json.dumps({"ok": True, "result": result}, separators=(",", ":")))
+    finally:
+        os.close(root_fd)
+except Exception as exc:
+    fail(type(exc).__name__, str(exc))
+`;
+
+type HelperOperation = "stat" | "readdir" | "mkdirp" | "remove" | "read" | "write" | "rename";
+
+const PYTHON_CANDIDATES = [
+  process.env.OPENCLAW_FS_SAFE_PYTHON,
+  process.env.OPENCLAW_PINNED_PYTHON,
+  "/usr/bin/python3",
+  "/opt/homebrew/bin/python3",
+  "/usr/local/bin/python3",
+].filter((value): value is string => Boolean(value));
+
+let cachedPython = "";
+
+function canExecute(binPath: string): boolean {
+  try {
+    fsSync.accessSync(binPath, fsSync.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolvePython(): string {
+  if (cachedPython) {
+    return cachedPython;
+  }
+  for (const candidate of PYTHON_CANDIDATES) {
+    if (canExecute(candidate)) {
+      cachedPython = candidate;
+      return cachedPython;
+    }
+  }
+  cachedPython = "python3";
+  return cachedPython;
+}
+
+function assertPinnedHelperSupported(): void {
+  if (process.platform === "win32") {
+    throw new FsSafeError(
+      "unsupported-platform",
+      "fd-relative pinned filesystem operations are not available on Windows",
+    );
+  }
+}
+
+function isSpawnUnavailable(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const maybeErrno = error as NodeJS.ErrnoException;
+  return (
+    typeof maybeErrno.syscall === "string" &&
+    maybeErrno.syscall.startsWith("spawn") &&
+    ["EACCES", "ENOENT", "ENOEXEC"].includes(maybeErrno.code ?? "")
+  );
+}
+
+export async function runPinnedHelper<T>(
+  operation: HelperOperation,
+  rootDir: string,
+  payload: Record<string, unknown>,
+): Promise<T> {
+  assertPinnedHelperSupported();
+  if (typeof payload.relativePath === "string") {
+    splitSafeRelativePath(payload.relativePath);
+  }
+  if (typeof payload.from === "string") {
+    splitSafeRelativePath(payload.from);
+  }
+  if (typeof payload.to === "string") {
+    splitSafeRelativePath(payload.to);
+  }
+
+  const child = spawn(resolvePython(), ["-c", PINNED_HELPER_SOURCE, operation, rootDir], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  child.stdin.end(JSON.stringify(payload));
+
+  const [code, signal] = await new Promise<[number | null, NodeJS.Signals | null]>(
+    (resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (exitCode, exitSignal) => resolve([exitCode, exitSignal]));
+    },
+  ).catch((error: unknown) => {
+    if (isSpawnUnavailable(error)) {
+      throw new FsSafeError("helper-unavailable", "Python helper is unavailable", { cause: error });
+    }
+    throw error;
+  });
+
+  const raw = code === 0 ? stdout : stderr;
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw.trim());
+  } catch {
+    throw new FsSafeError(
+      "helper-failed",
+      `pinned helper failed with code ${code ?? "null"} (${signal ?? "?"}): ${raw.trim()}`,
+    );
+  }
+
+  if (
+    typeof decoded !== "object" ||
+    decoded === null ||
+    !("ok" in decoded) ||
+    typeof decoded.ok !== "boolean"
+  ) {
+    throw new FsSafeError("helper-failed", "pinned helper returned an invalid response");
+  }
+  if (!decoded.ok) {
+    const helperCode = "code" in decoded && typeof decoded.code === "string" ? decoded.code : "";
+    const message =
+      "message" in decoded && typeof decoded.message === "string"
+        ? decoded.message
+        : "pinned helper failed";
+    if (helperCode === "FileNotFoundError") {
+      throw new FsSafeError("not-found", "file not found");
+    }
+    if (helperCode === "NotADirectoryError" || helperCode === "OSError") {
+      throw new FsSafeError("path-alias", message);
+    }
+    if (helperCode === "FileExistsError") {
+      throw new FsSafeError("already-exists", message);
+    }
+    throw new FsSafeError("helper-failed", message);
+  }
+  return (decoded as unknown as { result: T }).result;
+}
+
+export type HelperReadResult = {
+  base64: string;
+  stat: SafePathStat;
+};
+
+export async function helperStat(rootDir: string, relativePath: string): Promise<SafePathStat> {
+  return await runPinnedHelper<SafePathStat>("stat", rootDir, { relativePath });
+}
+
+export async function helperReaddir(
+  rootDir: string,
+  relativePath: string,
+  withFileTypes: false,
+): Promise<string[]>;
+export async function helperReaddir(
+  rootDir: string,
+  relativePath: string,
+  withFileTypes: true,
+): Promise<SafeDirEntry[]>;
+export async function helperReaddir(
+  rootDir: string,
+  relativePath: string,
+  withFileTypes: boolean,
+): Promise<string[] | SafeDirEntry[]> {
+  return await runPinnedHelper<string[] | SafeDirEntry[]>("readdir", rootDir, {
+    relativePath,
+    withFileTypes,
+  });
+}

--- a/src/pinned-open.ts
+++ b/src/pinned-open.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import { sameFileIdentity as hasSameFileIdentity } from "./file-identity.js";
+
+export type PinnedOpenSyncFailureReason = "path" | "validation" | "io";
+
+export type PinnedOpenSyncResult =
+  | { ok: true; path: string; fd: number; stat: fs.Stats }
+  | { ok: false; reason: PinnedOpenSyncFailureReason; error?: unknown };
+
+export type PinnedOpenSyncAllowedType = "file" | "directory";
+
+export type PinnedOpenSyncFs = Pick<
+  typeof fs,
+  "constants" | "lstatSync" | "realpathSync" | "openSync" | "fstatSync" | "closeSync"
+>;
+
+function isExpectedPathError(error: unknown): boolean {
+  const code =
+    typeof error === "object" && error !== null && "code" in error ? String(error.code) : "";
+  return code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP";
+}
+
+function sameFileIdentity(left: fs.Stats, right: fs.Stats): boolean {
+  return hasSameFileIdentity(left, right);
+}
+
+export function openPinnedFileSync(params: {
+  filePath: string;
+  resolvedPath?: string;
+  rejectPathSymlink?: boolean;
+  rejectHardlinks?: boolean;
+  maxBytes?: number;
+  allowedType?: PinnedOpenSyncAllowedType;
+  ioFs?: PinnedOpenSyncFs;
+}): PinnedOpenSyncResult {
+  const ioFs = params.ioFs ?? fs;
+  const allowedType = params.allowedType ?? "file";
+  const openReadFlags =
+    ioFs.constants.O_RDONLY |
+    (typeof ioFs.constants.O_NOFOLLOW === "number" ? ioFs.constants.O_NOFOLLOW : 0);
+  let fd: number | null = null;
+  try {
+    if (params.rejectPathSymlink) {
+      const candidateStat = ioFs.lstatSync(params.filePath);
+      if (candidateStat.isSymbolicLink()) {
+        return { ok: false, reason: "validation" };
+      }
+    }
+
+    const realPath = params.resolvedPath ?? ioFs.realpathSync(params.filePath);
+    const preOpenStat = ioFs.lstatSync(realPath);
+    if (!isAllowedType(preOpenStat, allowedType)) {
+      return { ok: false, reason: "validation" };
+    }
+    if (params.rejectHardlinks && preOpenStat.isFile() && preOpenStat.nlink > 1) {
+      return { ok: false, reason: "validation" };
+    }
+    if (
+      params.maxBytes !== undefined &&
+      preOpenStat.isFile() &&
+      preOpenStat.size > params.maxBytes
+    ) {
+      return { ok: false, reason: "validation" };
+    }
+
+    fd = ioFs.openSync(realPath, openReadFlags);
+    const openedStat = ioFs.fstatSync(fd);
+    if (!isAllowedType(openedStat, allowedType)) {
+      return { ok: false, reason: "validation" };
+    }
+    if (params.rejectHardlinks && openedStat.isFile() && openedStat.nlink > 1) {
+      return { ok: false, reason: "validation" };
+    }
+    if (params.maxBytes !== undefined && openedStat.isFile() && openedStat.size > params.maxBytes) {
+      return { ok: false, reason: "validation" };
+    }
+    if (!sameFileIdentity(preOpenStat, openedStat)) {
+      return { ok: false, reason: "validation" };
+    }
+
+    const opened = { ok: true as const, path: realPath, fd, stat: openedStat };
+    fd = null;
+    return opened;
+  } catch (error) {
+    if (isExpectedPathError(error)) {
+      return { ok: false, reason: "path", error };
+    }
+    return { ok: false, reason: "io", error };
+  } finally {
+    if (fd !== null) {
+      ioFs.closeSync(fd);
+    }
+  }
+}
+
+function isAllowedType(stat: fs.Stats, allowedType: PinnedOpenSyncAllowedType): boolean {
+  if (allowedType === "directory") {
+    return stat.isDirectory();
+  }
+  return stat.isFile();
+}

--- a/src/pinned-path.ts
+++ b/src/pinned-path.ts
@@ -1,0 +1,205 @@
+import { spawn } from "node:child_process";
+import fsSync from "node:fs";
+import { FsSafeError } from "./errors.js";
+
+const LOCAL_PINNED_PATH_PYTHON = [
+  "import errno",
+  "import json",
+  "import os",
+  "import stat",
+  "import sys",
+  "",
+  "operation = sys.argv[1]",
+  "root_path = sys.argv[2]",
+  "relative_path = sys.argv[3]",
+  "",
+  "DIR_FLAGS = os.O_RDONLY",
+  "if hasattr(os, 'O_DIRECTORY'):",
+  "    DIR_FLAGS |= os.O_DIRECTORY",
+  "if hasattr(os, 'O_NOFOLLOW'):",
+  "    DIR_FLAGS |= os.O_NOFOLLOW",
+  "",
+  "def open_dir(path_value, dir_fd=None):",
+  "    return os.open(path_value, DIR_FLAGS, dir_fd=dir_fd)",
+  "",
+  "def split_segments(relative_path):",
+  "    return [part for part in relative_path.split('/') if part and part != '.']",
+  "",
+  "def validate_segment(segment):",
+  "    if segment == '..':",
+  "        raise OSError(errno.EPERM, 'path traversal is not allowed', segment)",
+  "",
+  "def walk_existing_path(root_fd, segments):",
+  "    current_fd = os.dup(root_fd)",
+  "    try:",
+  "        for segment in segments:",
+  "            validate_segment(segment)",
+  "            next_fd = open_dir(segment, dir_fd=current_fd)",
+  "            os.close(current_fd)",
+  "            current_fd = next_fd",
+  "        return current_fd",
+  "    except Exception:",
+  "        os.close(current_fd)",
+  "        raise",
+  "",
+  "def mkdirp_within_root(root_fd, segments):",
+  "    current_fd = os.dup(root_fd)",
+  "    try:",
+  "        for segment in segments:",
+  "            validate_segment(segment)",
+  "            try:",
+  "                next_fd = open_dir(segment, dir_fd=current_fd)",
+  "            except FileNotFoundError:",
+  "                os.mkdir(segment, 0o777, dir_fd=current_fd)",
+  "                next_fd = open_dir(segment, dir_fd=current_fd)",
+  "            os.close(current_fd)",
+  "            current_fd = next_fd",
+  "    finally:",
+  "        os.close(current_fd)",
+  "",
+  "def remove_within_root(root_fd, segments):",
+  "    if not segments:",
+  "        raise OSError(errno.EPERM, 'refusing to remove root path')",
+  "    parent_segments = segments[:-1]",
+  "    basename = segments[-1]",
+  "    validate_segment(basename)",
+  "    parent_fd = walk_existing_path(root_fd, parent_segments)",
+  "    try:",
+  "        target_stat = os.lstat(basename, dir_fd=parent_fd)",
+  "        if stat.S_ISDIR(target_stat.st_mode) and not stat.S_ISLNK(target_stat.st_mode):",
+  "            os.rmdir(basename, dir_fd=parent_fd)",
+  "        else:",
+  "            os.unlink(basename, dir_fd=parent_fd)",
+  "    finally:",
+  "        os.close(parent_fd)",
+  "",
+  "def emit_error(exc):",
+  "    payload = {",
+  "        'name': exc.__class__.__name__,",
+  "        'errno': getattr(exc, 'errno', None),",
+  "        'message': str(exc),",
+  "    }",
+  "    print(json.dumps(payload), file=sys.stderr)",
+  "",
+  "root_fd = None",
+  "try:",
+  "    root_fd = open_dir(root_path)",
+  "    segments = split_segments(relative_path)",
+  "    if operation == 'mkdirp':",
+  "        mkdirp_within_root(root_fd, segments)",
+  "    elif operation == 'remove':",
+  "        remove_within_root(root_fd, segments)",
+  "    else:",
+  "        raise RuntimeError(f'unknown pinned path operation: {operation}')",
+  "except Exception as exc:",
+  "    emit_error(exc)",
+  "    sys.exit(1)",
+  "finally:",
+  "    if root_fd is not None:",
+  "        os.close(root_fd)",
+].join("\n");
+
+const PINNED_PATH_PYTHON_CANDIDATES = [
+  process.env.OPENCLAW_PINNED_PYTHON,
+  // Keep the write-specific alias for backwards compatibility.
+  process.env.OPENCLAW_PINNED_WRITE_PYTHON,
+  "/usr/bin/python3",
+  "/opt/homebrew/bin/python3",
+  "/usr/local/bin/python3",
+].filter((value): value is string => Boolean(value));
+
+let cachedPinnedPathPython = "";
+
+function canExecute(binPath: string): boolean {
+  try {
+    fsSync.accessSync(binPath, fsSync.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolvePinnedPathPython(): string {
+  if (cachedPinnedPathPython) {
+    return cachedPinnedPathPython;
+  }
+  for (const candidate of PINNED_PATH_PYTHON_CANDIDATES) {
+    if (canExecute(candidate)) {
+      cachedPinnedPathPython = candidate;
+      return cachedPinnedPathPython;
+    }
+  }
+  cachedPinnedPathPython = "python3";
+  return cachedPinnedPathPython;
+}
+
+function buildPinnedPathError(stderr: string, code: number | null, signal: NodeJS.Signals | null) {
+  const trimmed = stderr.trim();
+  if (trimmed.startsWith("{")) {
+    try {
+      const payload = JSON.parse(trimmed) as { errno?: number; message?: string; name?: string };
+      if (payload.errno === 2) {
+        return new FsSafeError("not-found", "file not found");
+      }
+      if (payload.errno === 20 || payload.errno === 40) {
+        return new FsSafeError("path-alias", "path is not under root");
+      }
+      if (payload.errno === 39) {
+        return new FsSafeError("not-empty", "directory is not empty");
+      }
+      if (payload.errno === 1 || payload.errno === 13 || payload.errno === 21) {
+        return new FsSafeError("not-removable", "path is not removable under root");
+      }
+      return new FsSafeError("helper-failed", payload.message || "pinned path helper failed");
+    } catch {
+      // Fall through to the generic helper failure below.
+    }
+  }
+  return new FsSafeError(
+    "helper-failed",
+    trimmed || `Pinned path helper failed with code ${code ?? "null"} (${signal ?? "?"})`,
+  );
+}
+
+export function isPinnedPathHelperSpawnError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const maybeErrno = error as NodeJS.ErrnoException;
+  if (typeof maybeErrno.syscall !== "string" || !maybeErrno.syscall.startsWith("spawn")) {
+    return false;
+  }
+
+  return ["EACCES", "ENOENT", "ENOEXEC"].includes(maybeErrno.code ?? "");
+}
+
+export async function runPinnedPathHelper(params: {
+  operation: "mkdirp" | "remove";
+  rootPath: string;
+  relativePath: string;
+}): Promise<void> {
+  const child = spawn(
+    resolvePinnedPathPython(),
+    ["-c", LOCAL_PINNED_PATH_PYTHON, params.operation, params.rootPath, params.relativePath],
+    {
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+
+  let stderr = "";
+  child.stderr.setEncoding?.("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const [code, signal] = await new Promise<[number | null, NodeJS.Signals | null]>(
+    (resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (exitCode, exitSignal) => resolve([exitCode, exitSignal]));
+    },
+  );
+  if (code !== 0) {
+    throw buildPinnedPathError(stderr, code, signal);
+  }
+}

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -1,0 +1,299 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { FileIdentityStat } from "./file-identity.js";
+
+type PinnedWriteInput =
+  | { kind: "buffer"; data: string | Buffer; encoding?: BufferEncoding }
+  | { kind: "stream"; stream: Readable };
+
+const LOCAL_PINNED_WRITE_PYTHON = [
+  "import errno",
+  "import os",
+  "import secrets",
+  "import stat",
+  "import sys",
+  "",
+  "root_path = sys.argv[1]",
+  "relative_parent = sys.argv[2]",
+  "basename = sys.argv[3]",
+  'mkdir_enabled = sys.argv[4] == "1"',
+  "file_mode = int(sys.argv[5], 8)",
+  'overwrite_enabled = sys.argv[6] == "1"',
+  "",
+  "DIR_FLAGS = os.O_RDONLY",
+  "if hasattr(os, 'O_DIRECTORY'):",
+  "    DIR_FLAGS |= os.O_DIRECTORY",
+  "if hasattr(os, 'O_NOFOLLOW'):",
+  "    DIR_FLAGS |= os.O_NOFOLLOW",
+  "",
+  "WRITE_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_EXCL",
+  "if hasattr(os, 'O_NOFOLLOW'):",
+  "    WRITE_FLAGS |= os.O_NOFOLLOW",
+  "",
+  "def open_dir(path_value, dir_fd=None):",
+  "    return os.open(path_value, DIR_FLAGS, dir_fd=dir_fd)",
+  "",
+  "def walk_parent(root_fd, rel_parent, mkdir_enabled):",
+  "    current_fd = os.dup(root_fd)",
+  "    try:",
+  "        for segment in [part for part in rel_parent.split('/') if part and part != '.']:",
+  "            if segment == '..':",
+  "                raise OSError(errno.EPERM, 'path traversal is not allowed', segment)",
+  "            try:",
+  "                next_fd = open_dir(segment, dir_fd=current_fd)",
+  "            except FileNotFoundError:",
+  "                if not mkdir_enabled:",
+  "                    raise",
+  "                os.mkdir(segment, 0o777, dir_fd=current_fd)",
+  "                next_fd = open_dir(segment, dir_fd=current_fd)",
+  "            os.close(current_fd)",
+  "            current_fd = next_fd",
+  "        return current_fd",
+  "    except Exception:",
+  "        os.close(current_fd)",
+  "        raise",
+  "",
+  "def create_temp_file(parent_fd, basename, mode):",
+  "    prefix = '.' + basename + '.'",
+  "    for _ in range(128):",
+  "        candidate = prefix + secrets.token_hex(6) + '.tmp'",
+  "        try:",
+  "            fd = os.open(candidate, WRITE_FLAGS, mode, dir_fd=parent_fd)",
+  "            return candidate, fd",
+  "        except FileExistsError:",
+  "            continue",
+  "    raise RuntimeError('failed to allocate pinned temp file')",
+  "",
+  "root_fd = open_dir(root_path)",
+  "parent_fd = None",
+  "temp_fd = None",
+  "temp_name = None",
+  "try:",
+  "    parent_fd = walk_parent(root_fd, relative_parent, mkdir_enabled)",
+  "    temp_name, temp_fd = create_temp_file(parent_fd, basename, file_mode)",
+  "    while True:",
+  "        chunk = sys.stdin.buffer.read(65536)",
+  "        if not chunk:",
+  "            break",
+  "        os.write(temp_fd, chunk)",
+  "    os.fsync(temp_fd)",
+  "    os.close(temp_fd)",
+  "    temp_fd = None",
+  "    if overwrite_enabled:",
+  "        os.replace(temp_name, basename, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)",
+  "        temp_name = None",
+  "    else:",
+  "        os.link(temp_name, basename, src_dir_fd=parent_fd, dst_dir_fd=parent_fd, follow_symlinks=False)",
+  "        os.unlink(temp_name, dir_fd=parent_fd)",
+  "        temp_name = None",
+  "    os.fsync(parent_fd)",
+  "    result_stat = os.stat(basename, dir_fd=parent_fd, follow_symlinks=False)",
+  "    print(f'{result_stat.st_dev}|{result_stat.st_ino}')",
+  "finally:",
+  "    if temp_fd is not None:",
+  "        os.close(temp_fd)",
+  "    if temp_name is not None and parent_fd is not None:",
+  "        try:",
+  "            os.unlink(temp_name, dir_fd=parent_fd)",
+  "        except FileNotFoundError:",
+  "            pass",
+  "    if parent_fd is not None:",
+  "        os.close(parent_fd)",
+  "    os.close(root_fd)",
+].join("\n");
+
+const PINNED_WRITE_PYTHON_CANDIDATES = [
+  process.env.OPENCLAW_PINNED_WRITE_PYTHON,
+  "/usr/bin/python3",
+  "/opt/homebrew/bin/python3",
+  "/usr/local/bin/python3",
+].filter((value): value is string => Boolean(value));
+
+let cachedPinnedWritePython = "";
+
+function canExecute(binPath: string): boolean {
+  try {
+    fsSync.accessSync(binPath, fsSync.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolvePinnedWritePython(): string {
+  if (cachedPinnedWritePython) {
+    return cachedPinnedWritePython;
+  }
+  for (const candidate of PINNED_WRITE_PYTHON_CANDIDATES) {
+    if (canExecute(candidate)) {
+      cachedPinnedWritePython = candidate;
+      return cachedPinnedWritePython;
+    }
+  }
+  cachedPinnedWritePython = "python3";
+  return cachedPinnedWritePython;
+}
+
+function parsePinnedIdentity(stdout: string): FileIdentityStat {
+  const line = stdout
+    .trim()
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .findLast(Boolean);
+  if (!line) {
+    throw new Error("Pinned write helper returned no identity");
+  }
+  const [devRaw, inoRaw] = line.split("|");
+  const dev = Number.parseInt(devRaw ?? "", 10);
+  const ino = Number.parseInt(inoRaw ?? "", 10);
+  if (!Number.isFinite(dev) || !Number.isFinite(ino)) {
+    throw new Error(`Pinned write helper returned invalid identity: ${line}`);
+  }
+  return { dev, ino };
+}
+
+export async function runPinnedWriteHelper(params: {
+  rootPath: string;
+  relativeParentPath: string;
+  basename: string;
+  mkdir: boolean;
+  mode: number;
+  overwrite?: boolean;
+  input: PinnedWriteInput;
+}): Promise<FileIdentityStat> {
+  const child = spawn(
+    resolvePinnedWritePython(),
+    [
+      "-c",
+      LOCAL_PINNED_WRITE_PYTHON,
+      params.rootPath,
+      params.relativeParentPath,
+      params.basename,
+      params.mkdir ? "1" : "0",
+      (params.mode || 0o600).toString(8),
+      params.overwrite === false ? "0" : "1",
+    ],
+    {
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding?.("utf8");
+  child.stderr.setEncoding?.("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const exitPromise = once(child, "close") as Promise<[number | null, NodeJS.Signals | null]>;
+  try {
+    if (!child.stdin) {
+      const identity = await runPinnedWriteFallback(params);
+      await exitPromise.catch(() => {});
+      return identity;
+    }
+
+    if (params.input.kind === "buffer") {
+      const input = params.input;
+      await new Promise<void>((resolve, reject) => {
+        child.stdin.once("error", reject);
+        if (typeof input.data === "string") {
+          child.stdin.end(input.data, input.encoding ?? "utf8", () => resolve());
+          return;
+        }
+        child.stdin.end(input.data, () => resolve());
+      });
+    } else {
+      await pipeline(params.input.stream, child.stdin);
+    }
+
+    const [code, signal] = await exitPromise;
+    if (code !== 0) {
+      throw new Error(
+        stderr.trim() ||
+          `Pinned write helper failed with code ${code ?? "null"} (${signal ?? "?"})`,
+      );
+    }
+    return parsePinnedIdentity(stdout);
+  } catch (error) {
+    child.kill("SIGKILL");
+    await exitPromise.catch(() => {});
+    throw error;
+  }
+}
+
+async function runPinnedWriteFallback(params: {
+  rootPath: string;
+  relativeParentPath: string;
+  basename: string;
+  mkdir: boolean;
+  mode: number;
+  overwrite?: boolean;
+  input: PinnedWriteInput;
+}): Promise<FileIdentityStat> {
+  const parentPath = params.relativeParentPath
+    ? path.join(params.rootPath, ...params.relativeParentPath.split("/"))
+    : params.rootPath;
+  if (params.mkdir) {
+    await fs.mkdir(parentPath, { recursive: true });
+  }
+  const targetPath = path.join(parentPath, params.basename);
+  if (params.overwrite === false) {
+    const handle = await fs.open(
+      targetPath,
+      fsSync.constants.O_WRONLY | fsSync.constants.O_CREAT | fsSync.constants.O_EXCL,
+      params.mode,
+    );
+    let created = true;
+    try {
+      if (params.input.kind === "buffer") {
+        if (typeof params.input.data === "string") {
+          await handle.writeFile(params.input.data, params.input.encoding ?? "utf8");
+        } else {
+          await handle.writeFile(params.input.data);
+        }
+      } else {
+        await pipeline(params.input.stream, handle.createWriteStream());
+      }
+      const stat = await handle.stat();
+      created = false;
+      return { dev: stat.dev, ino: stat.ino };
+    } finally {
+      await handle.close().catch(() => undefined);
+      if (created) {
+        await fs.rm(targetPath, { force: true }).catch(() => undefined);
+      }
+    }
+  }
+
+  const tempPath = path.join(parentPath, `.${params.basename}.fallback.tmp`);
+  if (params.input.kind === "buffer") {
+    if (typeof params.input.data === "string") {
+      await fs.writeFile(tempPath, params.input.data, {
+        encoding: params.input.encoding ?? "utf8",
+        mode: params.mode,
+      });
+    } else {
+      await fs.writeFile(tempPath, params.input.data, { mode: params.mode });
+    }
+  } else {
+    const handle = await fs.open(tempPath, "w", params.mode);
+    try {
+      await pipeline(params.input.stream, handle.createWriteStream());
+    } finally {
+      await handle.close().catch(() => {});
+    }
+  }
+  await fs.rename(tempPath, targetPath);
+  const stat = await fs.stat(targetPath);
+  return { dev: stat.dev, ino: stat.ino };
+}

--- a/src/private-file-store.ts
+++ b/src/private-file-store.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import fs from "node:fs";
+import { writePrivateSecretFileAtomic } from "./secret-file.js";
+
+export type PrivateFileStore = {
+  rootDir: string;
+  path(relativePath: string): string;
+  writeText(relativePath: string, content: string | Uint8Array): Promise<void>;
+  writeJson(relativePath: string, value: unknown, options?: { trailingNewline?: boolean }): Promise<void>;
+};
+
+function resolvePrivateStorePath(rootDir: string, relativePath: string): string {
+  const root = path.resolve(rootDir);
+  const raw = relativePath.trim();
+  if (!raw || path.isAbsolute(raw) || raw.includes("\0")) {
+    throw new Error("Private file path must be a relative path.");
+  }
+  const resolved = path.resolve(root, raw);
+  const rel = path.relative(root, resolved);
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new Error("Private file path must stay under the private store root.");
+  }
+  return resolved;
+}
+
+export async function writePrivateTextAtomic(params: {
+  rootDir: string;
+  filePath: string;
+  content: string | Uint8Array;
+}): Promise<void> {
+  await writePrivateSecretFileAtomic(params);
+}
+
+function ensurePrivateDirectorySync(rootDir: string, targetDir: string): void {
+  const root = path.resolve(rootDir);
+  const target = path.resolve(targetDir);
+  const relative = path.relative(root, target);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Private file directory must stay under the private store root.");
+  }
+  let current = root;
+  fs.mkdirSync(current, { recursive: true, mode: 0o700 });
+  const rootStat = fs.lstatSync(current);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+    throw new Error(`Private file root must be a directory: ${current}`);
+  }
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    try {
+      const stat = fs.lstatSync(current);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        throw new Error(`Private file directory component must be a directory: ${current}`);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+      fs.mkdirSync(current, { mode: 0o700 });
+    }
+    try {
+      fs.chmodSync(current, 0o700);
+    } catch {
+      // Best-effort on platforms that do not enforce POSIX modes.
+    }
+  }
+}
+
+export function writePrivateTextAtomicSync(params: {
+  rootDir: string;
+  filePath: string;
+  content: string | Uint8Array;
+}): void {
+  const root = path.resolve(params.rootDir);
+  const filePath = path.resolve(params.filePath);
+  const relative = path.relative(root, filePath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error("Private file path must stay under the private store root.");
+  }
+  ensurePrivateDirectorySync(root, path.dirname(filePath));
+  try {
+    const stat = fs.lstatSync(filePath);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      throw new Error(`Private file target must be a regular file: ${filePath}`);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+  const tempPath = path.join(path.dirname(filePath), `.tmp-${process.pid}-${randomUUID()}`);
+  let created = false;
+  try {
+    fs.writeFileSync(tempPath, params.content, { mode: 0o600, flag: "wx" });
+    created = true;
+    try {
+      fs.chmodSync(tempPath, 0o600);
+    } catch {
+      // Best-effort on platforms that do not enforce POSIX modes.
+    }
+    fs.renameSync(tempPath, filePath);
+    created = false;
+    try {
+      fs.chmodSync(filePath, 0o600);
+    } catch {
+      // Best-effort on platforms that do not enforce POSIX modes.
+    }
+  } finally {
+    if (created) {
+      try {
+        fs.unlinkSync(tempPath);
+      } catch {
+        // The temp file is best-effort cleanup after write failure.
+      }
+    }
+  }
+}
+
+export async function writePrivateJsonAtomic(params: {
+  rootDir: string;
+  filePath: string;
+  value: unknown;
+  trailingNewline?: boolean;
+}): Promise<void> {
+  const json = JSON.stringify(params.value, null, 2);
+  await writePrivateSecretFileAtomic({
+    rootDir: params.rootDir,
+    filePath: params.filePath,
+    content: params.trailingNewline && !json.endsWith("\n") ? `${json}\n` : json,
+  });
+}
+
+export function writePrivateJsonAtomicSync(params: {
+  rootDir: string;
+  filePath: string;
+  value: unknown;
+  trailingNewline?: boolean;
+}): void {
+  const json = JSON.stringify(params.value, null, 2);
+  writePrivateTextAtomicSync({
+    rootDir: params.rootDir,
+    filePath: params.filePath,
+    content: params.trailingNewline && !json.endsWith("\n") ? `${json}\n` : json,
+  });
+}
+
+export function privateFileStore(rootDir: string): PrivateFileStore {
+  const root = path.resolve(rootDir);
+  return {
+    rootDir: root,
+    path: (relativePath) => resolvePrivateStorePath(root, relativePath),
+    writeText: async (relativePath, content) => {
+      await writePrivateTextAtomic({
+        rootDir: root,
+        filePath: resolvePrivateStorePath(root, relativePath),
+        content,
+      });
+    },
+    writeJson: async (relativePath, value, options) => {
+      await writePrivateJsonAtomic({
+        rootDir: root,
+        filePath: resolvePrivateStorePath(root, relativePath),
+        value,
+        trailingNewline: options?.trailingNewline,
+      });
+    },
+  };
+}

--- a/src/private-temp-workspace.ts
+++ b/src/private-temp-workspace.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from "node:crypto";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type PrivateTempWorkspaceOptions = {
+  rootDir: string;
+  prefix: string;
+  dirMode?: number;
+  fileMode?: number;
+};
+
+export type PrivateTempWorkspace = {
+  dir: string;
+  path(fileName: string): string;
+  writePrivate(fileName: string, data: string | Uint8Array): Promise<string>;
+  read(fileName: string): Promise<Buffer>;
+  cleanup(): Promise<void>;
+};
+
+export type PrivateTempWorkspaceSync = {
+  dir: string;
+  path(fileName: string): string;
+  writePrivate(fileName: string, data: string | Uint8Array): string;
+  read(fileName: string): Buffer;
+  cleanup(): void;
+};
+
+function sanitizeTempPrefix(prefix: string): string {
+  const sanitized = prefix.trim().replace(/[^a-zA-Z0-9._-]/g, "-");
+  if (!sanitized || sanitized === "." || sanitized === "..") {
+    return "fs-safe-";
+  }
+  return sanitized.endsWith("-") ? sanitized : `${sanitized}-`;
+}
+
+function resolveWorkspaceLeaf(dir: string, fileName: string): string {
+  const raw = fileName.trim();
+  if (
+    !raw ||
+    raw === "." ||
+    raw === ".." ||
+    raw.includes("\0") ||
+    raw.includes("/") ||
+    raw.includes("\\") ||
+    path.basename(raw) !== raw
+  ) {
+    throw new Error(`Invalid temp workspace file name: ${JSON.stringify(fileName)}`);
+  }
+  return path.join(dir, raw);
+}
+
+async function ensurePrivateDirectory(dir: string, mode: number): Promise<void> {
+  await fs.mkdir(dir, { recursive: true, mode });
+  const stat = await fs.stat(dir);
+  if (!stat.isDirectory()) {
+    throw new Error(`Temp root must be a directory: ${dir}`);
+  }
+  await fs.chmod(dir, mode).catch(() => undefined);
+}
+
+function ensurePrivateDirectorySync(dir: string, mode: number): void {
+  fsSync.mkdirSync(dir, { recursive: true, mode });
+  const stat = fsSync.statSync(dir);
+  if (!stat.isDirectory()) {
+    throw new Error(`Temp root must be a directory: ${dir}`);
+  }
+  try {
+    fsSync.chmodSync(dir, mode);
+  } catch {
+    // Best-effort on platforms that do not enforce POSIX modes.
+  }
+}
+
+export async function createPrivateTempWorkspace(
+  options: PrivateTempWorkspaceOptions,
+): Promise<PrivateTempWorkspace> {
+  const dirMode = options.dirMode ?? 0o700;
+  const fileMode = options.fileMode ?? 0o600;
+  const requestedRoot = path.resolve(options.rootDir);
+  const root = await fs.realpath(requestedRoot).catch(() => requestedRoot);
+  await ensurePrivateDirectory(root, dirMode);
+  const dir = await fs.mkdtemp(path.join(root, sanitizeTempPrefix(options.prefix)));
+  await fs.chmod(dir, dirMode).catch(() => undefined);
+  const stat = await fs.lstat(dir);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`Temp workspace must be a directory: ${dir}`);
+  }
+
+  return {
+    dir,
+    path: (fileName) => resolveWorkspaceLeaf(dir, fileName),
+    writePrivate: async (fileName, data) => {
+      const filePath = resolveWorkspaceLeaf(dir, fileName);
+      await fs.writeFile(filePath, data, { mode: fileMode, flag: "wx" });
+      await fs.chmod(filePath, fileMode).catch(() => undefined);
+      return filePath;
+    },
+    read: async (fileName) => await fs.readFile(resolveWorkspaceLeaf(dir, fileName)),
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    },
+  };
+}
+
+export async function withPrivateTempWorkspace<T>(
+  options: PrivateTempWorkspaceOptions,
+  run: (workspace: PrivateTempWorkspace) => Promise<T>,
+): Promise<T> {
+  const workspace = await createPrivateTempWorkspace({
+    ...options,
+    prefix: `${sanitizeTempPrefix(options.prefix)}${randomUUID()}-`,
+  });
+  try {
+    return await run(workspace);
+  } finally {
+    await workspace.cleanup();
+  }
+}
+
+export function createPrivateTempWorkspaceSync(
+  options: PrivateTempWorkspaceOptions,
+): PrivateTempWorkspaceSync {
+  const dirMode = options.dirMode ?? 0o700;
+  const fileMode = options.fileMode ?? 0o600;
+  const requestedRoot = path.resolve(options.rootDir);
+  let root = requestedRoot;
+  try {
+    root = fsSync.realpathSync.native(requestedRoot);
+  } catch {
+    root = requestedRoot;
+  }
+  ensurePrivateDirectorySync(root, dirMode);
+  const dir = fsSync.mkdtempSync(path.join(root, sanitizeTempPrefix(options.prefix)));
+  try {
+    fsSync.chmodSync(dir, dirMode);
+  } catch {
+    // Best-effort on platforms that do not enforce POSIX modes.
+  }
+  const stat = fsSync.lstatSync(dir);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`Temp workspace must be a directory: ${dir}`);
+  }
+
+  return {
+    dir,
+    path: (fileName) => resolveWorkspaceLeaf(dir, fileName),
+    writePrivate: (fileName, data) => {
+      const filePath = resolveWorkspaceLeaf(dir, fileName);
+      fsSync.writeFileSync(filePath, data, { mode: fileMode, flag: "wx" });
+      try {
+        fsSync.chmodSync(filePath, fileMode);
+      } catch {
+        // Best-effort on platforms that do not enforce POSIX modes.
+      }
+      return filePath;
+    },
+    read: (fileName) => fsSync.readFileSync(resolveWorkspaceLeaf(dir, fileName)),
+    cleanup: () => {
+      try {
+        fsSync.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup.
+      }
+    },
+  };
+}
+
+export function withPrivateTempWorkspaceSync<T>(
+  options: PrivateTempWorkspaceOptions,
+  run: (workspace: PrivateTempWorkspaceSync) => T,
+): T {
+  const workspace = createPrivateTempWorkspaceSync({
+    ...options,
+    prefix: `${sanitizeTempPrefix(options.prefix)}${randomUUID()}-`,
+  });
+  try {
+    return run(workspace);
+  } finally {
+    workspace.cleanup();
+  }
+}

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -1,0 +1,39 @@
+import type { Stats } from "node:fs";
+import fs from "node:fs/promises";
+import { isNotFoundPathError } from "./path.js";
+
+export type RegularFileStatResult = { missing: true } | { missing: false; stat: Stats };
+
+export async function statRegularFile(filePath: string): Promise<RegularFileStatResult> {
+  let stat: Stats;
+  try {
+    stat = await fs.lstat(filePath);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      return { missing: true };
+    }
+    throw err;
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error("path must be a regular file");
+  }
+  return { missing: false, stat };
+}
+
+export async function readRegularFile(params: {
+  filePath: string;
+  maxBytes?: number;
+}): Promise<{ buffer: Buffer; stat: Stats }> {
+  const result = await statRegularFile(params.filePath);
+  if (result.missing) {
+    throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });
+  }
+  if (params.maxBytes !== undefined && result.stat.size > params.maxBytes) {
+    throw new Error(`File exceeds ${params.maxBytes} bytes: ${params.filePath}`);
+  }
+  const buffer = await fs.readFile(params.filePath);
+  if (params.maxBytes !== undefined && buffer.byteLength > params.maxBytes) {
+    throw new Error(`File exceeds ${params.maxBytes} bytes: ${params.filePath}`);
+  }
+  return { buffer, stat: result.stat };
+}

--- a/src/replace-directory.ts
+++ b/src/replace-directory.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type ReplaceDirectoryStagedOptions = {
+  stagedDir: string;
+  targetDir: string;
+  backupPrefix?: string;
+};
+
+export async function replaceDirectoryStaged(
+  options: ReplaceDirectoryStagedOptions,
+): Promise<void> {
+  const targetDir = path.resolve(options.targetDir);
+  const stagedDir = path.resolve(options.stagedDir);
+  const parentDir = path.dirname(targetDir);
+  const backupDir = path.join(
+    parentDir,
+    `${options.backupPrefix ?? ".fs-safe-dir-backup-"}${process.pid}-${Date.now()}`,
+  );
+  let backupCreated = false;
+
+  await fs.mkdir(parentDir, { recursive: true });
+  try {
+    await fs.rename(targetDir, backupDir);
+    backupCreated = true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+  }
+
+  try {
+    await fs.rename(stagedDir, targetDir);
+  } catch (err) {
+    if (backupCreated) {
+      await fs.rename(backupDir, targetDir).catch(() => undefined);
+      backupCreated = false;
+    }
+    throw err;
+  }
+
+  if (backupCreated) {
+    await fs.rm(backupDir, { recursive: true, force: true });
+  }
+}

--- a/src/replace-file.ts
+++ b/src/replace-file.ts
@@ -1,0 +1,384 @@
+import { randomUUID } from "node:crypto";
+import syncFs from "node:fs";
+import type { Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type ReplaceFileAtomicFileSystem = {
+  promises: Pick<
+    typeof fs,
+    | "mkdir"
+    | "chmod"
+    | "writeFile"
+    | "rename"
+    | "copyFile"
+    | "unlink"
+    | "rm"
+    | "open"
+    | "stat"
+  >;
+};
+
+export type ReplaceFileAtomicSyncFileSystem = Pick<
+  typeof syncFs,
+  | "mkdirSync"
+  | "chmodSync"
+  | "writeFileSync"
+  | "renameSync"
+  | "copyFileSync"
+  | "unlinkSync"
+  | "rmSync"
+  | "openSync"
+  | "fsyncSync"
+  | "closeSync"
+  | "statSync"
+>;
+
+type ReplaceFileAtomicBaseOptions = {
+  filePath: string;
+  content: string | Uint8Array;
+  dirMode?: number;
+  fileMode?: number;
+  preserveExistingMode?: boolean;
+  tempPrefix?: string;
+  renameMaxRetries?: number;
+  renameRetryBaseDelayMs?: number;
+  copyFallbackOnPermissionError?: boolean;
+  syncTempFile?: boolean;
+  syncParentDir?: boolean;
+  throwOnCleanupError?: boolean;
+};
+
+export type ReplaceFileAtomicOptions = ReplaceFileAtomicBaseOptions & {
+  fileSystem?: ReplaceFileAtomicFileSystem;
+  beforeRename?: (params: { filePath: string; tempPath: string }) => Promise<void>;
+};
+
+export type ReplaceFileAtomicSyncOptions = ReplaceFileAtomicBaseOptions & {
+  fileSystem?: ReplaceFileAtomicSyncFileSystem;
+  beforeRename?: (params: { filePath: string; tempPath: string }) => void;
+};
+
+export type ReplaceFileAtomicResult = {
+  method: "rename" | "copy-fallback";
+};
+
+function isRetryableRenameError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "EBUSY";
+}
+
+function isPermissionRenameError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "EPERM" || code === "EEXIST";
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function renameWithRetry(params: {
+  fsModule: ReplaceFileAtomicFileSystem["promises"];
+  src: string;
+  dest: string;
+  maxRetries: number;
+  baseDelayMs: number;
+  copyFallbackOnPermissionError: boolean;
+}): Promise<ReplaceFileAtomicResult> {
+  for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
+    try {
+      await params.fsModule.rename(params.src, params.dest);
+      return { method: "rename" };
+    } catch (error) {
+      if (isRetryableRenameError(error) && attempt < params.maxRetries) {
+        await sleep(params.baseDelayMs * 2 ** attempt);
+        continue;
+      }
+      if (params.copyFallbackOnPermissionError && isPermissionRenameError(error)) {
+        await params.fsModule.copyFile(params.src, params.dest);
+        await params.fsModule.unlink(params.src).catch(() => undefined);
+        return { method: "copy-fallback" };
+      }
+      throw error;
+    }
+  }
+  throw new Error("Atomic rename retry loop exhausted.");
+}
+
+function sleepSync(ms: number): void {
+  if (ms <= 0) {
+    return;
+  }
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function renameWithRetrySync(params: {
+  fsModule: ReplaceFileAtomicSyncFileSystem;
+  src: string;
+  dest: string;
+  maxRetries: number;
+  baseDelayMs: number;
+  copyFallbackOnPermissionError: boolean;
+}): ReplaceFileAtomicResult {
+  for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
+    try {
+      params.fsModule.renameSync(params.src, params.dest);
+      return { method: "rename" };
+    } catch (error) {
+      if (isRetryableRenameError(error) && attempt < params.maxRetries) {
+        sleepSync(params.baseDelayMs * 2 ** attempt);
+        continue;
+      }
+      if (params.copyFallbackOnPermissionError && isPermissionRenameError(error)) {
+        params.fsModule.copyFileSync(params.src, params.dest);
+        try {
+          params.fsModule.unlinkSync(params.src);
+        } catch {
+          // Best-effort cleanup after fallback replacement.
+        }
+        return { method: "copy-fallback" };
+      }
+      throw error;
+    }
+  }
+  throw new Error("Atomic rename retry loop exhausted.");
+}
+
+function validateReplaceFilePath(filePath: string): void {
+  if (!filePath || filePath.includes("\0")) {
+    throw new Error("Atomic replace file path must be non-empty.");
+  }
+}
+
+function buildReplaceTempPath(filePath: string, tempPrefix?: string): string {
+  const dir = path.dirname(filePath);
+  return path.join(dir, `${tempPrefix ?? ".fs-safe-replace"}.${process.pid}.${randomUUID()}.tmp`);
+}
+
+async function resolveFileMode(options: ReplaceFileAtomicOptions): Promise<number> {
+  const defaultMode = options.fileMode ?? 0o600;
+  if (!options.preserveExistingMode) {
+    return defaultMode;
+  }
+  const stat = await (options.fileSystem?.promises ?? fs).stat(options.filePath).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
+  return stat ? stat.mode : defaultMode;
+}
+
+function resolveFileModeSync(options: ReplaceFileAtomicSyncOptions): number {
+  const defaultMode = options.fileMode ?? 0o600;
+  if (!options.preserveExistingMode) {
+    return defaultMode;
+  }
+  const fsModule = options.fileSystem ?? syncFs;
+  let stat: Stats | undefined;
+  try {
+    stat = fsModule.statSync(options.filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  return stat ? stat.mode : defaultMode;
+}
+
+async function syncTempFile(fsModule: ReplaceFileAtomicFileSystem["promises"], tempPath: string) {
+  const handle = await fsModule.open(tempPath, "r+");
+  try {
+    await handle.sync();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EPERM") {
+      throw error;
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+function syncTempFileSync(fsModule: ReplaceFileAtomicSyncFileSystem, tempPath: string): void {
+  const fd = fsModule.openSync(tempPath, "r+");
+  try {
+    fsModule.fsyncSync(fd);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EPERM") {
+      throw error;
+    }
+  } finally {
+    fsModule.closeSync(fd);
+  }
+}
+
+async function syncDirectoryBestEffort(
+  fsModule: ReplaceFileAtomicFileSystem["promises"],
+  dirPath: string,
+): Promise<void> {
+  let handle: Awaited<ReturnType<ReplaceFileAtomicFileSystem["promises"]["open"]>> | undefined;
+  try {
+    handle = await fsModule.open(dirPath, "r");
+    await handle.sync();
+  } catch {
+    // Best-effort on platforms/filesystems that do not support directory fsync.
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+function syncDirectoryBestEffortSync(
+  fsModule: ReplaceFileAtomicSyncFileSystem,
+  dirPath: string,
+): void {
+  let fd: number | undefined;
+  try {
+    fd = fsModule.openSync(dirPath, "r");
+    fsModule.fsyncSync(fd);
+  } catch {
+    // Best-effort on platforms/filesystems that do not support directory fsync.
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fsModule.closeSync(fd);
+      } catch {
+        // Best-effort close after directory fsync.
+      }
+    }
+  }
+}
+
+async function cleanupTempFile(params: {
+  fsModule: ReplaceFileAtomicFileSystem["promises"];
+  tempPath: string;
+  originalError?: unknown;
+  throwOnCleanupError: boolean;
+}): Promise<void> {
+  const cleanupError = await params.fsModule
+    .rm(params.tempPath, { force: true })
+    .catch((error) => error);
+  if (cleanupError && params.throwOnCleanupError && params.originalError !== undefined) {
+    throw new Error(
+      `Atomic file replace failed (${String(params.originalError)}); cleanup also failed (${String(cleanupError)})`,
+      { cause: params.originalError },
+    );
+  }
+}
+
+export async function replaceFileAtomic(
+  options: ReplaceFileAtomicOptions,
+): Promise<ReplaceFileAtomicResult> {
+  const filePath = options.filePath;
+  validateReplaceFilePath(filePath);
+  const fsModule = options.fileSystem?.promises ?? fs;
+  const dir = path.dirname(filePath);
+  const dirMode = options.dirMode ?? 0o700;
+  const fileMode = await resolveFileMode(options);
+  const tempPath = buildReplaceTempPath(filePath, options.tempPrefix);
+  let tempExists = false;
+  let originalError: unknown;
+
+  await fsModule.mkdir(dir, { recursive: true, mode: dirMode });
+  await fsModule.chmod(dir, dirMode).catch(() => undefined);
+  try {
+    tempExists = true;
+    await fsModule.writeFile(tempPath, options.content, { mode: fileMode, flag: "wx" });
+    if (options.syncTempFile) {
+      await syncTempFile(fsModule, tempPath);
+    }
+    if (options.beforeRename) {
+      await options.beforeRename({ filePath, tempPath });
+    }
+    const result = await renameWithRetry({
+      fsModule,
+      src: tempPath,
+      dest: filePath,
+      maxRetries: options.renameMaxRetries ?? 0,
+      baseDelayMs: options.renameRetryBaseDelayMs ?? 50,
+      copyFallbackOnPermissionError: options.copyFallbackOnPermissionError === true,
+    });
+    tempExists = false;
+    await fsModule.chmod(filePath, fileMode).catch(() => undefined);
+    if (options.syncParentDir) {
+      await syncDirectoryBestEffort(fsModule, dir);
+    }
+    return result;
+  } catch (error) {
+    originalError = error;
+    throw error;
+  } finally {
+    if (tempExists) {
+      await cleanupTempFile({
+        fsModule,
+        tempPath,
+        originalError,
+        throwOnCleanupError: options.throwOnCleanupError === true,
+      });
+    }
+  }
+}
+
+export function replaceFileAtomicSync(
+  options: ReplaceFileAtomicSyncOptions,
+): ReplaceFileAtomicResult {
+  const filePath = options.filePath;
+  validateReplaceFilePath(filePath);
+  const fsModule = options.fileSystem ?? syncFs;
+  const dir = path.dirname(filePath);
+  const dirMode = options.dirMode ?? 0o700;
+  const fileMode = resolveFileModeSync(options);
+  const tempPath = buildReplaceTempPath(filePath, options.tempPrefix);
+  let tempExists = false;
+  let originalError: unknown;
+
+  fsModule.mkdirSync(dir, { recursive: true, mode: dirMode });
+  try {
+    fsModule.chmodSync(dir, dirMode);
+  } catch {
+    // Best-effort on platforms that do not enforce POSIX modes.
+  }
+  try {
+    tempExists = true;
+    fsModule.writeFileSync(tempPath, options.content, { mode: fileMode, flag: "wx" });
+    if (options.syncTempFile) {
+      syncTempFileSync(fsModule, tempPath);
+    }
+    if (options.beforeRename) {
+      options.beforeRename({ filePath, tempPath });
+    }
+    const result = renameWithRetrySync({
+      fsModule,
+      src: tempPath,
+      dest: filePath,
+      maxRetries: options.renameMaxRetries ?? 0,
+      baseDelayMs: options.renameRetryBaseDelayMs ?? 50,
+      copyFallbackOnPermissionError: options.copyFallbackOnPermissionError === true,
+    });
+    tempExists = false;
+    try {
+      fsModule.chmodSync(filePath, fileMode);
+    } catch {
+      // Best-effort on platforms that do not enforce POSIX modes.
+    }
+    if (options.syncParentDir) {
+      syncDirectoryBestEffortSync(fsModule, dir);
+    }
+    return result;
+  } catch (error) {
+    originalError = error;
+    throw error;
+  } finally {
+    if (tempExists) {
+      try {
+        fsModule.rmSync(tempPath, { force: true });
+      } catch (cleanupError) {
+        if (options.throwOnCleanupError && originalError !== undefined) {
+          throw new Error(
+            `Atomic file replace failed (${String(originalError)}); cleanup also failed (${String(cleanupError)})`,
+            { cause: originalError },
+          );
+        }
+        // The temp file is best-effort cleanup after write failure.
+      }
+    }
+  }
+}

--- a/src/root-file.ts
+++ b/src/root-file.ts
@@ -1,0 +1,224 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+  resolveRootPath,
+  resolveRootPathSync,
+  type ResolvedRootPath,
+} from "./root-path.js";
+import type { PathAliasPolicy } from "./path-policy.js";
+import {
+  openPinnedFileSync,
+  type PinnedOpenSyncAllowedType,
+  type PinnedOpenSyncFailureReason,
+} from "./pinned-open.js";
+
+type BoundaryReadFs = Pick<
+  typeof fs,
+  | "closeSync"
+  | "constants"
+  | "fstatSync"
+  | "lstatSync"
+  | "openSync"
+  | "readFileSync"
+  | "realpathSync"
+>;
+
+export type RootFileOpenFailureReason = PinnedOpenSyncFailureReason | "validation";
+
+export type RootFileOpenResult =
+  | { ok: true; path: string; fd: number; stat: fs.Stats; rootRealPath: string }
+  | { ok: false; reason: RootFileOpenFailureReason; error?: unknown };
+
+export type RootFileOpenFailure = Extract<RootFileOpenResult, { ok: false }>;
+
+export type OpenRootFileSyncParams = {
+  absolutePath: string;
+  rootPath: string;
+  boundaryLabel: string;
+  rootRealPath?: string;
+  maxBytes?: number;
+  rejectHardlinks?: boolean;
+  allowedType?: PinnedOpenSyncAllowedType;
+  skipLexicalRootCheck?: boolean;
+  ioFs?: BoundaryReadFs;
+};
+
+export type OpenRootFileParams = OpenRootFileSyncParams & {
+  aliasPolicy?: PathAliasPolicy;
+};
+
+type ResolvedRootFilePath = {
+  absolutePath: string;
+  resolvedPath: string;
+  rootRealPath: string;
+};
+
+export function canUseRootFileOpen(ioFs: typeof fs): boolean {
+  return (
+    typeof ioFs.openSync === "function" &&
+    typeof ioFs.closeSync === "function" &&
+    typeof ioFs.fstatSync === "function" &&
+    typeof ioFs.lstatSync === "function" &&
+    typeof ioFs.realpathSync === "function" &&
+    typeof ioFs.readFileSync === "function" &&
+    typeof ioFs.constants === "object" &&
+    ioFs.constants !== null
+  );
+}
+
+export function openRootFileSync(params: OpenRootFileSyncParams): RootFileOpenResult {
+  const ioFs = params.ioFs ?? fs;
+  const resolved = resolveRootFilePathGeneric({
+    absolutePath: params.absolutePath,
+    resolve: (absolutePath) =>
+      resolveRootPathSync({
+        absolutePath,
+        rootPath: params.rootPath,
+        rootCanonicalPath: params.rootRealPath,
+        boundaryLabel: params.boundaryLabel,
+        skipLexicalRootCheck: params.skipLexicalRootCheck,
+      }),
+  });
+  if (resolved instanceof Promise) {
+    return toBoundaryValidationError(new Error("Unexpected async boundary resolution"));
+  }
+  return finalizeRootFileOpen({
+    resolved,
+    maxBytes: params.maxBytes,
+    rejectHardlinks: params.rejectHardlinks,
+    allowedType: params.allowedType,
+    ioFs,
+  });
+}
+
+export function matchRootFileOpenFailure<T>(
+  failure: RootFileOpenFailure,
+  handlers: {
+    path?: (failure: RootFileOpenFailure) => T;
+    validation?: (failure: RootFileOpenFailure) => T;
+    io?: (failure: RootFileOpenFailure) => T;
+    fallback: (failure: RootFileOpenFailure) => T;
+  },
+): T {
+  switch (failure.reason) {
+    case "path":
+      return handlers.path ? handlers.path(failure) : handlers.fallback(failure);
+    case "validation":
+      return handlers.validation ? handlers.validation(failure) : handlers.fallback(failure);
+    case "io":
+      return handlers.io ? handlers.io(failure) : handlers.fallback(failure);
+  }
+  return handlers.fallback(failure);
+}
+
+function openRootFileResolved(params: {
+  absolutePath: string;
+  resolvedPath: string;
+  rootRealPath: string;
+  maxBytes?: number;
+  rejectHardlinks?: boolean;
+  allowedType?: PinnedOpenSyncAllowedType;
+  ioFs: BoundaryReadFs;
+}): RootFileOpenResult {
+  const opened = openPinnedFileSync({
+    filePath: params.absolutePath,
+    resolvedPath: params.resolvedPath,
+    rejectHardlinks: params.rejectHardlinks ?? true,
+    maxBytes: params.maxBytes,
+    allowedType: params.allowedType,
+    ioFs: params.ioFs,
+  });
+  if (!opened.ok) {
+    return opened;
+  }
+  return {
+    ok: true,
+    path: opened.path,
+    fd: opened.fd,
+    stat: opened.stat,
+    rootRealPath: params.rootRealPath,
+  };
+}
+
+function finalizeRootFileOpen(params: {
+  resolved: ResolvedRootFilePath | RootFileOpenResult;
+  maxBytes?: number;
+  rejectHardlinks?: boolean;
+  allowedType?: PinnedOpenSyncAllowedType;
+  ioFs: BoundaryReadFs;
+}): RootFileOpenResult {
+  if ("ok" in params.resolved) {
+    return params.resolved;
+  }
+  return openRootFileResolved({
+    absolutePath: params.resolved.absolutePath,
+    resolvedPath: params.resolved.resolvedPath,
+    rootRealPath: params.resolved.rootRealPath,
+    maxBytes: params.maxBytes,
+    rejectHardlinks: params.rejectHardlinks,
+    allowedType: params.allowedType,
+    ioFs: params.ioFs,
+  });
+}
+
+export async function openRootFile(
+  params: OpenRootFileParams,
+): Promise<RootFileOpenResult> {
+  const ioFs = params.ioFs ?? fs;
+  const maybeResolved = resolveRootFilePathGeneric({
+    absolutePath: params.absolutePath,
+    resolve: (absolutePath) =>
+      resolveRootPath({
+        absolutePath,
+        rootPath: params.rootPath,
+        rootCanonicalPath: params.rootRealPath,
+        boundaryLabel: params.boundaryLabel,
+        policy: params.aliasPolicy,
+        skipLexicalRootCheck: params.skipLexicalRootCheck,
+      }),
+  });
+  const resolved = maybeResolved instanceof Promise ? await maybeResolved : maybeResolved;
+  return finalizeRootFileOpen({
+    resolved,
+    maxBytes: params.maxBytes,
+    rejectHardlinks: params.rejectHardlinks,
+    allowedType: params.allowedType,
+    ioFs,
+  });
+}
+
+function toBoundaryValidationError(error: unknown): RootFileOpenResult {
+  return { ok: false, reason: "validation", error };
+}
+
+function mapResolvedRootPath(
+  absolutePath: string,
+  resolved: ResolvedRootPath,
+): ResolvedRootFilePath {
+  return {
+    absolutePath,
+    resolvedPath: resolved.canonicalPath,
+    rootRealPath: resolved.rootCanonicalPath,
+  };
+}
+
+function resolveRootFilePathGeneric(params: {
+  absolutePath: string;
+  resolve: (absolutePath: string) => ResolvedRootPath | Promise<ResolvedRootPath>;
+}):
+  | ResolvedRootFilePath
+  | RootFileOpenResult
+  | Promise<ResolvedRootFilePath | RootFileOpenResult> {
+  const absolutePath = path.resolve(params.absolutePath);
+  try {
+    const resolved = params.resolve(absolutePath);
+    if (resolved instanceof Promise) {
+      return resolved
+        .then((value) => mapResolvedRootPath(absolutePath, value))
+        .catch((error) => toBoundaryValidationError(error));
+    }
+    return mapResolvedRootPath(absolutePath, resolved);
+  } catch (error) {
+    return toBoundaryValidationError(error);
+  }
+}

--- a/src/root-path.ts
+++ b/src/root-path.ts
@@ -1,0 +1,861 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { isNotFoundPathError, isPathInside } from "./path.js";
+
+type RootPathIntent = "read" | "write" | "create" | "delete" | "stat";
+
+export type RootPathAliasPolicy = {
+  allowFinalSymlinkForUnlink?: boolean;
+  allowFinalHardlinkForUnlink?: boolean;
+};
+
+export const ROOT_PATH_ALIAS_POLICIES = {
+  strict: Object.freeze({
+    allowFinalSymlinkForUnlink: false,
+    allowFinalHardlinkForUnlink: false,
+  }),
+  unlinkTarget: Object.freeze({
+    allowFinalSymlinkForUnlink: true,
+    allowFinalHardlinkForUnlink: true,
+  }),
+} as const;
+
+type ResolveRootPathParams = {
+  absolutePath: string;
+  rootPath: string;
+  boundaryLabel: string;
+  intent?: RootPathIntent;
+  policy?: RootPathAliasPolicy;
+  skipLexicalRootCheck?: boolean;
+  rootCanonicalPath?: string;
+};
+
+type ResolvedRootPathKind = "missing" | "file" | "directory" | "symlink" | "other";
+
+export type ResolvedRootPath = {
+  absolutePath: string;
+  canonicalPath: string;
+  rootPath: string;
+  rootCanonicalPath: string;
+  relativePath: string;
+  exists: boolean;
+  kind: ResolvedRootPathKind;
+};
+
+export async function resolveRootPath(
+  params: ResolveRootPathParams,
+): Promise<ResolvedRootPath> {
+  const rootPath = path.resolve(params.rootPath);
+  const absolutePath = path.resolve(params.absolutePath);
+  const rootCanonicalPath = params.rootCanonicalPath
+    ? path.resolve(params.rootCanonicalPath)
+    : await resolvePathViaExistingAncestor(rootPath);
+  const context = createBoundaryResolutionContext({
+    resolveParams: params,
+    rootPath,
+    absolutePath,
+    rootCanonicalPath,
+    outsideLexicalCanonicalPath: await resolveOutsideLexicalCanonicalPathAsync({
+      rootPath,
+      absolutePath,
+    }),
+  });
+
+  const outsideResult = await resolveOutsideRootPathAsync({
+    boundaryLabel: params.boundaryLabel,
+    context,
+  });
+  if (outsideResult) {
+    return outsideResult;
+  }
+
+  return resolveRootPathLexicalAsync({
+    params,
+    absolutePath: context.absolutePath,
+    rootPath: context.rootPath,
+    rootCanonicalPath: context.rootCanonicalPath,
+  });
+}
+
+export function resolveRootPathSync(params: ResolveRootPathParams): ResolvedRootPath {
+  const rootPath = path.resolve(params.rootPath);
+  const absolutePath = path.resolve(params.absolutePath);
+  const rootCanonicalPath = params.rootCanonicalPath
+    ? path.resolve(params.rootCanonicalPath)
+    : resolvePathViaExistingAncestorSync(rootPath);
+  const context = createBoundaryResolutionContext({
+    resolveParams: params,
+    rootPath,
+    absolutePath,
+    rootCanonicalPath,
+    outsideLexicalCanonicalPath: resolveOutsideLexicalCanonicalPathSync({
+      rootPath,
+      absolutePath,
+    }),
+  });
+
+  const outsideResult = resolveOutsideRootPathSync({
+    boundaryLabel: params.boundaryLabel,
+    context,
+  });
+  if (outsideResult) {
+    return outsideResult;
+  }
+
+  return resolveRootPathLexicalSync({
+    params,
+    absolutePath: context.absolutePath,
+    rootPath: context.rootPath,
+    rootCanonicalPath: context.rootCanonicalPath,
+  });
+}
+
+type LexicalTraversalState = {
+  segments: string[];
+  allowFinalSymlink: boolean;
+  canonicalCursor: string;
+  lexicalCursor: string;
+  preserveFinalSymlink: boolean;
+};
+
+type BoundaryResolutionContext = {
+  rootPath: string;
+  absolutePath: string;
+  rootCanonicalPath: string;
+  lexicalInside: boolean;
+  canonicalOutsideLexicalPath: string;
+};
+
+function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+  return Boolean(
+    value &&
+    (typeof value === "object" || typeof value === "function") &&
+    "then" in value &&
+    typeof (value as { then?: unknown }).then === "function",
+  );
+}
+
+function createLexicalTraversalState(params: {
+  params: ResolveRootPathParams;
+  rootPath: string;
+  rootCanonicalPath: string;
+  absolutePath: string;
+}): LexicalTraversalState {
+  const relative = path.relative(params.rootPath, params.absolutePath);
+  return {
+    segments: relative.split(path.sep).filter(Boolean),
+    allowFinalSymlink: params.params.policy?.allowFinalSymlinkForUnlink === true,
+    canonicalCursor: params.rootCanonicalPath,
+    lexicalCursor: params.rootPath,
+    preserveFinalSymlink: false,
+  };
+}
+
+function assertLexicalCursorInsideBoundary(params: {
+  params: ResolveRootPathParams;
+  rootCanonicalPath: string;
+  absolutePath: string;
+  candidatePath: string;
+}): void {
+  assertInsideBoundary({
+    boundaryLabel: params.params.boundaryLabel,
+    rootCanonicalPath: params.rootCanonicalPath,
+    candidatePath: params.candidatePath,
+    absolutePath: params.absolutePath,
+  });
+}
+
+function applyMissingSuffixToCanonicalCursor(params: {
+  state: LexicalTraversalState;
+  missingFromIndex: number;
+  rootCanonicalPath: string;
+  params: ResolveRootPathParams;
+  absolutePath: string;
+}): void {
+  const missingSuffix = params.state.segments.slice(params.missingFromIndex);
+  params.state.canonicalCursor = path.resolve(params.state.canonicalCursor, ...missingSuffix);
+  assertLexicalCursorInsideBoundary({
+    params: params.params,
+    rootCanonicalPath: params.rootCanonicalPath,
+    candidatePath: params.state.canonicalCursor,
+    absolutePath: params.absolutePath,
+  });
+}
+
+function advanceCanonicalCursorForSegment(params: {
+  state: LexicalTraversalState;
+  segment: string;
+  rootCanonicalPath: string;
+  params: ResolveRootPathParams;
+  absolutePath: string;
+}): void {
+  params.state.canonicalCursor = path.resolve(params.state.canonicalCursor, params.segment);
+  assertLexicalCursorInsideBoundary({
+    params: params.params,
+    rootCanonicalPath: params.rootCanonicalPath,
+    candidatePath: params.state.canonicalCursor,
+    absolutePath: params.absolutePath,
+  });
+}
+
+function finalizeLexicalResolution(params: {
+  params: ResolveRootPathParams;
+  rootPath: string;
+  rootCanonicalPath: string;
+  absolutePath: string;
+  state: LexicalTraversalState;
+  kind: { exists: boolean; kind: ResolvedRootPathKind };
+}): ResolvedRootPath {
+  assertLexicalCursorInsideBoundary({
+    params: params.params,
+    rootCanonicalPath: params.rootCanonicalPath,
+    candidatePath: params.state.canonicalCursor,
+    absolutePath: params.absolutePath,
+  });
+  return buildResolvedRootPath({
+    absolutePath: params.absolutePath,
+    canonicalPath: params.state.canonicalCursor,
+    rootPath: params.rootPath,
+    rootCanonicalPath: params.rootCanonicalPath,
+    kind: params.kind,
+  });
+}
+
+function handleLexicalLstatFailure(params: {
+  error: unknown;
+  state: LexicalTraversalState;
+  missingFromIndex: number;
+  rootCanonicalPath: string;
+  resolveParams: ResolveRootPathParams;
+  absolutePath: string;
+}): boolean {
+  if (!isNotFoundPathError(params.error)) {
+    return false;
+  }
+  applyMissingSuffixToCanonicalCursor({
+    state: params.state,
+    missingFromIndex: params.missingFromIndex,
+    rootCanonicalPath: params.rootCanonicalPath,
+    params: params.resolveParams,
+    absolutePath: params.absolutePath,
+  });
+  return true;
+}
+
+function handleLexicalStatReadFailure(params: {
+  error: unknown;
+  state: LexicalTraversalState;
+  missingFromIndex: number;
+  rootCanonicalPath: string;
+  resolveParams: ResolveRootPathParams;
+  absolutePath: string;
+}): null {
+  if (
+    handleLexicalLstatFailure({
+      error: params.error,
+      state: params.state,
+      missingFromIndex: params.missingFromIndex,
+      rootCanonicalPath: params.rootCanonicalPath,
+      resolveParams: params.resolveParams,
+      absolutePath: params.absolutePath,
+    })
+  ) {
+    return null;
+  }
+  throw params.error;
+}
+
+function handleLexicalStatDisposition(params: {
+  state: LexicalTraversalState;
+  isSymbolicLink: boolean;
+  segment: string;
+  isLast: boolean;
+  rootCanonicalPath: string;
+  resolveParams: ResolveRootPathParams;
+  absolutePath: string;
+}): "continue" | "break" | "resolve-link" {
+  if (!params.isSymbolicLink) {
+    advanceCanonicalCursorForSegment({
+      state: params.state,
+      segment: params.segment,
+      rootCanonicalPath: params.rootCanonicalPath,
+      params: params.resolveParams,
+      absolutePath: params.absolutePath,
+    });
+    return "continue";
+  }
+
+  if (params.state.allowFinalSymlink && params.isLast) {
+    params.state.preserveFinalSymlink = true;
+    advanceCanonicalCursorForSegment({
+      state: params.state,
+      segment: params.segment,
+      rootCanonicalPath: params.rootCanonicalPath,
+      params: params.resolveParams,
+      absolutePath: params.absolutePath,
+    });
+    return "break";
+  }
+
+  return "resolve-link";
+}
+
+function applyResolvedSymlinkHop(params: {
+  state: LexicalTraversalState;
+  linkCanonical: string;
+  rootCanonicalPath: string;
+  boundaryLabel: string;
+}): void {
+  if (!isPathInside(params.rootCanonicalPath, params.linkCanonical)) {
+    throw symlinkEscapeError({
+      boundaryLabel: params.boundaryLabel,
+      rootCanonicalPath: params.rootCanonicalPath,
+      symlinkPath: params.state.lexicalCursor,
+    });
+  }
+  params.state.canonicalCursor = params.linkCanonical;
+  params.state.lexicalCursor = params.linkCanonical;
+}
+
+function readLexicalStat(params: {
+  state: LexicalTraversalState;
+  missingFromIndex: number;
+  rootCanonicalPath: string;
+  resolveParams: ResolveRootPathParams;
+  absolutePath: string;
+  read: (cursor: string) => fs.Stats | Promise<fs.Stats>;
+}): fs.Stats | null | Promise<fs.Stats | null> {
+  try {
+    const stat = params.read(params.state.lexicalCursor);
+    if (isPromiseLike<fs.Stats>(stat)) {
+      return Promise.resolve(stat).catch((error) =>
+        handleLexicalStatReadFailure({ ...params, error }),
+      );
+    }
+    return stat;
+  } catch (error) {
+    return handleLexicalStatReadFailure({ ...params, error });
+  }
+}
+
+function resolveAndApplySymlinkHop(params: {
+  state: LexicalTraversalState;
+  rootCanonicalPath: string;
+  boundaryLabel: string;
+  resolveLinkCanonical: (cursor: string) => string | Promise<string>;
+}): void | Promise<void> {
+  const linkCanonical = params.resolveLinkCanonical(params.state.lexicalCursor);
+  if (isPromiseLike<string>(linkCanonical)) {
+    return Promise.resolve(linkCanonical).then((value) =>
+      applyResolvedSymlinkHop({
+        state: params.state,
+        linkCanonical: value,
+        rootCanonicalPath: params.rootCanonicalPath,
+        boundaryLabel: params.boundaryLabel,
+      }),
+    );
+  }
+  applyResolvedSymlinkHop({
+    state: params.state,
+    linkCanonical,
+    rootCanonicalPath: params.rootCanonicalPath,
+    boundaryLabel: params.boundaryLabel,
+  });
+}
+
+type LexicalTraversalStep = {
+  idx: number;
+  segment: string;
+  isLast: boolean;
+};
+
+function* iterateLexicalTraversal(state: LexicalTraversalState): Iterable<LexicalTraversalStep> {
+  for (let idx = 0; idx < state.segments.length; idx += 1) {
+    const segment = state.segments[idx] ?? "";
+    const isLast = idx === state.segments.length - 1;
+    state.lexicalCursor = path.join(state.lexicalCursor, segment);
+    yield { idx, segment, isLast };
+  }
+}
+
+async function resolveRootPathLexicalAsync(params: {
+  params: ResolveRootPathParams;
+  absolutePath: string;
+  rootPath: string;
+  rootCanonicalPath: string;
+}): Promise<ResolvedRootPath> {
+  const state = createLexicalTraversalState(params);
+  const sharedStepParams = {
+    state,
+    rootCanonicalPath: params.rootCanonicalPath,
+    resolveParams: params.params,
+    absolutePath: params.absolutePath,
+  };
+
+  for (const { idx, segment, isLast } of iterateLexicalTraversal(state)) {
+    const stat = await readLexicalStat({
+      ...sharedStepParams,
+      missingFromIndex: idx,
+      read: (cursor) => fsp.lstat(cursor),
+    });
+    if (!stat) {
+      break;
+    }
+
+    const disposition = handleLexicalStatDisposition({
+      ...sharedStepParams,
+      isSymbolicLink: stat.isSymbolicLink(),
+      segment,
+      isLast,
+    });
+    if (disposition === "continue") {
+      continue;
+    }
+    if (disposition === "break") {
+      break;
+    }
+
+    await resolveAndApplySymlinkHop({
+      state,
+      rootCanonicalPath: params.rootCanonicalPath,
+      boundaryLabel: params.params.boundaryLabel,
+      resolveLinkCanonical: (cursor) => resolveSymlinkHopPath(cursor),
+    });
+  }
+
+  const kind = await getPathKind(params.absolutePath, state.preserveFinalSymlink);
+  return finalizeLexicalResolution({
+    ...params,
+    state,
+    kind,
+  });
+}
+
+function resolveRootPathLexicalSync(params: {
+  params: ResolveRootPathParams;
+  absolutePath: string;
+  rootPath: string;
+  rootCanonicalPath: string;
+}): ResolvedRootPath {
+  const state = createLexicalTraversalState(params);
+  for (let idx = 0; idx < state.segments.length; idx += 1) {
+    const segment = state.segments[idx] ?? "";
+    const isLast = idx === state.segments.length - 1;
+    state.lexicalCursor = path.join(state.lexicalCursor, segment);
+    const maybeStat = readLexicalStat({
+      state,
+      missingFromIndex: idx,
+      rootCanonicalPath: params.rootCanonicalPath,
+      resolveParams: params.params,
+      absolutePath: params.absolutePath,
+      read: (cursor) => fs.lstatSync(cursor),
+    });
+    if (isPromiseLike<fs.Stats | null>(maybeStat)) {
+      throw new Error("Unexpected async lexical stat");
+    }
+    const stat = maybeStat;
+    if (!stat) {
+      break;
+    }
+
+    const disposition = handleLexicalStatDisposition({
+      state,
+      isSymbolicLink: stat.isSymbolicLink(),
+      segment,
+      isLast,
+      rootCanonicalPath: params.rootCanonicalPath,
+      resolveParams: params.params,
+      absolutePath: params.absolutePath,
+    });
+    if (disposition === "continue") {
+      continue;
+    }
+    if (disposition === "break") {
+      break;
+    }
+
+    const maybeApplied = resolveAndApplySymlinkHop({
+      state,
+      rootCanonicalPath: params.rootCanonicalPath,
+      boundaryLabel: params.params.boundaryLabel,
+      resolveLinkCanonical: (cursor) => resolveSymlinkHopPathSync(cursor),
+    });
+    if (isPromiseLike<void>(maybeApplied)) {
+      throw new Error("Unexpected async symlink resolution");
+    }
+  }
+
+  const kind = getPathKindSync(params.absolutePath, state.preserveFinalSymlink);
+  return finalizeLexicalResolution({
+    ...params,
+    state,
+    kind,
+  });
+}
+
+function resolveCanonicalOutsideLexicalPath(params: {
+  absolutePath: string;
+  outsideLexicalCanonicalPath?: string;
+}): string {
+  return params.outsideLexicalCanonicalPath ?? params.absolutePath;
+}
+
+function createBoundaryResolutionContext(params: {
+  resolveParams: ResolveRootPathParams;
+  rootPath: string;
+  absolutePath: string;
+  rootCanonicalPath: string;
+  outsideLexicalCanonicalPath?: string;
+}): BoundaryResolutionContext {
+  const lexicalInside = isPathInside(params.rootPath, params.absolutePath);
+  const canonicalOutsideLexicalPath = resolveCanonicalOutsideLexicalPath({
+    absolutePath: params.absolutePath,
+    outsideLexicalCanonicalPath: params.outsideLexicalCanonicalPath,
+  });
+  assertLexicalBoundaryOrCanonicalAlias({
+    skipLexicalRootCheck: params.resolveParams.skipLexicalRootCheck,
+    lexicalInside,
+    canonicalOutsideLexicalPath,
+    rootCanonicalPath: params.rootCanonicalPath,
+    boundaryLabel: params.resolveParams.boundaryLabel,
+    rootPath: params.rootPath,
+    absolutePath: params.absolutePath,
+  });
+  return {
+    rootPath: params.rootPath,
+    absolutePath: params.absolutePath,
+    rootCanonicalPath: params.rootCanonicalPath,
+    lexicalInside,
+    canonicalOutsideLexicalPath,
+  };
+}
+
+async function resolveOutsideRootPathAsync(params: {
+  boundaryLabel: string;
+  context: BoundaryResolutionContext;
+}): Promise<ResolvedRootPath | null> {
+  if (params.context.lexicalInside) {
+    return null;
+  }
+  const kind = await getPathKind(params.context.absolutePath, false);
+  return buildOutsideRootPathFromContext({
+    boundaryLabel: params.boundaryLabel,
+    context: params.context,
+    kind,
+  });
+}
+
+function resolveOutsideRootPathSync(params: {
+  boundaryLabel: string;
+  context: BoundaryResolutionContext;
+}): ResolvedRootPath | null {
+  if (params.context.lexicalInside) {
+    return null;
+  }
+  const kind = getPathKindSync(params.context.absolutePath, false);
+  return buildOutsideRootPathFromContext({
+    boundaryLabel: params.boundaryLabel,
+    context: params.context,
+    kind,
+  });
+}
+
+function buildOutsideRootPathFromContext(params: {
+  boundaryLabel: string;
+  context: BoundaryResolutionContext;
+  kind: { exists: boolean; kind: ResolvedRootPathKind };
+}): ResolvedRootPath {
+  return buildOutsideLexicalRootPath({
+    boundaryLabel: params.boundaryLabel,
+    rootCanonicalPath: params.context.rootCanonicalPath,
+    absolutePath: params.context.absolutePath,
+    canonicalOutsideLexicalPath: params.context.canonicalOutsideLexicalPath,
+    rootPath: params.context.rootPath,
+    kind: params.kind,
+  });
+}
+
+async function resolveOutsideLexicalCanonicalPathAsync(params: {
+  rootPath: string;
+  absolutePath: string;
+}): Promise<string | undefined> {
+  if (isPathInside(params.rootPath, params.absolutePath)) {
+    return undefined;
+  }
+  return await resolvePathViaExistingAncestor(params.absolutePath);
+}
+
+function resolveOutsideLexicalCanonicalPathSync(params: {
+  rootPath: string;
+  absolutePath: string;
+}): string | undefined {
+  if (isPathInside(params.rootPath, params.absolutePath)) {
+    return undefined;
+  }
+  return resolvePathViaExistingAncestorSync(params.absolutePath);
+}
+
+function buildOutsideLexicalRootPath(params: {
+  boundaryLabel: string;
+  rootCanonicalPath: string;
+  absolutePath: string;
+  canonicalOutsideLexicalPath: string;
+  rootPath: string;
+  kind: { exists: boolean; kind: ResolvedRootPathKind };
+}): ResolvedRootPath {
+  assertInsideBoundary({
+    boundaryLabel: params.boundaryLabel,
+    rootCanonicalPath: params.rootCanonicalPath,
+    candidatePath: params.canonicalOutsideLexicalPath,
+    absolutePath: params.absolutePath,
+  });
+  return buildResolvedRootPath({
+    absolutePath: params.absolutePath,
+    canonicalPath: params.canonicalOutsideLexicalPath,
+    rootPath: params.rootPath,
+    rootCanonicalPath: params.rootCanonicalPath,
+    kind: params.kind,
+  });
+}
+
+function assertLexicalBoundaryOrCanonicalAlias(params: {
+  skipLexicalRootCheck?: boolean;
+  lexicalInside: boolean;
+  canonicalOutsideLexicalPath: string;
+  rootCanonicalPath: string;
+  boundaryLabel: string;
+  rootPath: string;
+  absolutePath: string;
+}): void {
+  if (params.skipLexicalRootCheck || params.lexicalInside) {
+    return;
+  }
+  if (isPathInside(params.rootCanonicalPath, params.canonicalOutsideLexicalPath)) {
+    return;
+  }
+  throw pathEscapeError({
+    boundaryLabel: params.boundaryLabel,
+    rootPath: params.rootPath,
+    absolutePath: params.absolutePath,
+  });
+}
+
+function buildResolvedRootPath(params: {
+  absolutePath: string;
+  canonicalPath: string;
+  rootPath: string;
+  rootCanonicalPath: string;
+  kind: { exists: boolean; kind: ResolvedRootPathKind };
+}): ResolvedRootPath {
+  return {
+    absolutePath: params.absolutePath,
+    canonicalPath: params.canonicalPath,
+    rootPath: params.rootPath,
+    rootCanonicalPath: params.rootCanonicalPath,
+    relativePath: relativeInsideRoot(params.rootCanonicalPath, params.canonicalPath),
+    exists: params.kind.exists,
+    kind: params.kind.kind,
+  };
+}
+
+async function resolvePathViaExistingAncestor(targetPath: string): Promise<string> {
+  const normalized = path.resolve(targetPath);
+  let cursor = normalized;
+  const missingSuffix: string[] = [];
+
+  while (!isFilesystemRoot(cursor) && !(await pathExists(cursor))) {
+    missingSuffix.unshift(path.basename(cursor));
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+
+  if (!(await pathExists(cursor))) {
+    return normalized;
+  }
+
+  try {
+    const resolvedAncestor = path.resolve(await fsp.realpath(cursor));
+    if (missingSuffix.length === 0) {
+      return resolvedAncestor;
+    }
+    return path.resolve(resolvedAncestor, ...missingSuffix);
+  } catch {
+    return normalized;
+  }
+}
+
+export function resolvePathViaExistingAncestorSync(targetPath: string): string {
+  const normalized = path.resolve(targetPath);
+  let cursor = normalized;
+  const missingSuffix: string[] = [];
+
+  while (!isFilesystemRoot(cursor) && !fs.existsSync(cursor)) {
+    missingSuffix.unshift(path.basename(cursor));
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+
+  if (!fs.existsSync(cursor)) {
+    return normalized;
+  }
+
+  try {
+    // Keep sync behavior aligned with async (`fsp.realpath`) to avoid
+    // platform-specific canonical alias drift (notably on Windows).
+    const resolvedAncestor = path.resolve(fs.realpathSync(cursor));
+    if (missingSuffix.length === 0) {
+      return resolvedAncestor;
+    }
+    return path.resolve(resolvedAncestor, ...missingSuffix);
+  } catch {
+    return normalized;
+  }
+}
+
+async function getPathKind(
+  absolutePath: string,
+  preserveFinalSymlink: boolean,
+): Promise<{ exists: boolean; kind: ResolvedRootPathKind }> {
+  try {
+    const stat = preserveFinalSymlink
+      ? await fsp.lstat(absolutePath)
+      : await fsp.stat(absolutePath);
+    return { exists: true, kind: toResolvedKind(stat) };
+  } catch (error) {
+    if (isNotFoundPathError(error)) {
+      return { exists: false, kind: "missing" };
+    }
+    throw error;
+  }
+}
+
+function getPathKindSync(
+  absolutePath: string,
+  preserveFinalSymlink: boolean,
+): { exists: boolean; kind: ResolvedRootPathKind } {
+  try {
+    const stat = preserveFinalSymlink ? fs.lstatSync(absolutePath) : fs.statSync(absolutePath);
+    return { exists: true, kind: toResolvedKind(stat) };
+  } catch (error) {
+    if (isNotFoundPathError(error)) {
+      return { exists: false, kind: "missing" };
+    }
+    throw error;
+  }
+}
+
+function toResolvedKind(stat: fs.Stats): ResolvedRootPathKind {
+  if (stat.isFile()) {
+    return "file";
+  }
+  if (stat.isDirectory()) {
+    return "directory";
+  }
+  if (stat.isSymbolicLink()) {
+    return "symlink";
+  }
+  return "other";
+}
+
+function relativeInsideRoot(rootPath: string, targetPath: string): string {
+  const relative = path.relative(path.resolve(rootPath), path.resolve(targetPath));
+  if (!relative || relative === ".") {
+    return "";
+  }
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return "";
+  }
+  return relative;
+}
+
+function assertInsideBoundary(params: {
+  boundaryLabel: string;
+  rootCanonicalPath: string;
+  candidatePath: string;
+  absolutePath: string;
+}): void {
+  if (isPathInside(params.rootCanonicalPath, params.candidatePath)) {
+    return;
+  }
+  throw new Error(
+    `Path resolves outside ${params.boundaryLabel} (${shortPath(params.rootCanonicalPath)}): ${shortPath(params.absolutePath)}`,
+  );
+}
+
+function pathEscapeError(params: {
+  boundaryLabel: string;
+  rootPath: string;
+  absolutePath: string;
+}): Error {
+  return new Error(
+    `Path escapes ${params.boundaryLabel} (${shortPath(params.rootPath)}): ${shortPath(params.absolutePath)}`,
+  );
+}
+
+function symlinkEscapeError(params: {
+  boundaryLabel: string;
+  rootCanonicalPath: string;
+  symlinkPath: string;
+}): Error {
+  return new Error(
+    `Symlink escapes ${params.boundaryLabel} (${shortPath(params.rootCanonicalPath)}): ${shortPath(params.symlinkPath)}`,
+  );
+}
+
+function shortPath(value: string): string {
+  const home = os.homedir();
+  if (value.startsWith(home)) {
+    return `~${value.slice(home.length)}`;
+  }
+  return value;
+}
+
+function isFilesystemRoot(candidate: string): boolean {
+  return path.parse(candidate).root === candidate;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fsp.lstat(targetPath);
+    return true;
+  } catch (error) {
+    if (isNotFoundPathError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function resolveSymlinkHopPath(symlinkPath: string): Promise<string> {
+  try {
+    return path.resolve(await fsp.realpath(symlinkPath));
+  } catch (error) {
+    if (!isNotFoundPathError(error)) {
+      throw error;
+    }
+    const linkTarget = await fsp.readlink(symlinkPath);
+    const linkAbsolute = path.resolve(path.dirname(symlinkPath), linkTarget);
+    return resolvePathViaExistingAncestor(linkAbsolute);
+  }
+}
+
+function resolveSymlinkHopPathSync(symlinkPath: string): string {
+  try {
+    return path.resolve(fs.realpathSync(symlinkPath));
+  } catch (error) {
+    if (!isNotFoundPathError(error)) {
+      throw error;
+    }
+    const linkTarget = fs.readlinkSync(symlinkPath);
+    const linkAbsolute = path.resolve(path.dirname(symlinkPath), linkTarget);
+    return resolvePathViaExistingAncestorSync(linkAbsolute);
+  }
+}

--- a/src/root-paths.ts
+++ b/src/root-paths.ts
@@ -1,0 +1,429 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { FsSafeError } from "./errors.js";
+import { isNotFoundPathError, isPathInside } from "./path.js";
+import { root as openRoot } from "./root.js";
+
+type InvalidPathResult = { ok: false; error: string };
+type ResolvePathsWithinRootParams = {
+  rootDir: string;
+  requestedPaths: string[];
+  scopeLabel: string;
+};
+type ResolvePathsWithinRootResult = { ok: true; paths: string[] } | InvalidPathResult;
+export type PathScopeResolveOptions = {
+  defaultName?: string;
+};
+export type PathScopeOptions = {
+  label: string;
+};
+export type PathScope = {
+  rootDir: string;
+  label: string;
+  resolve(
+    requestedPath: string,
+    options?: PathScopeResolveOptions,
+  ): { ok: true; path: string } | { ok: false; error: string };
+  resolveAll(requestedPaths: string[]): ResolvePathsWithinRootResult;
+  existing(requestedPaths: string[]): Promise<ResolvePathsWithinRootResult>;
+  files(requestedPaths: string[]): Promise<ResolvePathsWithinRootResult>;
+  writable(
+    requestedPath: string,
+    options?: PathScopeResolveOptions,
+  ): Promise<{ ok: true; path: string } | { ok: false; error: string }>;
+  ensureDir(
+    requestedPath: string,
+    options?: PathScopeResolveOptions & { mode?: number },
+  ): Promise<{ ok: true; path: string } | { ok: false; error: string }>;
+};
+
+function invalidPath(scopeLabel: string): InvalidPathResult {
+  return {
+    ok: false,
+    error: `Invalid path: must stay within ${scopeLabel}`,
+  };
+}
+
+async function resolveRealPathIfExists(targetPath: string): Promise<string | undefined> {
+  try {
+    return await fs.realpath(targetPath);
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveTrustedRootRealPath(rootDir: string): Promise<string | undefined> {
+  try {
+    const rootLstat = await fs.lstat(rootDir);
+    if (!rootLstat.isDirectory() || rootLstat.isSymbolicLink()) {
+      return undefined;
+    }
+    return await fs.realpath(rootDir);
+  } catch {
+    return undefined;
+  }
+}
+
+async function validateCanonicalPathWithinRoot(params: {
+  rootRealPath: string;
+  candidatePath: string;
+  expect: "directory" | "file";
+}): Promise<"ok" | "not-found" | "invalid"> {
+  try {
+    const candidateLstat = await fs.lstat(params.candidatePath);
+    if (candidateLstat.isSymbolicLink()) {
+      return "invalid";
+    }
+    if (params.expect === "directory" && !candidateLstat.isDirectory()) {
+      return "invalid";
+    }
+    if (params.expect === "file" && !candidateLstat.isFile()) {
+      return "invalid";
+    }
+    if (params.expect === "file" && candidateLstat.nlink > 1) {
+      return "invalid";
+    }
+    const candidateRealPath = await fs.realpath(params.candidatePath);
+    return isPathInside(params.rootRealPath, candidateRealPath) ? "ok" : "invalid";
+  } catch (err) {
+    return isNotFoundPathError(err) ? "not-found" : "invalid";
+  }
+}
+
+export function resolvePathWithinRoot(params: {
+  rootDir: string;
+  requestedPath: string;
+  scopeLabel: string;
+  defaultFileName?: string;
+}): { ok: true; path: string } | { ok: false; error: string } {
+  const root = path.resolve(params.rootDir);
+  const raw = params.requestedPath.trim();
+  if (!raw) {
+    if (!params.defaultFileName) {
+      return { ok: false, error: "path is required" };
+    }
+    return { ok: true, path: path.join(root, params.defaultFileName) };
+  }
+  const resolved = path.resolve(root, raw);
+  const rel = path.relative(root, resolved);
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+    return { ok: false, error: `Invalid path: must stay within ${params.scopeLabel}` };
+  }
+  return { ok: true, path: resolved };
+}
+
+export async function resolveWritablePathWithinRoot(params: {
+  rootDir: string;
+  requestedPath: string;
+  scopeLabel: string;
+  defaultFileName?: string;
+}): Promise<{ ok: true; path: string } | { ok: false; error: string }> {
+  const lexical = resolvePathWithinRoot(params);
+  if (!lexical.ok) {
+    return lexical;
+  }
+
+  const rootDir = path.resolve(params.rootDir);
+  const rootRealPath = await resolveTrustedRootRealPath(rootDir);
+  if (!rootRealPath) {
+    return invalidPath(params.scopeLabel);
+  }
+
+  const requestedPath = lexical.path;
+  const parentDir = path.dirname(requestedPath);
+  const parentStatus = await validateCanonicalPathWithinRoot({
+    rootRealPath,
+    candidatePath: parentDir,
+    expect: "directory",
+  });
+  if (parentStatus !== "ok") {
+    return invalidPath(params.scopeLabel);
+  }
+
+  const targetStatus = await validateCanonicalPathWithinRoot({
+    rootRealPath,
+    candidatePath: requestedPath,
+    expect: "file",
+  });
+  if (targetStatus === "invalid") {
+    return invalidPath(params.scopeLabel);
+  }
+
+  return lexical;
+}
+
+async function resolveNearestExistingPath(targetPath: string): Promise<string> {
+  let current = path.resolve(targetPath);
+  while (true) {
+    try {
+      await fs.lstat(current);
+      return current;
+    } catch (err) {
+      if (!isNotFoundPathError(err)) {
+        throw err;
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(`failed to resolve existing path for ${targetPath}`);
+    }
+    current = parent;
+  }
+}
+
+async function assertNoSymlinkSegments(params: {
+  rootDir: string;
+  targetPath: string;
+  scopeLabel: string;
+}): Promise<void> {
+  const relative = path.relative(params.rootDir, params.targetPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Invalid path: must stay within ${params.scopeLabel}`);
+  }
+  let current = params.rootDir;
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    try {
+      const stat = await fs.lstat(current);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Invalid path: must not traverse symlinks within ${params.scopeLabel}`);
+      }
+      if (!stat.isDirectory()) {
+        throw new Error(
+          `Invalid path: existing segment must be a directory within ${params.scopeLabel}`,
+        );
+      }
+    } catch (err) {
+      if (isNotFoundPathError(err)) {
+        return;
+      }
+      throw err;
+    }
+  }
+}
+
+export async function ensureDirectoryWithinRoot(params: {
+  rootDir: string;
+  requestedPath: string;
+  scopeLabel: string;
+  defaultDirName?: string;
+  mode?: number;
+}): Promise<{ ok: true; path: string } | { ok: false; error: string }> {
+  const lexical = resolvePathWithinRoot({
+    rootDir: params.rootDir,
+    requestedPath: params.requestedPath,
+    scopeLabel: params.scopeLabel,
+    defaultFileName: params.defaultDirName,
+  });
+  if (!lexical.ok) {
+    return lexical;
+  }
+
+  const rootDir = path.resolve(params.rootDir);
+  const targetPath = path.resolve(lexical.path);
+  try {
+    const rootStat = await fs.lstat(rootDir);
+    if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+      return invalidPath(params.scopeLabel);
+    }
+    await assertNoSymlinkSegments({ rootDir, targetPath, scopeLabel: params.scopeLabel });
+    const rootReal = await fs.realpath(rootDir);
+    const nearestExistingPath = await resolveNearestExistingPath(targetPath);
+    const nearestExistingReal = await fs.realpath(nearestExistingPath);
+    if (!isPathInside(rootReal, nearestExistingReal)) {
+      return invalidPath(params.scopeLabel);
+    }
+    const relative = path.relative(rootDir, targetPath);
+    let current = rootDir;
+    for (const segment of relative.split(path.sep).filter(Boolean)) {
+      current = path.join(current, segment);
+      while (true) {
+        try {
+          const stat = await fs.lstat(current);
+          if (stat.isSymbolicLink() || !stat.isDirectory()) {
+            return invalidPath(params.scopeLabel);
+          }
+          break;
+        } catch (err) {
+          if (!isNotFoundPathError(err)) {
+            throw err;
+          }
+          try {
+            await fs.mkdir(current, { mode: params.mode });
+          } catch (mkdirErr) {
+            if (isNotFoundPathError(mkdirErr)) {
+              throw mkdirErr;
+            }
+            if ((mkdirErr as NodeJS.ErrnoException).code === "EEXIST") {
+              continue;
+            }
+            throw mkdirErr;
+          }
+        }
+      }
+    }
+    const targetReal = await fs.realpath(targetPath);
+    if (!isPathInside(rootReal, targetReal)) {
+      return invalidPath(params.scopeLabel);
+    }
+    return { ok: true, path: targetPath };
+  } catch {
+    return invalidPath(params.scopeLabel);
+  }
+}
+
+export function resolvePathsWithinRoot(
+  params: ResolvePathsWithinRootParams,
+): ResolvePathsWithinRootResult {
+  const resolvedPaths: string[] = [];
+  for (const raw of params.requestedPaths) {
+    const pathResult = resolvePathWithinRoot({
+      rootDir: params.rootDir,
+      requestedPath: raw,
+      scopeLabel: params.scopeLabel,
+    });
+    if (!pathResult.ok) {
+      return { ok: false, error: pathResult.error };
+    }
+    resolvedPaths.push(pathResult.path);
+  }
+  return { ok: true, paths: resolvedPaths };
+}
+
+export async function resolveExistingPathsWithinRoot(
+  params: ResolvePathsWithinRootParams,
+): Promise<ResolvePathsWithinRootResult> {
+  return await resolveCheckedPathsWithinRoot(params, true);
+}
+
+export async function resolveStrictExistingPathsWithinRoot(
+  params: ResolvePathsWithinRootParams,
+): Promise<ResolvePathsWithinRootResult> {
+  return await resolveCheckedPathsWithinRoot(params, false);
+}
+
+export function pathScope(rootDir: string, options: PathScopeOptions): PathScope {
+  const base = { rootDir, scopeLabel: options.label };
+  return {
+    rootDir,
+    label: options.label,
+    resolve: (requestedPath, pathOptions) =>
+      resolvePathWithinRoot({
+        ...base,
+        requestedPath,
+        defaultFileName: pathOptions?.defaultName,
+      }),
+    resolveAll: (requestedPaths) =>
+      resolvePathsWithinRoot({
+        ...base,
+        requestedPaths,
+      }),
+    existing: (requestedPaths) =>
+      resolveExistingPathsWithinRoot({
+        ...base,
+        requestedPaths,
+      }),
+    files: (requestedPaths) =>
+      resolveStrictExistingPathsWithinRoot({
+        ...base,
+        requestedPaths,
+      }),
+    writable: (requestedPath, pathOptions) =>
+      resolveWritablePathWithinRoot({
+        ...base,
+        requestedPath,
+        defaultFileName: pathOptions?.defaultName,
+      }),
+    ensureDir: (requestedPath, pathOptions) =>
+      ensureDirectoryWithinRoot({
+        ...base,
+        requestedPath,
+        defaultDirName: pathOptions?.defaultName,
+        mode: pathOptions?.mode,
+      }),
+  };
+}
+
+async function resolveCheckedPathsWithinRoot(
+  params: ResolvePathsWithinRootParams,
+  allowMissingFallback: boolean,
+): Promise<ResolvePathsWithinRootResult> {
+  const rootDir = path.resolve(params.rootDir);
+  const rootRealPath = await resolveRealPathIfExists(rootDir);
+  const root = rootRealPath ? await openRoot(rootDir) : undefined;
+
+  const isInRoot = (relativePath: string) =>
+    Boolean(relativePath) && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+
+  const resolveExistingRelativePath = async (
+    requestedPath: string,
+  ): Promise<
+    { ok: true; relativePath: string; fallbackPath: string } | { ok: false; error: string }
+  > => {
+    const raw = requestedPath.trim();
+    const lexicalPathResult = resolvePathWithinRoot({
+      rootDir,
+      requestedPath,
+      scopeLabel: params.scopeLabel,
+    });
+    if (lexicalPathResult.ok) {
+      return {
+        ok: true,
+        relativePath: path.relative(rootDir, lexicalPathResult.path),
+        fallbackPath: lexicalPathResult.path,
+      };
+    }
+    if (!rootRealPath || !raw || !path.isAbsolute(raw)) {
+      return lexicalPathResult;
+    }
+    try {
+      const resolvedExistingPath = await fs.realpath(raw);
+      const relativePath = path.relative(rootRealPath, resolvedExistingPath);
+      if (!isInRoot(relativePath)) {
+        return lexicalPathResult;
+      }
+      return {
+        ok: true,
+        relativePath,
+        fallbackPath: resolvedExistingPath,
+      };
+    } catch {
+      return lexicalPathResult;
+    }
+  };
+
+  const resolvedPaths: string[] = [];
+  for (const raw of params.requestedPaths) {
+    const pathResult = await resolveExistingRelativePath(raw);
+    if (!pathResult.ok) {
+      return { ok: false, error: pathResult.error };
+    }
+
+    let opened: Awaited<ReturnType<NonNullable<typeof root>["open"]>> | undefined;
+    try {
+      if (!root) {
+        throw new FsSafeError("not-found", "root dir not found");
+      }
+      opened = await root.open(pathResult.relativePath);
+      resolvedPaths.push(opened.realPath);
+    } catch (err) {
+      if (allowMissingFallback && err instanceof FsSafeError && err.code === "not-found") {
+        resolvedPaths.push(pathResult.fallbackPath);
+        continue;
+      }
+      if (err instanceof FsSafeError && err.code === "outside-workspace") {
+        return {
+          ok: false,
+          error: `File is outside ${params.scopeLabel}`,
+        };
+      }
+      return {
+        ok: false,
+        error: `Invalid path: must stay within ${params.scopeLabel} and be a regular non-symlink file`,
+      };
+    } finally {
+      await opened?.handle.close().catch(() => {});
+    }
+  }
+  return { ok: true, paths: resolvedPaths };
+}

--- a/src/root.ts
+++ b/src/root.ts
@@ -1,0 +1,1441 @@
+import { randomUUID } from "node:crypto";
+import type { Stats } from "node:fs";
+import { constants as fsConstants } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+import { FsSafeError } from "./errors.js";
+import { sameFileIdentity } from "./file-identity.js";
+import { isPinnedPathHelperSpawnError, runPinnedPathHelper } from "./pinned-path.js";
+import { runPinnedWriteHelper } from "./pinned-write.js";
+import { expandHomePrefix } from "./home-dir.js";
+import { assertNoPathAliasEscape, PATH_ALIAS_POLICIES } from "./path-policy.js";
+import {
+  hasNodeErrorCode,
+  isNotFoundPathError,
+  isPathInside,
+  isSymlinkOpenError,
+} from "./path.js";
+import { helperReaddir, helperStat, runPinnedHelper } from "./pinned-helper.js";
+import { resolveRootPath } from "./root-path.js";
+import { getFsSafeTestHooks } from "./test-hooks.js";
+import type { SafeDirEntry, SafePathStat } from "./types.js";
+
+export type SafeOpenResult = {
+  handle: FileHandle;
+  realPath: string;
+  stat: Stats;
+};
+
+export type SafeLocalReadResult = {
+  buffer: Buffer;
+  realPath: string;
+  stat: Stats;
+};
+
+export type SafeRootContext = {
+  rootDir: string;
+  rootReal: string;
+  rootWithSep: string;
+};
+
+export type SafeRootOptions = {
+  rootDir: string;
+  defaults?: SafeRootDefaults;
+};
+
+export type SymlinkPolicy = "reject" | "follow-within-root";
+export type HardlinkPolicy = "reject" | "allow";
+
+export type RootDefaults = {
+  encoding?: BufferEncoding;
+  hardlinks?: HardlinkPolicy;
+  maxBytes?: number;
+  mkdir?: boolean;
+  nonBlockingRead?: boolean;
+  symlinks?: SymlinkPolicy;
+};
+
+export type SafeRootDefaults = RootDefaults;
+
+export type SafeRootReadOptions = Pick<
+  RootDefaults,
+  "hardlinks" | "maxBytes" | "nonBlockingRead" | "symlinks"
+>;
+
+export type SafeRootOpenOptions = Omit<SafeRootReadOptions, "maxBytes">;
+
+export type SafeRootWriteOptions = Pick<RootDefaults, "encoding" | "mkdir">;
+
+export type SafeRootOpenWritableOptions = Pick<RootDefaults, "mkdir"> & {
+  mode?: number;
+  truncateExisting?: boolean;
+  append?: boolean;
+};
+
+export type SafeRootCopyOptions = Pick<RootDefaults, "maxBytes" | "mkdir"> & {
+  sourceHardlinks?: HardlinkPolicy;
+};
+
+export type SafeRootWriteJsonOptions = SafeRootWriteOptions & {
+  replacer?: Parameters<typeof JSON.stringify>[1];
+  space?: Parameters<typeof JSON.stringify>[2];
+  trailingNewline?: boolean;
+};
+
+export type SafeRootCreateOptions = SafeRootWriteOptions;
+export type SafeRootCreateJsonOptions = SafeRootWriteJsonOptions;
+
+export type SafeRootAppendOptions = SafeRootWriteOptions & {
+  prependNewlineIfNeeded?: boolean;
+};
+
+type SafeRootReadParams = SafeRootReadOptions;
+
+function logWarn(message: string): void {
+  if (process.env.FS_SAFE_DEBUG_WARNINGS === "1") {
+    console.warn(message);
+  }
+}
+
+const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsConstants;
+const NONBLOCK_OPEN_FLAG = "O_NONBLOCK" in fsConstants ? fsConstants.O_NONBLOCK : 0;
+const OPEN_READ_FLAGS = fsConstants.O_RDONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+const OPEN_READ_NONBLOCK_FLAGS = OPEN_READ_FLAGS | NONBLOCK_OPEN_FLAG;
+const OPEN_READ_FOLLOW_FLAGS = fsConstants.O_RDONLY;
+const OPEN_READ_FOLLOW_NONBLOCK_FLAGS = OPEN_READ_FOLLOW_FLAGS | NONBLOCK_OPEN_FLAG;
+const OPEN_WRITE_EXISTING_FLAGS =
+  fsConstants.O_WRONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+const OPEN_WRITE_CREATE_FLAGS =
+  fsConstants.O_WRONLY |
+  fsConstants.O_CREAT |
+  fsConstants.O_EXCL |
+  (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+const OPEN_APPEND_EXISTING_FLAGS =
+  fsConstants.O_RDWR | fsConstants.O_APPEND | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+const OPEN_APPEND_CREATE_FLAGS =
+  fsConstants.O_RDWR |
+  fsConstants.O_APPEND |
+  fsConstants.O_CREAT |
+  fsConstants.O_EXCL |
+  (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+
+const ensureTrailingSep = (value: string) => (value.endsWith(path.sep) ? value : value + path.sep);
+
+let cachedHomePath: { raw: string; real: string } | undefined;
+
+async function expandRelativePathWithHome(relativePath: string): Promise<string> {
+  const rawHome = process.env.HOME || process.env.USERPROFILE || os.homedir();
+  if (cachedHomePath?.raw !== rawHome) {
+    let realHome = rawHome;
+    try {
+      realHome = await fs.realpath(rawHome);
+    } catch {
+      // If the home dir cannot be canonicalized, keep lexical expansion behavior.
+    }
+    cachedHomePath = { raw: rawHome, real: realHome };
+  }
+  return expandHomePrefix(relativePath, { home: cachedHomePath.real });
+}
+
+async function openVerifiedLocalFile(
+  filePath: string,
+  options?: {
+    hardlinks?: HardlinkPolicy;
+    nonBlockingRead?: boolean;
+    symlinks?: SymlinkPolicy;
+  },
+): Promise<SafeOpenResult> {
+  const fsSafeTestHooks = getFsSafeTestHooks();
+  // Reject directories before opening so we never surface EISDIR to callers (e.g. tool
+  // results that get sent to messaging channels). See openclaw/openclaw#31186.
+  try {
+    const preStat = await fs.lstat(filePath);
+    if (preStat.isDirectory()) {
+      throw new FsSafeError("not-file", "not a file");
+    }
+    await fsSafeTestHooks?.afterPreOpenLstat?.(filePath);
+  } catch (err) {
+    if (err instanceof FsSafeError) {
+      throw err;
+    }
+    // ENOENT and other lstat errors: fall through and let fs.open handle.
+  }
+
+  let handle: FileHandle;
+  try {
+    const openFlags = options?.symlinks === "follow-within-root"
+      ? options?.nonBlockingRead
+        ? OPEN_READ_FOLLOW_NONBLOCK_FLAGS
+        : OPEN_READ_FOLLOW_FLAGS
+      : options?.nonBlockingRead
+        ? OPEN_READ_NONBLOCK_FLAGS
+        : OPEN_READ_FLAGS;
+    await fsSafeTestHooks?.beforeOpen?.(filePath, openFlags);
+    handle = await fs.open(filePath, openFlags);
+    try {
+      await fsSafeTestHooks?.afterOpen?.(filePath, handle);
+    } catch (err) {
+      await handle.close().catch(() => {});
+      throw err;
+    }
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      throw new FsSafeError("not-found", "file not found");
+    }
+    if (isSymlinkOpenError(err)) {
+      throw new FsSafeError("symlink", "symlink open blocked", { cause: err });
+    }
+    // Defensive: if open still throws EISDIR (e.g. race), sanitize so it never leaks.
+    if (hasNodeErrorCode(err, "EISDIR")) {
+      throw new FsSafeError("not-file", "not a file");
+    }
+    throw err;
+  }
+
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new FsSafeError("not-file", "not a file");
+    }
+    if (options?.hardlinks === "reject" && stat.nlink > 1) {
+      throw new FsSafeError("hardlink", "hardlinked path not allowed");
+    }
+
+    if (options?.symlinks === "follow-within-root") {
+      const pathStat = await fs.stat(filePath);
+      if (!sameFileIdentity(stat, pathStat)) {
+        throw new FsSafeError("path-mismatch", "path changed during read");
+      }
+    } else {
+      const pathStat = await fs.lstat(filePath);
+      if (pathStat.isSymbolicLink()) {
+        throw new FsSafeError("symlink", "symlink not allowed");
+      }
+      if (!sameFileIdentity(stat, pathStat)) {
+        throw new FsSafeError("path-mismatch", "path changed during read");
+      }
+    }
+
+    const realPath = await resolveOpenedFileRealPathForHandle(handle, filePath);
+    const realStat = await fs.stat(realPath);
+    if (options?.hardlinks === "reject" && realStat.nlink > 1) {
+      throw new FsSafeError("hardlink", "hardlinked path not allowed");
+    }
+    if (!sameFileIdentity(stat, realStat)) {
+      throw new FsSafeError("path-mismatch", "path mismatch");
+    }
+
+    return { handle, realPath, stat };
+  } catch (err) {
+    await handle.close().catch(() => {});
+    if (err instanceof FsSafeError) {
+      throw err;
+    }
+    if (isNotFoundPathError(err)) {
+      throw new FsSafeError("not-found", "file not found");
+    }
+    throw err;
+  }
+}
+
+async function resolveSafeRootContext(rootDir: string): Promise<SafeRootContext> {
+  let rootReal: string;
+  try {
+    rootReal = await fs.realpath(rootDir);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      throw new FsSafeError("not-found", "root dir not found");
+    }
+    throw err;
+  }
+  return {
+    rootDir: path.resolve(rootDir),
+    rootReal,
+    rootWithSep: ensureTrailingSep(rootReal),
+  };
+}
+
+async function resolvePathInSafeRoot(
+  root: SafeRootContext,
+  relativePath: string,
+): Promise<{ rootReal: string; rootWithSep: string; resolved: string }> {
+  const expanded = await expandRelativePathWithHome(relativePath);
+  const resolved = path.resolve(root.rootWithSep, expanded);
+  if (!isPathInside(root.rootWithSep, resolved)) {
+    throw new FsSafeError("outside-workspace", "file is outside workspace root");
+  }
+  return { rootReal: root.rootReal, rootWithSep: root.rootWithSep, resolved };
+}
+
+async function resolvePathWithinRoot(params: {
+  rootDir: string;
+  relativePath: string;
+}): Promise<{ rootReal: string; rootWithSep: string; resolved: string }> {
+  return await resolvePathInSafeRoot(
+    await resolveSafeRootContext(params.rootDir),
+    params.relativePath,
+  );
+}
+
+export class SafeRoot {
+  readonly rootDir: string;
+  readonly rootReal: string;
+  readonly rootWithSep: string;
+  readonly defaults: SafeRootDefaults;
+
+  constructor(context: SafeRootContext, defaults: SafeRootDefaults = {}) {
+    this.rootDir = context.rootDir;
+    this.rootReal = context.rootReal;
+    this.rootWithSep = context.rootWithSep;
+    this.defaults = defaults;
+  }
+
+  private get context(): SafeRootContext {
+    return {
+      rootDir: this.rootDir,
+      rootReal: this.rootReal,
+      rootWithSep: this.rootWithSep,
+    };
+  }
+
+  async resolve(relativePath: string): Promise<string> {
+    return (await resolvePathInSafeRoot(this.context, relativePath)).resolved;
+  }
+
+  async open(relativePath: string, options: SafeRootOpenOptions = {}): Promise<SafeOpenResult> {
+    return await openFileInSafeRoot(this.context, {
+      relativePath,
+      ...readDefaults(this.defaults),
+      ...options,
+    });
+  }
+
+  async read(
+    relativePath: string,
+    options: SafeRootReadOptions = {},
+  ): Promise<SafeLocalReadResult> {
+    return await readFileInSafeRoot(this.context, {
+      relativePath,
+      ...readDefaults(this.defaults),
+      ...options,
+    });
+  }
+
+  async readBytes(relativePath: string, options: SafeRootReadOptions = {}): Promise<Buffer> {
+    return (await this.read(relativePath, options)).buffer;
+  }
+
+  async readText(
+    relativePath: string,
+    options: SafeRootReadOptions & { encoding?: BufferEncoding } = {},
+  ): Promise<string> {
+    const { encoding = this.defaults.encoding ?? "utf8", ...readOptions } = options;
+    return (await this.read(relativePath, readOptions)).buffer.toString(encoding);
+  }
+
+  async readJson<T = unknown>(
+    relativePath: string,
+    options: SafeRootReadOptions & { encoding?: BufferEncoding } = {},
+  ): Promise<T> {
+    return JSON.parse(await this.readText(relativePath, options)) as T;
+  }
+
+  async readPath(
+    filePath: string,
+    options: Pick<SafeRootReadOptions, "hardlinks" | "maxBytes"> = {},
+  ): Promise<SafeLocalReadResult> {
+    return await readPathInSafeRoot(this.context, {
+      filePath,
+      ...readDefaults(this.defaults),
+      ...options,
+    });
+  }
+
+  reader(options: Pick<SafeRootReadOptions, "hardlinks" | "maxBytes"> = {}) {
+    return async (filePath: string): Promise<Buffer> => {
+      return (await this.readPath(filePath, options)).buffer;
+    };
+  }
+
+  async openWritable(
+    relativePath: string,
+    options: SafeRootOpenWritableOptions = {},
+  ): Promise<SafeWritableOpenResult> {
+    return await openWritableFileInSafeRoot(this.context, {
+      relativePath,
+      mkdir: this.defaults.mkdir,
+      ...options,
+    });
+  }
+
+  async append(
+    relativePath: string,
+    data: string | Buffer,
+    options: SafeRootAppendOptions = {},
+  ): Promise<void> {
+    await appendFileInSafeRoot(this.context, {
+      relativePath,
+      data,
+      encoding: this.defaults.encoding,
+      mkdir: this.defaults.mkdir,
+      ...options,
+    });
+  }
+
+  async remove(relativePath: string): Promise<void> {
+    await removePathInSafeRoot(this.context, relativePath);
+  }
+
+  async mkdir(relativePath: string, options: { allowRoot?: boolean } = {}): Promise<void> {
+    await mkdirPathInSafeRoot(this.context, { relativePath, ...options });
+  }
+
+  async write(
+    relativePath: string,
+    data: string | Buffer,
+    options: SafeRootWriteOptions = {},
+  ): Promise<void> {
+    await writeFileInSafeRoot(this.context, {
+      relativePath,
+      data,
+      encoding: this.defaults.encoding,
+      mkdir: this.defaults.mkdir,
+      ...options,
+    });
+  }
+
+  async create(
+    relativePath: string,
+    data: string | Buffer,
+    options: SafeRootCreateOptions = {},
+  ): Promise<boolean> {
+    return await writeFileInSafeRoot(this.context, {
+      relativePath,
+      data,
+      encoding: this.defaults.encoding,
+      mkdir: this.defaults.mkdir,
+      ...options,
+      overwrite: false,
+    });
+  }
+
+  async writeJson(
+    relativePath: string,
+    data: unknown,
+    options: SafeRootWriteJsonOptions = {},
+  ): Promise<void> {
+    const { replacer, space, trailingNewline = true, ...writeOptions } = options;
+    const json = JSON.stringify(data, replacer, space);
+    await this.write(relativePath, trailingNewline ? `${json}\n` : json, writeOptions);
+  }
+
+  async createJson(
+    relativePath: string,
+    data: unknown,
+    options: SafeRootCreateJsonOptions = {},
+  ): Promise<boolean> {
+    const { replacer, space, trailingNewline = true, ...writeOptions } = options;
+    const json = JSON.stringify(data, replacer, space);
+    return await this.create(relativePath, trailingNewline ? `${json}\n` : json, writeOptions);
+  }
+
+  async copyFrom(
+    sourcePath: string,
+    relativePath: string,
+    options: SafeRootCopyOptions = {},
+  ): Promise<void> {
+    await copyFileInSafeRoot(this.context, {
+      sourcePath,
+      relativePath,
+      maxBytes: this.defaults.maxBytes,
+      mkdir: this.defaults.mkdir,
+      ...options,
+    });
+  }
+
+  async stat(relativePath: string): Promise<SafePathStat> {
+    return await helperStat(this.rootReal, relativePath);
+  }
+
+  async list(relativePath: string, options?: { withFileTypes?: false }): Promise<string[]>;
+  async list(relativePath: string, options: { withFileTypes: true }): Promise<SafeDirEntry[]>;
+  async list(
+    relativePath: string,
+    options: { withFileTypes?: boolean } = {},
+  ): Promise<string[] | SafeDirEntry[]> {
+    return options.withFileTypes === true
+      ? await helperReaddir(this.rootReal, relativePath, true)
+      : await helperReaddir(this.rootReal, relativePath, false);
+  }
+
+  async move(from: string, to: string, options: { overwrite?: boolean } = {}): Promise<void> {
+    await runPinnedHelper<void>("rename", this.rootReal, {
+      from,
+      overwrite: options.overwrite ?? true,
+      to,
+    });
+  }
+}
+
+function readDefaults(defaults: RootDefaults): SafeRootReadParams {
+  return {
+    hardlinks: defaults.hardlinks,
+    maxBytes: defaults.maxBytes,
+    nonBlockingRead: defaults.nonBlockingRead,
+    symlinks: defaults.symlinks,
+  };
+}
+
+export async function root(
+  rootDir: string,
+  defaults: RootDefaults = {},
+): Promise<SafeRoot> {
+  return new SafeRoot(await resolveSafeRootContext(rootDir), defaults);
+}
+
+async function openFileInSafeRoot(
+  root: SafeRootContext,
+  params: {
+    relativePath: string;
+    hardlinks?: HardlinkPolicy;
+    nonBlockingRead?: boolean;
+    symlinks?: SymlinkPolicy;
+  },
+): Promise<SafeOpenResult> {
+  const { rootWithSep, resolved } = await resolvePathInSafeRoot(root, params.relativePath);
+
+  let opened: SafeOpenResult;
+  try {
+    opened = await openVerifiedLocalFile(resolved, {
+      nonBlockingRead: params.nonBlockingRead,
+      symlinks: params.symlinks,
+    });
+  } catch (err) {
+    if (err instanceof FsSafeError) {
+      throw err;
+    }
+    throw err;
+  }
+
+  if (params.hardlinks !== "allow" && opened.stat.nlink > 1) {
+    await opened.handle.close().catch(() => {});
+    throw new FsSafeError("hardlink", "hardlinked path not allowed");
+  }
+
+  if (!isPathInside(rootWithSep, opened.realPath)) {
+    await opened.handle.close().catch(() => {});
+    throw new FsSafeError("outside-workspace", "file is outside workspace root");
+  }
+
+  return opened;
+}
+
+async function readFileInSafeRoot(
+  root: SafeRootContext,
+  params: {
+    relativePath: string;
+    hardlinks?: HardlinkPolicy;
+    nonBlockingRead?: boolean;
+    symlinks?: SymlinkPolicy;
+    maxBytes?: number;
+  },
+): Promise<SafeLocalReadResult> {
+  const opened = await openFileInSafeRoot(root, params);
+  try {
+    return await readOpenedFileSafely({ opened, maxBytes: params.maxBytes });
+  } finally {
+    await opened.handle.close().catch(() => {});
+  }
+}
+
+async function readPathInSafeRoot(
+  root: SafeRootContext,
+  params: {
+    filePath: string;
+    hardlinks?: HardlinkPolicy;
+    maxBytes?: number;
+  },
+): Promise<SafeLocalReadResult> {
+  const rootDir = root.rootDir;
+  const candidatePath = path.isAbsolute(params.filePath)
+    ? path.resolve(params.filePath)
+    : path.resolve(rootDir, params.filePath);
+  const relativePath = path.relative(rootDir, candidatePath);
+  return await readFileInSafeRoot(root, {
+    relativePath,
+    hardlinks: params.hardlinks,
+    maxBytes: params.maxBytes,
+  });
+}
+
+export async function readLocalFileSafely(params: {
+  filePath: string;
+  maxBytes?: number;
+}): Promise<SafeLocalReadResult> {
+  const opened = await openLocalFileSafely({ filePath: params.filePath });
+  try {
+    return await readOpenedFileSafely({ opened, maxBytes: params.maxBytes });
+  } finally {
+    await opened.handle.close().catch(() => {});
+  }
+}
+
+export async function openLocalFileSafely(params: { filePath: string }): Promise<SafeOpenResult> {
+  return await openVerifiedLocalFile(params.filePath);
+}
+
+async function readOpenedFileSafely(params: {
+  opened: SafeOpenResult;
+  maxBytes?: number;
+}): Promise<SafeLocalReadResult> {
+  if (params.maxBytes !== undefined && params.opened.stat.size > params.maxBytes) {
+    throw new FsSafeError(
+      "too-large",
+      `file exceeds limit of ${params.maxBytes} bytes (got ${params.opened.stat.size})`,
+    );
+  }
+  const buffer = await params.opened.handle.readFile();
+  return {
+    buffer,
+    realPath: params.opened.realPath,
+    stat: params.opened.stat,
+  };
+}
+
+export type SafeWritableOpenResult = {
+  handle: FileHandle;
+  createdForWrite: boolean;
+  realPath: string;
+  stat: Stats;
+};
+
+function emitWriteBoundaryWarning(reason: string) {
+  logWarn(`security: fs-safe write boundary warning (${reason})`);
+}
+
+function buildAtomicWriteTempPath(targetPath: string): string {
+  const dir = path.dirname(targetPath);
+  const base = path.basename(targetPath);
+  return path.join(dir, `.${base}.${process.pid}.${randomUUID()}.tmp`);
+}
+
+async function writeTempFileForAtomicReplace(params: {
+  tempPath: string;
+  data: string | Buffer;
+  encoding?: BufferEncoding;
+  mode: number;
+}): Promise<Stats> {
+  const tempHandle = await fs.open(params.tempPath, OPEN_WRITE_CREATE_FLAGS, params.mode);
+  try {
+    if (typeof params.data === "string") {
+      await tempHandle.writeFile(params.data, params.encoding ?? "utf8");
+    } else {
+      await tempHandle.writeFile(params.data);
+    }
+    return await tempHandle.stat();
+  } finally {
+    await tempHandle.close().catch(() => {});
+  }
+}
+
+async function verifyAtomicWriteResult(params: {
+  root: SafeRootContext;
+  targetPath: string;
+  expectedIdentity: { dev: number | bigint; ino: number | bigint };
+}): Promise<void> {
+  const opened = await openVerifiedLocalFile(params.targetPath, { hardlinks: "reject" });
+  try {
+    if (!sameFileIdentity(opened.stat, params.expectedIdentity)) {
+      throw new FsSafeError("path-mismatch", "path changed during write");
+    }
+    if (!isPathInside(params.root.rootWithSep, opened.realPath)) {
+      throw new FsSafeError("outside-workspace", "file is outside workspace root");
+    }
+  } finally {
+    await opened.handle.close().catch(() => {});
+  }
+}
+
+export async function resolveOpenedFileRealPathForHandle(
+  handle: FileHandle,
+  ioPath: string,
+): Promise<string> {
+  const handleStat = await handle.stat();
+  const fdCandidates =
+    process.platform === "linux"
+      ? [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`]
+      : process.platform === "win32"
+        ? []
+        : [`/dev/fd/${handle.fd}`];
+  for (const fdPath of fdCandidates) {
+    try {
+      const fdRealPath = await fs.realpath(fdPath);
+      const fdRealStat = await fs.stat(fdRealPath);
+      if (sameFileIdentity(handleStat, fdRealStat)) {
+        return fdRealPath;
+      }
+    } catch {
+      // try next fd path
+    }
+  }
+
+  try {
+    const ioRealPath = await fs.realpath(ioPath);
+    const ioRealStat = await fs.stat(ioRealPath);
+    if (sameFileIdentity(handleStat, ioRealStat)) {
+      return ioRealPath;
+    }
+  } catch (err) {
+    if (!isNotFoundPathError(err)) {
+      throw err;
+    }
+  }
+  const parentResolved = await resolveOpenedFileRealPathFromParent(handleStat, ioPath);
+  if (parentResolved) {
+    return parentResolved;
+  }
+  throw new FsSafeError("path-mismatch", "unable to resolve opened file path");
+}
+
+async function resolveOpenedFileRealPathFromParent(
+  handleStat: Stats,
+  ioPath: string,
+): Promise<string | null> {
+  let parentReal: string;
+  try {
+    parentReal = await fs.realpath(path.dirname(ioPath));
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      return null;
+    }
+    throw err;
+  }
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(parentReal);
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      return null;
+    }
+    throw err;
+  }
+
+  for (const entry of entries.toSorted()) {
+    const candidatePath = path.join(parentReal, entry);
+    try {
+      const candidateStat = await fs.lstat(candidatePath);
+      if (candidateStat.isFile() && sameFileIdentity(handleStat, candidateStat)) {
+        return await fs.realpath(candidatePath);
+      }
+    } catch (err) {
+      if (!isNotFoundPathError(err)) {
+        throw err;
+      }
+    }
+  }
+  return null;
+}
+
+async function openWritableFileInSafeRoot(
+  root: SafeRootContext,
+  params: {
+    relativePath: string;
+    mkdir?: boolean;
+    mode?: number;
+    truncateExisting?: boolean;
+    append?: boolean;
+  },
+): Promise<SafeWritableOpenResult> {
+  const { rootReal, rootWithSep, resolved } = await resolvePathInSafeRoot(
+    root,
+    params.relativePath,
+  );
+  try {
+    await assertNoPathAliasEscape({
+      absolutePath: resolved,
+      rootPath: rootReal,
+      boundaryLabel: "root",
+    });
+  } catch (err) {
+    throw new FsSafeError("path-alias", "path alias escape blocked", { cause: err });
+  }
+  if (params.mkdir !== false) {
+    await fs.mkdir(path.dirname(resolved), { recursive: true });
+  }
+
+  let ioPath = resolved;
+  try {
+    const resolvedRealPath = await fs.realpath(resolved);
+    if (!isPathInside(rootWithSep, resolvedRealPath)) {
+      throw new FsSafeError("outside-workspace", "file is outside workspace root");
+    }
+    ioPath = resolvedRealPath;
+  } catch (err) {
+    if (err instanceof FsSafeError) {
+      throw err;
+    }
+    if (!isNotFoundPathError(err)) {
+      throw err;
+    }
+  }
+
+  const fileMode = params.mode ?? 0o600;
+
+  let handle: FileHandle;
+  let createdForWrite = false;
+  const existingFlags = params.append ? OPEN_APPEND_EXISTING_FLAGS : OPEN_WRITE_EXISTING_FLAGS;
+  const createFlags = params.append ? OPEN_APPEND_CREATE_FLAGS : OPEN_WRITE_CREATE_FLAGS;
+  try {
+    try {
+      handle = await fs.open(ioPath, existingFlags, fileMode);
+    } catch (err) {
+      if (!isNotFoundPathError(err)) {
+        throw err;
+      }
+      handle = await fs.open(ioPath, createFlags, fileMode);
+      createdForWrite = true;
+    }
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      throw new FsSafeError("not-found", "file not found");
+    }
+    if (isSymlinkOpenError(err)) {
+      throw new FsSafeError("symlink", "symlink open blocked", { cause: err });
+    }
+    throw err;
+  }
+
+  let realPathForCleanup: string | null = null;
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new FsSafeError("invalid-path", "path is not a regular file under root");
+    }
+    if (stat.nlink > 1) {
+      throw new FsSafeError("hardlink", "hardlinked path not allowed");
+    }
+
+    try {
+      const lstat = await fs.lstat(ioPath);
+      if (lstat.isSymbolicLink() || !lstat.isFile()) {
+        throw new FsSafeError(
+          lstat.isSymbolicLink() ? "symlink" : "not-file",
+          "path is not a regular file under root",
+        );
+      }
+      if (!sameFileIdentity(stat, lstat)) {
+        throw new FsSafeError("path-mismatch", "path changed during write");
+      }
+    } catch (err) {
+      if (!isNotFoundPathError(err)) {
+        throw err;
+      }
+    }
+
+    const realPath = await resolveOpenedFileRealPathForHandle(handle, ioPath);
+    realPathForCleanup = realPath;
+    const realStat = await fs.stat(realPath);
+    if (!sameFileIdentity(stat, realStat)) {
+      throw new FsSafeError("path-mismatch", "path mismatch");
+    }
+    if (realStat.nlink > 1) {
+      throw new FsSafeError("hardlink", "hardlinked path not allowed");
+    }
+    if (!isPathInside(rootWithSep, realPath)) {
+      throw new FsSafeError("outside-workspace", "file is outside workspace root");
+    }
+
+    // Truncate only after boundary and identity checks complete. This avoids
+    // irreversible side effects if a symlink target changes before validation.
+    if (params.append !== true && params.truncateExisting !== false && !createdForWrite) {
+      await handle.truncate(0);
+    }
+    return {
+      handle,
+      createdForWrite,
+      realPath,
+      stat,
+    };
+  } catch (err) {
+    const cleanupCreatedPath = createdForWrite && err instanceof FsSafeError;
+    const cleanupPath = realPathForCleanup ?? ioPath;
+    await handle.close().catch(() => {});
+    if (cleanupCreatedPath) {
+      await fs.rm(cleanupPath, { force: true }).catch(() => {});
+    }
+    throw err;
+  }
+}
+
+async function appendFileInSafeRoot(
+  root: SafeRootContext,
+  params: {
+    relativePath: string;
+    data: string | Buffer;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    prependNewlineIfNeeded?: boolean;
+  },
+): Promise<void> {
+  const target = await openWritableFileInSafeRoot(root, {
+    relativePath: params.relativePath,
+    mkdir: params.mkdir,
+    truncateExisting: false,
+    append: true,
+  });
+  try {
+    let prefix = "";
+    if (
+      params.prependNewlineIfNeeded === true &&
+      !target.createdForWrite &&
+      target.stat.size > 0 &&
+      ((typeof params.data === "string" && !params.data.startsWith("\n")) ||
+        (Buffer.isBuffer(params.data) && params.data.length > 0 && params.data[0] !== 0x0a))
+    ) {
+      const lastByte = Buffer.alloc(1);
+      const { bytesRead } = await target.handle.read(lastByte, 0, 1, target.stat.size - 1);
+      if (bytesRead === 1 && lastByte[0] !== 0x0a) {
+        prefix = "\n";
+      }
+    }
+
+    if (typeof params.data === "string") {
+      await target.handle.appendFile(`${prefix}${params.data}`, params.encoding ?? "utf8");
+      return;
+    }
+
+    const payload =
+      prefix.length > 0 ? Buffer.concat([Buffer.from(prefix, "utf8"), params.data]) : params.data;
+    await target.handle.appendFile(payload);
+  } finally {
+    await target.handle.close().catch(() => {});
+  }
+}
+
+async function removePathInSafeRoot(root: SafeRootContext, relativePath: string): Promise<void> {
+  const resolved = await resolvePinnedRemovePathInSafeRoot(root, relativePath);
+  if (process.platform === "win32") {
+    await removePathFallback(resolved);
+    return;
+  }
+  try {
+    await runPinnedPathHelper({
+      operation: "remove",
+      rootPath: resolved.rootReal,
+      relativePath: resolved.relativePosix,
+    });
+  } catch (error) {
+    if (isPinnedPathHelperSpawnError(error)) {
+      await removePathFallback(resolved);
+      return;
+    }
+    throw normalizePinnedPathError(error);
+  }
+}
+
+async function mkdirPathInSafeRoot(
+  root: SafeRootContext,
+  params: {
+    relativePath: string;
+    allowRoot?: boolean;
+  },
+): Promise<void> {
+  const resolved = await resolvePinnedPathInSafeRoot(root, params);
+  if (process.platform === "win32") {
+    await mkdirPathFallback(resolved);
+    return;
+  }
+  try {
+    await runPinnedPathHelper({
+      operation: "mkdirp",
+      rootPath: resolved.rootReal,
+      relativePath: resolved.relativePosix,
+    });
+  } catch (error) {
+    if (isPinnedPathHelperSpawnError(error)) {
+      await mkdirPathFallback(resolved);
+      return;
+    }
+    throw normalizePinnedPathError(error);
+  }
+}
+
+async function writeFileInSafeRoot(
+  root: SafeRootContext,
+  params: {
+    relativePath: string;
+    data: string | Buffer;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    overwrite?: boolean;
+  },
+): Promise<boolean> {
+  if (process.platform === "win32") {
+    return await writeFileFallback(root, params);
+  }
+
+  const pinned = await resolvePinnedWriteTargetInSafeRoot(root, params.relativePath);
+
+  let identity;
+  try {
+    identity = await runPinnedWriteHelper({
+      rootPath: pinned.rootReal,
+      relativeParentPath: pinned.relativeParentPath,
+      basename: pinned.basename,
+      mkdir: params.mkdir !== false,
+      mode: pinned.mode,
+      overwrite: params.overwrite,
+      input: {
+        kind: "buffer",
+        data: params.data,
+        encoding: params.encoding,
+      },
+    });
+  } catch (error) {
+    if (params.overwrite === false && isAlreadyExistsError(error)) {
+      return false;
+    }
+    throw normalizePinnedWriteError(error);
+  }
+
+  try {
+    await verifyAtomicWriteResult({
+      root,
+      targetPath: pinned.targetPath,
+      expectedIdentity: identity,
+    });
+  } catch (err) {
+    emitWriteBoundaryWarning(`post-write verification failed: ${String(err)}`);
+    throw err;
+  }
+  return true;
+}
+
+async function copyFileInSafeRoot(
+  root: SafeRootContext,
+  params: {
+    sourcePath: string;
+    relativePath: string;
+    maxBytes?: number;
+    mkdir?: boolean;
+    sourceHardlinks?: HardlinkPolicy;
+  },
+): Promise<void> {
+  const source = await openVerifiedLocalFile(params.sourcePath, {
+    hardlinks: params.sourceHardlinks,
+  });
+  if (params.maxBytes !== undefined && source.stat.size > params.maxBytes) {
+    await source.handle.close().catch(() => {});
+    throw new FsSafeError(
+      "too-large",
+      `file exceeds limit of ${params.maxBytes} bytes (got ${source.stat.size})`,
+    );
+  }
+
+  try {
+    if (process.platform === "win32") {
+      await copyFileFallback(root, params, source);
+      return;
+    }
+
+    const pinned = await resolvePinnedWriteTargetInSafeRoot(root, params.relativePath);
+    const sourceStream = source.handle.createReadStream();
+    const identity = await runPinnedWriteHelper({
+      rootPath: pinned.rootReal,
+      relativeParentPath: pinned.relativeParentPath,
+      basename: pinned.basename,
+      mkdir: params.mkdir !== false,
+      mode: pinned.mode,
+      overwrite: true,
+      input: {
+        kind: "stream",
+        stream: sourceStream,
+      },
+    }).catch((error) => {
+      throw normalizePinnedWriteError(error);
+    });
+    try {
+      await verifyAtomicWriteResult({
+        root,
+        targetPath: pinned.targetPath,
+        expectedIdentity: identity,
+      });
+    } catch (err) {
+      emitWriteBoundaryWarning(`post-copy verification failed: ${String(err)}`);
+      throw err;
+    }
+  } finally {
+    await source.handle.close().catch(() => {});
+  }
+}
+
+async function resolvePinnedWriteTargetInSafeRoot(
+  root: SafeRootContext,
+  relativePath: string,
+): Promise<{
+  rootReal: string;
+  targetPath: string;
+  relativeParentPath: string;
+  basename: string;
+  mode: number;
+}> {
+  const { rootReal, rootWithSep, resolved } = await resolvePathInSafeRoot(root, relativePath);
+  try {
+    await assertNoPathAliasEscape({
+      absolutePath: resolved,
+      rootPath: rootReal,
+      boundaryLabel: "root",
+    });
+  } catch (err) {
+    throw new FsSafeError("path-alias", "path alias escape blocked", { cause: err });
+  }
+
+  const relativeResolved = path.relative(rootReal, resolved);
+  if (relativeResolved.startsWith("..") || path.isAbsolute(relativeResolved)) {
+    throw new FsSafeError("outside-workspace", "file is outside workspace root");
+  }
+  const relativePosix = relativeResolved
+    ? relativeResolved.split(path.sep).join(path.posix.sep)
+    : "";
+  const basename = path.posix.basename(relativePosix);
+  if (!basename || basename === "." || basename === "/") {
+    throw new FsSafeError("invalid-path", "invalid target path");
+  }
+  let mode = 0o600;
+  try {
+    const opened = await openFileInSafeRoot(root, {
+      relativePath,
+      hardlinks: "reject",
+      nonBlockingRead: true,
+    });
+    try {
+      mode = opened.stat.mode & 0o777;
+      if (!isPathInside(rootWithSep, opened.realPath)) {
+        throw new FsSafeError("outside-workspace", "file is outside workspace root");
+      }
+    } finally {
+      await opened.handle.close().catch(() => {});
+    }
+  } catch (err) {
+    if (!(err instanceof FsSafeError) || err.code !== "not-found") {
+      throw err;
+    }
+  }
+
+  return {
+    rootReal,
+    targetPath: resolved,
+    relativeParentPath:
+      path.posix.dirname(relativePosix) === "." ? "" : path.posix.dirname(relativePosix),
+    basename,
+    mode: mode || 0o600,
+  };
+}
+
+async function resolvePinnedPathInSafeRoot(
+  root: SafeRootContext,
+  params: {
+    relativePath: string;
+    allowRoot?: boolean;
+  },
+): Promise<{ rootReal: string; resolved: string; relativePosix: string }> {
+  const resolved = await resolvePinnedRootPathInSafeRoot(root, {
+    relativePath: params.relativePath,
+    policy: PATH_ALIAS_POLICIES.strict,
+  });
+  const relativeResolved = path.relative(resolved.rootReal, resolved.canonicalPath);
+  if ((relativeResolved === "" || relativeResolved === ".") && params.allowRoot === true) {
+    return { rootReal: resolved.rootReal, resolved: resolved.canonicalPath, relativePosix: "" };
+  }
+  if (
+    relativeResolved === "" ||
+    relativeResolved === "." ||
+    relativeResolved.startsWith("..") ||
+    path.isAbsolute(relativeResolved)
+  ) {
+    throw new FsSafeError("outside-workspace", "file is outside workspace root");
+  }
+
+  const relativePosix = relativeResolved.split(path.sep).join(path.posix.sep);
+  if (!isPathInside(resolved.rootWithSep, resolved.canonicalPath)) {
+    throw new FsSafeError("outside-workspace", "file is outside workspace root");
+  }
+
+  return { rootReal: resolved.rootReal, resolved: resolved.canonicalPath, relativePosix };
+}
+
+async function resolvePinnedRemovePathInSafeRoot(
+  root: SafeRootContext,
+  relativePath: string,
+): Promise<{ rootReal: string; resolved: string; relativePosix: string }> {
+  const resolved = await resolvePinnedRootPathInSafeRoot(root, {
+    relativePath,
+    policy: PATH_ALIAS_POLICIES.unlinkTarget,
+  });
+  const relativeResolved = path.relative(resolved.rootReal, resolved.canonicalPath);
+  if (
+    relativeResolved === "" ||
+    relativeResolved === "." ||
+    relativeResolved.startsWith("..") ||
+    path.isAbsolute(relativeResolved)
+  ) {
+    throw new FsSafeError("outside-workspace", "file is outside workspace root");
+  }
+  const relativePosix = relativeResolved.split(path.sep).join(path.posix.sep);
+  if (!isPathInside(resolved.rootWithSep, resolved.canonicalPath)) {
+    throw new FsSafeError("outside-workspace", "file is outside workspace root");
+  }
+
+  const parentRelative = path.posix.dirname(relativePosix);
+  if (parentRelative === "." || parentRelative === "") {
+    return { rootReal: resolved.rootReal, resolved: resolved.canonicalPath, relativePosix };
+  }
+  return { rootReal: resolved.rootReal, resolved: resolved.canonicalPath, relativePosix };
+}
+
+async function resolvePinnedRootPathInSafeRoot(
+  root: SafeRootContext,
+  params: {
+    relativePath: string;
+    policy: (typeof PATH_ALIAS_POLICIES)[keyof typeof PATH_ALIAS_POLICIES];
+  },
+): Promise<{ rootReal: string; rootWithSep: string; canonicalPath: string }> {
+  const rootReal = root.rootReal;
+  let resolved;
+  try {
+    resolved = await resolveRootPath({
+      absolutePath: path.resolve(rootReal, await expandRelativePathWithHome(params.relativePath)),
+      rootPath: rootReal,
+      rootCanonicalPath: rootReal,
+      boundaryLabel: "root",
+      policy: params.policy,
+    });
+  } catch (err) {
+    throw new FsSafeError("path-alias", "path alias escape blocked", { cause: err });
+  }
+  const rootWithSep = ensureTrailingSep(resolved.rootCanonicalPath);
+  return {
+    rootReal: resolved.rootCanonicalPath,
+    rootWithSep,
+    canonicalPath: resolved.canonicalPath,
+  };
+}
+
+function normalizePinnedWriteError(error: unknown): Error {
+  if (error instanceof FsSafeError) {
+    return error;
+  }
+  return new FsSafeError("invalid-path", "path is not a regular file under root", {
+    cause: error instanceof Error ? error : undefined,
+  });
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return hasNodeErrorCode(error, "EEXIST") || /File exists|EEXIST/i.test(String(error));
+}
+
+function normalizePinnedPathError(error: unknown): Error {
+  if (error instanceof FsSafeError) {
+    return error;
+  }
+  return new FsSafeError("path-alias", "path is not under root", {
+    cause: error instanceof Error ? error : undefined,
+  });
+}
+
+async function removePathFallback(resolved: { resolved: string }): Promise<void> {
+  await fs.rm(resolved.resolved);
+}
+
+async function mkdirPathFallback(resolved: { resolved: string }): Promise<void> {
+  await fs.mkdir(resolved.resolved, { recursive: true });
+}
+
+async function writeFileFallback(
+  root: SafeRootContext,
+  params: {
+    relativePath: string;
+    data: string | Buffer;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+    overwrite?: boolean;
+  },
+): Promise<boolean> {
+  if (params.overwrite === false) {
+    return await writeMissingFileFallback(root, params);
+  }
+
+  const target = await openWritableFileInSafeRoot(root, {
+    relativePath: params.relativePath,
+    mkdir: params.mkdir,
+    truncateExisting: false,
+  });
+  const destinationPath = target.realPath;
+  const targetMode = target.stat.mode & 0o777;
+  await target.handle.close().catch(() => {});
+  let tempPath: string | null = null;
+  try {
+    tempPath = buildAtomicWriteTempPath(destinationPath);
+    const writtenStat = await writeTempFileForAtomicReplace({
+      tempPath,
+      data: params.data,
+      encoding: params.encoding,
+      mode: targetMode || 0o600,
+    });
+    await fs.rename(tempPath, destinationPath);
+    tempPath = null;
+    try {
+      await verifyAtomicWriteResult({
+        root,
+        targetPath: destinationPath,
+        expectedIdentity: writtenStat,
+      });
+    } catch (err) {
+      emitWriteBoundaryWarning(`post-write verification failed: ${String(err)}`);
+      throw err;
+    }
+  } finally {
+    if (tempPath) {
+      await fs.rm(tempPath, { force: true }).catch(() => {});
+    }
+  }
+  return true;
+}
+
+async function writeMissingFileFallback(
+  root: SafeRootContext,
+  params: {
+    relativePath: string;
+    data: string | Buffer;
+    encoding?: BufferEncoding;
+    mkdir?: boolean;
+  },
+): Promise<boolean> {
+  const { rootReal, resolved } = await resolvePathInSafeRoot(root, params.relativePath);
+  try {
+    await assertNoPathAliasEscape({
+      absolutePath: resolved,
+      rootPath: rootReal,
+      boundaryLabel: "root",
+    });
+  } catch (err) {
+    throw new FsSafeError("path-alias", "path alias escape blocked", { cause: err });
+  }
+  if (params.mkdir !== false) {
+    await fs.mkdir(path.dirname(resolved), { recursive: true });
+  }
+
+  let handle: FileHandle | null = null;
+  let created = false;
+  try {
+    handle = await fs.open(resolved, OPEN_WRITE_CREATE_FLAGS, 0o600);
+    created = true;
+    if (typeof params.data === "string") {
+      await handle.writeFile(params.data, params.encoding ?? "utf8");
+    } else {
+      await handle.writeFile(params.data);
+    }
+    const writtenStat = await handle.stat();
+    await handle.close();
+    handle = null;
+    await verifyAtomicWriteResult({
+      root,
+      targetPath: resolved,
+      expectedIdentity: writtenStat,
+    });
+    created = false;
+    return true;
+  } catch (err) {
+    if (hasNodeErrorCode(err, "EEXIST")) {
+      return false;
+    }
+    throw err;
+  } finally {
+    await handle?.close().catch(() => undefined);
+    if (created) {
+      await fs.rm(resolved, { force: true }).catch(() => undefined);
+    }
+  }
+}
+
+async function copyFileFallback(
+  root: SafeRootContext,
+  params: {
+    sourcePath: string;
+    relativePath: string;
+    maxBytes?: number;
+    mkdir?: boolean;
+    sourceHardlinks?: HardlinkPolicy;
+  },
+  source: SafeOpenResult,
+): Promise<void> {
+  let target: SafeWritableOpenResult | null = null;
+  let sourceClosedByStream = false;
+  let targetClosedByUs = false;
+  let tempHandle: FileHandle | null = null;
+  let tempPath: string | null = null;
+  let tempClosedByStream = false;
+  try {
+    target = await openWritableFileInSafeRoot(root, {
+      relativePath: params.relativePath,
+      mkdir: params.mkdir,
+      truncateExisting: false,
+    });
+    const destinationPath = target.realPath;
+    const targetMode = target.stat.mode & 0o777;
+    await target.handle.close().catch(() => {});
+    targetClosedByUs = true;
+
+    tempPath = buildAtomicWriteTempPath(destinationPath);
+    tempHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, targetMode || 0o600);
+    const sourceStream = source.handle.createReadStream();
+    const targetStream = tempHandle.createWriteStream();
+    sourceStream.once("close", () => {
+      sourceClosedByStream = true;
+    });
+    targetStream.once("close", () => {
+      tempClosedByStream = true;
+    });
+    await pipeline(sourceStream, targetStream);
+    const writtenStat = await fs.stat(tempPath);
+    if (!tempClosedByStream) {
+      await tempHandle.close().catch(() => {});
+      tempClosedByStream = true;
+    }
+    tempHandle = null;
+    await fs.rename(tempPath, destinationPath);
+    tempPath = null;
+    try {
+      await verifyAtomicWriteResult({
+        root,
+        targetPath: destinationPath,
+        expectedIdentity: writtenStat,
+      });
+    } catch (err) {
+      emitWriteBoundaryWarning(`post-copy verification failed: ${String(err)}`);
+      throw err;
+    }
+  } catch (err) {
+    if (target?.createdForWrite) {
+      await fs.rm(target.realPath, { force: true }).catch(() => {});
+    }
+    throw err;
+  } finally {
+    if (tempPath) {
+      await fs.rm(tempPath, { force: true }).catch(() => {});
+    }
+    if (!sourceClosedByStream) {
+      await source.handle.close().catch(() => {});
+    }
+    if (tempHandle && !tempClosedByStream) {
+      await tempHandle.close().catch(() => {});
+    }
+    if (target && !targetClosedByUs) {
+      await target.handle.close().catch(() => {});
+    }
+  }
+}

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -1,0 +1,285 @@
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { resolveHomeRelativePath } from "./home-dir.js";
+import { openPinnedFileSync } from "./pinned-open.js";
+
+export const DEFAULT_SECRET_FILE_MAX_BYTES = 16 * 1024;
+export const PRIVATE_SECRET_DIR_MODE = 0o700;
+export const PRIVATE_SECRET_FILE_MODE = 0o600;
+
+export type SecretFileReadOptions = {
+  maxBytes?: number;
+  rejectSymlink?: boolean;
+};
+
+export type SecretFileReadResult =
+  | {
+      ok: true;
+      secret: string;
+      resolvedPath: string;
+    }
+  | {
+      ok: false;
+      message: string;
+      resolvedPath?: string;
+      error?: unknown;
+    };
+
+function normalizeSecretReadError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function resolveUserPath(input: string): string {
+  return resolveHomeRelativePath(input);
+}
+
+export function loadSecretFileSync(
+  filePath: string,
+  label: string,
+  options: SecretFileReadOptions = {},
+): SecretFileReadResult {
+  const trimmedPath = filePath.trim();
+  const resolvedPath = resolveUserPath(trimmedPath);
+  if (!resolvedPath) {
+    return { ok: false, message: `${label} file path is empty.` };
+  }
+
+  const maxBytes = options.maxBytes ?? DEFAULT_SECRET_FILE_MAX_BYTES;
+
+  let previewStat: fs.Stats;
+  try {
+    previewStat = fs.lstatSync(resolvedPath);
+  } catch (error) {
+    const normalized = normalizeSecretReadError(error);
+    return {
+      ok: false,
+      resolvedPath,
+      error: normalized,
+      message: `Failed to inspect ${label} file at ${resolvedPath}: ${String(normalized)}`,
+    };
+  }
+
+  if (options.rejectSymlink && previewStat.isSymbolicLink()) {
+    return {
+      ok: false,
+      resolvedPath,
+      message: `${label} file at ${resolvedPath} must not be a symlink.`,
+    };
+  }
+  if (!previewStat.isFile()) {
+    return {
+      ok: false,
+      resolvedPath,
+      message: `${label} file at ${resolvedPath} must be a regular file.`,
+    };
+  }
+  if (previewStat.size > maxBytes) {
+    return {
+      ok: false,
+      resolvedPath,
+      message: `${label} file at ${resolvedPath} exceeds ${maxBytes} bytes.`,
+    };
+  }
+
+  const opened = openPinnedFileSync({
+    filePath: resolvedPath,
+    rejectPathSymlink: options.rejectSymlink,
+    maxBytes,
+  });
+  if (!opened.ok) {
+    const error = normalizeSecretReadError(
+      opened.reason === "validation" ? new Error("security validation failed") : opened.error,
+    );
+    return {
+      ok: false,
+      resolvedPath,
+      error,
+      message: `Failed to read ${label} file at ${resolvedPath}: ${String(error)}`,
+    };
+  }
+
+  try {
+    const raw = fs.readFileSync(opened.fd, "utf8");
+    const secret = raw.trim();
+    if (!secret) {
+      return {
+        ok: false,
+        resolvedPath,
+        message: `${label} file at ${resolvedPath} is empty.`,
+      };
+    }
+    return { ok: true, secret, resolvedPath };
+  } catch (error) {
+    const normalized = normalizeSecretReadError(error);
+    return {
+      ok: false,
+      resolvedPath,
+      error: normalized,
+      message: `Failed to read ${label} file at ${resolvedPath}: ${String(normalized)}`,
+    };
+  } finally {
+    fs.closeSync(opened.fd);
+  }
+}
+
+export function readSecretFileSync(
+  filePath: string,
+  label: string,
+  options: SecretFileReadOptions = {},
+): string {
+  const result = loadSecretFileSync(filePath, label, options);
+  if (result.ok) {
+    return result.secret;
+  }
+  throw new Error(result.message, result.error ? { cause: result.error } : undefined);
+}
+
+export function tryReadSecretFileSync(
+  filePath: string | undefined,
+  label: string,
+  options: SecretFileReadOptions = {},
+): string | undefined {
+  if (!filePath?.trim()) {
+    return undefined;
+  }
+  const result = loadSecretFileSync(filePath, label, options);
+  return result.ok ? result.secret : undefined;
+}
+
+function assertPathWithinRoot(rootDir: string, targetPath: string): void {
+  const relative = path.relative(rootDir, targetPath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Private secret path must stay under ${rootDir}.`);
+  }
+}
+
+function assertRealPathWithinRoot(rootDir: string, targetPath: string): void {
+  const relative = path.relative(rootDir, targetPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Private secret path must stay under ${rootDir}.`);
+  }
+}
+
+async function enforcePrivatePathMode(
+  resolvedPath: string,
+  expectedMode: number,
+  kind: "directory" | "file",
+): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  await fsp.chmod(resolvedPath, expectedMode);
+  const stat = await fsp.stat(resolvedPath);
+  const actualMode = stat.mode & 0o777;
+  if (actualMode !== expectedMode) {
+    throw new Error(
+      `Private secret ${kind} ${resolvedPath} has insecure permissions ${actualMode.toString(8)}.`,
+    );
+  }
+}
+
+async function ensurePrivateDirectory(rootDir: string, targetDir: string): Promise<void> {
+  const resolvedRoot = path.resolve(rootDir);
+  const resolvedTarget = path.resolve(targetDir);
+  if (resolvedTarget === resolvedRoot) {
+    await fsp.mkdir(resolvedRoot, { recursive: true, mode: PRIVATE_SECRET_DIR_MODE });
+    const rootStat = await fsp.lstat(resolvedRoot);
+    if (rootStat.isSymbolicLink()) {
+      throw new Error(`Private secret root ${resolvedRoot} must not be a symlink.`);
+    }
+    if (!rootStat.isDirectory()) {
+      throw new Error(`Private secret root ${resolvedRoot} must be a directory.`);
+    }
+    await enforcePrivatePathMode(resolvedRoot, PRIVATE_SECRET_DIR_MODE, "directory");
+    return;
+  }
+
+  assertPathWithinRoot(resolvedRoot, resolvedTarget);
+  await ensurePrivateDirectory(resolvedRoot, resolvedRoot);
+  const resolvedRootReal = await fsp.realpath(resolvedRoot);
+
+  let current = resolvedRoot;
+  for (const segment of path
+    .relative(resolvedRoot, resolvedTarget)
+    .split(path.sep)
+    .filter(Boolean)) {
+    current = path.join(current, segment);
+    try {
+      const stat = await fsp.lstat(current);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Private secret directory component ${current} must not be a symlink.`);
+      }
+      if (!stat.isDirectory()) {
+        throw new Error(`Private secret directory component ${current} must be a directory.`);
+      }
+    } catch (error) {
+      if (!error || typeof error !== "object" || !("code" in error) || error.code !== "ENOENT") {
+        throw error;
+      }
+      await fsp.mkdir(current, { mode: PRIVATE_SECRET_DIR_MODE });
+    }
+    const currentReal = await fsp.realpath(current);
+    assertRealPathWithinRoot(resolvedRootReal, currentReal);
+    await enforcePrivatePathMode(currentReal, PRIVATE_SECRET_DIR_MODE, "directory");
+  }
+}
+
+export async function writePrivateSecretFileAtomic(params: {
+  rootDir: string;
+  filePath: string;
+  content: string | Uint8Array;
+}): Promise<void> {
+  const resolvedRoot = path.resolve(params.rootDir);
+  const resolvedFile = path.resolve(params.filePath);
+  assertPathWithinRoot(resolvedRoot, resolvedFile);
+  const intendedParentDir = path.dirname(resolvedFile);
+  await ensurePrivateDirectory(resolvedRoot, intendedParentDir);
+  const resolvedRootReal = await fsp.realpath(resolvedRoot);
+  const parentDir = await fsp.realpath(intendedParentDir);
+  assertRealPathWithinRoot(resolvedRootReal, parentDir);
+  const fileName = path.basename(resolvedFile);
+  const finalFilePath = path.join(parentDir, fileName);
+
+  try {
+    const stat = await fsp.lstat(finalFilePath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Private secret file ${finalFilePath} must not be a symlink.`);
+    }
+    if (!stat.isFile()) {
+      throw new Error(`Private secret file ${finalFilePath} must be a regular file.`);
+    }
+  } catch (error) {
+    if (!error || typeof error !== "object" || !("code" in error) || error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const tempPath = path.join(
+    parentDir,
+    `.tmp-${process.pid}-${Date.now()}-${randomBytes(6).toString("hex")}`,
+  );
+  let createdTemp = false;
+  try {
+    const handle = await fsp.open(tempPath, "wx", PRIVATE_SECRET_FILE_MODE);
+    createdTemp = true;
+    try {
+      await handle.writeFile(params.content);
+    } finally {
+      await handle.close();
+    }
+    await enforcePrivatePathMode(tempPath, PRIVATE_SECRET_FILE_MODE, "file");
+    const refreshedParentReal = await fsp.realpath(intendedParentDir);
+    if (refreshedParentReal !== parentDir) {
+      throw new Error(`Private secret parent directory changed during write for ${finalFilePath}.`);
+    }
+    await fsp.rename(tempPath, finalFilePath);
+    createdTemp = false;
+    await enforcePrivatePathMode(finalFilePath, PRIVATE_SECRET_FILE_MODE, "file");
+  } finally {
+    if (createdTemp) {
+      await fsp.unlink(tempPath).catch(() => undefined);
+    }
+  }
+}

--- a/src/secure-temp-dir.ts
+++ b/src/secure-temp-dir.ts
@@ -1,0 +1,193 @@
+import fs from "node:fs";
+import { tmpdir as getOsTmpDir } from "node:os";
+import path from "node:path";
+
+type MaybeNodeError = { code?: string };
+
+type SecureDirStat = {
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+  mode?: number;
+  uid?: number;
+};
+
+export type ResolveSecureTempRootOptions = {
+  accessSync?: (path: string, mode?: number) => void;
+  chmodSync?: (path: string, mode: number) => void;
+  fallbackPrefix: string;
+  getuid?: () => number | undefined;
+  lstatSync?: (path: string) => SecureDirStat;
+  mkdirSync?: (path: string, opts: { recursive: boolean; mode?: number }) => void;
+  platform?: NodeJS.Platform;
+  preferredDir?: string;
+  skipPreferredOnWindows?: boolean;
+  tmpdir?: () => string;
+  unsafeFallbackLabel?: string;
+  warn?: (message: string) => void;
+  warningPrefix?: string;
+};
+
+function isNodeErrorWithCode(err: unknown, code: string): err is MaybeNodeError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as MaybeNodeError).code === code
+  );
+}
+
+export function resolveSecureTempRoot(options: ResolveSecureTempRootOptions): string {
+  const TMP_DIR_ACCESS_MODE = fs.constants.W_OK | fs.constants.X_OK;
+  const accessSync = options.accessSync ?? fs.accessSync;
+  const chmodSync = options.chmodSync ?? fs.chmodSync;
+  const lstatSync = options.lstatSync ?? fs.lstatSync;
+  const mkdirSync = options.mkdirSync ?? fs.mkdirSync;
+  const warn = options.warn ?? ((message: string) => console.warn(message));
+  const warningPrefix = options.warningPrefix ?? "[fs-safe]";
+  const unsafeFallbackLabel = options.unsafeFallbackLabel ?? "secure temp dir";
+  const getuid =
+    options.getuid ??
+    (() => {
+      try {
+        return typeof process.getuid === "function" ? process.getuid() : undefined;
+      } catch {
+        return undefined;
+      }
+    });
+  const tmpdir = typeof options.tmpdir === "function" ? options.tmpdir : getOsTmpDir;
+  const platform = options.platform ?? process.platform;
+  const uid = getuid();
+
+  const isSecureDirForUser = (st: { mode?: number; uid?: number }): boolean => {
+    if (uid === undefined) {
+      return true;
+    }
+    if (typeof st.uid === "number" && st.uid !== uid) {
+      return false;
+    }
+    if (typeof st.mode === "number" && (st.mode & 0o022) !== 0) {
+      return false;
+    }
+    return true;
+  };
+
+  const fallback = (): string => {
+    const base = tmpdir();
+    const suffix = uid === undefined ? options.fallbackPrefix : `${options.fallbackPrefix}-${uid}`;
+    const joiner = platform === "win32" ? path.win32.join : path.join;
+    return joiner(base, suffix);
+  };
+
+  const isTrustedTmpDir = (st: SecureDirStat): boolean => {
+    return st.isDirectory() && !st.isSymbolicLink() && isSecureDirForUser(st);
+  };
+
+  const resolveDirState = (candidatePath: string): "available" | "missing" | "invalid" => {
+    try {
+      const candidate = lstatSync(candidatePath);
+      if (!isTrustedTmpDir(candidate)) {
+        return "invalid";
+      }
+      accessSync(candidatePath, TMP_DIR_ACCESS_MODE);
+      return "available";
+    } catch (err) {
+      if (isNodeErrorWithCode(err, "ENOENT")) {
+        return "missing";
+      }
+      return "invalid";
+    }
+  };
+
+  const tryRepairWritableBits = (candidatePath: string): boolean => {
+    try {
+      const st = lstatSync(candidatePath);
+      if (!st.isDirectory() || st.isSymbolicLink()) {
+        return false;
+      }
+      if (uid !== undefined && typeof st.uid === "number" && st.uid !== uid) {
+        return false;
+      }
+      if (typeof st.mode !== "number") {
+        return false;
+      }
+      if ((st.mode & 0o022) === 0) {
+        return resolveDirState(candidatePath) === "available";
+      }
+      try {
+        chmodSync(candidatePath, 0o700);
+      } catch (chmodErr) {
+        if (
+          isNodeErrorWithCode(chmodErr, "EPERM") ||
+          isNodeErrorWithCode(chmodErr, "EACCES") ||
+          isNodeErrorWithCode(chmodErr, "ENOENT")
+        ) {
+          return resolveDirState(candidatePath) === "available";
+        }
+        throw chmodErr;
+      }
+      warn(`${warningPrefix} tightened permissions on temp dir: ${candidatePath}`);
+      return resolveDirState(candidatePath) === "available";
+    } catch {
+      return false;
+    }
+  };
+
+  const ensureTrustedFallbackDir = (): string => {
+    const fallbackPath = fallback();
+    const state = resolveDirState(fallbackPath);
+    if (state === "available") {
+      return fallbackPath;
+    }
+    if (state === "invalid") {
+      if (tryRepairWritableBits(fallbackPath)) {
+        return fallbackPath;
+      }
+      throw new Error(`Unsafe fallback ${unsafeFallbackLabel}: ${fallbackPath}`);
+    }
+    try {
+      mkdirSync(fallbackPath, { recursive: true, mode: 0o700 });
+      chmodSync(fallbackPath, 0o700);
+    } catch {
+      throw new Error(`Unable to create fallback ${unsafeFallbackLabel}: ${fallbackPath}`);
+    }
+    if (resolveDirState(fallbackPath) !== "available" && !tryRepairWritableBits(fallbackPath)) {
+      throw new Error(`Unsafe fallback ${unsafeFallbackLabel}: ${fallbackPath}`);
+    }
+    return fallbackPath;
+  };
+
+  if (options.skipPreferredOnWindows === true && platform === "win32") {
+    return ensureTrustedFallbackDir();
+  }
+
+  if (!options.preferredDir) {
+    return ensureTrustedFallbackDir();
+  }
+
+  const existingPreferredState = resolveDirState(options.preferredDir);
+  if (existingPreferredState === "available") {
+    return options.preferredDir;
+  }
+  if (existingPreferredState === "invalid") {
+    if (tryRepairWritableBits(options.preferredDir)) {
+      return options.preferredDir;
+    }
+    return ensureTrustedFallbackDir();
+  }
+
+  try {
+    const preferredParentDir = path.dirname(options.preferredDir);
+    accessSync(preferredParentDir, TMP_DIR_ACCESS_MODE);
+    mkdirSync(options.preferredDir, { recursive: true, mode: 0o700 });
+    chmodSync(options.preferredDir, 0o700);
+    if (
+      resolveDirState(options.preferredDir) !== "available" &&
+      !tryRepairWritableBits(options.preferredDir)
+    ) {
+      return ensureTrustedFallbackDir();
+    }
+    return options.preferredDir;
+  } catch {
+    return ensureTrustedFallbackDir();
+  }
+}

--- a/src/sibling-temp.ts
+++ b/src/sibling-temp.ts
@@ -1,0 +1,144 @@
+import crypto, { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { sanitizeUntrustedFileName } from "./filename.js";
+import { root } from "./root.js";
+
+export type WriteSiblingTempFileOptions<T> = {
+  dir: string;
+  writeTemp: (tempPath: string) => Promise<T>;
+  resolveFinalPath: (result: T) => string;
+  tempPrefix?: string;
+  dirMode?: number;
+  fileMode?: number;
+  syncTempFile?: boolean;
+  syncParentDir?: boolean;
+};
+
+export type WriteSiblingTempFileResult<T> = {
+  filePath: string;
+  result: T;
+};
+
+function buildTempPath(dir: string, tempPrefix?: string): string {
+  return path.join(dir, `${tempPrefix ?? ".fs-safe-stream"}.${process.pid}.${randomUUID()}.tmp`);
+}
+
+async function syncFileBestEffort(filePath: string): Promise<void> {
+  const handle = await fs.open(filePath, "r+");
+  try {
+    await handle.sync();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EPERM") {
+      throw error;
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+async function syncDirectoryBestEffort(dirPath: string): Promise<void> {
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  try {
+    handle = await fs.open(dirPath, "r");
+    await handle.sync();
+  } catch {
+    // Best-effort on platforms/filesystems that do not support directory fsync.
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+function assertFinalPathIsSibling(dir: string, filePath: string): void {
+  const resolvedDir = path.resolve(dir);
+  const resolvedFile = path.resolve(filePath);
+  if (path.dirname(resolvedFile) !== resolvedDir) {
+    throw new Error("Final path must be in the sibling temp directory.");
+  }
+}
+
+export async function writeSiblingTempFile<T>(
+  options: WriteSiblingTempFileOptions<T>,
+): Promise<WriteSiblingTempFileResult<T>> {
+  const dir = path.resolve(options.dir);
+  await fs.mkdir(dir, { recursive: true, mode: options.dirMode ?? 0o700 });
+  await fs.chmod(dir, options.dirMode ?? 0o700).catch(() => undefined);
+  const tempPath = buildTempPath(dir, options.tempPrefix);
+  let tempExists = false;
+  try {
+    tempExists = true;
+    const result = await options.writeTemp(tempPath);
+    if (options.fileMode !== undefined) {
+      await fs.chmod(tempPath, options.fileMode).catch(() => undefined);
+    }
+    if (options.syncTempFile) {
+      await syncFileBestEffort(tempPath);
+    }
+    const filePath = path.resolve(options.resolveFinalPath(result));
+    assertFinalPathIsSibling(dir, filePath);
+    await fs.rename(tempPath, filePath);
+    tempExists = false;
+    if (options.fileMode !== undefined) {
+      await fs.chmod(filePath, options.fileMode).catch(() => undefined);
+    }
+    if (options.syncParentDir) {
+      await syncDirectoryBestEffort(dir);
+    }
+    return { filePath, result };
+  } finally {
+    if (tempExists) {
+      await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    }
+  }
+}
+
+function buildSiblingTempPath(params: {
+  targetPath: string;
+  fallbackFileName: string;
+  tempPrefix: string;
+}): string {
+  const id = crypto.randomUUID();
+  const safeTail = sanitizeUntrustedFileName(
+    path.basename(params.targetPath),
+    params.fallbackFileName,
+  );
+  return path.join(path.dirname(params.targetPath), `${params.tempPrefix}${id}-${safeTail}.part`);
+}
+
+export async function writeViaSiblingTempPath(params: {
+  rootDir: string;
+  targetPath: string;
+  writeTemp: (tempPath: string) => Promise<void>;
+  fallbackFileName?: string;
+  tempPrefix?: string;
+}): Promise<void> {
+  const rootDir = await fs
+    .realpath(path.resolve(params.rootDir))
+    .catch(() => path.resolve(params.rootDir));
+  const requestedTargetPath = path.resolve(params.targetPath);
+  const targetPath = await fs
+    .realpath(path.dirname(requestedTargetPath))
+    .then((realDir) => path.join(realDir, path.basename(requestedTargetPath)))
+    .catch(() => requestedTargetPath);
+  const relativeTargetPath = path.relative(rootDir, targetPath);
+  if (
+    !relativeTargetPath ||
+    relativeTargetPath === ".." ||
+    relativeTargetPath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeTargetPath)
+  ) {
+    throw new Error("Target path is outside the allowed root");
+  }
+  const tempPath = buildSiblingTempPath({
+    targetPath,
+    fallbackFileName: params.fallbackFileName ?? "output.bin",
+    tempPrefix: params.tempPrefix ?? ".fs-safe-output-",
+  });
+  try {
+    await params.writeTemp(tempPath);
+    const targetRoot = await root(rootDir);
+    await targetRoot.copyFrom(tempPath, relativeTargetPath, { mkdir: false });
+  } finally {
+    await fs.rm(tempPath, { force: true }).catch(() => {});
+  }
+}

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -1,0 +1,317 @@
+import fsSync from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type SidecarLockRetryOptions = {
+  retries?: number;
+  factor?: number;
+  minTimeout?: number;
+  maxTimeout?: number;
+  randomize?: boolean;
+};
+
+export type SidecarLockAcquireOptions<TPayload extends Record<string, unknown>> = {
+  targetPath: string;
+  lockPath?: string;
+  staleMs: number;
+  timeoutMs?: number;
+  retry?: SidecarLockRetryOptions;
+  allowReentrant?: boolean;
+  payload: () => TPayload | Promise<TPayload>;
+  shouldReclaim?: (params: {
+    lockPath: string;
+    normalizedTargetPath: string;
+    payload: Record<string, unknown> | null;
+    staleMs: number;
+    nowMs: number;
+    heldByThisProcess: boolean;
+  }) => boolean | Promise<boolean>;
+  metadata?: Record<string, unknown>;
+};
+
+export type SidecarLockHandle = {
+  lockPath: string;
+  normalizedTargetPath: string;
+  release: () => Promise<void>;
+};
+
+export type SidecarLockHeldEntry = {
+  normalizedTargetPath: string;
+  lockPath: string;
+  acquiredAt: number;
+  metadata: Record<string, unknown>;
+  forceRelease: () => Promise<boolean>;
+};
+
+type HeldLock = {
+  count: number;
+  handle: FileHandle;
+  lockPath: string;
+  acquiredAt: number;
+  metadata: Record<string, unknown>;
+  releasePromise?: Promise<void>;
+};
+
+type SidecarLockManagerState = {
+  cleanupRegistered: boolean;
+  held: Map<string, HeldLock>;
+};
+
+const GLOBAL_STATE_KEY = Symbol.for("fsSafe.sidecarLockManagers");
+
+function getGlobalManagers(): Map<string, SidecarLockManagerState> {
+  const globalWithState = globalThis as typeof globalThis & {
+    [GLOBAL_STATE_KEY]?: Map<string, SidecarLockManagerState>;
+  };
+  if (!globalWithState[GLOBAL_STATE_KEY]) {
+    globalWithState[GLOBAL_STATE_KEY] = new Map();
+  }
+  return globalWithState[GLOBAL_STATE_KEY];
+}
+
+function resolveManagerState(key: string): SidecarLockManagerState {
+  const managers = getGlobalManagers();
+  let state = managers.get(key);
+  if (!state) {
+    state = { cleanupRegistered: false, held: new Map() };
+    managers.set(key, state);
+  }
+  return state;
+}
+
+async function readJsonPayload(lockPath: string): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(lockPath, "utf8")) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveNormalizedTargetPath(targetPath: string): Promise<string> {
+  const resolved = path.resolve(targetPath);
+  const dir = path.dirname(resolved);
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    return path.join(await fs.realpath(dir), path.basename(resolved));
+  } catch {
+    return resolved;
+  }
+}
+
+function computeDelayMs(retry: SidecarLockRetryOptions, attempt: number): number {
+  const minTimeout = retry.minTimeout ?? 50;
+  const maxTimeout = retry.maxTimeout ?? 1000;
+  const factor = retry.factor ?? 1;
+  const base = Math.min(maxTimeout, Math.max(minTimeout, minTimeout * factor ** attempt));
+  const jitter = retry.randomize ? 1 + Math.random() : 1;
+  return Math.min(maxTimeout, Math.round(base * jitter));
+}
+
+async function defaultShouldReclaim(params: {
+  lockPath: string;
+  payload: Record<string, unknown> | null;
+  staleMs: number;
+  nowMs: number;
+}): Promise<boolean> {
+  const createdAt = typeof params.payload?.createdAt === "string" ? params.payload.createdAt : "";
+  const createdAtMs = Date.parse(createdAt);
+  if (Number.isFinite(createdAtMs) && params.nowMs - createdAtMs > params.staleMs) {
+    return true;
+  }
+  try {
+    const stat = await fs.stat(params.lockPath);
+    return params.nowMs - stat.mtimeMs > params.staleMs;
+  } catch {
+    return true;
+  }
+}
+
+function releaseAllLocksSync(state: SidecarLockManagerState): void {
+  for (const [normalizedTargetPath, held] of state.held) {
+    void held.handle.close().catch(() => undefined);
+    try {
+      fsSync.rmSync(held.lockPath, { force: true });
+    } catch {
+      // Best-effort process-exit cleanup.
+    }
+    state.held.delete(normalizedTargetPath);
+  }
+}
+
+async function releaseHeldLock(
+  state: SidecarLockManagerState,
+  normalizedTargetPath: string,
+  held: HeldLock,
+  opts: { force?: boolean } = {},
+): Promise<boolean> {
+  const current = state.held.get(normalizedTargetPath);
+  if (current !== held) {
+    return false;
+  }
+  if (opts.force) {
+    held.count = 0;
+  } else {
+    held.count -= 1;
+    if (held.count > 0) {
+      return false;
+    }
+  }
+  if (held.releasePromise) {
+    await held.releasePromise.catch(() => undefined);
+    return true;
+  }
+  state.held.delete(normalizedTargetPath);
+  held.releasePromise = (async () => {
+    await held.handle.close().catch(() => undefined);
+    await fs.rm(held.lockPath, { force: true }).catch(() => undefined);
+  })();
+  try {
+    await held.releasePromise;
+    return true;
+  } finally {
+    held.releasePromise = undefined;
+  }
+}
+
+export function createSidecarLockManager(key: string) {
+  const state = resolveManagerState(key);
+
+  function ensureExitCleanupRegistered(): void {
+    if (state.cleanupRegistered) {
+      return;
+    }
+    state.cleanupRegistered = true;
+    process.on("exit", () => releaseAllLocksSync(state));
+  }
+
+  async function acquire<TPayload extends Record<string, unknown>>(
+    options: SidecarLockAcquireOptions<TPayload>,
+  ): Promise<SidecarLockHandle> {
+    ensureExitCleanupRegistered();
+    const normalizedTargetPath = await resolveNormalizedTargetPath(options.targetPath);
+    const lockPath = options.lockPath ?? `${normalizedTargetPath}.lock`;
+    const held = state.held.get(normalizedTargetPath);
+    if (held && options.allowReentrant) {
+      held.count += 1;
+      return {
+        lockPath,
+        normalizedTargetPath,
+        release: () => releaseHeldLock(state, normalizedTargetPath, held).then(() => undefined),
+      };
+    }
+
+    const startedAt = Date.now();
+    const retry = options.retry ?? {};
+    const maxRetries = options.timeoutMs === Number.POSITIVE_INFINITY ? undefined : retry.retries;
+    let attempt = 0;
+    while (true) {
+      let handle: FileHandle | null = null;
+      try {
+        handle = await fs.open(lockPath, "wx");
+        const createdHeld: HeldLock = {
+          count: 1,
+          handle,
+          lockPath,
+          acquiredAt: Date.now(),
+          metadata: options.metadata ?? {},
+        };
+        state.held.set(normalizedTargetPath, createdHeld);
+        await handle.writeFile(`${JSON.stringify(await options.payload(), null, 2)}\n`, "utf8");
+        return {
+          lockPath,
+          normalizedTargetPath,
+          release: () =>
+            releaseHeldLock(state, normalizedTargetPath, createdHeld).then(() => undefined),
+        };
+      } catch (err) {
+        if (handle) {
+          const current = state.held.get(normalizedTargetPath);
+          if (current?.handle === handle) {
+            state.held.delete(normalizedTargetPath);
+          }
+          await handle.close().catch(() => undefined);
+          await fs.rm(lockPath, { force: true }).catch(() => undefined);
+        }
+        if ((err as { code?: unknown }).code !== "EEXIST") {
+          throw err;
+        }
+        const nowMs = Date.now();
+        const payload = await readJsonPayload(lockPath);
+        const shouldReclaim = options.shouldReclaim ?? defaultShouldReclaim;
+        if (
+          await shouldReclaim({
+            lockPath,
+            normalizedTargetPath,
+            payload,
+            staleMs: options.staleMs,
+            nowMs,
+            heldByThisProcess: state.held.has(normalizedTargetPath),
+          })
+        ) {
+          await fs.rm(lockPath, { force: true }).catch(() => undefined);
+          continue;
+        }
+        const elapsed = Date.now() - startedAt;
+        if (
+          (options.timeoutMs !== undefined &&
+            options.timeoutMs !== Number.POSITIVE_INFINITY &&
+            elapsed >= options.timeoutMs) ||
+          (maxRetries !== undefined && attempt >= maxRetries)
+        ) {
+          throw Object.assign(new Error(`file lock timeout for ${normalizedTargetPath}`), {
+            code: "file_lock_timeout",
+            lockPath,
+            normalizedTargetPath,
+          });
+        }
+        const remaining =
+          options.timeoutMs === undefined || options.timeoutMs === Number.POSITIVE_INFINITY
+            ? Number.POSITIVE_INFINITY
+            : Math.max(0, options.timeoutMs - elapsed);
+        const delay = Math.min(computeDelayMs(retry, attempt), remaining);
+        attempt += 1;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  async function withLock<T, TPayload extends Record<string, unknown>>(
+    options: SidecarLockAcquireOptions<TPayload>,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const lock = await acquire(options);
+    try {
+      return await fn();
+    } finally {
+      await lock.release();
+    }
+  }
+
+  async function drain(): Promise<void> {
+    for (const [normalizedTargetPath, held] of Array.from(state.held.entries())) {
+      await releaseHeldLock(state, normalizedTargetPath, held, { force: true }).catch(
+        () => undefined,
+      );
+    }
+  }
+
+  function reset(): void {
+    releaseAllLocksSync(state);
+  }
+
+  function heldEntries(): SidecarLockHeldEntry[] {
+    return Array.from(state.held.entries()).map(([normalizedTargetPath, held]) => ({
+      normalizedTargetPath,
+      lockPath: held.lockPath,
+      acquiredAt: held.acquiredAt,
+      metadata: held.metadata,
+      forceRelease: () => releaseHeldLock(state, normalizedTargetPath, held, { force: true }),
+    }));
+  }
+
+  return { acquire, withLock, drain, reset, heldEntries };
+}

--- a/src/string-coerce.ts
+++ b/src/string-coerce.ts
@@ -1,0 +1,84 @@
+export function readStringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+export function normalizeNullableString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function normalizeOptionalString(value: unknown): string | undefined {
+  return normalizeNullableString(value) ?? undefined;
+}
+
+export function normalizeStringifiedOptionalString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return normalizeOptionalString(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return normalizeOptionalString(String(value));
+  }
+  return undefined;
+}
+
+export function normalizeOptionalLowercaseString(value: unknown): string | undefined {
+  return normalizeOptionalString(value)?.toLowerCase();
+}
+
+export function normalizeLowercaseStringOrEmpty(value: unknown): string {
+  return normalizeOptionalLowercaseString(value) ?? "";
+}
+
+export function normalizeFastMode(raw?: string | boolean | null): boolean | undefined {
+  if (typeof raw === "boolean") {
+    return raw;
+  }
+  if (!raw) {
+    return undefined;
+  }
+  const key = normalizeLowercaseStringOrEmpty(raw);
+  if (["off", "false", "no", "0", "disable", "disabled", "normal"].includes(key)) {
+    return false;
+  }
+  if (["on", "true", "yes", "1", "enable", "enabled", "fast"].includes(key)) {
+    return true;
+  }
+  return undefined;
+}
+
+export function lowercasePreservingWhitespace(value: string): string {
+  return value.toLowerCase();
+}
+
+export function localeLowercasePreservingWhitespace(value: string): string {
+  return value.toLocaleLowerCase();
+}
+
+export function resolvePrimaryStringValue(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return normalizeOptionalString(value);
+  }
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return normalizeOptionalString((value as { primary?: unknown }).primary);
+}
+
+export function normalizeOptionalThreadValue(value: unknown): string | number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? Math.trunc(value) : undefined;
+  }
+  return normalizeOptionalString(value);
+}
+
+export function normalizeOptionalStringifiedId(value: unknown): string | undefined {
+  const normalized = normalizeOptionalThreadValue(value);
+  return normalized == null ? undefined : String(normalized);
+}
+
+export function hasNonEmptyString(value: unknown): value is string {
+  return normalizeOptionalString(value) !== undefined;
+}

--- a/src/symlink-parents.ts
+++ b/src/symlink-parents.ts
@@ -1,0 +1,97 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isNotFoundPathError } from "./path.js";
+
+export type AssertNoSymlinkParentsOptions = {
+  rootDir: string;
+  targetPath: string;
+  allowMissing?: boolean;
+  allowOutsideRoot?: boolean;
+  allowRootChildSymlink?: boolean;
+  requireDirectories?: boolean;
+  messagePrefix?: string;
+};
+
+function resolvePathWalk(params: AssertNoSymlinkParentsOptions): {
+  root: string;
+  segments: string[];
+} | null {
+  const root = path.resolve(params.rootDir);
+  const target = path.resolve(params.targetPath);
+  const relative = path.relative(root, target);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    if (params.allowOutsideRoot) {
+      return null;
+    }
+    throw new Error(`${params.messagePrefix ?? "Path"} must stay under ${root}.`);
+  }
+  return {
+    root,
+    segments: relative && relative !== "." ? relative.split(path.sep).filter(Boolean) : [],
+  };
+}
+
+function formatUnsafePath(params: AssertNoSymlinkParentsOptions, current: string): string {
+  return `${params.messagePrefix ?? "Path"} must not traverse symlinked directory: ${current}`;
+}
+
+export async function assertNoSymlinkParents(
+  params: AssertNoSymlinkParentsOptions,
+): Promise<void> {
+  const walk = resolvePathWalk(params);
+  if (!walk) {
+    return;
+  }
+  let current = walk.root;
+  for (const segment of walk.segments) {
+    current = path.join(current, segment);
+    try {
+      const stat = await fs.lstat(current);
+      if (stat.isSymbolicLink()) {
+        if (params.allowRootChildSymlink && path.dirname(current) === walk.root) {
+          continue;
+        }
+        throw new Error(formatUnsafePath(params, current));
+      }
+      if (params.requireDirectories && !stat.isDirectory()) {
+        throw new Error(`${params.messagePrefix ?? "Path"} must traverse directories: ${current}`);
+      }
+    } catch (err) {
+      if (isNotFoundPathError(err) && params.allowMissing !== false) {
+        return;
+      }
+      throw err;
+    }
+  }
+}
+
+export function assertNoSymlinkParentsSync(
+  params: AssertNoSymlinkParentsOptions,
+): void {
+  const walk = resolvePathWalk(params);
+  if (!walk) {
+    return;
+  }
+  let current = walk.root;
+  for (const segment of walk.segments) {
+    current = path.join(current, segment);
+    try {
+      const stat = fsSync.lstatSync(current);
+      if (stat.isSymbolicLink()) {
+        if (params.allowRootChildSymlink && path.dirname(current) === walk.root) {
+          continue;
+        }
+        throw new Error(formatUnsafePath(params, current));
+      }
+      if (params.requireDirectories && !stat.isDirectory()) {
+        throw new Error(`${params.messagePrefix ?? "Path"} must traverse directories: ${current}`);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT" && params.allowMissing !== false) {
+        return;
+      }
+      throw err;
+    }
+  }
+}

--- a/src/temp-target.ts
+++ b/src/temp-target.ts
@@ -1,0 +1,101 @@
+import crypto from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+
+export type TempFileTarget = {
+  dir: string;
+  path: string;
+  cleanup: () => Promise<void>;
+};
+
+function sanitizePrefix(prefix: string): string {
+  const normalized = prefix.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+  return normalized || "tmp";
+}
+
+function sanitizeExtension(extension?: string): string {
+  if (!extension) {
+    return "";
+  }
+  const normalized = extension.startsWith(".") ? extension : `.${extension}`;
+  const suffix = normalized.match(/[a-zA-Z0-9._-]+$/)?.[0] ?? "";
+  const token = suffix.replace(/^[._-]+/, "");
+  return token ? `.${token}` : "";
+}
+
+export function sanitizeTempFileName(fileName: string): string {
+  const base = path.basename(fileName).replace(/[^a-zA-Z0-9._-]+/g, "-");
+  const normalized = base.replace(/^-+|-+$/g, "");
+  return normalized || "download.bin";
+}
+
+export function buildRandomTempFilePath(params: {
+  rootDir: string;
+  prefix: string;
+  extension?: string;
+  now?: number;
+  uuid?: string;
+}): string {
+  const prefix = sanitizePrefix(params.prefix);
+  const extension = sanitizeExtension(params.extension);
+  const nowCandidate = params.now;
+  const now =
+    typeof nowCandidate === "number" && Number.isFinite(nowCandidate)
+      ? Math.trunc(nowCandidate)
+      : Date.now();
+  const uuid = params.uuid?.trim() || crypto.randomUUID();
+  return path.join(params.rootDir, `${prefix}-${now}-${uuid}${extension}`);
+}
+
+function isNodeErrorWithCode(err: unknown, code: string): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: string }).code === code
+  );
+}
+
+async function cleanupTempDir(dir: string, onCleanupError?: (error: unknown) => void) {
+  try {
+    await rm(dir, { recursive: true, force: true });
+  } catch (err) {
+    if (!isNodeErrorWithCode(err, "ENOENT")) {
+      onCleanupError?.(err);
+    }
+  }
+}
+
+export async function createTempFileTarget(params: {
+  rootDir: string;
+  prefix: string;
+  fileName?: string;
+  onCleanupError?: (error: unknown) => void;
+}): Promise<TempFileTarget> {
+  const prefix = `${sanitizePrefix(params.prefix)}-`;
+  const dir = await mkdtemp(path.join(params.rootDir, prefix));
+  return {
+    dir,
+    path: path.join(dir, sanitizeTempFileName(params.fileName ?? "download.bin")),
+    cleanup: async () => {
+      await cleanupTempDir(dir, params.onCleanupError);
+    },
+  };
+}
+
+export async function withTempFileTarget<T>(
+  params: {
+    rootDir: string;
+    prefix: string;
+    fileName?: string;
+    onCleanupError?: (error: unknown) => void;
+  },
+  fn: (tmpPath: string) => Promise<T>,
+): Promise<T> {
+  const target = await createTempFileTarget(params);
+  try {
+    return await fn(target.path);
+  } finally {
+    await target.cleanup();
+  }
+}

--- a/src/temp.ts
+++ b/src/temp.ts
@@ -1,0 +1,23 @@
+export {
+  createPrivateTempWorkspace,
+  createPrivateTempWorkspaceSync,
+  withPrivateTempWorkspace,
+  withPrivateTempWorkspaceSync,
+  type PrivateTempWorkspace,
+  type PrivateTempWorkspaceOptions,
+  type PrivateTempWorkspaceSync,
+} from "./private-temp-workspace.js";
+export {
+  buildRandomTempFilePath,
+  createTempFileTarget,
+  sanitizeTempFileName,
+  withTempFileTarget,
+  type TempFileTarget,
+} from "./temp-target.js";
+export {
+  writeSiblingTempFile,
+  writeViaSiblingTempPath,
+  type WriteSiblingTempFileOptions,
+  type WriteSiblingTempFileResult,
+} from "./sibling-temp.js";
+export { resolveSecureTempRoot, type ResolveSecureTempRootOptions } from "./secure-temp-dir.js";

--- a/src/test-hooks.ts
+++ b/src/test-hooks.ts
@@ -1,0 +1,24 @@
+import type { FileHandle } from "node:fs/promises";
+
+export type FsSafeTestHooks = {
+  afterPreOpenLstat?: (filePath: string) => Promise<void> | void;
+  beforeOpen?: (filePath: string, flags: number) => Promise<void> | void;
+  afterOpen?: (filePath: string, handle: FileHandle) => Promise<void> | void;
+};
+
+let fsSafeTestHooks: FsSafeTestHooks | undefined;
+
+function allowFsSafeTestHooks(): boolean {
+  return process.env.NODE_ENV === "test" || process.env.VITEST === "true";
+}
+
+export function getFsSafeTestHooks(): FsSafeTestHooks | undefined {
+  return fsSafeTestHooks;
+}
+
+export function __setFsSafeTestHooksForTest(hooks?: FsSafeTestHooks): void {
+  if (hooks && !allowFsSafeTestHooks()) {
+    throw new Error("__setFsSafeTestHooksForTest is only available in tests");
+  }
+  fsSafeTestHooks = hooks;
+}

--- a/src/timing.ts
+++ b/src/timing.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs/promises";
-
 export async function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
@@ -20,14 +18,5 @@ export async function withTimeout<T>(
     if (timeoutId) {
       clearTimeout(timeoutId);
     }
-  }
-}
-
-export async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    await fs.stat(filePath);
-    return true;
-  } catch {
-    return false;
   }
 }

--- a/src/trash.ts
+++ b/src/trash.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type MovePathToTrashOptions = {
+  allowedRoots?: Iterable<string>;
+};
+
+const TRASH_DESTINATION_COLLISION_CODES = new Set(["EEXIST", "ENOTEMPTY", "ERR_FS_CP_EEXIST"]);
+const TRASH_DESTINATION_RETRY_LIMIT = 4;
+
+function getFsErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return undefined;
+  }
+  const code = (error as NodeJS.ErrnoException).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function isTrashDestinationCollision(error: unknown): boolean {
+  const code = getFsErrorCode(error);
+  return Boolean(code && TRASH_DESTINATION_COLLISION_CODES.has(code));
+}
+
+function isSameOrChildPath(candidate: string, parent: string): boolean {
+  return candidate === parent || candidate.startsWith(`${parent}${path.sep}`);
+}
+
+function resolveAllowedTrashRoots(allowedRoots?: Iterable<string>): string[] {
+  const roots = [...(allowedRoots ?? [os.homedir(), os.tmpdir()])].map((root) => {
+    try {
+      return path.resolve(fs.realpathSync.native(root));
+    } catch {
+      return path.resolve(root);
+    }
+  });
+  return [...new Set(roots)];
+}
+
+function assertAllowedTrashTarget(targetPath: string, allowedRoots?: Iterable<string>): void {
+  let resolvedTargetPath = path.resolve(targetPath);
+  try {
+    resolvedTargetPath = path.resolve(fs.realpathSync.native(targetPath));
+  } catch {
+    // The subsequent move will surface missing or inaccessible targets.
+  }
+  const isAllowed = resolveAllowedTrashRoots(allowedRoots).some(
+    (root) => resolvedTargetPath !== root && isSameOrChildPath(resolvedTargetPath, root),
+  );
+  if (!isAllowed) {
+    throw new Error(`Refusing to trash path outside allowed roots: ${targetPath}`);
+  }
+}
+
+function resolveTrashDir(): string {
+  const homeDir = os.homedir();
+  const trashDir = path.join(homeDir, ".Trash");
+  fs.mkdirSync(trashDir, { recursive: true, mode: 0o700 });
+  const trashDirStat = fs.lstatSync(trashDir);
+  if (!trashDirStat.isDirectory() || trashDirStat.isSymbolicLink()) {
+    throw new Error(`Refusing to use non-directory/symlink trash directory: ${trashDir}`);
+  }
+  const realHome = path.resolve(fs.realpathSync.native(homeDir));
+  const resolvedTrashDir = path.resolve(fs.realpathSync.native(trashDir));
+  if (resolvedTrashDir === realHome || !isSameOrChildPath(resolvedTrashDir, realHome)) {
+    throw new Error(`Trash directory escaped home directory: ${trashDir}`);
+  }
+  return resolvedTrashDir;
+}
+
+function trashBaseName(targetPath: string): string {
+  const resolvedTargetPath = path.resolve(targetPath);
+  if (resolvedTargetPath === path.parse(resolvedTargetPath).root) {
+    throw new Error(`Refusing to trash root path: ${targetPath}`);
+  }
+  const base = path.basename(resolvedTargetPath).replace(/[\\/]+/g, "");
+  if (!base) {
+    throw new Error(`Unable to derive safe trash basename for: ${targetPath}`);
+  }
+  return base;
+}
+
+function resolveContainedPath(root: string, leaf: string): string {
+  const resolvedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(resolvedRoot, leaf);
+  if (!isSameOrChildPath(resolvedPath, resolvedRoot) || resolvedPath === resolvedRoot) {
+    throw new Error(`Trash destination escaped trash directory: ${resolvedPath}`);
+  }
+  return resolvedPath;
+}
+
+function reserveTrashDestination(trashDir: string, base: string, timestamp: number): string {
+  const containerPrefix = resolveContainedPath(trashDir, `${base}-${timestamp}-`);
+  const container = fs.mkdtempSync(containerPrefix);
+  const resolvedContainer = path.resolve(container);
+  const resolvedTrashDir = path.resolve(trashDir);
+  if (
+    resolvedContainer === resolvedTrashDir ||
+    !isSameOrChildPath(resolvedContainer, resolvedTrashDir)
+  ) {
+    throw new Error(`Trash destination escaped trash directory: ${container}`);
+  }
+  return resolveContainedPath(container, base);
+}
+
+function movePathToDestination(targetPath: string, dest: string): boolean {
+  try {
+    fs.renameSync(targetPath, dest);
+    return true;
+  } catch (error) {
+    if (getFsErrorCode(error) !== "EXDEV") {
+      if (isTrashDestinationCollision(error)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  try {
+    fs.cpSync(targetPath, dest, { recursive: true, force: false, errorOnExist: true });
+    fs.rmSync(targetPath, { recursive: true, force: false });
+    return true;
+  } catch (error) {
+    if (isTrashDestinationCollision(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export async function movePathToTrash(
+  targetPath: string,
+  options: MovePathToTrashOptions = {},
+): Promise<string> {
+  // Avoid resolving external trash helpers through the service PATH during cleanup.
+  const base = trashBaseName(targetPath);
+  assertAllowedTrashTarget(targetPath, options.allowedRoots);
+  const trashDir = resolveTrashDir();
+  const timestamp = Date.now();
+  for (let attempt = 0; attempt < TRASH_DESTINATION_RETRY_LIMIT; attempt += 1) {
+    const dest = reserveTrashDestination(trashDir, base, timestamp);
+    if (movePathToDestination(targetPath, dest)) {
+      return dest;
+    }
+  }
+
+  throw new Error(`Unable to choose a unique trash destination for ${targetPath}`);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,26 @@
+export type FastPathMode = "auto" | "never" | "require";
+
+export type SafeEncoding = BufferEncoding | null;
+
+export type SafePathStat = {
+  dev: number;
+  gid: number;
+  ino: number;
+  isDirectory: boolean;
+  isFile: boolean;
+  isSymbolicLink: boolean;
+  mode: number;
+  mtimeMs: number;
+  nlink: number;
+  size: number;
+  uid: number;
+};
+
+export type SafeDirEntry = SafePathStat & {
+  name: string;
+};
+
+export type BasePathOptions = {
+  rootDir: string;
+  relativePath: string;
+};

--- a/test/archive-staging.test.ts
+++ b/test/archive-staging.test.ts
@@ -1,0 +1,191 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ArchiveSecurityError,
+  createArchiveSymlinkTraversalError,
+  mergeExtractedTreeIntoDestination,
+  prepareArchiveDestinationDir,
+  prepareArchiveOutputPath,
+  withStagedArchiveDestination,
+} from "../src/archive-staging.js";
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : undefined;
+const tempDirs = new Set<string>();
+
+async function withTempDir<T>(prefix: string, run: (root: string) => Promise<T>): Promise<T> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.add(root);
+  try {
+    return await run(root);
+  } finally {
+    tempDirs.delete(root);
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+afterEach(async () => {
+  for (const dir of tempDirs) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("archive-staging helpers", () => {
+  it("accepts real destination directories and returns their real path", async () => {
+    await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
+      const destDir = path.join(rootDir, "dest");
+      await fs.mkdir(destDir, { recursive: true });
+
+      await expect(prepareArchiveDestinationDir(destDir)).resolves.toBe(await fs.realpath(destDir));
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects symlink and non-directory archive destinations",
+    async () => {
+      await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
+        const realDestDir = path.join(rootDir, "real-dest");
+        const symlinkDestDir = path.join(rootDir, "dest-link");
+        const fileDest = path.join(rootDir, "dest.txt");
+        await fs.mkdir(realDestDir, { recursive: true });
+        await fs.symlink(realDestDir, symlinkDestDir, directorySymlinkType);
+        await fs.writeFile(fileDest, "nope", "utf8");
+
+        await expect(prepareArchiveDestinationDir(symlinkDestDir)).rejects.toMatchObject({
+          code: "destination-symlink",
+        } satisfies Partial<ArchiveSecurityError>);
+        await expect(prepareArchiveDestinationDir(fileDest)).rejects.toMatchObject({
+          code: "destination-not-directory",
+        } satisfies Partial<ArchiveSecurityError>);
+      });
+    },
+  );
+
+  it("creates in-destination parent directories for file outputs", async () => {
+    await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
+      const destDir = path.join(rootDir, "dest");
+      await fs.mkdir(destDir, { recursive: true });
+      const destinationRealDir = await prepareArchiveDestinationDir(destDir);
+      const outPath = path.join(destDir, "nested", "payload.txt");
+
+      await expect(
+        prepareArchiveOutputPath({
+          destinationDir: destDir,
+          destinationRealDir,
+          relPath: "nested/payload.txt",
+          outPath,
+          originalPath: "nested/payload.txt",
+          isDirectory: false,
+        }),
+      ).resolves.toBeUndefined();
+
+      await expect(fs.stat(path.dirname(outPath))).resolves.toMatchObject({
+        isDirectory: expect.any(Function),
+      });
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects output paths that traverse a destination symlink",
+    async () => {
+      await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
+        const destDir = path.join(rootDir, "dest");
+        const outsideDir = path.join(rootDir, "outside");
+        const linkDir = path.join(destDir, "escape");
+        await fs.mkdir(destDir, { recursive: true });
+        await fs.mkdir(outsideDir, { recursive: true });
+        await fs.symlink(outsideDir, linkDir, directorySymlinkType);
+        const destinationRealDir = await prepareArchiveDestinationDir(destDir);
+
+        await expect(
+          prepareArchiveOutputPath({
+            destinationDir: destDir,
+            destinationRealDir,
+            relPath: "escape/payload.txt",
+            outPath: path.join(linkDir, "payload.txt"),
+            originalPath: "escape/payload.txt",
+            isDirectory: false,
+          }),
+        ).rejects.toMatchObject({
+          code: "destination-symlink-traversal",
+        } satisfies Partial<ArchiveSecurityError>);
+      });
+    },
+  );
+
+  it("cleans up staged archive directories after success and failure", async () => {
+    await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
+      const destDir = path.join(rootDir, "dest");
+      await fs.mkdir(destDir, { recursive: true });
+      const destinationRealDir = await prepareArchiveDestinationDir(destDir);
+      let successStage = "";
+
+      await withStagedArchiveDestination({
+        destinationRealDir,
+        run: async (stagingDir) => {
+          successStage = stagingDir;
+          await fs.writeFile(path.join(stagingDir, "payload.txt"), "ok", "utf8");
+        },
+      });
+      await expect(fs.stat(successStage)).rejects.toMatchObject({ code: "ENOENT" });
+
+      let failureStage = "";
+      await expect(
+        withStagedArchiveDestination({
+          destinationRealDir,
+          run: async (stagingDir) => {
+            failureStage = stagingDir;
+            throw new Error("boom");
+          },
+        }),
+      ).rejects.toThrow("boom");
+      await expect(fs.stat(failureStage)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "merges staged trees and rejects symlink entries from the source",
+    async () => {
+      await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
+        const sourceDir = path.join(rootDir, "source");
+        const sourceNestedDir = path.join(sourceDir, "nested");
+        const destDir = path.join(rootDir, "dest");
+        const outsideDir = path.join(rootDir, "outside");
+        await fs.mkdir(sourceNestedDir, { recursive: true });
+        await fs.mkdir(destDir, { recursive: true });
+        await fs.mkdir(outsideDir, { recursive: true });
+        await fs.writeFile(path.join(sourceNestedDir, "payload.txt"), "hi", "utf8");
+
+        const destinationRealDir = await prepareArchiveDestinationDir(destDir);
+        await mergeExtractedTreeIntoDestination({
+          sourceDir,
+          destinationDir: destDir,
+          destinationRealDir,
+        });
+        await expect(
+          fs.readFile(path.join(destDir, "nested", "payload.txt"), "utf8"),
+        ).resolves.toBe("hi");
+
+        await fs.symlink(outsideDir, path.join(sourceDir, "escape"), directorySymlinkType);
+        await expect(
+          mergeExtractedTreeIntoDestination({
+            sourceDir,
+            destinationDir: destDir,
+            destinationRealDir,
+          }),
+        ).rejects.toMatchObject({
+          code: "destination-symlink-traversal",
+        } satisfies Partial<ArchiveSecurityError>);
+      });
+    },
+  );
+
+  it("builds a typed archive symlink traversal error", () => {
+    const error = createArchiveSymlinkTraversalError("nested/payload.txt");
+    expect(error).toBeInstanceOf(ArchiveSecurityError);
+    expect(error.code).toBe("destination-symlink-traversal");
+    expect(error.message).toContain("nested/payload.txt");
+  });
+});

--- a/test/archive.test.ts
+++ b/test/archive.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import JSZip from "jszip";
+import { afterEach, describe, expect, it } from "vitest";
+import { extractArchive, resolvePackedRootDir } from "../src/archive.js";
+import {
+  buildRandomTempFilePath,
+  createTempFileTarget,
+  sanitizeTempFileName,
+  withTempFileTarget,
+} from "../src/temp-target.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
+});
+
+describe("archive extraction", () => {
+  it("extracts zip archives through safe destination checks", async () => {
+    const root = await tempRoot("fs-safe-archive-");
+    const archivePath = path.join(root, "pkg.zip");
+    const destDir = path.join(root, "dest");
+    await fs.mkdir(destDir, { recursive: true });
+
+    const zip = new JSZip();
+    zip.file("package/hello.txt", "hi");
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+
+    await extractArchive({ archivePath, destDir, timeoutMs: 15_000 });
+    const packageDir = await resolvePackedRootDir(destDir);
+    await expect(fs.readFile(path.join(packageDir, "hello.txt"), "utf8")).resolves.toBe("hi");
+  });
+});
+
+describe("temp file targets", () => {
+  it("sanitizes file names and cleans target directories", async () => {
+    const root = await tempRoot("fs-safe-temp-target-");
+    expect(sanitizeTempFileName("../bad name?.txt")).toBe("bad-name-.txt");
+    expect(
+      buildRandomTempFilePath({
+        rootDir: root,
+        prefix: "demo!",
+        extension: "txt",
+        now: 123,
+        uuid: "abc",
+      }),
+    ).toBe(path.join(root, "demo-123-abc.txt"));
+
+    let targetDir = "";
+    await withTempFileTarget(
+      { rootDir: root, prefix: "download", fileName: "../x.txt" },
+      async (filePath) => {
+        targetDir = path.dirname(filePath);
+        await fs.writeFile(filePath, "ok", "utf8");
+        await expect(fs.readFile(filePath, "utf8")).resolves.toBe("ok");
+      },
+    );
+    await expect(fs.stat(targetDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("creates explicit temp file targets", async () => {
+    const root = await tempRoot("fs-safe-temp-target-");
+    const target = await createTempFileTarget({ rootDir: root, prefix: "download" });
+    await fs.writeFile(target.path, "ok", "utf8");
+    await target.cleanup();
+    await expect(fs.stat(target.dir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/test/extracted-helpers.test.ts
+++ b/test/extracted-helpers.test.ts
@@ -1,0 +1,198 @@
+import fs from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_SECRET_FILE_MAX_BYTES,
+  PRIVATE_SECRET_DIR_MODE,
+  PRIVATE_SECRET_FILE_MODE,
+  assertCanonicalPathWithinBase,
+  basenameFromMediaSource,
+  formatPosixMode,
+  isPathInside,
+  isWindowsDrivePath,
+  isWithinDir,
+  loadSecretFileSync,
+  loadJsonFile,
+  normalizeArchiveEntryPath,
+  readSecretFileSync,
+  readJsonFile,
+  resolveArchiveOutputPath,
+  resolveSafeBaseDir,
+  resolveSafeInstallDir,
+  safeDirName,
+  safeFileURLToPath,
+  safePathSegmentHashed,
+  saveJsonFile,
+  stripArchivePath,
+  validateArchiveEntryPath,
+  writePrivateSecretFileAtomic,
+  writeJsonAtomic,
+} from "../src/index.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
+});
+
+describe("local file access helpers", () => {
+  it("accepts local file URLs and rejects remote hosts or encoded separators", () => {
+    const filePath = path.join(path.sep, "tmp", "demo.txt");
+    expect(safeFileURLToPath(new URL(`file://${filePath}`).href)).toBe(fileURLToPath(new URL(`file://${filePath}`)));
+    expect(() => safeFileURLToPath("file://example.com/tmp/demo.txt")).toThrow(/remote hosts/);
+    expect(() => safeFileURLToPath("file:///tmp/a%2Fb.txt")).toThrow(/encode path separators/);
+  });
+
+  it("extracts basenames from file paths and URLs", () => {
+    expect(basenameFromMediaSource("https://example.com/files/report.txt?x=1")).toBe("report.txt");
+    expect(basenameFromMediaSource("/tmp/report.txt")).toBe("report.txt");
+  });
+});
+
+describe("path helpers", () => {
+  it("checks containment and formats modes", () => {
+    const root = path.join(path.sep, "tmp", "root");
+    expect(resolveSafeBaseDir(root)).toBe(`${root}${path.sep}`);
+    expect(isWithinDir(root, path.join(root, "file.txt"))).toBe(true);
+    expect(isPathInside(root, path.join(path.sep, "tmp", "root-other"))).toBe(false);
+    expect(formatPosixMode(0o100755)).toBe("755");
+  });
+});
+
+describe("install path helpers", () => {
+  it("normalizes path segments and resolves install dirs under the base", () => {
+    expect(safeDirName("../demo/plugin")).toBe("..__demo__plugin");
+    expect(safePathSegmentHashed("../../demo/skill")).toMatch(/-[a-f0-9]{10}$/);
+    expect(
+      resolveSafeInstallDir({
+        baseDir: "/tmp/plugins",
+        id: "@openclaw/matrix",
+        invalidNameMessage: "invalid plugin name",
+      }),
+    ).toEqual({
+      ok: true,
+      path: path.join("/tmp/plugins", "@openclaw__matrix"),
+    });
+  });
+
+  it("validates canonical paths under a base directory", async () => {
+    const baseDir = await tempRoot("fs-safe-install-");
+    const candidate = path.join(baseDir, "tools", "plugin");
+    await fs.mkdir(path.dirname(candidate), { recursive: true });
+    await expect(
+      assertCanonicalPathWithinBase({
+        baseDir,
+        candidatePath: candidate,
+        boundaryLabel: "install directory",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("json helpers", () => {
+  it("writes and reads sync and async JSON files", async () => {
+    const root = await tempRoot("fs-safe-json-");
+    const syncPath = path.join(root, "sync", "state.json");
+    const asyncPath = path.join(root, "async", "state.json");
+
+    saveJsonFile(syncPath, { ok: true });
+    expect(loadJsonFile(syncPath)).toEqual({ ok: true });
+
+    await writeJsonAtomic(asyncPath, { ok: true }, { trailingNewline: true });
+    await expect(readJsonFile(asyncPath)).resolves.toEqual({ ok: true });
+    await expect(fs.readFile(asyncPath, "utf8")).resolves.toBe("{\n  \"ok\": true\n}\n");
+  });
+});
+
+describe("archive entry helpers", () => {
+  it("validates and strips archive paths", () => {
+    expect(isWindowsDrivePath("C:\\temp\\file.txt")).toBe(true);
+    expect(normalizeArchiveEntryPath("dir\\file.txt")).toBe("dir/file.txt");
+    expect(stripArchivePath("a//b/file.txt", 1)).toBe("b/file.txt");
+    expect(stripArchivePath("./", 0)).toBeNull();
+    expect(() => validateArchiveEntryPath("../escape.txt", { escapeLabel: "targetDir" })).toThrow(
+      "archive entry escapes targetDir: ../escape.txt",
+    );
+    expect(() => validateArchiveEntryPath("C:\\temp\\file.txt")).toThrow(
+      "archive entry uses a drive path",
+    );
+  });
+
+  it("resolves archive output paths under the destination root", () => {
+    const rootDir = path.join(path.sep, "tmp", "archive-root");
+    expect(
+      resolveArchiveOutputPath({
+        rootDir,
+        relPath: "sub/file.txt",
+        originalPath: "sub/file.txt",
+      }),
+    ).toBe(path.resolve(rootDir, "sub/file.txt"));
+    expect(() =>
+      resolveArchiveOutputPath({
+        rootDir,
+        relPath: "../escape.txt",
+        originalPath: "../escape.txt",
+        escapeLabel: "targetDir",
+      }),
+    ).toThrow("archive entry escapes targetDir: ../escape.txt");
+  });
+});
+
+describe("secret file helpers", () => {
+  it("reads and validates secret files", async () => {
+    const root = await tempRoot("fs-safe-secret-");
+    const filePath = path.join(root, "secret.txt");
+    await fs.writeFile(filePath, " top-secret \n", "utf8");
+
+    expect(readSecretFileSync(filePath, "Gateway password")).toBe("top-secret");
+    expect(loadSecretFileSync(filePath, "Gateway password")).toMatchObject({
+      ok: true,
+      resolvedPath: filePath,
+      secret: "top-secret",
+    });
+
+    await fs.writeFile(filePath, "x".repeat(DEFAULT_SECRET_FILE_MAX_BYTES + 1), "utf8");
+    expect(() => readSecretFileSync(filePath, "Gateway password")).toThrow(
+      `Gateway password file at ${filePath} exceeds ${DEFAULT_SECRET_FILE_MAX_BYTES} bytes.`,
+    );
+  });
+
+  it("writes private secret files without following symlink parents", async () => {
+    const root = await tempRoot("fs-safe-secret-write-");
+    const filePath = path.join(root, "nested", "auth.json");
+    await writePrivateSecretFileAtomic({
+      rootDir: root,
+      filePath,
+      content: '{"ok":true}\n',
+    });
+
+    expect(loadSecretFileSync(filePath, "Gateway password")).toMatchObject({
+      ok: true,
+      secret: '{"ok":true}',
+    });
+    if (process.platform !== "win32") {
+      const dirStat = await fs.stat(path.dirname(filePath));
+      const fileStat = await fs.stat(filePath);
+      expect(dirStat.mode & 0o777).toBe(PRIVATE_SECRET_DIR_MODE);
+      expect(fileStat.mode & 0o777).toBe(PRIVATE_SECRET_FILE_MODE);
+    }
+
+    const outside = await tempRoot("fs-safe-secret-outside-");
+    await fs.symlink(outside, path.join(root, "linked"));
+    await expect(
+      writePrivateSecretFileAtomic({
+        rootDir: root,
+        filePath: path.join(root, "linked", "auth.json"),
+        content: '{"ok":true}\n',
+      }),
+    ).rejects.toThrow("must not be a symlink");
+  });
+});

--- a/test/filename.test.ts
+++ b/test/filename.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeUntrustedFileName } from "../src/filename.js";
+
+describe("sanitizeUntrustedFileName", () => {
+  it("keeps only the basename and strips control characters", () => {
+    expect(sanitizeUntrustedFileName("../nested/rep\u0000ort.pdf", "fallback.bin")).toBe(
+      "report.pdf",
+    );
+  });
+
+  it("uses fallback for empty or path-alias names", () => {
+    expect(sanitizeUntrustedFileName(" ", "fallback.bin")).toBe("fallback.bin");
+    expect(sanitizeUntrustedFileName("..", "fallback.bin")).toBe("fallback.bin");
+  });
+});

--- a/test/fs-safe.test.ts
+++ b/test/fs-safe.test.ts
@@ -1,0 +1,174 @@
+import { mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { root as openRoot } from "../src/index.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  const { rm } = await import("node:fs/promises");
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+});
+
+describe("@openclaw/fs-safe", () => {
+  it("reuses a root capability across filesystem operations", async () => {
+    const rootPath = await tempRoot("fs-root-object-");
+    const root = await openRoot(rootPath);
+
+    await root.mkdir("nested");
+    await root.write("nested/file.txt", "hello");
+    await root.append("nested/file.txt", " world");
+
+    await expect(root.readText("nested/file.txt")).resolves.toBe("hello world");
+    await expect(root.readBytes("nested/file.txt")).resolves.toEqual(
+      Buffer.from("hello world"),
+    );
+
+    const stat = await root.stat("nested/file.txt");
+    expect(stat.isFile).toBe(true);
+
+    await expect(root.list("nested")).resolves.toEqual(["file.txt"]);
+    await root.move("nested/file.txt", "nested/renamed.txt");
+    await expect(root.read("nested/renamed.txt")).resolves.toMatchObject({
+      realPath: expect.stringContaining("renamed.txt"),
+    });
+
+    await root.remove("nested/renamed.txt");
+    await expect(root.stat("nested/renamed.txt")).rejects.toMatchObject({
+      code: "not-found",
+    });
+  });
+
+  it("applies per-root defaults", async () => {
+    const rootPath = await tempRoot("fs-safe-defaults-");
+    const root = await openRoot(rootPath, {
+      hardlinks: "reject",
+      mkdir: true,
+    });
+
+    await root.writeJson("nested/config.json", { ok: true }, { space: 2 });
+
+    await expect(root.readJson("nested/config.json")).resolves.toEqual({ ok: true });
+    await expect(readFile(path.join(rootPath, "nested/config.json"), "utf8")).resolves.toBe(
+      '{\n  "ok": true\n}\n',
+    );
+  });
+
+  it("creates files only when missing", async () => {
+    const rootPath = await tempRoot("fs-safe-if-missing-");
+    const root = await openRoot(rootPath);
+
+    await expect(root.create("nested/file.txt", "first")).resolves.toBe(true);
+    await expect(root.create("nested/file.txt", "second")).resolves.toBe(false);
+    await expect(readFile(path.join(rootPath, "nested/file.txt"), "utf8")).resolves.toBe("first");
+
+    await expect(root.createJson("state.json", { ok: true })).resolves.toBe(true);
+    await expect(root.createJson("state.json", { ok: false })).resolves.toBe(false);
+    await expect(readFile(path.join(rootPath, "state.json"), "utf8")).resolves.toBe(
+      '{"ok":true}\n',
+    );
+  });
+
+  it("writes, reads, stats, and lists files within a root", async () => {
+    const root = await openRoot(await tempRoot("fs-safe-basic-"));
+
+    await root.mkdir("nested");
+    await root.write("nested/file.txt", "hello");
+
+    const read = await root.read("nested/file.txt");
+    expect(read.buffer.toString("utf8")).toBe("hello");
+
+    const stat = await root.stat("nested/file.txt");
+    expect(stat.isFile).toBe(true);
+    expect(stat.size).toBe(5);
+
+    await expect(root.list("nested")).resolves.toEqual(["file.txt"]);
+    const entries = await root.list("nested", { withFileTypes: true });
+    expect(entries).toMatchObject([{ isFile: true, name: "file.txt" }]);
+  });
+
+  it("rejects traversal and absolute paths before touching the filesystem", async () => {
+    const root = await openRoot(await tempRoot("fs-safe-traversal-"));
+
+    await expect(root.stat("../outside")).rejects.toMatchObject({ code: "invalid-path" });
+    await expect(root.read("/etc/passwd")).rejects.toMatchObject({ code: "outside-workspace" });
+    await expect(root.write("../write", "")).rejects.toMatchObject({
+      code: "outside-workspace",
+    });
+  });
+
+  it("rejects symlink parents", async () => {
+    const rootPath = await tempRoot("fs-safe-symlink-parent-");
+    const root = await openRoot(rootPath);
+    const outside = await tempRoot("fs-safe-outside-");
+    await writeFile(path.join(outside, "secret.txt"), "secret");
+    await symlink(outside, path.join(rootPath, "link"), "dir");
+
+    await expect(root.read("link/secret.txt")).rejects.toMatchObject({
+      code: "outside-workspace",
+    });
+    await expect(root.list("link")).rejects.toMatchObject({ code: "path-alias" });
+  });
+
+  it("rejects symlink leaves for stat and read", async () => {
+    const rootPath = await tempRoot("fs-safe-symlink-leaf-");
+    const root = await openRoot(rootPath);
+    const outside = await tempRoot("fs-safe-outside-");
+    await writeFile(path.join(outside, "secret.txt"), "secret");
+    await symlink(path.join(outside, "secret.txt"), path.join(rootPath, "secret-link"), "file");
+
+    await expect(root.stat("secret-link")).rejects.toMatchObject({ code: "path-alias" });
+    await expect(root.read("secret-link")).rejects.toMatchObject({ code: "symlink" });
+  });
+
+  it("renames paths within the same root and rejects symlink sources", async () => {
+    const rootPath = await tempRoot("fs-safe-rename-");
+    const root = await openRoot(rootPath);
+    const outside = await tempRoot("fs-safe-outside-");
+    await root.write("from.txt", "move me");
+
+    await root.move("from.txt", "to.txt");
+    await expect(readFile(path.join(rootPath, "to.txt"), "utf8")).resolves.toBe("move me");
+
+    await writeFile(path.join(outside, "secret.txt"), "secret");
+    await symlink(path.join(outside, "secret.txt"), path.join(rootPath, "link"), "file");
+    await expect(root.move("link", "moved-link")).rejects.toMatchObject({
+      code: "path-alias",
+    });
+  });
+
+  it("removes symlink leaves without following them", async () => {
+    const rootPath = await tempRoot("fs-safe-remove-");
+    const root = await openRoot(rootPath);
+    const outside = await tempRoot("fs-safe-outside-");
+    const outsideFile = path.join(outside, "kept.txt");
+    await writeFile(outsideFile, "kept");
+    await symlink(outsideFile, path.join(rootPath, "link"), "file");
+
+    await root.remove("link");
+
+    await expect(readFile(outsideFile, "utf8")).resolves.toBe("kept");
+    await expect(root.stat("link")).rejects.toMatchObject({
+      code: "not-found",
+    });
+  });
+
+  it("opens a file handle for fast reads when kernel fd path validation is available", async () => {
+    const root = await openRoot(await tempRoot("fs-safe-open-"));
+    await root.write("file.txt", "fast");
+
+    const opened = await root.open("file.txt");
+    try {
+      await expect(opened.handle.readFile("utf8")).resolves.toBe("fast");
+    } finally {
+      await opened.handle.close();
+    }
+  });
+});

--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -1,0 +1,422 @@
+import fs from "node:fs/promises";
+import syncFs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { privateFileStore, writePrivateJsonAtomicSync } from "../src/private-file-store.js";
+import { statRegularFile } from "../src/regular-file.js";
+import {
+  createPrivateTempWorkspace,
+  createPrivateTempWorkspaceSync,
+  withPrivateTempWorkspace,
+  withPrivateTempWorkspaceSync,
+} from "../src/private-temp-workspace.js";
+import {
+  assertNoSymlinkParents,
+  assertNoSymlinkParentsSync,
+} from "../src/symlink-parents.js";
+import { pathScope } from "../src/root-paths.js";
+import { replaceFileAtomic, replaceFileAtomicSync } from "../src/replace-file.js";
+import { movePathWithCopyFallback } from "../src/move-path.js";
+import { writeSiblingTempFile } from "../src/sibling-temp.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-new-"));
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("private temp workspaces", () => {
+  it("writes private files and removes the workspace", async () => {
+    let workspaceDir = "";
+    const content = await withPrivateTempWorkspace({ rootDir: root, prefix: "work-" }, async (tmp) => {
+      workspaceDir = tmp.dir;
+      const filePath = await tmp.writePrivate("input.txt", "hello");
+      expect(await fs.readFile(filePath, "utf8")).toBe("hello");
+      return await tmp.read("input.txt");
+    });
+
+    expect(content.toString("utf8")).toBe("hello");
+    await expect(fs.stat(workspaceDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects path-like file names", async () => {
+    const tmp = await createPrivateTempWorkspace({ rootDir: root, prefix: "work-" });
+    try {
+      await expect(tmp.writePrivate("../escape.txt", "nope")).rejects.toThrow(/Invalid/);
+    } finally {
+      await tmp.cleanup();
+    }
+  });
+
+  it("supports sync temp workspaces", async () => {
+    let workspaceDir = "";
+    const result = withPrivateTempWorkspaceSync({ rootDir: root, prefix: "sync-" }, (tmp) => {
+      workspaceDir = tmp.dir;
+      const filePath = tmp.writePrivate("input.txt", "hello");
+      expect(tmp.read("input.txt").toString("utf8")).toBe("hello");
+      return filePath;
+    });
+    expect(path.basename(result)).toBe("input.txt");
+    await expect(fs.stat(workspaceDir)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const tmp = createPrivateTempWorkspaceSync({ rootDir: root, prefix: "sync-" });
+    try {
+      expect(tmp.writePrivate("again.txt", "ok")).toContain("again.txt");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+});
+
+describe("private file store", () => {
+  it("writes JSON under the store root", async () => {
+    const store = privateFileStore(root);
+    await store.writeJson("nested/state.json", { ok: true }, { trailingNewline: true });
+    expect(await fs.readFile(path.join(root, "nested", "state.json"), "utf8")).toBe(
+      '{\n  "ok": true\n}\n',
+    );
+  });
+
+  it("rejects paths outside the store root", async () => {
+    const store = privateFileStore(root);
+    await expect(store.writeText("../escape.txt", "nope")).rejects.toThrow(/stay under/);
+  });
+
+  it("supports sync JSON writes", async () => {
+    const filePath = path.join(root, "sync.json");
+    writePrivateJsonAtomicSync({ rootDir: root, filePath, value: { ok: true } });
+    expect(JSON.parse(await fs.readFile(filePath, "utf8"))).toEqual({ ok: true });
+  });
+});
+
+describe("atomic file replacement", () => {
+  it("retries transient rename failures and preserves destination spelling", async () => {
+    const filePath = path.join(root, "state.json");
+    const originalRename = fs.rename.bind(fs);
+    const destinations: string[] = [];
+    let busyCount = 0;
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (src, dest) => {
+      destinations.push(String(dest));
+      if (busyCount < 2) {
+        busyCount++;
+        const error = new Error("busy") as NodeJS.ErrnoException;
+        error.code = "EBUSY";
+        throw error;
+      }
+      return await originalRename(src, dest);
+    });
+
+    try {
+      await replaceFileAtomic({
+        filePath,
+        content: "ok",
+        renameMaxRetries: 2,
+        renameRetryBaseDelayMs: 0,
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(busyCount).toBe(2);
+    expect(destinations).toEqual([filePath, filePath, filePath]);
+    expect(await fs.readFile(filePath, "utf8")).toBe("ok");
+  });
+
+  it("can fall back to copy/unlink for permission-style rename failures", async () => {
+    const filePath = path.join(root, "windows.json");
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async () => {
+      const error = new Error("permission") as NodeJS.ErrnoException;
+      error.code = "EPERM";
+      throw error;
+    });
+
+    try {
+      await replaceFileAtomic({
+        filePath,
+        content: "copied",
+        copyFallbackOnPermissionError: true,
+      });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    expect(await fs.readFile(filePath, "utf8")).toBe("copied");
+  });
+
+  it("cleans the temp file after failed replacement", async () => {
+    const filePath = path.join(root, "fail.json");
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async () => {
+      const error = new Error("denied") as NodeJS.ErrnoException;
+      error.code = "EACCES";
+      throw error;
+    });
+
+    try {
+      await expect(
+        replaceFileAtomic({
+          filePath,
+          content: "nope",
+          tempPrefix: ".cron-store",
+        }),
+      ).rejects.toMatchObject({ code: "EACCES" });
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    const entries = await fs.readdir(root);
+    expect(entries.filter((entry) => entry.startsWith(".cron-store"))).toEqual([]);
+  });
+
+  it("applies requested directory and file modes", async () => {
+    const filePath = path.join(root, "nested", "mode.txt");
+    await replaceFileAtomic({
+      filePath,
+      content: "mode",
+      dirMode: 0o755,
+      fileMode: 0o644,
+    });
+
+    if (process.platform !== "win32") {
+      expect((await fs.stat(path.dirname(filePath))).mode & 0o777).toBe(0o755);
+      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o644);
+    }
+  });
+
+  it("supports sync replacement", async () => {
+    const filePath = path.join(root, "sync", "state.txt");
+    replaceFileAtomicSync({
+      filePath,
+      content: "sync",
+      dirMode: 0o755,
+      fileMode: 0o644,
+      tempPrefix: ".sync-replace",
+    });
+
+    expect(await fs.readFile(filePath, "utf8")).toBe("sync");
+    if (process.platform !== "win32") {
+      expect((await fs.stat(path.dirname(filePath))).mode & 0o777).toBe(0o755);
+      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o644);
+    }
+  });
+
+  it("preserves an existing destination mode when requested", async () => {
+    const filePath = path.join(root, "preserve-mode.txt");
+    await fs.writeFile(filePath, "old", { mode: 0o640 });
+
+    await replaceFileAtomic({
+      filePath,
+      content: "new",
+      preserveExistingMode: true,
+    });
+
+    expect(await fs.readFile(filePath, "utf8")).toBe("new");
+    if (process.platform !== "win32") {
+      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o640);
+    }
+  });
+
+  it("syncs the temp file before rename when requested", async () => {
+    const filePath = path.join(root, "sync-temp.txt");
+    let syncCalls = 0;
+    const fileSystem = {
+      promises: {
+        ...fs,
+        open: async (...args: Parameters<typeof fs.open>) => {
+          const handle = await fs.open(...args);
+          return {
+            sync: async () => {
+              syncCalls += 1;
+            },
+            close: async () => await handle.close(),
+          } as Awaited<ReturnType<typeof fs.open>>;
+        },
+      },
+    };
+
+    await replaceFileAtomic({
+      filePath,
+      content: "durable",
+      syncTempFile: true,
+      fileSystem,
+    });
+
+    expect(syncCalls).toBe(1);
+    expect(await fs.readFile(filePath, "utf8")).toBe("durable");
+  });
+
+  it("can use injected async filesystem operations", async () => {
+    const filePath = path.join(root, "injected.txt");
+    const renamed: string[] = [];
+    const fileSystem = {
+      promises: {
+        ...fs,
+        rename: async (src: string, dest: string) => {
+          renamed.push(dest);
+          await fs.rename(src, dest);
+        },
+      },
+    };
+
+    await replaceFileAtomic({
+      filePath,
+      content: "injected",
+      fileSystem,
+    });
+
+    expect(renamed).toEqual([filePath]);
+    expect(await fs.readFile(filePath, "utf8")).toBe("injected");
+  });
+
+  it("syncs the parent directory when requested", async () => {
+    const filePath = path.join(root, "parent-sync.txt");
+    let openedDir = "";
+    const fileSystem = {
+      promises: {
+        ...fs,
+        open: async (...args: Parameters<typeof fs.open>) => {
+          openedDir = String(args[0]);
+          const handle = await fs.open(...args);
+          return {
+            sync: async () => undefined,
+            close: async () => await handle.close(),
+          } as Awaited<ReturnType<typeof fs.open>>;
+        },
+      },
+    };
+
+    await replaceFileAtomic({
+      filePath,
+      content: "durable-parent",
+      syncParentDir: true,
+      fileSystem,
+    });
+
+    expect(openedDir).toBe(root);
+  });
+
+  it("cleans the sync temp file after failed replacement", async () => {
+    const filePath = path.join(root, "sync-fail.json");
+    const renameSpy = vi.spyOn(syncFs, "renameSync").mockImplementation(() => {
+      const error = new Error("denied") as NodeJS.ErrnoException;
+      error.code = "EACCES";
+      throw error;
+    });
+
+    try {
+      expect(() =>
+        replaceFileAtomicSync({
+          filePath,
+          content: "nope",
+          tempPrefix: ".sync-store",
+        }),
+      ).toThrow();
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    const entries = await fs.readdir(root);
+    expect(entries.filter((entry) => entry.startsWith(".sync-store"))).toEqual([]);
+  });
+});
+
+describe("path moves", () => {
+  it("moves paths with rename", async () => {
+    const from = path.join(root, "from.txt");
+    const to = path.join(root, "to.txt");
+    await fs.writeFile(from, "moved");
+
+    await movePathWithCopyFallback({ from, to });
+
+    await expect(fs.access(from)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await fs.readFile(to, "utf8")).toBe("moved");
+  });
+});
+
+describe("sibling temp files", () => {
+  it("writes through a sibling temp file and cleans failures", async () => {
+    const finalPath = path.join(root, "download.bin");
+    const writtenTempPaths: string[] = [];
+    const result = await writeSiblingTempFile({
+      dir: root,
+      fileMode: 0o644,
+      writeTemp: async (tempPath) => {
+        writtenTempPaths.push(tempPath);
+        await fs.writeFile(tempPath, "streamed");
+        return { name: "download.bin" };
+      },
+      resolveFinalPath: (value) => path.join(root, value.name),
+    });
+
+    expect(result.filePath).toBe(finalPath);
+    expect(await fs.readFile(finalPath, "utf8")).toBe("streamed");
+    await expect(fs.access(writtenTempPaths[0])).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects final paths outside the temp directory", async () => {
+    await expect(
+      writeSiblingTempFile({
+        dir: root,
+        writeTemp: async (tempPath) => {
+          await fs.writeFile(tempPath, "escape");
+          return "escape";
+        },
+        resolveFinalPath: () => path.join(path.dirname(root), "escape.txt"),
+      }),
+    ).rejects.toThrow(/sibling temp directory/);
+    expect(await fs.readdir(root)).toEqual([]);
+  });
+});
+
+describe("regular file helpers", () => {
+  it("rejects directories", async () => {
+    await expect(statRegularFile(root)).rejects.toThrow(/regular file/);
+  });
+});
+
+describe("path scope directory creation", () => {
+  it("creates directories inside the root", async () => {
+    const result = await pathScope(root, { label: "test root" }).ensureDir("a/b", { mode: 0o700 });
+    expect(result).toEqual({ ok: true, path: path.join(root, "a", "b") });
+    await expect(fs.stat(path.join(root, "a", "b"))).resolves.toMatchObject({});
+  });
+
+  it("rejects escapes", async () => {
+    const result = await pathScope(root, { label: "test root" }).ensureDir("../out");
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("symlink parent guards", () => {
+  it("rejects symlink path components", async () => {
+    const real = path.join(root, "real");
+    const link = path.join(root, "link");
+    await fs.mkdir(real);
+    await fs.symlink(real, link);
+    await expect(
+      assertNoSymlinkParents({
+        rootDir: root,
+        targetPath: path.join(link, "file.txt"),
+        requireDirectories: true,
+      }),
+    ).rejects.toThrow(/symlinked/);
+  });
+
+  it("has a sync variant", async () => {
+    const real = path.join(root, "real-sync");
+    const link = path.join(root, "link-sync");
+    await fs.mkdir(real);
+    await fs.symlink(real, link);
+    expect(() =>
+      assertNoSymlinkParentsSync({
+        rootDir: root,
+        targetPath: path.join(link, "file.txt"),
+        requireDirectories: true,
+      }),
+    ).toThrow(/symlinked/);
+  });
+});

--- a/test/pinned-open.test.ts
+++ b/test/pinned-open.test.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { openPinnedFileSync } from "../src/pinned-open.js";
+
+type PinnedOpenSyncFs = NonNullable<Parameters<typeof openPinnedFileSync>[0]["ioFs"]>;
+type PinnedOpenSyncLstatSync = PinnedOpenSyncFs["lstatSync"];
+type PinnedOpenSyncRealpathSync = PinnedOpenSyncFs["realpathSync"];
+type PinnedOpenSyncFstatSync = PinnedOpenSyncFs["fstatSync"];
+
+const tempDirs: string[] = [];
+
+async function withTempDir<T>(prefix: string, run: (root: string) => Promise<T>): Promise<T> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return await run(dir);
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
+});
+
+function mockStat(params: {
+  isFile?: boolean;
+  isDirectory?: boolean;
+  nlink?: number;
+  size?: number;
+  dev?: number;
+  ino?: number;
+}): fs.Stats {
+  return {
+    isFile: () => params.isFile ?? false,
+    isDirectory: () => params.isDirectory ?? false,
+    isSymbolicLink: () => false,
+    nlink: params.nlink ?? 1,
+    size: params.size ?? 0,
+    dev: params.dev ?? 1,
+    ino: params.ino ?? 1,
+  } as unknown as fs.Stats;
+}
+
+function mockRealpathSync(result: string): PinnedOpenSyncRealpathSync {
+  const resolvePath = ((_: fs.PathLike) => result) as PinnedOpenSyncRealpathSync;
+  resolvePath.native = ((_: fs.PathLike) => result) as typeof resolvePath.native;
+  return resolvePath;
+}
+
+function mockLstatSync(read: (filePath: fs.PathLike) => fs.Stats): PinnedOpenSyncLstatSync {
+  return ((filePath: fs.PathLike) => read(filePath)) as unknown as PinnedOpenSyncLstatSync;
+}
+
+function mockFstatSync(stat: fs.Stats): PinnedOpenSyncFstatSync {
+  return ((_: number) => stat) as unknown as PinnedOpenSyncFstatSync;
+}
+
+async function expectOpenFailure(params: {
+  setup: (root: string) => Promise<Parameters<typeof openPinnedFileSync>[0]>;
+  expectedReason: "path" | "validation" | "io";
+}): Promise<void> {
+  await withTempDir("fs-safe-open-", async (root) => {
+    const opened = openPinnedFileSync(await params.setup(root));
+    expect(opened.ok).toBe(false);
+    if (!opened.ok) {
+      expect(opened.reason).toBe(params.expectedReason);
+    }
+  });
+}
+
+function expectOpenReason(
+  opened: ReturnType<typeof openPinnedFileSync>,
+  expectedReason: "path" | "validation" | "io",
+): void {
+  expect(opened.ok).toBe(false);
+  if (opened.ok) {
+    return;
+  }
+  expect(opened.reason).toBe(expectedReason);
+}
+
+describe("openPinnedFileSync", () => {
+  it.each([
+    {
+      name: "missing files",
+      expectedReason: "path" as const,
+      setup: async (root: string) => ({ filePath: path.join(root, "missing.txt") }),
+    },
+    {
+      name: "directories by default",
+      expectedReason: "validation" as const,
+      setup: async (root: string) => {
+        const targetDir = path.join(root, "nested");
+        await fsp.mkdir(targetDir, { recursive: true });
+        return { filePath: targetDir };
+      },
+    },
+    {
+      name: "symlink paths when rejectPathSymlink is enabled",
+      expectedReason: "validation" as const,
+      setup: async (root: string) => {
+        const targetFile = path.join(root, "target.txt");
+        const linkFile = path.join(root, "link.txt");
+        await fsp.writeFile(targetFile, "hello");
+        await fsp.symlink(targetFile, linkFile);
+        return {
+          filePath: linkFile,
+          rejectPathSymlink: true,
+        };
+      },
+    },
+    {
+      name: "files larger than maxBytes",
+      expectedReason: "validation" as const,
+      setup: async (root: string) => {
+        const filePath = path.join(root, "payload.txt");
+        await fsp.writeFile(filePath, "hello");
+        return {
+          filePath,
+          maxBytes: 4,
+        };
+      },
+    },
+  ])("fails for $name", async ({ setup, expectedReason }) => {
+    await expectOpenFailure({ setup, expectedReason });
+  });
+
+  it("accepts directories when allowedType is directory", async () => {
+    await withTempDir("fs-safe-open-", async (root) => {
+      const targetDir = path.join(root, "nested");
+      await fsp.mkdir(targetDir, { recursive: true });
+
+      const opened = openPinnedFileSync({
+        filePath: targetDir,
+        allowedType: "directory",
+        rejectHardlinks: true,
+      });
+      expect(opened.ok).toBe(true);
+      if (!opened.ok) {
+        return;
+      }
+      expect(opened.stat.isDirectory()).toBe(true);
+      fs.closeSync(opened.fd);
+    });
+  });
+
+  it("rejects post-open validation mismatches and closes the fd", () => {
+    const closeSync = (fd: number) => {
+      closed.push(fd);
+    };
+    const closed: number[] = [];
+    const ioFs: PinnedOpenSyncFs = {
+      constants: fs.constants,
+      lstatSync: mockLstatSync((filePath) =>
+        String(filePath) === "/real/file.txt"
+          ? mockStat({ isFile: true, size: 1, dev: 1, ino: 1 })
+          : mockStat({ isFile: false }),
+      ),
+      realpathSync: mockRealpathSync("/real/file.txt"),
+      openSync: () => 42,
+      fstatSync: mockFstatSync(mockStat({ isFile: true, size: 1, dev: 2, ino: 1 })),
+      closeSync,
+    };
+
+    const opened = openPinnedFileSync({
+      filePath: "/input/file.txt",
+      ioFs,
+    });
+    expectOpenReason(opened, "validation");
+    expect(closed).toEqual([42]);
+  });
+
+  it("reports non-path filesystem failures as io errors", () => {
+    const ioFs: PinnedOpenSyncFs = {
+      constants: fs.constants,
+      lstatSync: () => {
+        const err = new Error("permission denied") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        throw err;
+      },
+      realpathSync: mockRealpathSync("/real/file.txt"),
+      openSync: () => 42,
+      fstatSync: mockFstatSync(mockStat({ isFile: true })),
+      closeSync: () => {},
+    };
+
+    const opened = openPinnedFileSync({
+      filePath: "/input/file.txt",
+      rejectPathSymlink: true,
+      ioFs,
+    });
+    expectOpenReason(opened, "io");
+  });
+});

--- a/test/root-file.test.ts
+++ b/test/root-file.test.ts
@@ -1,0 +1,240 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveRootPathSyncMock = vi.hoisted(() => vi.fn());
+const resolveRootPathMock = vi.hoisted(() => vi.fn());
+const openPinnedFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/root-path.js", () => ({
+  resolveRootPathSync: (...args: unknown[]) => resolveRootPathSyncMock(...args),
+  resolveRootPath: (...args: unknown[]) => resolveRootPathMock(...args),
+}));
+
+vi.mock("../src/pinned-open.js", () => ({
+  openPinnedFileSync: (...args: unknown[]) => openPinnedFileSyncMock(...args),
+}));
+
+let canUseRootFileOpen: typeof import("../src/root-file.js").canUseRootFileOpen;
+let matchRootFileOpenFailure: typeof import("../src/root-file.js").matchRootFileOpenFailure;
+let openRootFile: typeof import("../src/root-file.js").openRootFile;
+let openRootFileSync: typeof import("../src/root-file.js").openRootFileSync;
+
+describe("root-file", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({
+      canUseRootFileOpen,
+      matchRootFileOpenFailure,
+      openRootFile,
+      openRootFileSync,
+    } = await import("../src/root-file.js"));
+    resolveRootPathSyncMock.mockReset();
+    resolveRootPathMock.mockReset();
+    openPinnedFileSyncMock.mockReset();
+  });
+
+  it("recognizes the required sync fs surface", () => {
+    const validFs = {
+      openSync() {},
+      closeSync() {},
+      fstatSync() {},
+      lstatSync() {},
+      realpathSync() {},
+      readFileSync() {},
+      constants: {},
+    };
+
+    expect(canUseRootFileOpen(validFs as never)).toBe(true);
+    expect(
+      canUseRootFileOpen({
+        ...validFs,
+        openSync: undefined,
+      } as never),
+    ).toBe(false);
+    expect(
+      canUseRootFileOpen({
+        ...validFs,
+        constants: null,
+      } as never),
+    ).toBe(false);
+  });
+
+  it("maps sync boundary resolution into verified file opens", () => {
+    const stat = { size: 3 } as never;
+    const ioFs = { marker: "io" } as never;
+    const absolutePath = path.resolve("plugin.json");
+
+    resolveRootPathSyncMock.mockReturnValue({
+      canonicalPath: "/real/plugin.json",
+      rootCanonicalPath: "/real/root",
+    });
+    openPinnedFileSyncMock.mockReturnValue({
+      ok: true,
+      path: "/real/plugin.json",
+      fd: 7,
+      stat,
+    });
+
+    const opened = openRootFileSync({
+      absolutePath: "plugin.json",
+      rootPath: "/workspace",
+      boundaryLabel: "plugin root",
+      ioFs,
+    });
+
+    expect(resolveRootPathSyncMock).toHaveBeenCalledWith({
+      absolutePath,
+      rootPath: "/workspace",
+      rootCanonicalPath: undefined,
+      boundaryLabel: "plugin root",
+      skipLexicalRootCheck: undefined,
+    });
+    expect(openPinnedFileSyncMock).toHaveBeenCalledWith({
+      filePath: absolutePath,
+      resolvedPath: "/real/plugin.json",
+      rejectHardlinks: true,
+      maxBytes: undefined,
+      allowedType: undefined,
+      ioFs,
+    });
+    expect(opened).toEqual({
+      ok: true,
+      path: "/real/plugin.json",
+      fd: 7,
+      stat,
+      rootRealPath: "/real/root",
+    });
+  });
+
+  it("returns validation errors when sync boundary resolution throws", () => {
+    const error = new Error("outside root");
+    resolveRootPathSyncMock.mockImplementation(() => {
+      throw error;
+    });
+
+    const opened = openRootFileSync({
+      absolutePath: "plugin.json",
+      rootPath: "/workspace",
+      boundaryLabel: "plugin root",
+    });
+
+    expect(opened).toEqual({
+      ok: false,
+      reason: "validation",
+      error,
+    });
+    expect(openPinnedFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("guards against unexpected async sync-resolution results", () => {
+    resolveRootPathSyncMock.mockReturnValue(
+      Promise.resolve({
+        canonicalPath: "/real/plugin.json",
+        rootCanonicalPath: "/real/root",
+      }),
+    );
+
+    const opened = openRootFileSync({
+      absolutePath: "plugin.json",
+      rootPath: "/workspace",
+      boundaryLabel: "plugin root",
+    });
+
+    expect(opened.ok).toBe(false);
+    if (opened.ok) {
+      return;
+    }
+    expect(opened.reason).toBe("validation");
+    expect(String(opened.error)).toContain("Unexpected async boundary resolution");
+  });
+
+  it("awaits async boundary resolution before verifying the file", async () => {
+    const ioFs = { marker: "io" } as never;
+    const absolutePath = path.resolve("notes.txt");
+
+    resolveRootPathMock.mockResolvedValue({
+      canonicalPath: "/real/notes.txt",
+      rootCanonicalPath: "/real/root",
+    });
+    openPinnedFileSyncMock.mockReturnValue({
+      ok: false,
+      reason: "validation",
+      error: new Error("blocked"),
+    });
+
+    const opened = await openRootFile({
+      absolutePath: "notes.txt",
+      rootPath: "/workspace",
+      boundaryLabel: "workspace",
+      aliasPolicy: { allowFinalSymlinkForUnlink: true },
+      ioFs,
+    });
+
+    expect(resolveRootPathMock).toHaveBeenCalledWith({
+      absolutePath,
+      rootPath: "/workspace",
+      rootCanonicalPath: undefined,
+      boundaryLabel: "workspace",
+      policy: { allowFinalSymlinkForUnlink: true },
+      skipLexicalRootCheck: undefined,
+    });
+    expect(openPinnedFileSyncMock).toHaveBeenCalledWith({
+      filePath: absolutePath,
+      resolvedPath: "/real/notes.txt",
+      rejectHardlinks: true,
+      maxBytes: undefined,
+      allowedType: undefined,
+      ioFs,
+    });
+    expect(opened).toEqual({
+      ok: false,
+      reason: "validation",
+      error: expect.any(Error),
+    });
+  });
+
+  it("maps async boundary resolution failures to validation errors", async () => {
+    const error = new Error("escaped");
+    resolveRootPathMock.mockRejectedValue(error);
+
+    const opened = await openRootFile({
+      absolutePath: "notes.txt",
+      rootPath: "/workspace",
+      boundaryLabel: "workspace",
+    });
+
+    expect(opened).toEqual({
+      ok: false,
+      reason: "validation",
+      error,
+    });
+    expect(openPinnedFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("matches boundary file failures by reason with fallback support", () => {
+    const missing = matchRootFileOpenFailure(
+      { ok: false, reason: "path", error: new Error("missing") },
+      {
+        path: () => "missing",
+        fallback: () => "fallback",
+      },
+    );
+    const io = matchRootFileOpenFailure(
+      { ok: false, reason: "io", error: new Error("io") },
+      {
+        io: () => "io",
+        fallback: () => "fallback",
+      },
+    );
+    const validation = matchRootFileOpenFailure(
+      { ok: false, reason: "validation", error: new Error("blocked") },
+      {
+        fallback: (failure) => failure.reason,
+      },
+    );
+
+    expect(missing).toBe("missing");
+    expect(io).toBe("io");
+    expect(validation).toBe("validation");
+  });
+});

--- a/test/root-paths.test.ts
+++ b/test/root-paths.test.ts
@@ -1,0 +1,132 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  pathScope,
+  resolveExistingPathsWithinRoot,
+  resolvePathWithinRoot,
+  resolveStrictExistingPathsWithinRoot,
+  resolveWritablePathWithinRoot,
+} from "../src/root-paths.js";
+
+async function withFixtureRoot<T>(
+  run: (ctx: { baseDir: string; uploadsDir: string }) => Promise<T>,
+): Promise<T> {
+  const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-root-paths-"));
+  const uploadsDir = path.join(baseDir, "uploads");
+  await fs.mkdir(uploadsDir, { recursive: true });
+  try {
+    return await run({ baseDir, uploadsDir });
+  } finally {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  }
+}
+
+function expectInvalidResult(result: { ok: true; paths: string[] } | { ok: false; error: string }) {
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.error).toContain("uploads directory");
+  }
+}
+
+describe("root path list helpers", () => {
+  it("creates a root-scoped helper with shorter method names", async () => {
+    await withFixtureRoot(async ({ uploadsDir }) => {
+      const uploads = pathScope(uploadsDir, { label: "uploads directory" });
+      const filePath = path.join(uploadsDir, "ok.txt");
+      await fs.writeFile(filePath, "ok", "utf8");
+
+      await expect(uploads.files(["ok.txt"])).resolves.toEqual({
+        ok: true,
+        paths: [await fs.realpath(filePath)],
+      });
+      await expect(uploads.writable(" ", { defaultName: "fallback.txt" })).resolves.toEqual({
+        ok: true,
+        path: path.join(uploadsDir, "fallback.txt"),
+      });
+    });
+  });
+
+  it("accepts existing files under the root", async () => {
+    await withFixtureRoot(async ({ uploadsDir }) => {
+      const filePath = path.join(uploadsDir, "ok.txt");
+      await fs.writeFile(filePath, "ok", "utf8");
+
+      const result = await resolveExistingPathsWithinRoot({
+        rootDir: uploadsDir,
+        requestedPaths: [filePath],
+        scopeLabel: "uploads directory",
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.paths).toEqual([await fs.realpath(filePath)]);
+      }
+    });
+  });
+
+  it("keeps lexical in-root paths when missing fallbacks are allowed", async () => {
+    await withFixtureRoot(async ({ uploadsDir }) => {
+      const result = await resolveExistingPathsWithinRoot({
+        rootDir: uploadsDir,
+        requestedPaths: ["missing.txt"],
+        scopeLabel: "uploads directory",
+      });
+
+      expect(result).toEqual({ ok: true, paths: [path.join(uploadsDir, "missing.txt")] });
+    });
+  });
+
+  it("rejects missing files in strict mode", async () => {
+    await withFixtureRoot(async ({ uploadsDir }) => {
+      const result = await resolveStrictExistingPathsWithinRoot({
+        rootDir: uploadsDir,
+        requestedPaths: ["missing.txt"],
+        scopeLabel: "uploads directory",
+      });
+
+      expectInvalidResult(result);
+    });
+  });
+
+  it.runIf(process.platform !== "win32")("rejects symlink escapes", async () => {
+    await withFixtureRoot(async ({ baseDir, uploadsDir }) => {
+      const outsideDir = path.join(baseDir, "outside");
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(path.join(outsideDir, "secret.txt"), "secret", "utf8");
+      await fs.symlink(outsideDir, path.join(uploadsDir, "alias"));
+
+      const result = await resolveExistingPathsWithinRoot({
+        rootDir: uploadsDir,
+        requestedPaths: ["alias/secret.txt"],
+        scopeLabel: "uploads directory",
+      });
+
+      expect(result).toEqual({ ok: false, error: "File is outside uploads directory" });
+    });
+  });
+
+  it("uses a default file name for blank writable paths", async () => {
+    await withFixtureRoot(async ({ uploadsDir }) => {
+      const result = await resolveWritablePathWithinRoot({
+        rootDir: uploadsDir,
+        requestedPath: " ",
+        scopeLabel: "uploads directory",
+        defaultFileName: "fallback.txt",
+      });
+
+      expect(result).toEqual({ ok: true, path: path.join(uploadsDir, "fallback.txt") });
+    });
+  });
+
+  it("rejects root-level path aliases", () => {
+    const result = resolvePathWithinRoot({
+      rootDir: "/tmp/uploads",
+      requestedPath: ".",
+      scopeLabel: "uploads directory",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});

--- a/test/secure-temp-dir.test.ts
+++ b/test/secure-temp-dir.test.ts
@@ -1,0 +1,163 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { resolveSecureTempRoot, type ResolveSecureTempRootOptions } from "../src/secure-temp-dir.js";
+
+type TmpDirOptions = ResolveSecureTempRootOptions;
+
+function nodeErrorWithCode(code: string) {
+  const err = new Error(code) as Error & { code?: string };
+  err.code = code;
+  return err;
+}
+
+function secureDirStat(uid = 501) {
+  return {
+    isDirectory: () => true,
+    isSymbolicLink: () => false,
+    uid,
+    mode: 0o40700,
+  };
+}
+
+function makeDirStat(params?: {
+  isDirectory?: boolean;
+  isSymbolicLink?: boolean;
+  uid?: number;
+  mode?: number;
+}) {
+  return {
+    isDirectory: () => params?.isDirectory ?? true,
+    isSymbolicLink: () => params?.isSymbolicLink ?? false,
+    uid: params?.uid ?? 501,
+    mode: params?.mode ?? 0o40700,
+  };
+}
+
+function resolveWithMocks(params: {
+  preferredDir?: string;
+  lstatSync: NonNullable<TmpDirOptions["lstatSync"]>;
+  fallbackLstatSync?: NonNullable<TmpDirOptions["lstatSync"]>;
+  accessSync?: NonNullable<TmpDirOptions["accessSync"]>;
+  chmodSync?: NonNullable<TmpDirOptions["chmodSync"]>;
+  warn?: NonNullable<TmpDirOptions["warn"]>;
+  uid?: number;
+  tmpdirPath?: string;
+}) {
+  const uid = params.uid ?? 501;
+  const preferredDir = params.preferredDir ?? "/tmp/example";
+  const fallbackPath = path.join("/var/fallback", `example-${uid}`);
+  const accessSync = params.accessSync ?? vi.fn();
+  const chmodSync = params.chmodSync ?? vi.fn();
+  const warn = params.warn ?? vi.fn();
+  const wrappedLstatSync = vi.fn((target: string) => {
+    if (target === preferredDir) {
+      return params.lstatSync(target);
+    }
+    if (target === fallbackPath) {
+      return params.fallbackLstatSync ? params.fallbackLstatSync(target) : secureDirStat(uid);
+    }
+    return secureDirStat(uid);
+  }) as NonNullable<TmpDirOptions["lstatSync"]>;
+  const mkdirSync = vi.fn();
+  const tmpdir = vi.fn(() => params.tmpdirPath ?? "/var/fallback");
+  const resolved = resolveSecureTempRoot({
+    accessSync,
+    chmodSync,
+    fallbackPrefix: "example",
+    getuid: vi.fn(() => uid),
+    lstatSync: wrappedLstatSync,
+    mkdirSync,
+    preferredDir,
+    tmpdir,
+    unsafeFallbackLabel: "Example temp dir",
+    warn,
+    warningPrefix: "[example]",
+  });
+  return { resolved, accessSync, chmodSync, lstatSync: wrappedLstatSync, mkdirSync, tmpdir };
+}
+
+describe("resolveSecureTempRoot", () => {
+  it("prefers an existing secure preferred directory", () => {
+    const { resolved, tmpdir } = resolveWithMocks({
+      lstatSync: vi.fn(() => secureDirStat()),
+    });
+
+    expect(resolved).toBe("/tmp/example");
+    expect(tmpdir).not.toHaveBeenCalled();
+  });
+
+  it("creates the preferred directory when the parent is writable", () => {
+    const lstatSync = vi
+      .fn<NonNullable<TmpDirOptions["lstatSync"]>>()
+      .mockImplementationOnce(() => {
+        throw nodeErrorWithCode("ENOENT");
+      })
+      .mockImplementationOnce(() => secureDirStat());
+
+    const { resolved, accessSync, mkdirSync } = resolveWithMocks({ lstatSync });
+
+    expect(resolved).toBe("/tmp/example");
+    expect(accessSync).toHaveBeenCalledWith("/tmp", expect.any(Number));
+    expect(mkdirSync).toHaveBeenCalledWith("/tmp/example", { recursive: true, mode: 0o700 });
+  });
+
+  it("falls back to a uid-scoped secure temp directory", () => {
+    const { resolved, tmpdir } = resolveWithMocks({
+      accessSync: vi.fn((target: string) => {
+        if (target === "/tmp") {
+          throw new Error("read-only");
+        }
+      }),
+      lstatSync: vi.fn(() => {
+        throw nodeErrorWithCode("ENOENT");
+      }),
+    });
+
+    expect(resolved).toBe(path.join("/var/fallback", "example-501"));
+    expect(tmpdir).toHaveBeenCalled();
+  });
+
+  it("repairs broad permissions before accepting a directory", () => {
+    let preferredMode = 0o40777;
+    const chmodSync = vi.fn((target: string, mode: number) => {
+      if (target === "/tmp/example" && mode === 0o700) {
+        preferredMode = 0o40700;
+      }
+    });
+    const warn = vi.fn();
+
+    const { resolved } = resolveWithMocks({
+      chmodSync,
+      lstatSync: vi.fn(() => makeDirStat({ mode: preferredMode })),
+      warn,
+    });
+
+    expect(resolved).toBe("/tmp/example");
+    expect(chmodSync).toHaveBeenCalledWith("/tmp/example", 0o700);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("[example] tightened permissions"));
+  });
+
+  it("skips the preferred POSIX path on Windows when requested", () => {
+    const winFallback = path.win32.join("C:\\Temp", "example-501");
+    const result = resolveSecureTempRoot({
+      accessSync: vi.fn(),
+      chmodSync: vi.fn(),
+      fallbackPrefix: "example",
+      getuid: vi.fn(() => 501),
+      lstatSync: vi.fn((target: string) => {
+        if (target === "/tmp/example" || target === winFallback) {
+          return secureDirStat();
+        }
+        throw nodeErrorWithCode("ENOENT");
+      }),
+      mkdirSync: vi.fn(),
+      platform: "win32",
+      preferredDir: "/tmp/example",
+      skipPreferredOnWindows: true,
+      tmpdir: vi.fn(() => "C:\\Temp"),
+      warn: vi.fn(),
+    });
+
+    expect(result).toBe(winFallback);
+  });
+});

--- a/test/sibling-temp-write.test.ts
+++ b/test/sibling-temp-write.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { writeViaSiblingTempPath } from "../src/sibling-temp.js";
+
+async function withTempDir<T>(run: (root: string) => Promise<T>): Promise<T> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-sibling-write-"));
+  try {
+    return await run(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+describe("writeViaSiblingTempPath", () => {
+  it("writes through a sibling temp file and removes the temp", async () => {
+    await withTempDir(async (root) => {
+      const targetPath = path.join(root, "out.txt");
+      let tempPath = "";
+
+      await writeViaSiblingTempPath({
+        rootDir: root,
+        targetPath,
+        tempPrefix: ".test-output-",
+        writeTemp: async (candidate) => {
+          tempPath = candidate;
+          await fs.writeFile(candidate, "ok", "utf8");
+        },
+      });
+
+      expect(path.basename(tempPath)).toContain(".test-output-");
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("ok");
+      await expect(fs.stat(tempPath)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("rejects targets outside the root", async () => {
+    await withTempDir(async (root) => {
+      await expect(
+        writeViaSiblingTempPath({
+          rootDir: path.join(root, "inner"),
+          targetPath: path.join(root, "out.txt"),
+          writeTemp: async () => {},
+        }),
+      ).rejects.toThrow("Target path is outside the allowed root");
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "target": "ES2022",
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    pool: "forks",
+  },
+});


### PR DESCRIPTION
## Summary

This PR turns the safe filesystem helpers extracted from OpenClaw into the initial `@openclaw/fs-safe` package.

It adds a focused Node package for race-resistant, root-bounded filesystem access:

- `root()` / `SafeRoot` for reads, writes, creates, copies, moves, mkdir, remove, stat, and directory listing under a trusted root
- explicit hardlink and symlink policies instead of ad hoc boolean flag soup at each call site
- pinned open/write helpers that verify opened file identity where the platform allows it
- atomic replace, sibling temp, private temp workspace, secret/private file, sidecar lock, archive extraction, JSON, filename, file URL, path-scope, path-existence, and timeout helpers
- canonical `FsSafeError` exports for downstream `instanceof` checks
- named subpath exports for `root`, `path`, `fs`, `timing`, `json`, `atomic`, `temp`, `archive`, `errors`, `types`, and test/internal helpers

## Motivation

OpenClaw touches many paths that may originate from agents, plugins, archives, uploads, config files, or workspace input. Before this extraction, those call sites carried their own variants of "within root" checks, symlink handling, hardlink checks, temp-file writes, archive limits, and JSON read/write semantics.

That made the system harder to audit. A string check like `path.resolve(root, input).startsWith(root)` only validates one path snapshot; it does not pin the opened file, defend against a symlink swap between check and use, reject hardlinked aliases, or verify that an atomic write still landed on the intended file. Keeping those details duplicated inside OpenClaw made it too easy for fixes to improve one surface while leaving another subtly different.

The goal here is to make the safe path behavior reusable, testable, and boring:

- define the trusted root once
- pass relative paths through a small API
- choose symlink and hardlink behavior explicitly
- centralize the tricky platform-specific operations
- move OpenClaw-specific call sites toward a smaller, auditable primitive set

## API Review Notes

The public surface is organized by job rather than implementation detail:

- `@openclaw/fs-safe` and `/root` are the primary application API
- `/path` contains canonical path resolution and path-scope helpers
- `/fs` contains generic filesystem predicates such as `pathExists()`; it follows `fs.stat()` semantics, so broken symlinks return false
- `/timing` contains generic timeout helpers instead of shelving them under archive APIs
- `/json`, `/atomic`, `/temp`, and `/archive` expose lower-level building blocks
- `/errors` exposes the canonical catchable error type
- `/internal/*` remains exported for OpenClaw helper-process shims and tests, but is documented as reserved and unsupported for general consumers

This PR also avoids the previous archive JSON naming trap: `readJsonFile()` remains the nullable JSON helper under `/json`, while `readJsonFileStrict()` is the throwing helper for install manifests and other must-parse files. `/archive` no longer exports a second `readJsonFile` with incompatible nullability.

The archive API is now archive-only: generic `pathExists()` and `withTimeout()` moved out to `/fs` and `/timing`.

The archive implementation is split so review boundaries are clearer:

- `archive-kind.ts` for archive kind and packed-root detection
- `archive-limits.ts` for size/count limits and budget errors
- `archive-tar.ts` for TAR entry preflight
- `archive-zip-preflight.ts` for ZIP central-directory preflight
- `archive.ts` for extraction orchestration

## Verification

- `pnpm check`
- OpenClaw companion branch validation:
  - `pnpm tsgo:all`
  - `pnpm test src/plugins/install.test.ts src/hooks/install.test.ts src/infra/archive-helpers.test.ts src/infra/install-target.test.ts src/agents/skills-clawhub.test.ts`
  - `git diff --check`

Companion OpenClaw PR: https://github.com/openclaw/openclaw/pull/73442
