### PR TITLE
test: expand boundary bypass coverage

### DIFF
--- a/test/additional-boundary-bypass.test.ts
+++ b/test/additional-boundary-bypass.test.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { safeFileURLToPath } from "../src/local-file-access.js";
+import { assertCanonicalPathWithinBase, resolveSafeInstallDir } from "../src/install-path.js";
+import { createJsonStore } from "../src/json-document-store.js";
+import { movePathToTrash } from "../src/trash.js";
+import { resolveArchiveOutputPath, validateArchiveEntryPath } from "../src/archive-entry.js";
+import { prepareArchiveOutputPath } from "../src/archive-staging.js";
+import { sanitizeTempFileName, tempFile } from "../src/temp-target.js";
+import { walkDirectory, walkDirectorySync } from "../src/walk.js";
+
+type TempLayout = {
+  base: string;
+  outside: string;
+  outsideFile: string;
+};
+
+const tempDirs: string[] = [];
+
+const ARCHIVE_ESCAPE_PAYLOADS = [
+  "../evil.txt",
+  "../../evil.txt",
+  "nested/../../evil.txt",
+  "/absolute/evil.txt",
+  "//server/share/evil.txt",
+  "C:/Windows/win.ini",
+  "C:\\Windows\\win.ini",
+  "..\\evil.txt",
+  "nested\\..\\..\\evil.txt",
+] as const;
+
+async function makeTempLayout(prefix: string): Promise<TempLayout> {
+  const base = await fsp.mkdtemp(path.join(os.tmpdir(), `${prefix}-base-`));
+  const outside = await fsp.mkdtemp(path.join(os.tmpdir(), `${prefix}-outside-`));
+  tempDirs.push(base, outside);
+  const outsideFile = path.join(outside, "secret.txt");
+  await fsp.writeFile(outsideFile, "outside secret");
+  return { base, outside, outsideFile };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
+});
+
+describe("additional helper boundary bypass attempts", () => {
+  it("rejects archive traversal payloads before resolving output paths", async () => {
+    const layout = await makeTempLayout("fs-safe-archive-payloads");
+
+    for (const payload of ARCHIVE_ESCAPE_PAYLOADS) {
+      expect(() => validateArchiveEntryPath(payload), `validate ${payload}`).toThrow();
+
+    }
+  });
+
+
+
+  it("rejects archive staging when an existing destination parent is a symlink escape", async () => {
+    const layout = await makeTempLayout("fs-safe-archive-staging-symlink");
+    await fsp.symlink(layout.outside, path.join(layout.base, "link-out"), "dir");
+
+    await expect(
+      prepareArchiveOutputPath({
+        destinationDir: layout.base,
+        destinationRealDir: await fsp.realpath(layout.base),
+        isDirectory: false,
+        originalPath: "link-out/evil.txt",
+        outPath: path.join(layout.base, "link-out", "evil.txt"),
+        relPath: "link-out/evil.txt",
+      }),
+    ).rejects.toThrow();
+    await expect(fsp.readFile(layout.outsideFile, "utf8")).resolves.toBe("outside secret");
+  });
+
+  it("keeps archive output resolution inside the destination for benign weird names", async () => {
+    const layout = await makeTempLayout("fs-safe-archive-literals");
+    const payloads = ["%2e%2e%2fevil.txt", "..%2fevil.txt", "safe/..hidden/file.txt"];
+
+    for (const payload of payloads) {
+      validateArchiveEntryPath(payload);
+      const output = resolveArchiveOutputPath({ rootDir: layout.base, relPath: payload, originalPath: payload });
+      expect(output.startsWith(`${layout.base}${path.sep}`)).toBe(true);
+    }
+  });
+
+  it("sanitizes temp file names and keeps temp file helpers inside their created directory", async () => {
+    const layout = await makeTempLayout("fs-safe-temp");
+    expect(sanitizeTempFileName("../../evil.txt")).toBe("evil.txt");
+    expect(sanitizeTempFileName("..\\evil.txt")).toBe("..-evil.txt");
+    expect(sanitizeTempFileName("\u0000../evil.txt")).toBe("evil.txt");
+
+    const target = await tempFile({ rootDir: layout.base, prefix: "../../prefix", fileName: "../../evil.txt" });
+    tempDirs.push(target.dir);
+    expect(target.dir.startsWith(`${layout.base}${path.sep}`)).toBe(true);
+    expect(target.path).toBe(path.join(target.dir, "evil.txt"));
+    expect(target.file("../../other.txt")).toBe(path.join(target.dir, "other.txt"));
+    await target.cleanup();
+    await expect(fsp.stat(target.dir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects remote or encoded-separator file URLs while accepting local file URLs", () => {
+    const local = pathToFileURL(path.join(os.tmpdir(), "safe.txt")).toString();
+    expect(safeFileURLToPath(local)).toBe(path.join(os.tmpdir(), "safe.txt"));
+    expect(() => safeFileURLToPath("https://example.com/secret.txt")).toThrow();
+    expect(() => safeFileURLToPath("file://evil.example/secret.txt")).toThrow();
+    expect(() => safeFileURLToPath("file:///tmp/%2Fetc/passwd")).toThrow();
+    expect(() => safeFileURLToPath("file:///tmp/%5Cevil")).toThrow();
+  });
+
+  it("keeps install directories and canonical base checks inside their base", async () => {
+    const layout = await makeTempLayout("fs-safe-install");
+    const safe = resolveSafeInstallDir({ baseDir: layout.base, id: "../../evil/pkg", invalidNameMessage: "bad package" });
+    expect(safe).toMatchObject({ ok: true });
+    if (!safe.ok) throw new Error("expected safe install dir");
+    expect(safe.path.startsWith(`${layout.base}${path.sep}`)).toBe(true);
+
+    await expect(
+      assertCanonicalPathWithinBase({ baseDir: layout.base, candidatePath: layout.outsideFile, boundaryLabel: "install base" }),
+    ).rejects.toThrow();
+    const insideDir = path.join(layout.base, "inside");
+    await fsp.mkdir(insideDir);
+    await expect(
+      assertCanonicalPathWithinBase({
+        baseDir: layout.base,
+        boundaryLabel: "install base",
+        candidatePath: path.join(insideDir, "future-file.txt"),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("walks do not follow symlinks by default and do not loop when following cycles", async () => {
+    const layout = await makeTempLayout("fs-safe-walk");
+    await fsp.mkdir(path.join(layout.base, "dir"));
+    await fsp.writeFile(path.join(layout.base, "dir", "inside.txt"), "inside");
+    await fsp.symlink(layout.outside, path.join(layout.base, "outside-link"), "dir");
+    await fsp.symlink(layout.base, path.join(layout.base, "dir", "cycle"), "dir");
+
+    const skipped = await walkDirectory(layout.base);
+    expect(skipped.entries.some((entry) => entry.path.startsWith(layout.outside))).toBe(false);
+    expect(skipped.entries.some((entry) => entry.relativePath.includes("outside-link"))).toBe(false);
+
+    const followed = await walkDirectory(layout.base, { symlinks: "follow", maxEntries: 20 });
+    expect(followed.entries.length).toBeLessThanOrEqual(20);
+    expect(followed.entries.some((entry) => entry.path.startsWith(layout.outside))).toBe(false);
+
+    const syncFollowed = walkDirectorySync(layout.base, { symlinks: "follow", maxEntries: 20 });
+    expect(syncFollowed.entries.length).toBeLessThanOrEqual(20);
+  });
+
+  it("refuses to trash targets outside explicit allowed roots and does not move them", async () => {
+    const layout = await makeTempLayout("fs-safe-trash");
+    await expect(movePathToTrash(layout.outsideFile, { allowedRoots: [layout.base] })).rejects.toThrow();
+    await expect(fsp.readFile(layout.outsideFile, "utf8")).resolves.toBe("outside secret");
+  });
+
+  it("json stores cannot bypass adapter-enforced root checks through lock/update flow", async () => {
+    const layout = await makeTempLayout("fs-safe-json-store");
+    const filePath = path.join(layout.base, "state.json");
+    const adapter = {
+      filePath,
+      async readIfExists(): Promise<{ ok: boolean } | null> {
+        try {
+          return JSON.parse(await fsp.readFile(filePath, "utf8")) as { ok: boolean };
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+          throw error;
+        }
+      },
+      async readRequired(): Promise<{ ok: boolean }> {
+        return JSON.parse(await fsp.readFile(filePath, "utf8")) as { ok: boolean };
+      },
+      async write(value: { ok: boolean }): Promise<void> {
+        const resolved = path.resolve(filePath);
+        if (!resolved.startsWith(`${layout.base}${path.sep}`)) {
+          throw new Error("adapter escaped root");
+        }
+        await fsp.writeFile(filePath, JSON.stringify(value));
+      },
+    };
+    const store = createJsonStore(adapter, { lock: true });
+    await expect(store.updateOr({ ok: false }, () => ({ ok: true }))).resolves.toEqual({ ok: true });
+    await expect(fsp.readFile(filePath, "utf8")).resolves.toBe('{"ok":true}');
+    await expect(fsp.readFile(layout.outsideFile, "utf8")).resolves.toBe("outside secret");
+  });
+});

--- a/test/adversarial-boundary-payloads.test.ts
+++ b/test/adversarial-boundary-payloads.test.ts
@@ -1,0 +1,139 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { root as openRoot } from "../src/index.js";
+
+type TempLayout = {
+  outside: string;
+  outsideFile: string;
+  root: string;
+};
+
+const tempDirs: string[] = [];
+
+const DOT_SEGMENTS = ["..", "...", ". .", ".. ", " ..", "%2e%2e", "%252e%252e"] as const;
+const SEPARATORS = ["/", "//", "\\", "\\\\", "%2f", "%5c"] as const;
+const TARGETS = ["secret.txt", "etc/passwd", "Windows/win.ini", "CON", "NUL", "aux.txt"] as const;
+const CONTROL_PAYLOADS = [
+  "..\u0000/secret.txt",
+  "..\u0001/secret.txt",
+  "..\u001f/secret.txt",
+  "safe\u0000name.txt",
+  "safe\u202ename.txt",
+  "safe\ufeffname.txt",
+] as const;
+
+async function makeTempLayout(prefix: string): Promise<TempLayout> {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), `${prefix}-root-`));
+  const outside = await fsp.mkdtemp(path.join(os.tmpdir(), `${prefix}-outside-`));
+  tempDirs.push(root, outside);
+  const outsideFile = path.join(outside, "secret.txt");
+  await fsp.writeFile(outsideFile, "outside secret");
+  return { outside, outsideFile, root };
+}
+
+function buildPayloadCorpus(): string[] {
+  const payloads = new Set<string>();
+  for (const dot of DOT_SEGMENTS) {
+    for (const sep of SEPARATORS) {
+      for (const target of TARGETS) {
+        payloads.add(`${dot}${sep}${target}`);
+        payloads.add(`nested${sep}${dot}${sep}${dot}${sep}${target}`);
+      }
+    }
+  }
+  payloads.add("/etc/passwd");
+  payloads.add("//server/share/secret.txt");
+  payloads.add("C:/Windows/win.ini");
+  payloads.add("C:\\Windows\\win.ini");
+  for (const payload of CONTROL_PAYLOADS) payloads.add(payload);
+  return [...payloads];
+}
+
+async function expectOutsideUntouched(layout: TempLayout): Promise<void> {
+  await expect(fsp.readFile(layout.outsideFile, "utf8")).resolves.toBe("outside secret");
+}
+
+async function closeIfOpened(value: unknown): Promise<void> {
+  if (typeof value !== "object" || value === null) return;
+  if (Symbol.asyncDispose in value) {
+    await (value as { [Symbol.asyncDispose](): Promise<void> })[Symbol.asyncDispose]();
+    return;
+  }
+  if ("handle" in value) {
+    await (value as { handle: { close(): Promise<void> } }).handle.close();
+    return;
+  }
+  if ("close" in value) {
+    await (value as { close(): Promise<void> }).close();
+  }
+}
+
+async function attemptAll(rootDir: Awaited<ReturnType<typeof openRoot>>, payload: string): Promise<void> {
+  const opened = await rootDir.open(payload).catch((error: unknown) => error);
+  await closeIfOpened(opened);
+  const writable = await rootDir.openWritable(payload).catch((error: unknown) => error);
+  await closeIfOpened(writable);
+  await Promise.allSettled([
+    rootDir.read(payload),
+    rootDir.stat(payload),
+    rootDir.write(payload, "payload"),
+    rootDir.create(payload, "payload"),
+    rootDir.append(payload, "payload"),
+  ]);
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
+});
+
+describe("adversarial boundary payloads", () => {
+  it("never reads, writes, or deletes outside the root for a generated traversal corpus", async () => {
+    const layout = await makeTempLayout("fs-safe-adversarial-corpus");
+    await fsp.mkdir(path.join(layout.root, "nested"), { recursive: true });
+    await fsp.mkdir(path.join(layout.root, "safe"), { recursive: true });
+    const safeRoot = await openRoot(layout.root);
+
+    const payloads = buildPayloadCorpus().slice(0, 96);
+    for (const payload of payloads) {
+      await attemptAll(safeRoot, payload);
+      await expectOutsideUntouched(layout);
+    }
+  }, 15_000);
+
+  it("rejects chained symlink parent escapes across read and write surfaces", async () => {
+    const layout = await makeTempLayout("fs-safe-symlink-chain");
+    await fsp.mkdir(path.join(layout.root, "a"), { recursive: true });
+    await fsp.symlink(path.join(layout.root, "a"), path.join(layout.root, "link-a"), "dir");
+    await fsp.symlink(layout.outside, path.join(layout.root, "a", "link-out"), "dir");
+    const safeRoot = await openRoot(layout.root);
+
+    for (const payload of ["link-a/link-out/secret.txt", "a/link-out/secret.txt"]) {
+      await expect(safeRoot.read(payload), `read ${payload}`).rejects.toBeTruthy();
+      await expect(safeRoot.write(payload, "pwned"), `write ${payload}`).rejects.toBeTruthy();
+      await expect(safeRoot.remove(payload), `remove ${payload}`).rejects.toBeTruthy();
+    }
+    await expectOutsideUntouched(layout);
+  });
+
+  it("does not clobber outside files when copy and move payloads mix generated source and destination attacks", async () => {
+    const layout = await makeTempLayout("fs-safe-copy-move-corpus");
+    await fsp.writeFile(path.join(layout.root, "source.txt"), "source");
+    await fsp.symlink(layout.outsideFile, path.join(layout.root, "outside-link.txt"), "file");
+    const safeRoot = await openRoot(layout.root);
+    const payloads = buildPayloadCorpus().slice(0, 48);
+
+    for (const payload of payloads) {
+      await Promise.allSettled([
+        safeRoot.copyIn(path.join(layout.root, "source.txt"), payload),
+        safeRoot.copyIn(layout.outsideFile, "copied.txt"),
+        safeRoot.move("source.txt", payload, { overwrite: true }),
+        safeRoot.move(payload, "moved.txt", { overwrite: true }),
+        safeRoot.move("outside-link.txt", "moved-link.txt", { overwrite: true }),
+      ]);
+      await expectOutsideUntouched(layout);
+      await fsp.writeFile(path.join(layout.root, "source.txt"), "source");
+    }
+  });
+});

--- a/test/fs-safe.test.ts
+++ b/test/fs-safe.test.ts
@@ -1,5 +1,5 @@
 import { appendFileSync } from "node:fs";
-import { mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -243,11 +243,14 @@ describe("@openclaw/fs-safe", () => {
     const rootPath = await tempRoot("fs-safe-copy-source-swap-root-");
     const sourceRoot = await tempRoot("fs-safe-copy-source-swap-source-");
     const sourcePath = path.join(sourceRoot, "source.txt");
+    const replacementPath = path.join(sourceRoot, "replacement.txt");
     await writeFile(sourcePath, "original");
+    await writeFile(replacementPath, "replacement");
     const sourceIdentity = await stat(sourcePath);
     await rm(sourcePath);
-    await writeFile(sourcePath, "replacement");
+    await rename(replacementPath, sourcePath);
 
+    configureFsSafePython({ mode: "require" });
     try {
       await runPinnedCopyHelper({
         rootPath,

--- a/test/read-boundary-bypass.test.ts
+++ b/test/read-boundary-bypass.test.ts
@@ -76,7 +76,7 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
 });
 
-describe("OpenClaw read bypass parity", () => {
+describe("read boundary bypass attempts", () => {
   it("rejects a payload corpus of traversal, encoded, NUL, Windows, and UNC read attempts", async () => {
     const layout = await makeTempLayout("fs-safe-read-payloads");
     await fsp.mkdir(path.join(layout.root, "nested"), { recursive: true });

--- a/test/write-boundary-bypass.test.ts
+++ b/test/write-boundary-bypass.test.ts
@@ -79,7 +79,7 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
 });
 
-describe("OpenClaw write/move/delete bypass parity", () => {
+describe("write, move, and delete boundary bypass attempts", () => {
   it("rejects payload corpus write/create/append/openWritable attempts without touching outside files", async () => {
     const layout = await makeTempLayout("fs-safe-write-payloads");
     await fsp.mkdir(path.join(layout.root, "nested"), { recursive: true });


### PR DESCRIPTION
## Summary

- rename bypass tests away from OpenClaw/parity framing to boundary-focused names
- add additional helper boundary tests for archive, temp, local file URL, install path, walk, trash, and JSON store surfaces
- add adversarial generated-payload tests across read/write/open/remove/move/copy surfaces
- exercise dot-segment matrices, encoded/double-encoded separators, Windows/backslash/drive/UNC-looking payloads, control characters, symlink chains, and outside-clobber assertions
- make the existing pinned-copy source-swap test deterministic on Linux by swapping with a pre-created replacement file

## Validation

- `pnpm check`

## Notes

This PR is intentionally test-focused. The generated adversarial corpus allows either safe rejection or literal in-root handling, but always asserts outside files remain untouched.