### PR TITLE
test: rename boundary bypass suites

### DIFF
--- a/test/additional-boundary-bypass.test.ts
+++ b/test/additional-boundary-bypass.test.ts
@@ -47,7 +47,7 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
 });
 
-describe("additional bypass parity", () => {
+describe("additional helper boundary bypass attempts", () => {
   it("rejects archive traversal payloads before resolving output paths", async () => {
     const layout = await makeTempLayout("fs-safe-archive-payloads");
 

--- a/test/read-boundary-bypass.test.ts
+++ b/test/read-boundary-bypass.test.ts
@@ -33,7 +33,7 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
 });
 
-describe("OpenClaw read bypass parity", () => {
+describe("read boundary bypass attempts", () => {
   it("rejects a payload corpus of traversal, encoded, NUL, Windows, and UNC read attempts", async () => {
     const layout = await makeTempLayout("fs-safe-read-payloads");
     await fsp.mkdir(path.join(layout.root, "nested"), { recursive: true });

--- a/test/write-boundary-bypass.test.ts
+++ b/test/write-boundary-bypass.test.ts
@@ -28,7 +28,7 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
 });
 
-describe("OpenClaw write/move/delete bypass parity", () => {
+describe("write, move, and delete boundary bypass attempts", () => {
   it("rejects payload corpus write/create/append/openWritable attempts without touching outside files", async () => {
     const layout = await makeTempLayout("fs-safe-write-payloads");
     await fsp.mkdir(path.join(layout.root, "nested"), { recursive: true });


### PR DESCRIPTION
## Summary

- rename bypass test files away from OpenClaw/parity framing
- update suite names to describe boundary-bypass intent directly
- no behavior/test assertion changes

## Validation

- `pnpm check`