### PR TITLE
[codex] centralize filesystem boundary guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Reject `fileStore()` and `fileStoreSync()` writes through symlinked parent directories so store commits cannot escape the configured root.
 - Harden Root fallback mutators, archive merges, private store reads/writes, durable queue ids, JSON fallback writes, sibling temp writes, temp filename sanitization, and trash moves against symlink-swap and path traversal edge cases.
 - Centralize safe path segment validation, directory identity guards, and guarded mutation wrappers so future filesystem helpers reuse the same race-resistant checks.
-- Route JSON sync writes, archive ZIP staging, temp workspace sync reads, secret-file commits, and atomic move/replace fallbacks through shared pinned-read or guarded-write primitives.
+- Route archive ZIP staging, temp workspace sync reads, secret-file commits, and atomic move/replace fallbacks through shared pinned-read or guarded-write primitives without applying private-directory modes to public paths.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Fixes
 
 - Reject `fileStore()` and `fileStoreSync()` writes through symlinked parent directories so store commits cannot escape the configured root.
+- Harden Root fallback mutators, archive merges, private store reads/writes, durable queue ids, JSON fallback writes, sibling temp writes, temp filename sanitization, and trash moves against symlink-swap and path traversal edge cases.
 
 ### Tests
 
+- Added regression coverage for the filesystem race and traversal findings fixed in this release.
 - Increased filesystem edge coverage around secure temp fallback handling, sibling-temp cleanup, local-root resolution, file locks, and file identity checks.
 - Prevented POSIX test runs from leaving Windows-style secure-temp fallback paths in the repository root.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Centralize safe path segment validation, directory identity guards, and guarded mutation wrappers so future filesystem helpers reuse the same race-resistant checks.
 - Route archive ZIP staging, temp workspace sync reads, secret-file commits, and atomic move/replace fallbacks through shared pinned-read or guarded-write primitives without applying private-directory modes to public paths.
 - Close guarded fallback write handles without following path names if post-write directory verification fails, avoiding descriptor leaks and unsafe cleanup in symlink-swap races.
+- Preserve empty-directory pruning and broken-symlink trash moves across guarded fallback paths.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 - Reject `fileStore()` and `fileStoreSync()` writes through symlinked parent directories so store commits cannot escape the configured root.
 - Harden Root fallback mutators, archive merges, private store reads/writes, durable queue ids, JSON fallback writes, sibling temp writes, temp filename sanitization, and trash moves against symlink-swap and path traversal edge cases.
+- Centralize safe path segment validation, directory identity guards, and guarded mutation wrappers so future filesystem helpers reuse the same race-resistant checks.
+- Route JSON sync writes, archive ZIP staging, temp workspace sync reads, secret-file commits, and atomic move/replace fallbacks through shared pinned-read or guarded-write primitives.
 
 ### Tests
 
 - Added regression coverage for the filesystem race and traversal findings fixed in this release.
+- Added a static filesystem-boundary primitive check that blocks reintroducing known raw copy/read/guard patterns.
 - Increased filesystem edge coverage around secure temp fallback handling, sibling-temp cleanup, local-root resolution, file locks, and file identity checks.
 - Prevented POSIX test runs from leaving Windows-style secure-temp fallback paths in the repository root.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Harden Root fallback mutators, archive merges, private store reads/writes, durable queue ids, JSON fallback writes, sibling temp writes, temp filename sanitization, and trash moves against symlink-swap and path traversal edge cases.
 - Centralize safe path segment validation, directory identity guards, and guarded mutation wrappers so future filesystem helpers reuse the same race-resistant checks.
 - Route archive ZIP staging, temp workspace sync reads, secret-file commits, and atomic move/replace fallbacks through shared pinned-read or guarded-write primitives without applying private-directory modes to public paths.
-- Close guarded fallback write handles if post-write directory verification fails, avoiding descriptor leaks in symlink-swap races.
+- Close guarded fallback write handles without following path names if post-write directory verification fails, avoiding descriptor leaks and unsafe cleanup in symlink-swap races.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Harden Root fallback mutators, archive merges, private store reads/writes, durable queue ids, JSON fallback writes, sibling temp writes, temp filename sanitization, and trash moves against symlink-swap and path traversal edge cases.
 - Centralize safe path segment validation, directory identity guards, and guarded mutation wrappers so future filesystem helpers reuse the same race-resistant checks.
 - Route archive ZIP staging, temp workspace sync reads, secret-file commits, and atomic move/replace fallbacks through shared pinned-read or guarded-write primitives without applying private-directory modes to public paths.
+- Close guarded fallback write handles if post-write directory verification fails, avoiding descriptor leaks in symlink-swap races.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Route archive ZIP staging, temp workspace sync reads, secret-file commits, and atomic move/replace fallbacks through shared pinned-read or guarded-write primitives without applying private-directory modes to public paths.
 - Close guarded fallback write handles without following path names if post-write directory verification fails, avoiding descriptor leaks and unsafe cleanup in symlink-swap races.
 - Preserve empty-directory pruning and broken-symlink trash moves across guarded fallback paths.
+- Preserve sync file-store read policy errors for directory and hardlink validation failures.
 
 ### Tests
 

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -68,7 +68,12 @@ If `beforeRename` throws, the rename is skipped and the temp file is removed —
 
 ### `EPERM` and copy fallback
 
-On systems where `rename` fails with `EPERM`/`EEXIST`, pass `copyFallbackOnPermissionError: true` to fall back to copy + unlink. The fallback refuses symlink destinations before copying so it does not write through a replaced destination link.
+On systems where `rename` fails with `EPERM`/`EEXIST`, pass
+`copyFallbackOnPermissionError: true` to fall back to a non-atomic copy
+replacement. The fallback removes the old destination, opens the replacement
+with exclusive/no-follow flags where the platform supports them, and refuses
+known symlink destinations so it does not write through a replaced destination
+link.
 
 ### Sync variant
 
@@ -117,9 +122,8 @@ Rename a path. If the rename fails with `EXDEV` (cross-device) or `EPERM`, fall 
 import { movePathWithCopyFallback } from "@openclaw/fs-safe/atomic";
 
 await movePathWithCopyFallback({
-  source: "/srv/cache/blob.bin",
-  destination: "/srv/persistent/blob.bin",
-  overwrite: true,
+  from: "/srv/cache/blob.bin",
+  to: "/srv/persistent/blob.bin",
 });
 ```
 

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -116,7 +116,10 @@ await writeTextAtomic("/srv/workspace/rendered.md", rendered, {
 
 ## `movePathWithCopyFallback`
 
-Rename a path. If the rename fails with `EXDEV` (cross-device) or `EPERM`, fall back to copy + remove. Preserves atomicity at the destination by writing the copy through `replaceFileAtomic` (for files) or staged-rename (for directories).
+Rename a path. If the rename fails with `EXDEV` (cross-device), fall back to
+copying into a staged sibling path, renaming that staged path into place, and
+then removing the source. The fallback avoids buffering regular files into
+memory and does not tighten the destination parent directory mode.
 
 ```ts
 import { movePathWithCopyFallback } from "@openclaw/fs-safe/atomic";

--- a/docs/store.md
+++ b/docs/store.md
@@ -60,6 +60,10 @@ await writeJsonDurableQueueEntry({
 const pending = await loadPendingJsonDurableQueueEntries({ queueDir, tempPrefix: "queue" });
 ```
 
+`id` must be a single safe path segment: non-empty, not dot-prefixed, and made
+from letters, numbers, `_`, `-`, and `.`. Slashes, backslashes, NUL bytes, `.`,
+and `..` are rejected.
+
 Use `ackJsonDurableQueueEntry()` after durable processing succeeds and
 `moveJsonDurableQueueEntryToFailed()` when the caller wants to quarantine an
 entry for inspection.

--- a/docs/temp.md
+++ b/docs/temp.md
@@ -177,7 +177,9 @@ const result = await writeSiblingTempFile<string>({
 
 ### `writeViaSiblingTempPath`
 
-A higher-level convenience — write content + rename in one call:
+A higher-level convenience for callback-based producers. The callback writes to
+a private temp path, then the helper copies the result into `targetPath` through
+the root boundary:
 
 ```ts
 import { writeViaSiblingTempPath } from "@openclaw/fs-safe/advanced";
@@ -191,7 +193,9 @@ await writeViaSiblingTempPath({
 });
 ```
 
-If `replaceFileAtomic` does what you need, prefer that — `writeViaSiblingTempPath` is the lower-level building block.
+If `replaceFileAtomic` does what you need, prefer that. Use
+`writeViaSiblingTempPath` when the producer needs a concrete temp pathname but
+the final destination still needs root-boundary checks.
 
 ## Secure temp root
 

--- a/docs/temp.md
+++ b/docs/temp.md
@@ -175,6 +175,10 @@ const result = await writeSiblingTempFile<string>({
 
 `writeSiblingTempFile` chooses a random sibling name in `dir`, calls your `writeTemp()` callback, validates that `resolveFinalPath(result)` is still inside that same directory, and renames the temp file there.
 
+By default it preserves the historical private-helper behavior of chmodding
+`dir` to `dirMode` (default `0o700`). Pass `chmodDir: false` when the directory
+is a public staging/output path whose existing mode must be preserved.
+
 ### `writeViaSiblingTempPath`
 
 A higher-level convenience for callback-based producers. The callback writes to

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -159,6 +159,16 @@ Run only the security boundary corpus while iterating on root/path/archive/temp 
 pnpm test:security
 ```
 
+Run the static primitive guard after changing low-level filesystem helpers:
+
+```sh
+pnpm lint:fs-boundary
+```
+
+It catches the specific raw fallback patterns that previously led to
+check-then-use bugs, such as direct copy-to-destination fallback and sync temp
+workspace reads that bypass pinned file descriptors.
+
 `pnpm check` also runs `pnpm lint:file-size`. New source and test files should stay under 500 lines. Existing larger files have explicit budgets in `scripts/check-file-size.mjs`; do not increase those budgets as part of unrelated work.
 
 ## See also

--- a/package.json
+++ b/package.json
@@ -97,11 +97,12 @@
     "benchmark": "node scripts/benchmark.mjs",
     "build": "tsc -p tsconfig.json",
     "lint:file-size": "node scripts/check-file-size.mjs",
+    "lint:fs-boundary": "node scripts/check-fs-boundary-primitives.mjs",
     "prepack": "node scripts/prepack-build.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:security": "vitest run test/fs-safe.test.ts test/openclaw-read-bypass-parity.test.ts test/openclaw-write-bypass-parity.test.ts test/additional-bypass-parity.test.ts test/adversarial-boundary-payloads.test.ts",
-    "check": "pnpm lint:file-size && pnpm build && pnpm test",
+    "check": "pnpm lint:file-size && pnpm lint:fs-boundary && pnpm build && pnpm test",
     "docs:site": "node scripts/build-docs-site.mjs"
   },
   "optionalDependencies": {

--- a/scripts/check-fs-boundary-primitives.mjs
+++ b/scripts/check-fs-boundary-primitives.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+const checks = [
+  {
+    file: "src/replace-file.ts",
+    forbidden: [
+      {
+        pattern: /\.copyFile(?:Sync)?\([^,\n]+,\s*(?:params\.)?dest\b/,
+        message: "replace-file fallback must not copy directly to the destination path",
+      },
+    ],
+  },
+  {
+    file: "src/move-path.ts",
+    forbidden: [
+      {
+        pattern: /fs\.cp\(\s*options\.from,\s*options\.to\b/,
+        message: "cross-device move fallback must stage before replacing the destination",
+      },
+      {
+        pattern: /fs\.rm\(\s*options\.from\b/,
+        message: "move fallback source removal must go through guardedRm",
+      },
+    ],
+  },
+  {
+    file: "src/private-temp-workspace.ts",
+    forbidden: [
+      {
+        pattern: /readFileSync\(\s*filePath\b/,
+        message: "tempWorkspaceSync.read must use a pinned root-file fd",
+      },
+    ],
+  },
+  {
+    file: "src/sibling-temp.ts",
+    forbidden: [
+      {
+        pattern: /type DirectoryGuard\b/,
+        message: "sibling-temp must use the shared directory guard",
+      },
+    ],
+  },
+  {
+    file: "src/archive-staging.ts",
+    forbidden: [
+      {
+        pattern: /type DirectoryIdentityGuard\b/,
+        message: "archive staging must use the shared directory guard",
+      },
+    ],
+  },
+];
+
+const requiredImports = [
+  {
+    file: "src/json-durable-queue.ts",
+    pattern: /assertSafePathSegment/,
+    message: "durable queue ids must use the shared safe path segment helper",
+  },
+  {
+    file: "src/temp-target.ts",
+    pattern: /sanitizeSafePathSegment/,
+    message: "temp filenames must use the shared safe path segment sanitizer",
+  },
+];
+
+const failures = [];
+
+for (const check of checks) {
+  const source = read(check.file);
+  for (const rule of check.forbidden) {
+    if (rule.pattern.test(source)) {
+      failures.push(`${check.file}: ${rule.message}`);
+    }
+  }
+}
+
+for (const check of requiredImports) {
+  const source = read(check.file);
+  if (!check.pattern.test(source)) {
+    failures.push(`${check.file}: ${check.message}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}

--- a/src/archive-staging.ts
+++ b/src/archive-staging.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs/promises";
+import fsSync from "node:fs";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
-import { root } from "./root.js";
+import { resolveOpenedFileRealPathForHandle, root } from "./root.js";
 import { isNotFoundPathError, isPathInside } from "./path.js";
 import { resolveSecureTempRoot } from "./secure-temp-dir.js";
+import { getFsSafeTestHooks } from "./test-hooks.js";
 
 const ERROR_ARCHIVE_ENTRY_TRAVERSES_SYMLINK = "archive entry traverses symlink in destination";
 const ARCHIVE_STAGING_MODE = 0o700;
@@ -28,6 +30,37 @@ function symlinkTraversalError(originalPath: string): ArchiveSecurityError {
     "destination-symlink-traversal",
     `${ERROR_ARCHIVE_ENTRY_TRAVERSES_SYMLINK}: ${originalPath}`,
   );
+}
+
+type DirectoryIdentityGuard = {
+  dir: string;
+  realPath: string;
+  dev: number | bigint;
+  ino: number | bigint;
+};
+
+async function createDirectoryIdentityGuard(dir: string): Promise<DirectoryIdentityGuard> {
+  const stat = await fs.lstat(dir);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new ArchiveSecurityError("destination-symlink", "archive destination is a symlink");
+  }
+  return { dir, realPath: await fs.realpath(dir), dev: stat.dev, ino: stat.ino };
+}
+
+async function assertDirectoryIdentityGuard(guard: DirectoryIdentityGuard): Promise<void> {
+  const stat = await fs.lstat(guard.dir);
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isDirectory() ||
+    stat.dev !== guard.dev ||
+    stat.ino !== guard.ino ||
+    (await fs.realpath(guard.dir)) !== guard.realPath
+  ) {
+    throw new ArchiveSecurityError(
+      "destination-symlink-traversal",
+      "archive destination changed during extraction",
+    );
+  }
 }
 
 export async function prepareArchiveDestinationDir(destDir: string): Promise<string> {
@@ -95,14 +128,20 @@ export async function prepareArchiveOutputPath(params: {
   originalPath: string;
   isDirectory: boolean;
 }): Promise<void> {
+  const targetRoot = await root(params.destinationRealDir);
+  const destinationGuard = await createDirectoryIdentityGuard(params.destinationRealDir);
+  const relPath = params.relPath.split(path.sep).join(path.posix.sep);
   await assertNoSymlinkTraversal({
     rootDir: params.destinationDir,
-    relPath: params.relPath,
+    relPath,
     originalPath: params.originalPath,
   });
 
   if (params.isDirectory) {
-    await fs.mkdir(params.outPath, { recursive: true });
+    await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("mkdir", params.outPath);
+    await assertDirectoryIdentityGuard(destinationGuard);
+    await targetRoot.mkdir(relPath);
+    await assertDirectoryIdentityGuard(destinationGuard);
     await assertResolvedInsideDestination({
       destinationRealDir: params.destinationRealDir,
       targetPath: params.outPath,
@@ -111,13 +150,57 @@ export async function prepareArchiveOutputPath(params: {
     return;
   }
 
-  const parentDir = path.dirname(params.outPath);
-  await fs.mkdir(parentDir, { recursive: true });
+  const parentRel = path.posix.dirname(relPath);
+  if (parentRel !== ".") {
+    await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("mkdir", path.dirname(params.outPath));
+    await assertDirectoryIdentityGuard(destinationGuard);
+    await targetRoot.mkdir(parentRel);
+    await assertDirectoryIdentityGuard(destinationGuard);
+  }
   await assertResolvedInsideDestination({
     destinationRealDir: params.destinationRealDir,
-    targetPath: parentDir,
+    targetPath: path.dirname(params.outPath),
     originalPath: params.originalPath,
   });
+}
+
+async function chmodInsideDestinationBestEffort(params: {
+  destinationRealDir: string;
+  destinationPath: string;
+  mode: number;
+  originalPath: string;
+}): Promise<void> {
+  await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("chmod", params.destinationPath);
+  const destinationGuard = await createDirectoryIdentityGuard(params.destinationRealDir);
+  await assertDirectoryIdentityGuard(destinationGuard);
+  const noFollowFlag =
+    process.platform !== "win32" && "O_NOFOLLOW" in fsSync.constants
+      ? fsSync.constants.O_NOFOLLOW
+      : 0;
+  const handle = await fs
+    .open(params.destinationPath, fsSync.constants.O_RDONLY | noFollowFlag)
+    .catch(() => null);
+  if (!handle) {
+    const stat = await fs.lstat(params.destinationPath).catch(() => null);
+    if (stat?.isSymbolicLink()) {
+      throw symlinkTraversalError(params.originalPath);
+    }
+    return;
+  }
+  try {
+    const stat = await handle.stat();
+    if (!stat.isDirectory() && !stat.isFile()) {
+      return;
+    }
+    const realPath = await resolveOpenedFileRealPathForHandle(handle, params.destinationPath);
+    if (!isPathInside(params.destinationRealDir, realPath)) {
+      throw symlinkTraversalError(params.originalPath);
+    }
+    await handle.chmod(params.mode).catch(() => undefined);
+    await assertDirectoryIdentityGuard(destinationGuard);
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
 }
 
 async function applyStagedEntryMode(params: {
@@ -133,7 +216,12 @@ async function applyStagedEntryMode(params: {
     originalPath: params.originalPath,
   });
   if (params.mode !== 0) {
-    await fs.chmod(destinationPath, params.mode).catch(() => undefined);
+    await chmodInsideDestinationBestEffort({
+      destinationRealDir: params.destinationRealDir,
+      destinationPath,
+      mode: params.mode,
+      originalPath: params.originalPath,
+    });
   }
 }
 

--- a/src/archive-staging.ts
+++ b/src/archive-staging.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs/promises";
 import fsSync from "node:fs";
 import path from "node:path";
+import {
+  assertAsyncDirectoryGuard,
+  createAsyncDirectoryGuard,
+  type AsyncDirectoryGuard,
+} from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { resolveOpenedFileRealPathForHandle, root } from "./root.js";
 import { isNotFoundPathError, isPathInside } from "./path.js";
@@ -32,34 +37,28 @@ function symlinkTraversalError(originalPath: string): ArchiveSecurityError {
   );
 }
 
-type DirectoryIdentityGuard = {
-  dir: string;
-  realPath: string;
-  dev: number | bigint;
-  ino: number | bigint;
-};
-
-async function createDirectoryIdentityGuard(dir: string): Promise<DirectoryIdentityGuard> {
-  const stat = await fs.lstat(dir);
-  if (stat.isSymbolicLink() || !stat.isDirectory()) {
-    throw new ArchiveSecurityError("destination-symlink", "archive destination is a symlink");
+async function createDirectoryIdentityGuard(dir: string): Promise<AsyncDirectoryGuard> {
+  try {
+    return await createAsyncDirectoryGuard(dir);
+  } catch (err) {
+    if (err instanceof FsSafeError && err.code === "not-file") {
+      throw new ArchiveSecurityError("destination-symlink", "archive destination is a symlink");
+    }
+    throw err;
   }
-  return { dir, realPath: await fs.realpath(dir), dev: stat.dev, ino: stat.ino };
 }
 
-async function assertDirectoryIdentityGuard(guard: DirectoryIdentityGuard): Promise<void> {
-  const stat = await fs.lstat(guard.dir);
-  if (
-    stat.isSymbolicLink() ||
-    !stat.isDirectory() ||
-    stat.dev !== guard.dev ||
-    stat.ino !== guard.ino ||
-    (await fs.realpath(guard.dir)) !== guard.realPath
-  ) {
-    throw new ArchiveSecurityError(
-      "destination-symlink-traversal",
-      "archive destination changed during extraction",
-    );
+async function assertDirectoryIdentityGuard(guard: AsyncDirectoryGuard): Promise<void> {
+  try {
+    await assertAsyncDirectoryGuard(guard);
+  } catch (err) {
+    if (err instanceof FsSafeError) {
+      throw new ArchiveSecurityError(
+        "destination-symlink-traversal",
+        "archive destination changed during extraction",
+      );
+    }
+    throw err;
   }
 }
 

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -183,6 +183,7 @@ async function writeZipFileEntry(params: {
     await writeSiblingTempFile({
       dir: path.dirname(destinationPath),
       tempPrefix: `.${path.basename(destinationPath)}.fs-safe-archive`,
+      chmodDir: false,
       writeTemp: async (tempPath) => {
         tempHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, 0o666);
         const writable = tempHandle.createWriteStream();

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
@@ -33,6 +32,7 @@ import {
 } from "./archive-tar.js";
 import { loadZipArchiveWithPreflight } from "./archive-zip-preflight.js";
 import { isNotFoundPathError } from "./path.js";
+import { writeSiblingTempFile } from "./sibling-temp.js";
 import { withTimeout } from "./timing.js";
 
 export type ArchiveLogger = {
@@ -93,13 +93,6 @@ async function cleanupPartialRegularFile(filePath: string): Promise<void> {
   if (stat.isFile()) {
     await fs.unlink(filePath).catch(() => undefined);
   }
-}
-
-function buildArchiveAtomicTempPath(targetPath: string): string {
-  return path.join(
-    path.dirname(targetPath),
-    `.${path.basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`,
-  );
 }
 
 type ZipEntry = {
@@ -184,29 +177,33 @@ async function writeZipFileEntry(params: {
   const destinationPath = params.outPath;
 
   let tempHandle: FileHandle | null = null;
-  let tempPath: string | null = null;
   let handleClosedByStream = false;
 
   try {
-    tempPath = buildArchiveAtomicTempPath(destinationPath);
-    tempHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, 0o666);
-    const writable = tempHandle.createWriteStream();
-    writable.once("close", () => {
-      handleClosedByStream = true;
-    });
+    await writeSiblingTempFile({
+      dir: path.dirname(destinationPath),
+      tempPrefix: `.${path.basename(destinationPath)}.fs-safe-archive`,
+      writeTemp: async (tempPath) => {
+        tempHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, 0o666);
+        const writable = tempHandle.createWriteStream();
+        writable.once("close", () => {
+          handleClosedByStream = true;
+        });
 
-    await pipeline(
-      readable,
-      createExtractBudgetTransform({ onChunkBytes: params.budget.addBytes }),
-      writable,
-    );
-    if (!handleClosedByStream) {
-      await tempHandle.close().catch(() => undefined);
-      handleClosedByStream = true;
-    }
-    tempHandle = null;
-    await fs.rename(tempPath, destinationPath);
-    tempPath = null;
+        await pipeline(
+          readable,
+          createExtractBudgetTransform({ onChunkBytes: params.budget.addBytes }),
+          writable,
+        );
+        if (!handleClosedByStream) {
+          await tempHandle.close().catch(() => undefined);
+          handleClosedByStream = true;
+        }
+        tempHandle = null;
+        return destinationPath;
+      },
+      resolveFinalPath: (filePath) => filePath,
+    });
 
     // Best-effort permission restore for zip entries created on unix.
     if (typeof params.entry.unixPermissions === "number") {
@@ -216,15 +213,12 @@ async function writeZipFileEntry(params: {
       }
     }
   } catch (err) {
-    if (tempPath) {
-      await fs.rm(tempPath, { force: true }).catch(() => undefined);
-    } else {
-      await cleanupPartialRegularFile(destinationPath).catch(() => undefined);
-    }
+    await cleanupPartialRegularFile(destinationPath).catch(() => undefined);
     throw err;
   } finally {
-    if (tempHandle && !handleClosedByStream) {
-      await tempHandle.close().catch(() => undefined);
+    const openTempHandle = tempHandle as FileHandle | null;
+    if (openTempHandle && !handleClosedByStream) {
+      await openTempHandle.close().catch(() => undefined);
     }
   }
 }

--- a/src/bounded-read-stream.ts
+++ b/src/bounded-read-stream.ts
@@ -1,0 +1,30 @@
+import { Transform } from "node:stream";
+import { FsSafeError } from "./errors.js";
+
+export function createMaxBytesTransform(maxBytes: number): Transform {
+  let bytes = 0;
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      const buffer = chunk instanceof Buffer ? chunk : Buffer.from(chunk as Uint8Array);
+      bytes += buffer.byteLength;
+      if (bytes > maxBytes) {
+        callback(
+          new FsSafeError(
+            "too-large",
+            `file exceeds limit of ${maxBytes} bytes (got at least ${bytes})`,
+          ),
+        );
+        return;
+      }
+      callback(null, buffer);
+    },
+  });
+}
+
+export function createBoundedReadStream(
+  opened: { handle: { createReadStream(): NodeJS.ReadableStream } },
+  maxBytes: number | undefined,
+): NodeJS.ReadableStream {
+  const stream = opened.handle.createReadStream();
+  return maxBytes === undefined ? stream : stream.pipe(createMaxBytesTransform(maxBytes));
+}

--- a/src/directory-guard.ts
+++ b/src/directory-guard.ts
@@ -1,4 +1,5 @@
 import type { Stats } from "node:fs";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
@@ -6,6 +7,12 @@ import { sameFileIdentity } from "./file-identity.js";
 import { isNotFoundPathError } from "./path.js";
 
 export type AsyncDirectoryGuard = {
+  dir: string;
+  realPath: string;
+  stat: Stats;
+};
+
+export type SyncDirectoryGuard = {
   dir: string;
   realPath: string;
   stat: Stats;
@@ -29,6 +36,24 @@ export async function assertAsyncDirectoryGuard(guard: AsyncDirectoryGuard): Pro
   }
 }
 
+export function createSyncDirectoryGuard(dir: string): SyncDirectoryGuard {
+  const stat = fsSync.lstatSync(dir);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new FsSafeError("not-file", "directory component must be a directory");
+  }
+  return { dir, realPath: fsSync.realpathSync(dir), stat };
+}
+
+export function assertSyncDirectoryGuard(guard: SyncDirectoryGuard): void {
+  const stat = fsSync.lstatSync(guard.dir);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new FsSafeError("not-file", "directory component must be a directory");
+  }
+  if (!sameFileIdentity(stat, guard.stat) || fsSync.realpathSync(guard.dir) !== guard.realPath) {
+    throw new FsSafeError("path-mismatch", "directory changed during operation");
+  }
+}
+
 export async function createNearestExistingDirectoryGuard(
   rootReal: string,
   targetPath: string,
@@ -46,4 +71,23 @@ export async function createNearestExistingDirectoryGuard(
     }
   }
   return await createAsyncDirectoryGuard(root);
+}
+
+export function createNearestExistingSyncDirectoryGuard(
+  rootReal: string,
+  targetPath: string,
+): SyncDirectoryGuard {
+  let current = path.resolve(targetPath);
+  const root = path.resolve(rootReal);
+  while (current !== root) {
+    try {
+      return createSyncDirectoryGuard(current);
+    } catch (error) {
+      if (!isNotFoundPathError(error)) {
+        throw error;
+      }
+      current = path.dirname(current);
+    }
+  }
+  return createSyncDirectoryGuard(root);
 }

--- a/src/directory-guard.ts
+++ b/src/directory-guard.ts
@@ -1,0 +1,49 @@
+import type { Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { FsSafeError } from "./errors.js";
+import { sameFileIdentity } from "./file-identity.js";
+import { isNotFoundPathError } from "./path.js";
+
+export type AsyncDirectoryGuard = {
+  dir: string;
+  realPath: string;
+  stat: Stats;
+};
+
+export async function createAsyncDirectoryGuard(dir: string): Promise<AsyncDirectoryGuard> {
+  const stat = await fs.lstat(dir);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new FsSafeError("not-file", "directory component must be a directory");
+  }
+  return { dir, realPath: await fs.realpath(dir), stat };
+}
+
+export async function assertAsyncDirectoryGuard(guard: AsyncDirectoryGuard): Promise<void> {
+  const stat = await fs.lstat(guard.dir);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new FsSafeError("not-file", "directory component must be a directory");
+  }
+  if (!sameFileIdentity(stat, guard.stat) || (await fs.realpath(guard.dir)) !== guard.realPath) {
+    throw new FsSafeError("path-mismatch", "directory changed during operation");
+  }
+}
+
+export async function createNearestExistingDirectoryGuard(
+  rootReal: string,
+  targetPath: string,
+): Promise<AsyncDirectoryGuard> {
+  let current = path.resolve(targetPath);
+  const root = path.resolve(rootReal);
+  while (current !== root) {
+    try {
+      return await createAsyncDirectoryGuard(current);
+    } catch (error) {
+      if (!isNotFoundPathError(error)) {
+        throw error;
+      }
+      current = path.dirname(current);
+    }
+  }
+  return await createAsyncDirectoryGuard(root);
+}

--- a/src/file-store-boundary.ts
+++ b/src/file-store-boundary.ts
@@ -3,15 +3,17 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Transform, type Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import {
+  assertSyncDirectoryGuard as assertDirectoryGuardSync,
+  createSyncDirectoryGuard,
+  type SyncDirectoryGuard,
+} from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { isPathInside } from "./path.js";
 import { resolveOpenedFileRealPathForHandle, root, type Root } from "./root.js";
 import { resolveSecureTempRoot } from "./secure-temp-dir.js";
 
-export type SyncParentGuard = {
-  dir: string;
-  realPath: string;
-};
+export type SyncParentGuard = SyncDirectoryGuard;
 
 function parentRelativePath(relativePath: string): string {
   const parent = path.posix.dirname(relativePath);
@@ -132,13 +134,15 @@ export async function writeStreamToTempSource(params: {
 }
 
 export function assertSyncDirectoryGuard(guard: SyncParentGuard): void {
-  const stat = syncFs.lstatSync(guard.dir);
-  if (stat.isSymbolicLink() || !stat.isDirectory()) {
-    throw new FsSafeError("not-file", `store directory component must be a directory: ${guard.dir}`);
-  }
-  const realPath = syncFs.realpathSync(guard.dir);
-  if (realPath !== guard.realPath) {
-    throw new FsSafeError("path-mismatch", "store directory changed during write");
+  try {
+    assertDirectoryGuardSync(guard);
+  } catch (error) {
+    if (error instanceof FsSafeError && error.code === "path-mismatch") {
+      throw new FsSafeError("path-mismatch", "store directory changed during write", {
+        cause: error,
+      });
+    }
+    throw error;
   }
 }
 
@@ -191,7 +195,7 @@ export function ensureParentSync(params: {
     chmodDirectorySyncBestEffort(current, params.mode);
   }
 
-  const guard = { dir, realPath: syncFs.realpathSync(dir) };
+  const guard = createSyncDirectoryGuard(dir);
   assertSyncDirectoryGuard(guard);
   return guard;
 }

--- a/src/file-store-prune.ts
+++ b/src/file-store-prune.ts
@@ -1,0 +1,104 @@
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { FsSafeError } from "./errors.js";
+import { isPathInside } from "./path.js";
+import { root } from "./root.js";
+import { getFsSafeTestHooks } from "./test-hooks.js";
+
+export type FileStorePruneOptions = {
+  ttlMs: number;
+  recursive?: boolean;
+  maxDepth?: number;
+  pruneEmptyDirs?: boolean;
+};
+
+export async function pruneExpiredStoreEntries(params: {
+  rootDir: string;
+  dirMode: number;
+  options: FileStorePruneOptions;
+}): Promise<void> {
+  const now = Date.now();
+  const recursive = params.options.recursive ?? false;
+  const maxDepth = params.options.maxDepth;
+  const pruneEmptyDirs =
+    (recursive || maxDepth !== undefined) && (params.options.pruneEmptyDirs ?? false);
+  await fs.mkdir(params.rootDir, { recursive: true, mode: params.dirMode });
+  const rootReal = await fs.realpath(params.rootDir);
+  const scopedRoot = await root(rootReal);
+  const rootGuard = {
+    dir: rootReal,
+    realPath: rootReal,
+    stat: await fs.lstat(rootReal),
+  };
+
+  async function assertRootGuard(): Promise<void> {
+    const stat = await fs.lstat(rootGuard.dir);
+    if (
+      stat.isSymbolicLink() ||
+      !stat.isDirectory() ||
+      stat.dev !== rootGuard.stat.dev ||
+      stat.ino !== rootGuard.stat.ino ||
+      (await fs.realpath(rootGuard.dir)) !== rootGuard.realPath
+    ) {
+      throw new FsSafeError("path-mismatch", "store root changed during prune");
+    }
+  }
+
+  async function readStableDirectory(dir: string): Promise<Dirent[] | null> {
+    const before = await fs.lstat(dir).catch(() => null);
+    if (!before || before.isSymbolicLink() || !before.isDirectory()) {
+      return null;
+    }
+    const real = await fs.realpath(dir).catch(() => null);
+    if (!real || !isPathInside(rootReal, real)) {
+      return null;
+    }
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => null);
+    if (!entries) {
+      return null;
+    }
+    const after = await fs.lstat(dir).catch(() => null);
+    if (!after || before.dev !== after.dev || before.ino !== after.ino) {
+      return null;
+    }
+    return entries;
+  }
+
+  async function pruneDir(dir: string, relativeDir: string, depth: number): Promise<boolean> {
+    const entries = await readStableDirectory(dir);
+    if (!entries) {
+      return false;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+      const stat = await fs.lstat(fullPath).catch(() => null);
+      if (!stat || stat.isSymbolicLink()) {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        const shouldDescend = maxDepth !== undefined ? depth < maxDepth : recursive;
+        if (shouldDescend) {
+          await getFsSafeTestHooks()?.beforeFileStorePruneDescend?.(fullPath);
+        }
+        if (shouldDescend && (await pruneDir(fullPath, relativePath, depth + 1))) {
+          await assertRootGuard();
+          await scopedRoot.remove(relativePath).catch(() => undefined);
+        }
+        continue;
+      }
+      if (stat.isFile() && now - stat.mtimeMs > params.options.ttlMs) {
+        await assertRootGuard();
+        await scopedRoot.remove(relativePath).catch(() => undefined);
+      }
+    }
+    if (!pruneEmptyDirs) {
+      return false;
+    }
+    const remaining = await readStableDirectory(dir);
+    return remaining !== null && remaining.length === 0;
+  }
+
+  await pruneDir(rootReal, "", 0);
+}

--- a/src/file-store-prune.ts
+++ b/src/file-store-prune.ts
@@ -84,6 +84,8 @@ export async function pruneExpiredStoreEntries(params: {
         }
         if (shouldDescend && (await pruneDir(fullPath, relativePath, depth + 1))) {
           await assertRootGuard();
+          // Keep empty-dir pruning on the same root-bounded remove path as files;
+          // the Root fallback handles empty directories without recursive delete.
           await scopedRoot.remove(relativePath).catch(() => undefined);
         }
         continue;

--- a/src/file-store.ts
+++ b/src/file-store.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import type { Readable } from "node:stream";
 import { FsSafeError } from "./errors.js";
 import {
+  pruneExpiredStoreEntries,
+  type FileStorePruneOptions,
+} from "./file-store-prune.js";
+export type { FileStorePruneOptions } from "./file-store-prune.js";
+import {
   assertSyncDirectoryGuard,
   ensureParentInRoot,
   ensureParentSync,
@@ -15,7 +20,9 @@ import {
 import { createJsonStore, type JsonFileStoreOptions, type JsonStore } from "./json-document-store.js";
 import { isPathInside, resolveSafeRelativePath } from "./path.js";
 import { root, type OpenResult, type ReadResult, type Root, type RootReadOptions } from "./root.js";
+import { openRootFileSync } from "./root-file.js";
 import { writeSecretFileAtomic } from "./secret-file.js";
+import { getFsSafeTestHooks } from "./test-hooks.js";
 
 export type FileStoreOptions = {
   rootDir: string;
@@ -33,13 +40,6 @@ export type FileStoreWriteOptions = {
 };
 
 export type FileStoreReadOptions = RootReadOptions & { encoding?: BufferEncoding };
-
-export type FileStorePruneOptions = {
-  ttlMs: number;
-  recursive?: boolean;
-  maxDepth?: number;
-  pruneEmptyDirs?: boolean;
-};
 
 export type FileStore = {
   readonly rootDir: string;
@@ -359,43 +359,12 @@ export function fileStore(options: FileStoreOptions): FileStore {
       );
     },
     pruneExpired: async (pruneOptions) => {
-      const now = Date.now();
-      const recursive = pruneOptions.recursive ?? false;
-      const maxDepth = pruneOptions.maxDepth;
-      const pruneEmptyDirs =
-        (recursive || maxDepth !== undefined) && (pruneOptions.pruneEmptyDirs ?? false);
-      async function pruneDir(dir: string, depth: number): Promise<boolean> {
-        const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
-        for (const entry of entries) {
-          const fullPath = path.join(dir, entry.name);
-          const stat = await fs.lstat(fullPath).catch(() => null);
-          if (!stat || stat.isSymbolicLink()) {
-            continue;
-          }
-          if (stat.isDirectory()) {
-            const shouldDescend = maxDepth !== undefined ? depth < maxDepth : recursive;
-            if (shouldDescend && (await pruneDir(fullPath, depth + 1))) {
-              await fs.rmdir(fullPath).catch(() => undefined);
-            }
-            continue;
-          }
-          if (stat.isFile() && now - stat.mtimeMs > pruneOptions.ttlMs) {
-            await fs.rm(fullPath, { force: true }).catch(() => undefined);
-          }
-        }
-        if (!pruneEmptyDirs) {
-          return false;
-        }
-        const remaining = await fs.readdir(dir).catch(() => null);
-        return remaining !== null && remaining.length === 0;
-      }
-      await fs.mkdir(rootDir, { recursive: true, mode: dirMode });
-      await pruneDir(rootDir, 0);
+      await pruneExpiredStoreEntries({ rootDir, dirMode, options: pruneOptions });
     },
   };
 }
 
-function ensurePrivateDirectorySync(rootDir: string, targetDir: string, mode: number): void {
+function ensurePrivateDirectorySync(rootDir: string, targetDir: string, mode: number): SyncParentGuard {
   const root = path.resolve(rootDir);
   const target = path.resolve(targetDir);
   assertStoreFilePath(root, target);
@@ -437,6 +406,9 @@ function ensurePrivateDirectorySync(rootDir: string, targetDir: string, mode: nu
       // Best-effort on platforms that do not enforce POSIX modes.
     }
   }
+  const guard = { dir: target, realPath: syncFs.realpathSync(target) };
+  assertSyncDirectoryGuard(guard);
+  return guard;
 }
 
 function writeFileSyncAtomic(params: {
@@ -451,7 +423,7 @@ function writeFileSyncAtomic(params: {
   assertStoreFilePath(params.rootDir, filePath);
   let parentGuard: SyncParentGuard | undefined;
   if (params.privateMode) {
-    ensurePrivateDirectorySync(params.rootDir, path.dirname(filePath), params.dirMode);
+    parentGuard = ensurePrivateDirectorySync(params.rootDir, path.dirname(filePath), params.dirMode);
     try {
       const stat = syncFs.lstatSync(filePath);
       if (stat.isSymbolicLink() || !stat.isFile()) {
@@ -475,6 +447,7 @@ function writeFileSyncAtomic(params: {
   );
   let tempExists = false;
   try {
+    getFsSafeTestHooks()?.beforeFileStoreSyncPrivateWrite?.(filePath);
     if (parentGuard) {
       assertSyncDirectoryGuard(parentGuard);
     }
@@ -540,21 +513,27 @@ export function fileStoreSync(options: FileStoreOptions): FileStoreSync {
     path: (relativePath) => resolveStorePath(rootDir, relativePath),
     readTextIfExists: (relativePath, readOptions) => {
       const targetPath = resolveStorePath(rootDir, relativePath);
-      try {
-        const stat = syncFs.lstatSync(targetPath);
-        if (stat.isSymbolicLink() || !stat.isFile()) {
-          throw new FsSafeError("not-file", "store target is not a file");
-        }
-        assertMaxBytes(stat.size, readOptions?.maxBytes ?? maxBytes);
-        if (privateMode && stat.nlink > 1) {
-          throw new FsSafeError("hardlink", "private store target must not be hardlinked");
-        }
-        return syncFs.readFileSync(targetPath, "utf8");
-      } catch (error) {
-        if (isNotFound(error)) {
+      const opened = openRootFileSync({
+        absolutePath: targetPath,
+        rootPath: rootDir,
+        boundaryLabel: "store root",
+        rejectHardlinks: privateMode,
+      });
+      if (!opened.ok) {
+        if (isNotFound(opened.error)) {
           return null;
         }
-        throw error;
+        throw new FsSafeError("path-mismatch", "store target changed during read", {
+          cause: opened.error instanceof Error ? opened.error : undefined,
+        });
+      }
+      try {
+        assertMaxBytes(opened.stat.size, readOptions?.maxBytes ?? maxBytes);
+        const raw = syncFs.readFileSync(opened.fd, "utf8");
+        assertMaxBytes(Buffer.byteLength(raw, "utf8"), readOptions?.maxBytes ?? maxBytes);
+        return raw;
+      } finally {
+        syncFs.closeSync(opened.fd);
       }
     },
     readJsonIfExists: <T = unknown>(relativePath: string, readOptions?: { maxBytes?: number }) => {

--- a/src/file-store.ts
+++ b/src/file-store.ts
@@ -21,7 +21,7 @@ import {
 import { createJsonStore, type JsonFileStoreOptions, type JsonStore } from "./json-document-store.js";
 import { isPathInside, resolveSafeRelativePath } from "./path.js";
 import { root, type OpenResult, type ReadResult, type Root, type RootReadOptions } from "./root.js";
-import { openRootFileSync } from "./root-file.js";
+import { matchRootFileOpenFailure, openRootFileSync, type RootFileOpenFailure } from "./root-file.js";
 import { writeSecretFileAtomic } from "./secret-file.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
 
@@ -129,10 +129,38 @@ function assertMaxBytes(size: number, maxBytes?: number): void {
 }
 
 function isNotFound(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
   return error instanceof FsSafeError
     ? error.code === "not-found"
     : (error as NodeJS.ErrnoException).code === "ENOENT" ||
         (error as NodeJS.ErrnoException).code === "ENOTDIR";
+}
+
+function handleSyncStoreReadOpenFailure(opened: RootFileOpenFailure): null {
+  return matchRootFileOpenFailure<null>(opened, {
+    path: (failure) => {
+      if (isNotFound(failure.error)) {
+        return null;
+      }
+      throw new FsSafeError("path-mismatch", "store target changed during read", {
+        cause: failure.error instanceof Error ? failure.error : undefined,
+      });
+    },
+    validation: (failure) => {
+      // Validation failures mean the path existed but violated store policy
+      // (directory, hardlink, symlink race). Do not report them as missing.
+      throw new FsSafeError("path-mismatch", "store target failed read validation", {
+        cause: failure.error instanceof Error ? failure.error : undefined,
+      });
+    },
+    fallback: (failure) => {
+      throw new FsSafeError("path-mismatch", "store target changed during read", {
+        cause: failure.error instanceof Error ? failure.error : undefined,
+      });
+    },
+  });
 }
 
 async function copyIntoRoot(params: {
@@ -521,12 +549,7 @@ export function fileStoreSync(options: FileStoreOptions): FileStoreSync {
         rejectHardlinks: privateMode,
       });
       if (!opened.ok) {
-        if (isNotFound(opened.error)) {
-          return null;
-        }
-        throw new FsSafeError("path-mismatch", "store target changed during read", {
-          cause: opened.error instanceof Error ? opened.error : undefined,
-        });
+        return handleSyncStoreReadOpenFailure(opened);
       }
       try {
         assertMaxBytes(opened.stat.size, readOptions?.maxBytes ?? maxBytes);

--- a/src/file-store.ts
+++ b/src/file-store.ts
@@ -3,6 +3,7 @@ import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { Readable } from "node:stream";
+import { createSyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import {
   pruneExpiredStoreEntries,
@@ -406,7 +407,7 @@ function ensurePrivateDirectorySync(rootDir: string, targetDir: string, mode: nu
       // Best-effort on platforms that do not enforce POSIX modes.
     }
   }
-  const guard = { dir: target, realPath: syncFs.realpathSync(target) };
+  const guard = createSyncDirectoryGuard(target);
   assertSyncDirectoryGuard(guard);
   return guard;
 }

--- a/src/guarded-mutation.ts
+++ b/src/guarded-mutation.ts
@@ -32,6 +32,9 @@ export async function withAsyncDirectoryGuards<T>(
     } catch (error) {
       if (options.onPostGuardFailure) {
         try {
+          // The mutation may have returned an owned resource before the post-guard
+          // check detected a swapped directory. Give callers one chance to close
+          // handles without letting cleanup hide the boundary failure.
           await options.onPostGuardFailure(result, error);
         } catch {
           // Preserve the boundary failure. Cleanup is best-effort.

--- a/src/guarded-mutation.ts
+++ b/src/guarded-mutation.ts
@@ -1,0 +1,120 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  assertAsyncDirectoryGuard,
+  assertSyncDirectoryGuard,
+  createAsyncDirectoryGuard,
+  createNearestExistingDirectoryGuard,
+  createNearestExistingSyncDirectoryGuard,
+  createSyncDirectoryGuard,
+  type AsyncDirectoryGuard,
+  type SyncDirectoryGuard,
+} from "./directory-guard.js";
+
+export async function withAsyncDirectoryGuards<T>(
+  guards: readonly AsyncDirectoryGuard[],
+  mutate: () => Promise<T>,
+  options: { verifyAfter?: boolean } = {},
+): Promise<T> {
+  for (const guard of guards) {
+    await assertAsyncDirectoryGuard(guard);
+  }
+  const result = await mutate();
+  if (options.verifyAfter !== false) {
+    for (const guard of guards) {
+      await assertAsyncDirectoryGuard(guard);
+    }
+  }
+  return result;
+}
+
+export function withSyncDirectoryGuards<T>(
+  guards: readonly SyncDirectoryGuard[],
+  mutate: () => T,
+  options: { verifyAfter?: boolean } = {},
+): T {
+  for (const guard of guards) {
+    assertSyncDirectoryGuard(guard);
+  }
+  const result = mutate();
+  if (options.verifyAfter !== false) {
+    for (const guard of guards) {
+      assertSyncDirectoryGuard(guard);
+    }
+  }
+  return result;
+}
+
+export async function guardedRename(params: {
+  from: string;
+  to: string;
+  targetRoot?: string;
+  verifyAfter?: boolean;
+}): Promise<void> {
+  const sourceGuard = await createAsyncDirectoryGuard(path.dirname(params.from));
+  const targetGuard = params.targetRoot
+    ? await createNearestExistingDirectoryGuard(params.targetRoot, path.dirname(params.to))
+    : await createAsyncDirectoryGuard(path.dirname(params.to));
+  await withAsyncDirectoryGuards(
+    [sourceGuard, targetGuard],
+    async () => {
+      await fs.rename(params.from, params.to);
+    },
+    { verifyAfter: params.verifyAfter },
+  );
+}
+
+export function guardedRenameSync(params: {
+  from: string;
+  to: string;
+  targetRoot?: string;
+  verifyAfter?: boolean;
+}): void {
+  const sourceGuard = createSyncDirectoryGuard(path.dirname(params.from));
+  const targetGuard = params.targetRoot
+    ? createNearestExistingSyncDirectoryGuard(params.targetRoot, path.dirname(params.to))
+    : createSyncDirectoryGuard(path.dirname(params.to));
+  withSyncDirectoryGuards(
+    [sourceGuard, targetGuard],
+    () => fsSync.renameSync(params.from, params.to),
+    { verifyAfter: params.verifyAfter },
+  );
+}
+
+export async function guardedRm(params: {
+  target: string;
+  recursive?: boolean;
+  force?: boolean;
+  verifyAfter?: boolean;
+}): Promise<void> {
+  const guard = await createAsyncDirectoryGuard(path.dirname(params.target));
+  await withAsyncDirectoryGuards(
+    [guard],
+    async () => {
+      await fs.rm(params.target, {
+        ...(params.recursive !== undefined ? { recursive: params.recursive } : {}),
+        ...(params.force !== undefined ? { force: params.force } : {}),
+      });
+    },
+    { verifyAfter: params.verifyAfter },
+  );
+}
+
+export function guardedRmSync(params: {
+  target: string;
+  recursive?: boolean;
+  force?: boolean;
+  verifyAfter?: boolean;
+}): void {
+  const guard = createSyncDirectoryGuard(path.dirname(params.target));
+  withSyncDirectoryGuards(
+    [guard],
+    () =>
+      fsSync.rmSync(params.target, {
+        ...(params.recursive !== undefined ? { recursive: params.recursive } : {}),
+        ...(params.force !== undefined ? { force: params.force } : {}),
+      }),
+    { verifyAfter: params.verifyAfter },
+  );
+}

--- a/src/guarded-mutation.ts
+++ b/src/guarded-mutation.ts
@@ -15,15 +15,29 @@ import {
 export async function withAsyncDirectoryGuards<T>(
   guards: readonly AsyncDirectoryGuard[],
   mutate: () => Promise<T>,
-  options: { verifyAfter?: boolean } = {},
+  options: {
+    verifyAfter?: boolean;
+    onPostGuardFailure?: (result: T, error: unknown) => Promise<void> | void;
+  } = {},
 ): Promise<T> {
   for (const guard of guards) {
     await assertAsyncDirectoryGuard(guard);
   }
   const result = await mutate();
   if (options.verifyAfter !== false) {
-    for (const guard of guards) {
-      await assertAsyncDirectoryGuard(guard);
+    try {
+      for (const guard of guards) {
+        await assertAsyncDirectoryGuard(guard);
+      }
+    } catch (error) {
+      if (options.onPostGuardFailure) {
+        try {
+          await options.onPostGuardFailure(result, error);
+        } catch {
+          // Preserve the boundary failure. Cleanup is best-effort.
+        }
+      }
+      throw error;
     }
   }
   return result;

--- a/src/json-durable-queue.ts
+++ b/src/json-durable-queue.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { FsSafeError } from "./errors.js";
 import { replaceFileAtomic } from "./replace-file.js";
+import { assertSafePathSegment } from "./safe-path-segment.js";
 
 export type JsonDurableQueueEntryPaths = {
   jsonPath: string;
@@ -27,18 +27,7 @@ function getErrnoCode(error: unknown): string | null {
 }
 
 function assertSafeQueueEntryId(id: string): void {
-  if (
-    !id ||
-    id === "." ||
-    id === ".." ||
-    id.startsWith(".") ||
-    id.includes("/") ||
-    id.includes("\\") ||
-    id.includes("\0") ||
-    !/^[A-Za-z0-9_-][A-Za-z0-9._-]*$/.test(id)
-  ) {
-    throw new FsSafeError("invalid-path", "queue entry id must be a safe path segment");
-  }
+  assertSafePathSegment(id, { label: "queue entry id" });
 }
 
 export async function unlinkBestEffort(filePath: string): Promise<void> {

--- a/src/json-durable-queue.ts
+++ b/src/json-durable-queue.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { FsSafeError } from "./errors.js";
 import { replaceFileAtomic } from "./replace-file.js";
 
 export type JsonDurableQueueEntryPaths = {
@@ -23,6 +24,21 @@ function getErrnoCode(error: unknown): string | null {
   return error && typeof error === "object" && "code" in error
     ? String((error as { code?: unknown }).code)
     : null;
+}
+
+function assertSafeQueueEntryId(id: string): void {
+  if (
+    !id ||
+    id === "." ||
+    id === ".." ||
+    id.startsWith(".") ||
+    id.includes("/") ||
+    id.includes("\\") ||
+    id.includes("\0") ||
+    !/^[A-Za-z0-9_-][A-Za-z0-9._-]*$/.test(id)
+  ) {
+    throw new FsSafeError("invalid-path", "queue entry id must be a safe path segment");
+  }
 }
 
 export async function unlinkBestEffort(filePath: string): Promise<void> {
@@ -62,6 +78,7 @@ export function resolveJsonDurableQueueEntryPaths(
   queueDir: string,
   id: string,
 ): JsonDurableQueueEntryPaths {
+  assertSafeQueueEntryId(id);
   return {
     jsonPath: path.join(queueDir, `${id}.json`),
     deliveredPath: path.join(queueDir, `${id}.delivered`),
@@ -193,6 +210,7 @@ export async function moveJsonDurableQueueEntryToFailed(params: {
   failedDir: string;
   id: string;
 }): Promise<void> {
+  assertSafeQueueEntryId(params.id);
   await fs.promises.mkdir(params.failedDir, { recursive: true, mode: 0o700 });
   await fs.promises.rename(
     path.join(params.queueDir, `${params.id}.json`),

--- a/src/json.ts
+++ b/src/json.ts
@@ -75,8 +75,8 @@ function renameJsonFileWithFallback(tmpPath: string, pathname: string) {
         fsSync.renameSync(tmpPath, pathname);
         return;
       }
-      fsSync.copyFileSync(tmpPath, pathname);
-      fsSync.rmSync(tmpPath, { force: true });
+      fsSync.rmSync(pathname, { force: true });
+      fsSync.renameSync(tmpPath, pathname);
       return;
     }
     throw error;

--- a/src/json.ts
+++ b/src/json.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import path from "node:path";
 import { readRegularFile, readRegularFileSync } from "./regular-file.js";
+import { replaceFileAtomicSync } from "./replace-file.js";
 import { openRootFileSync, type RootFileOpenFailure } from "./root-file.js";
 import { writeTextAtomic } from "./text-atomic.js";
 
@@ -104,23 +105,20 @@ export function tryReadJsonSync<T = unknown>(pathname: string): T | null {
 
 export function writeJsonSync(pathname: string, data: unknown) {
   const targetPath = pathname;
-  const tmpPath = `${targetPath}.${randomUUID()}.tmp`;
   const payload = `${JSON.stringify(data, null, 2)}\n`;
 
-  fsSync.mkdirSync(path.dirname(targetPath), { recursive: true, mode: JSON_DIR_MODE });
-  try {
-    writeTempJsonFile(tmpPath, payload);
-    trySetSecureMode(tmpPath);
-    renameJsonFileWithFallback(tmpPath, targetPath);
-    trySetSecureMode(targetPath);
-    trySyncDirectory(targetPath);
-  } finally {
-    try {
-      fsSync.rmSync(tmpPath, { force: true });
-    } catch {
-      // best-effort cleanup when rename does not happen
-    }
-  }
+  replaceFileAtomicSync({
+    filePath: targetPath,
+    content: payload,
+    mode: JSON_FILE_MODE,
+    dirMode: JSON_DIR_MODE,
+    copyFallbackOnPermissionError: true,
+    syncTempFile: true,
+    syncParentDir: true,
+    tempPrefix: `.fs-safe-json.${randomUUID()}`,
+  });
+  trySetSecureMode(targetPath);
+  trySyncDirectory(targetPath);
 }
 
 export class JsonFileReadError extends Error {

--- a/src/json.ts
+++ b/src/json.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import path from "node:path";
 import { readRegularFile, readRegularFileSync } from "./regular-file.js";
-import { replaceFileAtomicSync } from "./replace-file.js";
 import { openRootFileSync, type RootFileOpenFailure } from "./root-file.js";
 import { writeTextAtomic } from "./text-atomic.js";
 
@@ -105,20 +104,23 @@ export function tryReadJsonSync<T = unknown>(pathname: string): T | null {
 
 export function writeJsonSync(pathname: string, data: unknown) {
   const targetPath = pathname;
+  const tmpPath = `${targetPath}.${randomUUID()}.tmp`;
   const payload = `${JSON.stringify(data, null, 2)}\n`;
 
-  replaceFileAtomicSync({
-    filePath: targetPath,
-    content: payload,
-    mode: JSON_FILE_MODE,
-    dirMode: JSON_DIR_MODE,
-    copyFallbackOnPermissionError: true,
-    syncTempFile: true,
-    syncParentDir: true,
-    tempPrefix: `.fs-safe-json.${randomUUID()}`,
-  });
-  trySetSecureMode(targetPath);
-  trySyncDirectory(targetPath);
+  fsSync.mkdirSync(path.dirname(targetPath), { recursive: true, mode: JSON_DIR_MODE });
+  try {
+    writeTempJsonFile(tmpPath, payload);
+    trySetSecureMode(tmpPath);
+    renameJsonFileWithFallback(tmpPath, targetPath);
+    trySetSecureMode(targetPath);
+    trySyncDirectory(targetPath);
+  } finally {
+    try {
+      fsSync.rmSync(tmpPath, { force: true });
+    } catch {
+      // best-effort cleanup when rename does not happen
+    }
+  }
 }
 
 export class JsonFileReadError extends Error {

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -1,4 +1,8 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import path from "node:path";
+import { guardedRename, guardedRm } from "./guarded-mutation.js";
+import { replaceFileAtomic } from "./replace-file.js";
 
 export type MovePathWithCopyFallbackOptions = {
   from: string;
@@ -9,17 +13,38 @@ export async function movePathWithCopyFallback(
   options: MovePathWithCopyFallbackOptions,
 ): Promise<void> {
   try {
-    await fs.rename(options.from, options.to);
+    await guardedRename({ from: options.from, to: options.to });
     return;
   } catch (error) {
     if ((error as NodeJS.ErrnoException | null)?.code !== "EXDEV") {
       throw error;
     }
   }
-  await fs.cp(options.from, options.to, {
-    recursive: true,
-    force: true,
-    dereference: false,
-  });
-  await fs.rm(options.from, { recursive: true, force: true });
+  const sourceStat = await fs.lstat(options.from);
+  if (sourceStat.isFile()) {
+    await replaceFileAtomic({
+      filePath: options.to,
+      content: await fs.readFile(options.from),
+      mode: sourceStat.mode & 0o777,
+      syncTempFile: true,
+      syncParentDir: true,
+    });
+    await guardedRm({ target: options.from, force: true, verifyAfter: false });
+    return;
+  }
+
+  const targetDir = path.dirname(path.resolve(options.to));
+  const staged = path.join(targetDir, `.fs-safe-move-${process.pid}-${randomUUID()}.tmp`);
+  try {
+    await fs.cp(options.from, staged, {
+      recursive: true,
+      force: false,
+      errorOnExist: true,
+      dereference: false,
+    });
+    await guardedRename({ from: staged, to: options.to });
+    await guardedRm({ target: options.from, recursive: true, force: true, verifyAfter: false });
+  } finally {
+    await fs.rm(staged, { recursive: true, force: true }).catch(() => undefined);
+  }
 }

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { guardedRename, guardedRm } from "./guarded-mutation.js";
-import { replaceFileAtomic } from "./replace-file.js";
 
 export type MovePathWithCopyFallbackOptions = {
   from: string;
@@ -20,19 +19,6 @@ export async function movePathWithCopyFallback(
       throw error;
     }
   }
-  const sourceStat = await fs.lstat(options.from);
-  if (sourceStat.isFile()) {
-    await replaceFileAtomic({
-      filePath: options.to,
-      content: await fs.readFile(options.from),
-      mode: sourceStat.mode & 0o777,
-      syncTempFile: true,
-      syncParentDir: true,
-    });
-    await guardedRm({ target: options.from, force: true, verifyAfter: false });
-    return;
-  }
-
   const targetDir = path.dirname(path.resolve(options.to));
   const staged = path.join(targetDir, `.fs-safe-move-${process.pid}-${randomUUID()}.tmp`);
   try {

--- a/src/path-stat.ts
+++ b/src/path-stat.ts
@@ -1,0 +1,18 @@
+import type { Stats } from "node:fs";
+import type { PathStat } from "./types.js";
+
+export function pathStatFromStats(stat: Stats): PathStat {
+  return {
+    dev: Number(stat.dev),
+    gid: Number(stat.gid),
+    ino: Number(stat.ino),
+    isDirectory: stat.isDirectory(),
+    isFile: stat.isFile(),
+    isSymbolicLink: stat.isSymbolicLink(),
+    mode: stat.mode,
+    mtimeMs: stat.mtimeMs,
+    nlink: stat.nlink,
+    size: stat.size,
+    uid: stat.uid,
+  };
+}

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -4,8 +4,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Transform, type Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { createNearestExistingDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import type { FileIdentityStat } from "./file-identity.js";
+import { withAsyncDirectoryGuards } from "./guarded-mutation.js";
 import { canFallbackFromPythonError, getFsSafePythonConfig } from "./pinned-python-config.js";
 import {
   assertPinnedPythonOperationAvailable,
@@ -197,15 +199,20 @@ async function runPinnedWriteFallback(params: {
   const parentPath = params.relativeParentPath
     ? path.join(params.rootPath, ...params.relativeParentPath.split("/"))
     : params.rootPath;
+  const parentGuard = await createNearestExistingDirectoryGuard(params.rootPath, parentPath);
   if (params.mkdir) {
-    await fs.mkdir(parentPath, { recursive: true });
+    await withAsyncDirectoryGuards([parentGuard], async () => {
+      await fs.mkdir(parentPath, { recursive: true });
+    });
   }
   const targetPath = path.join(parentPath, params.basename);
   if (params.overwrite === false) {
-    const handle = await fs.open(
-      targetPath,
-      fsSync.constants.O_WRONLY | fsSync.constants.O_CREAT | fsSync.constants.O_EXCL,
-      params.mode,
+    let handle = await withAsyncDirectoryGuards([parentGuard], async () =>
+      await fs.open(
+        targetPath,
+        fsSync.constants.O_WRONLY | fsSync.constants.O_CREAT | fsSync.constants.O_EXCL,
+        params.mode,
+      )
     );
     let created = true;
     try {
@@ -270,7 +277,9 @@ async function runPinnedWriteFallback(params: {
       await handle.close().catch(() => undefined);
       handle = undefined;
     }
-    await fs.rename(tempPath, targetPath);
+    await withAsyncDirectoryGuards([parentGuard], async () => {
+      await fs.rename(tempPath, targetPath);
+    });
   } catch (error) {
     if (handle && !handleClosedByStream) {
       await handle.close().catch(() => undefined);

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -218,7 +218,6 @@ async function runPinnedWriteFallback(params: {
       {
         onPostGuardFailure: async (openedHandle) => {
           await openedHandle.close().catch(() => undefined);
-          await fs.rm(targetPath, { force: true }).catch(() => undefined);
         },
       },
     );

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -207,12 +207,20 @@ async function runPinnedWriteFallback(params: {
   }
   const targetPath = path.join(parentPath, params.basename);
   if (params.overwrite === false) {
-    let handle = await withAsyncDirectoryGuards([parentGuard], async () =>
-      await fs.open(
-        targetPath,
-        fsSync.constants.O_WRONLY | fsSync.constants.O_CREAT | fsSync.constants.O_EXCL,
-        params.mode,
-      )
+    let handle = await withAsyncDirectoryGuards(
+      [parentGuard],
+      async () =>
+        await fs.open(
+          targetPath,
+          fsSync.constants.O_WRONLY | fsSync.constants.O_CREAT | fsSync.constants.O_EXCL,
+          params.mode,
+        ),
+      {
+        onPostGuardFailure: async (openedHandle) => {
+          await openedHandle.close().catch(() => undefined);
+          await fs.rm(targetPath, { force: true }).catch(() => undefined);
+        },
+      },
     );
     let created = true;
     try {

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -217,6 +217,8 @@ async function runPinnedWriteFallback(params: {
         ),
       {
         onPostGuardFailure: async (openedHandle) => {
+          // The parent failed verification, so targetPath may now resolve
+          // somewhere else. Close the fd, but do not clean up by path.
           await openedHandle.close().catch(() => undefined);
         },
       },

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -111,13 +112,13 @@ export async function runPinnedWriteHelper(params: {
   maxBytes?: number;
   input: PinnedWriteInput;
 }): Promise<FileIdentityStat> {
-  if (getFsSafePythonConfig().mode === "off") {
-    return await runPinnedWriteFallback(params);
-  }
   assertSafeBasename(params.basename);
   validatePinnedOperationPayload({
     relativeParentPath: params.relativeParentPath,
   });
+  if (getFsSafePythonConfig().mode === "off") {
+    return await runPinnedWriteFallback(params);
+  }
   if (params.input.kind === "stream") {
     try {
       assertPinnedPythonOperationAvailable();
@@ -236,35 +237,44 @@ async function runPinnedWriteFallback(params: {
     }
   }
 
-  const tempPath = path.join(parentPath, `.${params.basename}.fallback.tmp`);
+  const tempPath = path.join(parentPath, `.${params.basename}.${randomUUID()}.fallback.tmp`);
+  const tempFlags =
+    fsSync.constants.O_WRONLY |
+    fsSync.constants.O_CREAT |
+    fsSync.constants.O_EXCL |
+    (process.platform !== "win32" && "O_NOFOLLOW" in fsSync.constants
+      ? fsSync.constants.O_NOFOLLOW
+      : 0);
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  let handleClosedByStream = false;
   try {
+    handle = await fs.open(tempPath, tempFlags, params.mode);
     if (params.input.kind === "buffer") {
       assertWithinMaxBytes(
         byteLength(params.input.data, params.input.encoding),
         params.maxBytes,
       );
       if (typeof params.input.data === "string") {
-        await fs.writeFile(tempPath, params.input.data, {
-          encoding: params.input.encoding ?? "utf8",
-          mode: params.mode,
-        });
+        await handle.writeFile(params.input.data, params.input.encoding ?? "utf8");
       } else {
-        await fs.writeFile(tempPath, params.input.data, { mode: params.mode });
+        await handle.writeFile(params.input.data);
       }
     } else {
-      const handle = await fs.open(tempPath, "w", params.mode);
-      try {
-        await pipelineWithMaxBytes(
-          params.input.stream,
-          handle.createWriteStream(),
-          params.maxBytes,
-        );
-      } finally {
-        await handle.close().catch(() => {});
-      }
+      const writable = handle.createWriteStream();
+      writable.once("close", () => {
+        handleClosedByStream = true;
+      });
+      await pipelineWithMaxBytes(params.input.stream, writable, params.maxBytes);
+    }
+    if (!handleClosedByStream) {
+      await handle.close().catch(() => undefined);
+      handle = undefined;
     }
     await fs.rename(tempPath, targetPath);
   } catch (error) {
+    if (handle && !handleClosedByStream) {
+      await handle.close().catch(() => undefined);
+    }
     await fs.rm(tempPath, { force: true }).catch(() => undefined);
     throw error;
   }

--- a/src/private-temp-workspace.ts
+++ b/src/private-temp-workspace.ts
@@ -9,7 +9,6 @@ import {
   type FileStoreSync,
 } from "./file-store.js";
 import { openRootFileSync } from "./root-file.js";
-import { isSafePathSegment } from "./safe-path-segment.js";
 import { registerTempPathForExit } from "./temp-cleanup.js";
 
 export type TempWorkspaceOptions = {
@@ -62,7 +61,15 @@ function resolveWorkspaceLeaf(dir: string, fileName: string): string {
 
 function assertWorkspaceFileName(fileName: string): string {
   const value = fileName.trim();
-  if (!isSafePathSegment(value)) {
+  if (
+    !value ||
+    value === "." ||
+    value === ".." ||
+    value.includes("\0") ||
+    value.includes("/") ||
+    value.includes("\\") ||
+    path.basename(value) !== value
+  ) {
     throw new Error(`Invalid temp workspace file name: ${JSON.stringify(fileName)}`);
   }
   return value;

--- a/src/private-temp-workspace.ts
+++ b/src/private-temp-workspace.ts
@@ -8,6 +8,8 @@ import {
   type FileStore,
   type FileStoreSync,
 } from "./file-store.js";
+import { openRootFileSync } from "./root-file.js";
+import { isSafePathSegment } from "./safe-path-segment.js";
 import { registerTempPathForExit } from "./temp-cleanup.js";
 
 export type TempWorkspaceOptions = {
@@ -55,24 +57,15 @@ function sanitizeTempPrefix(prefix: string): string {
 }
 
 function resolveWorkspaceLeaf(dir: string, fileName: string): string {
-  const raw = fileName.trim();
-  if (
-    !raw ||
-    raw === "." ||
-    raw === ".." ||
-    raw.includes("\0") ||
-    raw.includes("/") ||
-    raw.includes("\\") ||
-    path.basename(raw) !== raw
-  ) {
-    throw new Error(`Invalid temp workspace file name: ${JSON.stringify(fileName)}`);
-  }
-  return path.join(dir, raw);
+  return path.join(dir, assertWorkspaceFileName(fileName));
 }
 
 function assertWorkspaceFileName(fileName: string): string {
-  resolveWorkspaceLeaf(".", fileName);
-  return fileName.trim();
+  const value = fileName.trim();
+  if (!isSafePathSegment(value)) {
+    throw new Error(`Invalid temp workspace file name: ${JSON.stringify(fileName)}`);
+  }
+  return value;
 }
 
 async function ensurePrivateDirectory(dir: string, mode: number): Promise<void> {
@@ -208,8 +201,20 @@ export function tempWorkspaceSync(
         trailingNewline: writeOptions?.trailingNewline,
       }),
     read: (fileName) => {
-      const filePath = store.path(assertWorkspaceFileName(fileName));
-      return fsSync.readFileSync(filePath);
+      const opened = openRootFileSync({
+        absolutePath: store.path(assertWorkspaceFileName(fileName)),
+        rootPath: dir,
+        boundaryLabel: "temp workspace",
+        rejectHardlinks: true,
+      });
+      if (!opened.ok) {
+        throw Object.assign(new Error(`File not found: ${fileName}`), { code: "ENOENT" });
+      }
+      try {
+        return fsSync.readFileSync(opened.fd);
+      } finally {
+        fsSync.closeSync(opened.fd);
+      }
     },
     cleanup: () => {
       try {

--- a/src/replace-directory.ts
+++ b/src/replace-directory.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { guardedRename, guardedRm } from "./guarded-mutation.js";
 
 export type ReplaceDirectoryAtomicOptions = {
   stagedDir: string;
@@ -21,7 +22,7 @@ export async function replaceDirectoryAtomic(
 
   await fs.mkdir(parentDir, { recursive: true });
   try {
-    await fs.rename(targetDir, backupDir);
+    await guardedRename({ from: targetDir, to: backupDir });
     backupCreated = true;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -30,16 +31,16 @@ export async function replaceDirectoryAtomic(
   }
 
   try {
-    await fs.rename(stagedDir, targetDir);
+    await guardedRename({ from: stagedDir, to: targetDir });
   } catch (err) {
     if (backupCreated) {
-      await fs.rename(backupDir, targetDir).catch(() => undefined);
+      await guardedRename({ from: backupDir, to: targetDir }).catch(() => undefined);
       backupCreated = false;
     }
     throw err;
   }
 
   if (backupCreated) {
-    await fs.rm(backupDir, { recursive: true, force: true });
+    await guardedRm({ target: backupDir, recursive: true, force: true, verifyAfter: false });
   }
 }

--- a/src/replace-file.ts
+++ b/src/replace-file.ts
@@ -26,6 +26,7 @@ export type ReplaceFileAtomicSyncFileSystem = Pick<
   typeof syncFs,
   | "mkdirSync"
   | "chmodSync"
+  | "readFileSync"
   | "writeFileSync"
   | "renameSync"
   | "copyFileSync"
@@ -76,6 +77,15 @@ function isPermissionRenameError(error: unknown): boolean {
   return code === "EPERM" || code === "EEXIST";
 }
 
+const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in syncFs.constants;
+const OPEN_READ_FLAGS =
+  syncFs.constants.O_RDONLY | (SUPPORTS_NOFOLLOW ? syncFs.constants.O_NOFOLLOW : 0);
+const OPEN_WRITE_EXCLUSIVE_FLAGS =
+  syncFs.constants.O_WRONLY |
+  syncFs.constants.O_CREAT |
+  syncFs.constants.O_EXCL |
+  (SUPPORTS_NOFOLLOW ? syncFs.constants.O_NOFOLLOW : 0);
+
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -98,17 +108,7 @@ async function renameWithRetry(params: {
         continue;
       }
       if (params.copyFallbackOnPermissionError && isPermissionRenameError(error)) {
-        const stat = await params.fsModule.lstat(params.dest).catch((lstatError) => {
-          if ((lstatError as NodeJS.ErrnoException).code === "ENOENT") {
-            return null;
-          }
-          throw lstatError;
-        });
-        if (stat?.isSymbolicLink()) {
-          throw new Error(`Refusing copy fallback through symlink destination: ${params.dest}`);
-        }
-        await params.fsModule.copyFile(params.src, params.dest);
-        await params.fsModule.unlink(params.src).catch(() => undefined);
+        await copyFallbackReplace(params.fsModule, params.src, params.dest);
         return { method: "copy-fallback" };
       }
       throw error;
@@ -142,29 +142,103 @@ function renameWithRetrySync(params: {
         continue;
       }
       if (params.copyFallbackOnPermissionError && isPermissionRenameError(error)) {
-        let stat: Stats | null = null;
-        try {
-          stat = params.fsModule.lstatSync(params.dest);
-        } catch (lstatError) {
-          if ((lstatError as NodeJS.ErrnoException).code !== "ENOENT") {
-            throw lstatError;
-          }
-        }
-        if (stat?.isSymbolicLink()) {
-          throw new Error(`Refusing copy fallback through symlink destination: ${params.dest}`);
-        }
-        params.fsModule.copyFileSync(params.src, params.dest);
-        try {
-          params.fsModule.unlinkSync(params.src);
-        } catch {
-          // Best-effort cleanup after fallback replacement.
-        }
+        copyFallbackReplaceSync(params.fsModule, params.src, params.dest);
         return { method: "copy-fallback" };
       }
       throw error;
     }
   }
   throw new Error("Atomic rename retry loop exhausted.");
+}
+
+async function copyFallbackReplace(
+  fsModule: ReplaceFileAtomicFileSystem["promises"],
+  src: string,
+  dest: string,
+): Promise<void> {
+  const sourceStat = await fsModule.lstat(src);
+  if (sourceStat.isSymbolicLink() || !sourceStat.isFile()) {
+    throw new Error(`Refusing copy fallback from non-file source: ${src}`);
+  }
+  const destStat = await fsModule.lstat(dest).catch((lstatError) => {
+    if ((lstatError as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw lstatError;
+  });
+  if (destStat?.isSymbolicLink()) {
+    throw new Error(`Refusing copy fallback through symlink destination: ${dest}`);
+  }
+  if (destStat) {
+    await fsModule.rm(dest, { force: true });
+  }
+
+  let sourceHandle: Awaited<ReturnType<ReplaceFileAtomicFileSystem["promises"]["open"]>> | null =
+    null;
+  let destHandle: Awaited<ReturnType<ReplaceFileAtomicFileSystem["promises"]["open"]>> | null =
+    null;
+  try {
+    sourceHandle = await fsModule.open(src, OPEN_READ_FLAGS);
+    destHandle = await fsModule.open(dest, OPEN_WRITE_EXCLUSIVE_FLAGS, sourceStat.mode & 0o777);
+    await destHandle.writeFile(await sourceHandle.readFile());
+  } finally {
+    await destHandle?.close().catch(() => undefined);
+    await sourceHandle?.close().catch(() => undefined);
+  }
+  await fsModule.unlink(src).catch(() => undefined);
+}
+
+function copyFallbackReplaceSync(
+  fsModule: ReplaceFileAtomicSyncFileSystem,
+  src: string,
+  dest: string,
+): void {
+  const sourceStat = fsModule.lstatSync(src);
+  if (sourceStat.isSymbolicLink() || !sourceStat.isFile()) {
+    throw new Error(`Refusing copy fallback from non-file source: ${src}`);
+  }
+  let destStat: Stats | null = null;
+  try {
+    destStat = fsModule.lstatSync(dest);
+  } catch (lstatError) {
+    if ((lstatError as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw lstatError;
+    }
+  }
+  if (destStat?.isSymbolicLink()) {
+    throw new Error(`Refusing copy fallback through symlink destination: ${dest}`);
+  }
+  if (destStat) {
+    fsModule.rmSync(dest, { force: true });
+  }
+
+  let sourceFd: number | undefined;
+  let destFd: number | undefined;
+  try {
+    sourceFd = fsModule.openSync(src, OPEN_READ_FLAGS);
+    destFd = fsModule.openSync(dest, OPEN_WRITE_EXCLUSIVE_FLAGS, sourceStat.mode & 0o777);
+    fsModule.writeFileSync(destFd, fsModule.readFileSync(sourceFd));
+  } finally {
+    if (destFd !== undefined) {
+      try {
+        fsModule.closeSync(destFd);
+      } catch {
+        // Best-effort close after fallback replacement.
+      }
+    }
+    if (sourceFd !== undefined) {
+      try {
+        fsModule.closeSync(sourceFd);
+      } catch {
+        // Best-effort close after fallback replacement.
+      }
+    }
+  }
+  try {
+    fsModule.unlinkSync(src);
+  } catch {
+    // Best-effort cleanup after fallback replacement.
+  }
 }
 
 function validateReplaceFilePath(filePath: string): void {

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1606,7 +1606,6 @@ async function writeMissingFileFallback(
     await fs.mkdir(path.dirname(resolved), { recursive: true });
   }
   const parentGuard = await createAsyncDirectoryGuard(path.dirname(resolved));
-
   let created = false;
   try {
     const { handle, writtenStat } = await withAsyncDirectoryGuards(
@@ -1628,6 +1627,7 @@ async function writeMissingFileFallback(
       },
       {
         onPostGuardFailure: async ({ handle }) => {
+          created = false;
           await handle.close().catch(() => undefined);
         },
       },

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1609,21 +1609,29 @@ async function writeMissingFileFallback(
 
   let created = false;
   try {
-    const { handle, writtenStat } = await withAsyncDirectoryGuards([parentGuard], async () => {
-      const handle = await fs.open(resolved, OPEN_WRITE_CREATE_FLAGS, params.mode ?? 0o600);
-      created = true;
-      try {
-        if (typeof params.data === "string") {
-          await handle.writeFile(params.data, params.encoding ?? "utf8");
-        } else {
-          await handle.writeFile(params.data);
+    const { handle, writtenStat } = await withAsyncDirectoryGuards(
+      [parentGuard],
+      async () => {
+        const handle = await fs.open(resolved, OPEN_WRITE_CREATE_FLAGS, params.mode ?? 0o600);
+        created = true;
+        try {
+          if (typeof params.data === "string") {
+            await handle.writeFile(params.data, params.encoding ?? "utf8");
+          } else {
+            await handle.writeFile(params.data);
+          }
+          return { handle, writtenStat: await handle.stat() };
+        } catch (error) {
+          await handle.close().catch(() => undefined);
+          throw error;
         }
-        return { handle, writtenStat: await handle.stat() };
-      } catch (error) {
-        await handle.close().catch(() => undefined);
-        throw error;
-      }
-    });
+      },
+      {
+        onPostGuardFailure: async ({ handle }) => {
+          await handle.close().catch(() => undefined);
+        },
+      },
+    );
     await handle.close();
     await verifyAtomicWriteResult({
       root,

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1379,7 +1379,7 @@ async function removePathFallback(resolved: { resolved: string }): Promise<void>
   const guard = await createAsyncDirectoryGuard(path.dirname(resolved.resolved));
   await getFsSafeTestHooks()?.beforeRootFallbackMutation?.("remove", resolved.resolved);
   await assertAsyncDirectoryGuard(guard);
-  await fs.rm(resolved.resolved);
+  await ((await fs.lstat(resolved.resolved)).isDirectory() ? fs.rmdir(resolved.resolved) : fs.rm(resolved.resolved));
   await assertAsyncDirectoryGuard(guard).catch(() => undefined);
 }
 

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1627,7 +1627,7 @@ async function writeMissingFileFallback(
       },
       {
         onPostGuardFailure: async ({ handle }) => {
-          created = false;
+          created = false; // Parent is untrusted now; skip outer path cleanup by name.
           await handle.close().catch(() => undefined);
         },
       },

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -6,6 +6,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard, createNearestExistingDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { isPinnedPathHelperSpawnError, runPinnedPathHelper } from "./pinned-path.js";
@@ -24,6 +25,7 @@ import {
   helperStat,
   runPinnedHelper,
 } from "./pinned-helper.js";
+import { pathStatFromStats } from "./path-stat.js";
 import { resolveRootPath } from "./root-path.js";
 import {
   assertValidRootRelativePath,
@@ -1395,27 +1397,19 @@ async function resolvePinnedRootPathInRoot(
 }
 
 async function removePathFallback(resolved: { resolved: string }): Promise<void> {
+  const guard = await createAsyncDirectoryGuard(path.dirname(resolved.resolved));
+  await getFsSafeTestHooks()?.beforeRootFallbackMutation?.("remove", resolved.resolved);
+  await assertAsyncDirectoryGuard(guard);
   await fs.rm(resolved.resolved);
+  await assertAsyncDirectoryGuard(guard).catch(() => undefined);
 }
 
-async function mkdirPathFallback(resolved: { resolved: string }): Promise<void> {
+async function mkdirPathFallback(resolved: { rootReal: string; resolved: string }): Promise<void> {
+  const guard = await createNearestExistingDirectoryGuard(resolved.rootReal, resolved.resolved);
+  await getFsSafeTestHooks()?.beforeRootFallbackMutation?.("mkdir", resolved.resolved);
+  await assertAsyncDirectoryGuard(guard);
   await fs.mkdir(resolved.resolved, { recursive: true });
-}
-
-function pathStatFromStats(stat: Stats): PathStat {
-  return {
-    dev: Number(stat.dev),
-    gid: Number(stat.gid),
-    ino: Number(stat.ino),
-    isDirectory: stat.isDirectory(),
-    isFile: stat.isFile(),
-    isSymbolicLink: stat.isSymbolicLink(),
-    mode: stat.mode,
-    mtimeMs: stat.mtimeMs,
-    nlink: stat.nlink,
-    size: stat.size,
-    uid: stat.uid,
-  };
+  await assertAsyncDirectoryGuard(guard);
 }
 
 async function statPathFallback(root: RootContext, relativePath: string): Promise<PathStat> {
@@ -1524,6 +1518,11 @@ async function movePathFallback(
     }
   }
 
+  const sourceParentGuard = await createAsyncDirectoryGuard(path.dirname(source.resolved));
+  const targetParentGuard = await createNearestExistingDirectoryGuard(target.rootReal, path.dirname(target.resolved));
+  await getFsSafeTestHooks()?.beforeRootFallbackMutation?.("move", target.resolved);
+  await assertAsyncDirectoryGuard(sourceParentGuard);
+  await assertAsyncDirectoryGuard(targetParentGuard);
   try {
     await fs.rename(source.resolved, target.resolved);
   } catch (error) {
@@ -1539,6 +1538,7 @@ async function movePathFallback(
     }
     throw error;
   }
+  await assertAsyncDirectoryGuard(targetParentGuard).catch(() => undefined);
 }
 
 async function writeFileFallback(

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -4,11 +4,12 @@ import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
+import { createBoundedReadStream } from "./bounded-read-stream.js";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard, createNearestExistingDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
+import { withAsyncDirectoryGuards } from "./guarded-mutation.js";
 import { isPinnedPathHelperSpawnError, runPinnedPathHelper } from "./pinned-path.js";
 import { runPinnedCopyHelper, runPinnedWriteHelper } from "./pinned-write.js";
 import { canFallbackFromPythonError, getFsSafePythonConfig } from "./pinned-python-config.js";
@@ -741,31 +742,6 @@ function rootWriteQueueKey(root: RootContext, relativePath: string): string {
   return `${root.rootReal}\0${relativePath}`;
 }
 
-function createMaxBytesTransform(maxBytes: number): Transform {
-  let bytes = 0;
-  return new Transform({
-    transform(chunk, _encoding, callback) {
-      const buffer = chunk instanceof Buffer ? chunk : Buffer.from(chunk as Uint8Array);
-      bytes += buffer.byteLength;
-      if (bytes > maxBytes) {
-        callback(
-          new FsSafeError(
-            "too-large",
-            `file exceeds limit of ${maxBytes} bytes (got at least ${bytes})`,
-          ),
-        );
-        return;
-      }
-      callback(null, buffer);
-    },
-  });
-}
-
-function createBoundedReadStream(opened: OpenResult, maxBytes: number | undefined) {
-  const stream = opened.handle.createReadStream();
-  return maxBytes === undefined ? stream : stream.pipe(createMaxBytesTransform(maxBytes));
-}
-
 async function writeTempFileForAtomicReplace(params: {
   tempPath: string;
   data: string | Buffer;
@@ -908,7 +884,10 @@ async function openWritableFileInRoot(
     throw new FsSafeError("path-alias", "path alias escape blocked", { cause: err });
   }
   if (params.mkdir !== false) {
-    await fs.mkdir(path.dirname(resolved), { recursive: true });
+    const parentGuard = await createNearestExistingDirectoryGuard(rootReal, path.dirname(resolved));
+    await withAsyncDirectoryGuards([parentGuard], async () => {
+      await fs.mkdir(path.dirname(resolved), { recursive: true });
+    });
   }
 
   let ioPath = resolved;
@@ -1566,6 +1545,7 @@ async function writeFileFallback(
   const destinationPath = target.realPath;
   const mode = params.mode ?? (target.stat.mode & 0o777);
   await target.handle.close().catch(() => {});
+  const destinationGuard = await createAsyncDirectoryGuard(path.dirname(destinationPath));
   let tempPath: string | null = null;
   let unregisterTempPath: (() => void) | null = null;
   try {
@@ -1577,7 +1557,10 @@ async function writeFileFallback(
       encoding: params.encoding,
       mode: mode || 0o600,
     });
-    await fs.rename(tempPath, destinationPath);
+    const commitTempPath = tempPath;
+    await withAsyncDirectoryGuards([destinationGuard], async () => {
+      await fs.rename(commitTempPath, destinationPath);
+    });
     tempPath = null;
     unregisterTempPath();
     unregisterTempPath = null;
@@ -1622,20 +1605,26 @@ async function writeMissingFileFallback(
   if (params.mkdir !== false) {
     await fs.mkdir(path.dirname(resolved), { recursive: true });
   }
+  const parentGuard = await createAsyncDirectoryGuard(path.dirname(resolved));
 
-  let handle: FileHandle | null = null;
   let created = false;
   try {
-    handle = await fs.open(resolved, OPEN_WRITE_CREATE_FLAGS, params.mode ?? 0o600);
-    created = true;
-    if (typeof params.data === "string") {
-      await handle.writeFile(params.data, params.encoding ?? "utf8");
-    } else {
-      await handle.writeFile(params.data);
-    }
-    const writtenStat = await handle.stat();
+    const { handle, writtenStat } = await withAsyncDirectoryGuards([parentGuard], async () => {
+      const handle = await fs.open(resolved, OPEN_WRITE_CREATE_FLAGS, params.mode ?? 0o600);
+      created = true;
+      try {
+        if (typeof params.data === "string") {
+          await handle.writeFile(params.data, params.encoding ?? "utf8");
+        } else {
+          await handle.writeFile(params.data);
+        }
+        return { handle, writtenStat: await handle.stat() };
+      } catch (error) {
+        await handle.close().catch(() => undefined);
+        throw error;
+      }
+    });
     await handle.close();
-    handle = null;
     await verifyAtomicWriteResult({
       root,
       targetPath: resolved,
@@ -1650,7 +1639,6 @@ async function writeMissingFileFallback(
     }
     throw err;
   } finally {
-    await handle?.close().catch(() => undefined);
     if (created) {
       await fs.rm(resolved, { force: true }).catch(() => undefined);
     }
@@ -1687,6 +1675,7 @@ async function copyFileFallback(
     const mode = params.mode ?? (target.stat.mode & 0o777);
     await target.handle.close().catch(() => {});
     targetClosedByUs = true;
+    const destinationGuard = await createAsyncDirectoryGuard(path.dirname(destinationPath));
 
     tempPath = buildAtomicWriteTempPath(destinationPath);
     unregisterTempPath = registerTempPathForExit(tempPath);
@@ -1706,7 +1695,10 @@ async function copyFileFallback(
       tempClosedByStream = true;
     }
     tempHandle = null;
-    await fs.rename(tempPath, destinationPath);
+    const commitTempPath = tempPath;
+    await withAsyncDirectoryGuards([destinationGuard], async () => {
+      await fs.rename(commitTempPath, destinationPath);
+    });
     tempPath = null;
     unregisterTempPath();
     unregisterTempPath = null;

--- a/src/safe-path-segment.ts
+++ b/src/safe-path-segment.ts
@@ -1,0 +1,58 @@
+import { FsSafeError } from "./errors.js";
+
+const SAFE_PATH_SEGMENT_PATTERN = /^[A-Za-z0-9_-][A-Za-z0-9._-]*$/;
+const SAFE_DOT_PREFIX_PATH_SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+export type SafePathSegmentOptions = {
+  allowDotPrefix?: boolean;
+  label?: string;
+};
+
+export function isSafePathSegment(
+  segment: string,
+  options: SafePathSegmentOptions = {},
+): boolean {
+  return (
+    segment !== "" &&
+    segment !== "." &&
+    segment !== ".." &&
+    !segment.includes("/") &&
+    !segment.includes("\\") &&
+    !segment.includes("\0") &&
+    (options.allowDotPrefix === true || !segment.startsWith(".")) &&
+    (options.allowDotPrefix === true
+      ? SAFE_DOT_PREFIX_PATH_SEGMENT_PATTERN.test(segment)
+      : SAFE_PATH_SEGMENT_PATTERN.test(segment))
+  );
+}
+
+export function assertSafePathSegment(
+  segment: string,
+  options: SafePathSegmentOptions = {},
+): string {
+  const value = segment.trim();
+  if (!isSafePathSegment(value, options)) {
+    throw new FsSafeError(
+      "invalid-path",
+      `${options.label ?? "path segment"} must be a safe path segment`,
+    );
+  }
+  return value;
+}
+
+export function sanitizeSafePathSegment(
+  value: string,
+  fallback: string,
+  options: SafePathSegmentOptions = {},
+): string {
+  const sanitized = value
+    .trim()
+    .replace(/[\\/]+/g, "-")
+    .replace(/\0/g, "")
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (isSafePathSegment(sanitized, options)) {
+    return sanitized;
+  }
+  return assertSafePathSegment(fallback, { ...options, label: "fallback path segment" });
+}

--- a/src/safe-path-segment.ts
+++ b/src/safe-path-segment.ts
@@ -30,14 +30,13 @@ export function assertSafePathSegment(
   segment: string,
   options: SafePathSegmentOptions = {},
 ): string {
-  const value = segment.trim();
-  if (!isSafePathSegment(value, options)) {
+  if (!isSafePathSegment(segment, options)) {
     throw new FsSafeError(
       "invalid-path",
       `${options.label ?? "path segment"} must be a safe path segment`,
     );
   }
-  return value;
+  return segment;
 }
 
 export function sanitizeSafePathSegment(

--- a/src/safe-path-segment.ts
+++ b/src/safe-path-segment.ts
@@ -30,6 +30,8 @@ export function assertSafePathSegment(
   segment: string,
   options: SafePathSegmentOptions = {},
 ): string {
+  // Validate the exact value callers will later join into paths; trimming here
+  // would let whitespace-padded ids pass and then be used verbatim.
   if (!isSafePathSegment(segment, options)) {
     throw new FsSafeError(
       "invalid-path",

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -2,7 +2,9 @@ import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { createAsyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError, type FsSafeErrorCode } from "./errors.js";
+import { withAsyncDirectoryGuards } from "./guarded-mutation.js";
 import { resolveHomeRelativePath } from "./home-dir.js";
 import { openPinnedFileSync } from "./pinned-open.js";
 
@@ -241,6 +243,7 @@ export async function writeSecretFileAtomic(params: {
   const resolvedRootReal = await fsp.realpath(resolvedRoot);
   const parentDir = await fsp.realpath(intendedParentDir);
   assertRealPathWithinRoot(resolvedRootReal, parentDir);
+  const parentGuard = await createAsyncDirectoryGuard(parentDir);
   const fileName = path.basename(resolvedFile);
   const finalFilePath = path.join(parentDir, fileName);
 
@@ -276,7 +279,9 @@ export async function writeSecretFileAtomic(params: {
     if (refreshedParentReal !== parentDir) {
       throw new Error(`Private secret parent directory changed during write for ${finalFilePath}.`);
     }
-    await fsp.rename(tempPath, finalFilePath);
+    await withAsyncDirectoryGuards([parentGuard], async () => {
+      await fsp.rename(tempPath, finalFilePath);
+    });
     createdTemp = false;
     await enforcePrivatePathMode(finalFilePath, mode, "file");
   } finally {

--- a/src/sibling-temp.ts
+++ b/src/sibling-temp.ts
@@ -3,7 +3,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { sanitizeUntrustedFileName } from "./filename.js";
 import { root } from "./root.js";
+import { resolveSecureTempRoot } from "./secure-temp-dir.js";
 import { registerTempPathForExit } from "./temp-cleanup.js";
+import { getFsSafeTestHooks } from "./test-hooks.js";
 import { serializePathWrite } from "./write-queue.js";
 
 export type WriteSiblingTempFileOptions<T> = {
@@ -56,6 +58,34 @@ function assertFinalPathIsSibling(dir: string, filePath: string): void {
   const resolvedFile = path.resolve(filePath);
   if (path.dirname(resolvedFile) !== resolvedDir) {
     throw new Error("Final path must be in the sibling temp directory.");
+  }
+}
+
+type DirectoryGuard = {
+  dir: string;
+  realPath: string;
+  dev: number | bigint;
+  ino: number | bigint;
+};
+
+async function createDirectoryGuard(dir: string): Promise<DirectoryGuard> {
+  const stat = await fs.lstat(dir);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`Directory changed during sibling-temp write: ${dir}`);
+  }
+  return { dir, realPath: await fs.realpath(dir), dev: stat.dev, ino: stat.ino };
+}
+
+async function assertDirectoryGuard(guard: DirectoryGuard): Promise<void> {
+  const stat = await fs.lstat(guard.dir);
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isDirectory() ||
+    stat.dev !== guard.dev ||
+    stat.ino !== guard.ino ||
+    (await fs.realpath(guard.dir)) !== guard.realPath
+  ) {
+    throw new Error(`Directory changed during sibling-temp write: ${guard.dir}`);
   }
 }
 
@@ -136,18 +166,32 @@ export async function writeViaSiblingTempPath(params: {
   ) {
     throw new Error("Target path is outside the allowed root");
   }
+  const rootGuard = await createDirectoryGuard(rootDir);
+  const tempDir = await fs.mkdtemp(
+    path.join(
+      resolveSecureTempRoot({
+        fallbackPrefix: "fs-safe-output",
+        unsafeFallbackLabel: "sibling temp output dir",
+        warn: () => undefined,
+      }),
+      "fs-safe-output-",
+    ),
+  );
   const tempPath = buildSiblingTempPath({
-    targetPath,
+    targetPath: path.join(tempDir, path.basename(targetPath)),
     fallbackFileName: params.fallbackFileName ?? "output.bin",
     tempPrefix: params.tempPrefix ?? ".fs-safe-output-",
   });
-  const unregisterTempPath = registerTempPathForExit(tempPath);
+  const unregisterTempPath = registerTempPathForExit(tempDir, { recursive: true });
   try {
+    await getFsSafeTestHooks()?.beforeSiblingTempWrite?.(tempPath);
     await params.writeTemp(tempPath);
+    await assertDirectoryGuard(rootGuard);
     const targetRoot = await root(rootDir);
     await targetRoot.copyIn(relativeTargetPath, tempPath, { mkdir: false });
+    await assertDirectoryGuard(rootGuard);
   } finally {
-    await fs.rm(tempPath, { force: true }).catch(() => {});
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
     unregisterTempPath();
   }
 }

--- a/src/sibling-temp.ts
+++ b/src/sibling-temp.ts
@@ -16,6 +16,7 @@ export type WriteSiblingTempFileOptions<T> = {
   resolveFinalPath: (result: T) => string;
   tempPrefix?: string;
   dirMode?: number;
+  chmodDir?: boolean;
   mode?: number;
   syncTempFile?: boolean;
   syncParentDir?: boolean;
@@ -68,7 +69,9 @@ export async function writeSiblingTempFile<T>(
 ): Promise<WriteSiblingTempFileResult<T>> {
   const dir = path.resolve(options.dir);
   await fs.mkdir(dir, { recursive: true, mode: options.dirMode ?? 0o700 });
-  await fs.chmod(dir, options.dirMode ?? 0o700).catch(() => undefined);
+  if (options.chmodDir !== false) {
+    await fs.chmod(dir, options.dirMode ?? 0o700).catch(() => undefined);
+  }
   const dirGuard = await createAsyncDirectoryGuard(dir);
   const tempPath = buildTempPath(dir, options.tempPrefix);
   const unregisterTempPath = registerTempPathForExit(tempPath);

--- a/src/sibling-temp.ts
+++ b/src/sibling-temp.ts
@@ -1,6 +1,8 @@
 import crypto, { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard } from "./directory-guard.js";
+import { withAsyncDirectoryGuards } from "./guarded-mutation.js";
 import { sanitizeUntrustedFileName } from "./filename.js";
 import { root } from "./root.js";
 import { resolveSecureTempRoot } from "./secure-temp-dir.js";
@@ -61,40 +63,13 @@ function assertFinalPathIsSibling(dir: string, filePath: string): void {
   }
 }
 
-type DirectoryGuard = {
-  dir: string;
-  realPath: string;
-  dev: number | bigint;
-  ino: number | bigint;
-};
-
-async function createDirectoryGuard(dir: string): Promise<DirectoryGuard> {
-  const stat = await fs.lstat(dir);
-  if (stat.isSymbolicLink() || !stat.isDirectory()) {
-    throw new Error(`Directory changed during sibling-temp write: ${dir}`);
-  }
-  return { dir, realPath: await fs.realpath(dir), dev: stat.dev, ino: stat.ino };
-}
-
-async function assertDirectoryGuard(guard: DirectoryGuard): Promise<void> {
-  const stat = await fs.lstat(guard.dir);
-  if (
-    stat.isSymbolicLink() ||
-    !stat.isDirectory() ||
-    stat.dev !== guard.dev ||
-    stat.ino !== guard.ino ||
-    (await fs.realpath(guard.dir)) !== guard.realPath
-  ) {
-    throw new Error(`Directory changed during sibling-temp write: ${guard.dir}`);
-  }
-}
-
 export async function writeSiblingTempFile<T>(
   options: WriteSiblingTempFileOptions<T>,
 ): Promise<WriteSiblingTempFileResult<T>> {
   const dir = path.resolve(options.dir);
   await fs.mkdir(dir, { recursive: true, mode: options.dirMode ?? 0o700 });
   await fs.chmod(dir, options.dirMode ?? 0o700).catch(() => undefined);
+  const dirGuard = await createAsyncDirectoryGuard(dir);
   const tempPath = buildTempPath(dir, options.tempPrefix);
   const unregisterTempPath = registerTempPathForExit(tempPath);
   let tempExists = false;
@@ -110,7 +85,9 @@ export async function writeSiblingTempFile<T>(
     const filePath = path.resolve(options.resolveFinalPath(result));
     assertFinalPathIsSibling(dir, filePath);
     await serializePathWrite(filePath, async () => {
-      await fs.rename(tempPath, filePath);
+      await withAsyncDirectoryGuards([dirGuard], async () => {
+        await fs.rename(tempPath, filePath);
+      });
       tempExists = false;
       unregisterTempPath();
       if (options.mode !== undefined) {
@@ -166,7 +143,7 @@ export async function writeViaSiblingTempPath(params: {
   ) {
     throw new Error("Target path is outside the allowed root");
   }
-  const rootGuard = await createDirectoryGuard(rootDir);
+  const rootGuard = await createAsyncDirectoryGuard(rootDir);
   const tempDir = await fs.mkdtemp(
     path.join(
       resolveSecureTempRoot({
@@ -186,10 +163,10 @@ export async function writeViaSiblingTempPath(params: {
   try {
     await getFsSafeTestHooks()?.beforeSiblingTempWrite?.(tempPath);
     await params.writeTemp(tempPath);
-    await assertDirectoryGuard(rootGuard);
+    await assertAsyncDirectoryGuard(rootGuard);
     const targetRoot = await root(rootDir);
     await targetRoot.copyIn(relativeTargetPath, tempPath, { mkdir: false });
-    await assertDirectoryGuard(rootGuard);
+    await assertAsyncDirectoryGuard(rootGuard);
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
     unregisterTempPath();

--- a/src/temp-target.ts
+++ b/src/temp-target.ts
@@ -30,6 +30,9 @@ function sanitizeExtension(extension?: string): string {
 export function sanitizeTempFileName(fileName: string): string {
   const base = path.basename(fileName).replace(/[^a-zA-Z0-9._-]+/g, "-");
   const normalized = base.replace(/^-+|-+$/g, "");
+  if (normalized === "." || normalized === "..") {
+    return "download.bin";
+  }
   return normalized || "download.bin";
 }
 

--- a/src/temp-target.ts
+++ b/src/temp-target.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import path from "node:path";
+import { sanitizeSafePathSegment } from "./safe-path-segment.js";
 import { resolveSecureTempRoot } from "./secure-temp-dir.js";
 import { registerTempPathForExit } from "./temp-cleanup.js";
 
@@ -28,12 +29,9 @@ function sanitizeExtension(extension?: string): string {
 }
 
 export function sanitizeTempFileName(fileName: string): string {
-  const base = path.basename(fileName).replace(/[^a-zA-Z0-9._-]+/g, "-");
-  const normalized = base.replace(/^-+|-+$/g, "");
-  if (normalized === "." || normalized === "..") {
-    return "download.bin";
-  }
-  return normalized || "download.bin";
+  return sanitizeSafePathSegment(path.basename(fileName), "download.bin", {
+    allowDotPrefix: true,
+  });
 }
 
 export function buildRandomTempFilePath(params: {

--- a/src/test-hooks.ts
+++ b/src/test-hooks.ts
@@ -4,6 +4,18 @@ export type FsSafeTestHooks = {
   afterPreOpenLstat?: (filePath: string) => Promise<void> | void;
   beforeOpen?: (filePath: string, flags: number) => Promise<void> | void;
   afterOpen?: (filePath: string, handle: FileHandle) => Promise<void> | void;
+  beforeArchiveOutputMutation?: (
+    operation: "mkdir" | "chmod",
+    targetPath: string,
+  ) => Promise<void> | void;
+  beforeFileStorePruneDescend?: (dirPath: string) => Promise<void> | void;
+  beforeFileStoreSyncPrivateWrite?: (filePath: string) => void;
+  beforeRootFallbackMutation?: (
+    operation: "mkdir" | "move" | "remove",
+    targetPath: string,
+  ) => Promise<void> | void;
+  beforeSiblingTempWrite?: (tempPath: string) => Promise<void> | void;
+  beforeTrashMove?: (targetPath: string, destPath: string) => void;
 };
 
 let fsSafeTestHooks: FsSafeTestHooks | undefined;

--- a/src/trash.ts
+++ b/src/trash.ts
@@ -30,11 +30,14 @@ function isSameOrChildPath(candidate: string, parent: string): boolean {
 }
 
 function resolveAllowedTrashRoots(allowedRoots?: Iterable<string>): string[] {
-  const roots = [...(allowedRoots ?? [os.homedir(), os.tmpdir()])].map((root) => {
+  const roots = [...(allowedRoots ?? [os.homedir(), os.tmpdir()])].flatMap((root) => {
+    const lexicalRoot = path.resolve(root);
     try {
-      return path.resolve(fs.realpathSync.native(root));
+      // Keep both spellings: broken symlink targets cannot be realpathed and
+      // may only compare equal to the caller's lexical allowed root.
+      return [path.resolve(fs.realpathSync.native(root)), lexicalRoot];
     } catch {
-      return path.resolve(root);
+      return [lexicalRoot];
     }
   });
   return [...new Set(roots)];
@@ -43,27 +46,39 @@ function resolveAllowedTrashRoots(allowedRoots?: Iterable<string>): string[] {
 type TrashTargetGuard = {
   path: string;
   realPath: string;
+  realPathResolved: boolean;
   stat: fs.Stats;
 };
+
+function resolveTrashTargetPath(targetPath: string): { path: string; resolved: boolean } {
+  try {
+    return { path: path.resolve(fs.realpathSync.native(targetPath)), resolved: true };
+  } catch {
+    // Broken symlinks are valid trash targets. Fall back to the lexical path,
+    // then rely on lstat identity so the move renames the symlink itself.
+    return { path: path.resolve(targetPath), resolved: false };
+  }
+}
 
 function assertAllowedTrashTarget(
   targetPath: string,
   allowedRoots?: Iterable<string>,
 ): TrashTargetGuard {
-  let resolvedTargetPath = path.resolve(targetPath);
-  const stat = fs.lstatSync(resolvedTargetPath);
-  try {
-    resolvedTargetPath = path.resolve(fs.realpathSync.native(targetPath));
-  } catch {
-    // The subsequent move will surface missing or inaccessible targets.
-  }
+  const stat = fs.lstatSync(path.resolve(targetPath));
+  const resolvedTarget = resolveTrashTargetPath(targetPath);
+  const resolvedTargetPath = resolvedTarget.path;
   const isAllowed = resolveAllowedTrashRoots(allowedRoots).some(
     (root) => resolvedTargetPath !== root && isSameOrChildPath(resolvedTargetPath, root),
   );
   if (!isAllowed) {
     throw new Error(`Refusing to trash path outside allowed roots: ${targetPath}`);
   }
-  return { path: path.resolve(targetPath), realPath: resolvedTargetPath, stat };
+  return {
+    path: path.resolve(targetPath),
+    realPath: resolvedTargetPath,
+    realPathResolved: resolvedTarget.resolved,
+    stat,
+  };
 }
 
 function assertTrashTargetGuard(guard: TrashTargetGuard): void {
@@ -71,8 +86,11 @@ function assertTrashTargetGuard(guard: TrashTargetGuard): void {
   if (!sameFileIdentity(stat, guard.stat)) {
     throw new Error(`Refusing to trash path after it changed: ${guard.path}`);
   }
-  const realPath = path.resolve(fs.realpathSync.native(guard.path));
-  if (realPath !== guard.realPath) {
+  const current = resolveTrashTargetPath(guard.path);
+  if (guard.realPathResolved && (!current.resolved || current.path !== guard.realPath)) {
+    throw new Error(`Refusing to trash path after it changed: ${guard.path}`);
+  }
+  if (!guard.realPathResolved && current.resolved) {
     throw new Error(`Refusing to trash path after it changed: ${guard.path}`);
   }
 }

--- a/src/trash.ts
+++ b/src/trash.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { sameFileIdentity } from "./file-identity.js";
+import { getFsSafeTestHooks } from "./test-hooks.js";
 
 export type MovePathToTrashOptions = {
   allowedRoots?: Iterable<string>;
@@ -37,8 +39,18 @@ function resolveAllowedTrashRoots(allowedRoots?: Iterable<string>): string[] {
   return [...new Set(roots)];
 }
 
-function assertAllowedTrashTarget(targetPath: string, allowedRoots?: Iterable<string>): void {
+type TrashTargetGuard = {
+  path: string;
+  realPath: string;
+  stat: fs.Stats;
+};
+
+function assertAllowedTrashTarget(
+  targetPath: string,
+  allowedRoots?: Iterable<string>,
+): TrashTargetGuard {
   let resolvedTargetPath = path.resolve(targetPath);
+  const stat = fs.lstatSync(resolvedTargetPath);
   try {
     resolvedTargetPath = path.resolve(fs.realpathSync.native(targetPath));
   } catch {
@@ -49,6 +61,18 @@ function assertAllowedTrashTarget(targetPath: string, allowedRoots?: Iterable<st
   );
   if (!isAllowed) {
     throw new Error(`Refusing to trash path outside allowed roots: ${targetPath}`);
+  }
+  return { path: path.resolve(targetPath), realPath: resolvedTargetPath, stat };
+}
+
+function assertTrashTargetGuard(guard: TrashTargetGuard): void {
+  const stat = fs.lstatSync(guard.path);
+  if (!sameFileIdentity(stat, guard.stat)) {
+    throw new Error(`Refusing to trash path after it changed: ${guard.path}`);
+  }
+  const realPath = path.resolve(fs.realpathSync.native(guard.path));
+  if (realPath !== guard.realPath) {
+    throw new Error(`Refusing to trash path after it changed: ${guard.path}`);
   }
 }
 
@@ -103,9 +127,11 @@ function reserveTrashDestination(trashDir: string, base: string, timestamp: numb
   return resolveContainedPath(container, base);
 }
 
-function movePathToDestination(targetPath: string, dest: string): boolean {
+function movePathToDestination(target: TrashTargetGuard, dest: string): boolean {
+  getFsSafeTestHooks()?.beforeTrashMove?.(target.path, dest);
+  assertTrashTargetGuard(target);
   try {
-    fs.renameSync(targetPath, dest);
+    fs.renameSync(target.path, dest);
     return true;
   } catch (error) {
     if (getFsErrorCode(error) !== "EXDEV") {
@@ -117,8 +143,10 @@ function movePathToDestination(targetPath: string, dest: string): boolean {
   }
 
   try {
-    fs.cpSync(targetPath, dest, { recursive: true, force: false, errorOnExist: true });
-    fs.rmSync(targetPath, { recursive: true, force: false });
+    assertTrashTargetGuard(target);
+    fs.cpSync(target.path, dest, { recursive: true, force: false, errorOnExist: true });
+    assertTrashTargetGuard(target);
+    fs.rmSync(target.path, { recursive: true, force: false });
     return true;
   } catch (error) {
     if (isTrashDestinationCollision(error)) {
@@ -134,12 +162,12 @@ export async function movePathToTrash(
 ): Promise<string> {
   // Avoid resolving external trash helpers through the service PATH during cleanup.
   const base = trashBaseName(targetPath);
-  assertAllowedTrashTarget(targetPath, options.allowedRoots);
+  const target = assertAllowedTrashTarget(targetPath, options.allowedRoots);
   const trashDir = resolveTrashDir();
   const timestamp = Date.now();
   for (let attempt = 0; attempt < TRASH_DESTINATION_RETRY_LIMIT; attempt += 1) {
     const dest = reserveTrashDestination(trashDir, base, timestamp);
-    if (movePathToDestination(targetPath, dest)) {
+    if (movePathToDestination(target, dest)) {
       return dest;
     }
   }

--- a/src/trash.ts
+++ b/src/trash.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { sameFileIdentity } from "./file-identity.js";
+import { guardedRenameSync, guardedRmSync } from "./guarded-mutation.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
 
 export type MovePathToTrashOptions = {
@@ -131,7 +132,7 @@ function movePathToDestination(target: TrashTargetGuard, dest: string): boolean 
   getFsSafeTestHooks()?.beforeTrashMove?.(target.path, dest);
   assertTrashTargetGuard(target);
   try {
-    fs.renameSync(target.path, dest);
+    guardedRenameSync({ from: target.path, to: dest });
     return true;
   } catch (error) {
     if (getFsErrorCode(error) !== "EXDEV") {
@@ -146,7 +147,7 @@ function movePathToDestination(target: TrashTargetGuard, dest: string): boolean 
     assertTrashTargetGuard(target);
     fs.cpSync(target.path, dest, { recursive: true, force: false, errorOnExist: true });
     assertTrashTargetGuard(target);
-    fs.rmSync(target.path, { recursive: true, force: false });
+    guardedRmSync({ target: target.path, recursive: true, force: false, verifyAfter: false });
     return true;
   } catch (error) {
     if (isTrashDestinationCollision(error)) {

--- a/test/edge-coverage.test.ts
+++ b/test/edge-coverage.test.ts
@@ -229,4 +229,21 @@ describe("trash edge paths", () => {
       await fs.rm(path.dirname(copiedDest), { recursive: true, force: true });
     }
   });
+
+  it.runIf(process.platform !== "win32")("moves broken symlinks to trash", async () => {
+    const root = await tempRoot("fs-safe-trash-broken-link-");
+    const linkPath = path.join(root, "broken-link");
+    const missingTarget = path.join(root, "missing-target");
+    await fs.symlink(missingTarget, linkPath);
+
+    const dest = await movePathToTrash(linkPath, { allowedRoots: [root] });
+    try {
+      // Broken links cannot be realpathed; the guard keeps lstat identity and
+      // renames the link itself instead of requiring the target to exist.
+      await expect(fs.readlink(dest)).resolves.toBe(missingTarget);
+      await expect(fs.lstat(linkPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await fs.rm(path.dirname(dest), { recursive: true, force: true });
+    }
+  });
 });

--- a/test/file-store-sync-read-validation.test.ts
+++ b/test/file-store-sync-read-validation.test.ts
@@ -1,0 +1,42 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { fileStoreSync } from "../src/file-store.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("sync file-store read validation failures", () => {
+  it("surfaces directories as filesystem safety errors", async () => {
+    const root = await tempRoot("fs-safe-sync-store-validation-");
+    await fs.mkdir(path.join(root, "not-a-file"));
+    const store = fileStoreSync({ rootDir: root, private: true });
+
+    expect(() => store.readTextIfExists("not-a-file")).toThrow(
+      expect.objectContaining({ code: "path-mismatch" }),
+    );
+  });
+
+  it.runIf(process.platform !== "win32")("surfaces hardlinks as filesystem safety errors", async () => {
+    const root = await tempRoot("fs-safe-sync-store-hardlink-");
+    const filePath = path.join(root, "value.txt");
+    await fs.writeFile(filePath, "secret");
+    fsSync.linkSync(filePath, path.join(root, "alias.txt"));
+    const store = fileStoreSync({ rootDir: root, private: true });
+
+    expect(() => store.readTextIfExists("value.txt")).toThrow(
+      expect.objectContaining({ code: "path-mismatch" }),
+    );
+  });
+});

--- a/test/findings-regression.test.ts
+++ b/test/findings-regression.test.ts
@@ -1,0 +1,333 @@
+import fsSync from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafePython, root as openRoot } from "../src/index.js";
+import { prepareArchiveDestinationDir, prepareArchiveOutputPath, mergeExtractedTreeIntoDestination } from "../src/archive-staging.js";
+import { fileStore, fileStoreSync } from "../src/file-store.js";
+import { writeJsonSync } from "../src/json.js";
+import { moveJsonDurableQueueEntryToFailed, resolveJsonDurableQueueEntryPaths } from "../src/json-durable-queue.js";
+import { runPinnedWriteHelper } from "../src/pinned-write.js";
+import { writeViaSiblingTempPath } from "../src/sibling-temp.js";
+import { sanitizeTempFileName, tempFile } from "../src/temp-target.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { movePathToTrash } from "../src/trash.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeOldFile(filePath: string, content = "old"): Promise<void> {
+  await fsp.writeFile(filePath, content);
+  const old = new Date(Date.now() - 60_000);
+  await fsp.utimes(filePath, old, old);
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  configureFsSafePython({ mode: "auto", pythonPath: undefined });
+  __setFsSafeTestHooksForTest(undefined);
+  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
+});
+
+describe("security finding regressions", () => {
+  it.runIf(process.platform !== "win32")("guards Root fallback mutators against parent swaps", async () => {
+    configureFsSafePython({ mode: "off" });
+    const base = await tempRoot("fs-safe-root-fallback-race-");
+    const outside = await tempRoot("fs-safe-root-fallback-outside-");
+    await fsp.mkdir(path.join(base, "nested"));
+    await fsp.writeFile(path.join(base, "nested", "delete.txt"), "inside");
+    await fsp.writeFile(path.join(base, "from.txt"), "move");
+    await fsp.writeFile(path.join(outside, "delete.txt"), "outside");
+    const scoped = await openRoot(base);
+
+    __setFsSafeTestHooksForTest({
+      async beforeRootFallbackMutation(operation) {
+        if (operation !== "remove") return;
+        await fsp.rename(path.join(base, "nested"), path.join(base, "nested-real"));
+        await fsp.symlink(outside, path.join(base, "nested"), "dir");
+      },
+    });
+    await expect(scoped.remove("nested/delete.txt")).rejects.toBeTruthy();
+    await expect(fsp.readFile(path.join(outside, "delete.txt"), "utf8")).resolves.toBe("outside");
+
+    await fsp.rm(path.join(base, "nested"));
+    await fsp.rename(path.join(base, "nested-real"), path.join(base, "nested"));
+    __setFsSafeTestHooksForTest({
+      async beforeRootFallbackMutation(operation) {
+        if (operation !== "mkdir") return;
+        await fsp.rename(path.join(base, "nested"), path.join(base, "nested-real"));
+        await fsp.symlink(outside, path.join(base, "nested"), "dir");
+      },
+    });
+    await expect(scoped.mkdir("nested/created")).rejects.toBeTruthy();
+    await expect(fsp.stat(path.join(outside, "created"))).rejects.toMatchObject({ code: "ENOENT" });
+
+    await fsp.rm(path.join(base, "nested"));
+    await fsp.rename(path.join(base, "nested-real"), path.join(base, "nested"));
+    __setFsSafeTestHooksForTest({
+      async beforeRootFallbackMutation(operation) {
+        if (operation !== "move") return;
+        await fsp.rename(path.join(base, "nested"), path.join(base, "nested-real"));
+        await fsp.symlink(outside, path.join(base, "nested"), "dir");
+      },
+    });
+    await expect(scoped.move("from.txt", "nested/moved.txt")).rejects.toBeTruthy();
+    await expect(fsp.stat(path.join(outside, "moved.txt"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(process.platform !== "win32")("does not create archive directories through a swapped destination", async () => {
+    const base = await tempRoot("fs-safe-archive-dir-race-");
+    const dest = path.join(base, "dest");
+    const outside = await tempRoot("fs-safe-archive-dir-outside-");
+    await fsp.mkdir(dest);
+    const destinationRealDir = await prepareArchiveDestinationDir(dest);
+
+    __setFsSafeTestHooksForTest({
+      async beforeArchiveOutputMutation(operation) {
+        if (operation !== "mkdir") return;
+        await fsp.rename(dest, path.join(base, "dest-real"));
+        await fsp.symlink(outside, dest, "dir");
+      },
+    });
+
+    await expect(
+      prepareArchiveOutputPath({
+        destinationDir: dest,
+        destinationRealDir,
+        relPath: "nested/payload.txt",
+        outPath: path.join(dest, "nested", "payload.txt"),
+        originalPath: "nested/payload.txt",
+        isDirectory: false,
+      }),
+    ).rejects.toBeTruthy();
+    await expect(fsp.stat(path.join(outside, "nested"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(process.platform !== "win32")("does not chmod through an archive entry symlink swap", async () => {
+    const base = await tempRoot("fs-safe-archive-chmod-race-");
+    const source = path.join(base, "source");
+    const dest = path.join(base, "dest");
+    const outside = await tempRoot("fs-safe-archive-chmod-outside-");
+    const outsideFile = path.join(outside, "outside.txt");
+    await fsp.mkdir(source);
+    await fsp.mkdir(dest);
+    await fsp.writeFile(path.join(source, "payload.txt"), "payload");
+    await fsp.writeFile(outsideFile, "outside");
+    await fsp.chmod(outsideFile, 0o600);
+    const destinationRealDir = await prepareArchiveDestinationDir(dest);
+
+    __setFsSafeTestHooksForTest({
+      async beforeArchiveOutputMutation(operation, targetPath) {
+        if (operation !== "chmod" || !targetPath.endsWith("payload.txt")) return;
+        await fsp.rm(targetPath, { force: true });
+        await fsp.symlink(outsideFile, targetPath, "file");
+      },
+    });
+
+    await expect(
+      mergeExtractedTreeIntoDestination({ sourceDir: source, destinationDir: dest, destinationRealDir }),
+    ).rejects.toBeTruthy();
+    expect((await fsp.stat(outsideFile)).mode & 0o777).toBe(0o600);
+  });
+
+  it.runIf(process.platform !== "win32")("uses unguessable no-follow temp files in pinned write fallback", async () => {
+    configureFsSafePython({ mode: "off" });
+    const base = await tempRoot("fs-safe-pinned-write-fallback-");
+    const outside = await tempRoot("fs-safe-pinned-write-outside-");
+    const outsideFile = path.join(outside, "outside.txt");
+    await fsp.writeFile(outsideFile, "outside");
+    await fsp.symlink(outsideFile, path.join(base, ".victim.txt.fallback.tmp"), "file");
+
+    await runPinnedWriteHelper({
+      rootPath: base,
+      relativeParentPath: "",
+      basename: "victim.txt",
+      mkdir: true,
+      mode: 0o600,
+      overwrite: true,
+      input: { kind: "buffer", data: "safe" },
+    });
+
+    await expect(fsp.readFile(path.join(base, "victim.txt"), "utf8")).resolves.toBe("safe");
+    await expect(fsp.readFile(outsideFile, "utf8")).resolves.toBe("outside");
+  });
+
+  it("validates pinned write fallback payloads even when Python mode is off", async () => {
+    configureFsSafePython({ mode: "off" });
+    const base = await tempRoot("fs-safe-pinned-write-validation-");
+    await expect(
+      runPinnedWriteHelper({
+        rootPath: base,
+        relativeParentPath: "../escape",
+        basename: "victim.txt",
+        mkdir: true,
+        mode: 0o600,
+        overwrite: true,
+        input: { kind: "buffer", data: "bad" },
+      }),
+    ).rejects.toBeTruthy();
+  });
+
+  it.runIf(process.platform !== "win32")("guards private sync store writes against parent swaps", async () => {
+    const base = await tempRoot("fs-safe-sync-private-write-");
+    const outside = await tempRoot("fs-safe-sync-private-outside-");
+    await fsp.mkdir(path.join(base, "nested"));
+    const store = fileStoreSync({ rootDir: base, private: true });
+
+    __setFsSafeTestHooksForTest({
+      beforeFileStoreSyncPrivateWrite() {
+        fsSync.renameSync(path.join(base, "nested"), path.join(base, "nested-real"));
+        fsSync.symlinkSync(outside, path.join(base, "nested"), "dir");
+      },
+    });
+
+    expect(() => store.writeText("nested/value.txt", "secret")).toThrow();
+    await expect(fsp.stat(path.join(outside, "value.txt"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(process.platform !== "win32")("pins sync store reads against final symlink swaps", async () => {
+    const base = await tempRoot("fs-safe-sync-read-race-");
+    const outside = await tempRoot("fs-safe-sync-read-outside-");
+    const filePath = path.join(base, "value.txt");
+    const outsideFile = path.join(outside, "outside.txt");
+    await fsp.writeFile(filePath, "inside");
+    await fsp.writeFile(outsideFile, "outside");
+    const originalReadFileSync = fsSync.readFileSync;
+    let swapped = false;
+    vi.spyOn(fsSync, "readFileSync").mockImplementation((target, options) => {
+      if (!swapped && typeof target === "number") {
+        swapped = true;
+        fsSync.rmSync(filePath);
+        fsSync.symlinkSync(outsideFile, filePath, "file");
+      }
+      return originalReadFileSync.call(fsSync, target, options as never);
+    });
+
+    const store = fileStoreSync({ rootDir: base, private: true });
+    expect(store.readTextIfExists("value.txt")).toBe("inside");
+    expect(fsSync.readFileSync(outsideFile, "utf8")).toBe("outside");
+  });
+
+  it.runIf(process.platform !== "win32")("does not recurse prune through a swapped directory symlink", async () => {
+    const base = await tempRoot("fs-safe-prune-race-");
+    const outside = await tempRoot("fs-safe-prune-outside-");
+    await fsp.mkdir(path.join(base, "cache"));
+    await writeOldFile(path.join(base, "cache", "old.txt"));
+    await writeOldFile(path.join(outside, "old.txt"), "outside");
+    const store = fileStore({ rootDir: base });
+
+    __setFsSafeTestHooksForTest({
+      async beforeFileStorePruneDescend(dirPath) {
+        if (!dirPath.endsWith("cache")) return;
+        await fsp.rename(path.join(base, "cache"), path.join(base, "cache-real"));
+        await fsp.symlink(outside, path.join(base, "cache"), "dir");
+      },
+    });
+
+    await store.pruneExpired({ ttlMs: 1, recursive: true });
+    await expect(fsp.readFile(path.join(outside, "old.txt"), "utf8")).resolves.toBe("outside");
+  });
+
+  it.runIf(process.platform !== "win32")("does not copy JSON through a raced fallback symlink", async () => {
+    const base = await tempRoot("fs-safe-json-fallback-race-");
+    const outside = await tempRoot("fs-safe-json-fallback-outside-");
+    const target = path.join(base, "state.json");
+    const outsideFile = path.join(outside, "outside.json");
+    await fsp.writeFile(target, "{}");
+    await fsp.writeFile(outsideFile, "outside");
+    const originalRenameSync = fsSync.renameSync;
+    const originalLstatSync = fsSync.lstatSync;
+    let forced = false;
+    let swapped = false;
+    vi.spyOn(fsSync, "renameSync").mockImplementation((from, to) => {
+      if (!forced && to === target) {
+        forced = true;
+        throw Object.assign(new Error("forced EPERM"), { code: "EPERM" });
+      }
+      return originalRenameSync.call(fsSync, from, to);
+    });
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((candidate, options) => {
+      const stat = originalLstatSync.call(fsSync, candidate, options as never);
+      if (!swapped && candidate === target && forced) {
+        swapped = true;
+        fsSync.rmSync(target);
+        fsSync.symlinkSync(outsideFile, target, "file");
+      }
+      return stat;
+    });
+
+    writeJsonSync(target, { ok: true });
+    await expect(fsp.readFile(outsideFile, "utf8")).resolves.toBe("outside");
+    await expect(fsp.readFile(target, "utf8")).resolves.toContain('"ok": true');
+  });
+
+  it("rejects durable queue ids that are not safe path segments", async () => {
+    const base = await tempRoot("fs-safe-queue-id-");
+    expect(() => resolveJsonDurableQueueEntryPaths(base, "../escape")).toThrow();
+    await expect(
+      moveJsonDurableQueueEntryToFailed({ queueDir: base, failedDir: path.join(base, "failed"), id: "nested/escape" }),
+    ).rejects.toBeTruthy();
+  });
+
+  it("keeps dot-only temp filenames inside the private temp directory", async () => {
+    const base = await tempRoot("fs-safe-temp-dot-");
+    expect(sanitizeTempFileName("..")).toBe("download.bin");
+    expect(sanitizeTempFileName("./..")).toBe("download.bin");
+    const target = await tempFile({ rootDir: base, prefix: "download", fileName: ".." });
+    try {
+      expect(target.path).toBe(path.join(target.dir, "download.bin"));
+      expect(target.file("..")).toBe(path.join(target.dir, "download.bin"));
+    } finally {
+      await target.cleanup();
+    }
+  });
+
+  it.runIf(process.platform !== "win32")("writes sibling-temp content from a private temp path, not a swapped target parent", async () => {
+    const base = await tempRoot("fs-safe-sibling-temp-race-");
+    const outside = await tempRoot("fs-safe-sibling-temp-outside-");
+    await fsp.mkdir(path.join(base, "nested"));
+
+    __setFsSafeTestHooksForTest({
+      async beforeSiblingTempWrite() {
+        await fsp.rename(path.join(base, "nested"), path.join(base, "nested-real"));
+        await fsp.symlink(outside, path.join(base, "nested"), "dir");
+      },
+    });
+
+    await expect(
+      writeViaSiblingTempPath({
+        rootDir: base,
+        targetPath: path.join(base, "nested", "out.txt"),
+        writeTemp: async (tempPath) => {
+          await fsp.writeFile(tempPath, "secret");
+        },
+      }),
+    ).rejects.toBeTruthy();
+    await expect(fsp.stat(path.join(outside, "out.txt"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(process.platform !== "win32")("does not trash a different path after an allowed parent swap", async () => {
+    const base = await tempRoot("fs-safe-trash-race-");
+    const outside = await tempRoot("fs-safe-trash-outside-");
+    await fsp.mkdir(path.join(base, "dir"));
+    await fsp.writeFile(path.join(base, "dir", "victim.txt"), "inside");
+    await fsp.writeFile(path.join(outside, "victim.txt"), "outside");
+
+    __setFsSafeTestHooksForTest({
+      beforeTrashMove() {
+        fsSync.renameSync(path.join(base, "dir"), path.join(base, "dir-real"));
+        fsSync.symlinkSync(outside, path.join(base, "dir"), "dir");
+      },
+    });
+
+    await expect(movePathToTrash(path.join(base, "dir", "victim.txt"), { allowedRoots: [base] }))
+      .rejects.toBeTruthy();
+    await expect(fsp.readFile(path.join(outside, "victim.txt"), "utf8")).resolves.toBe("outside");
+  });
+});

--- a/test/findings-regression.test.ts
+++ b/test/findings-regression.test.ts
@@ -15,7 +15,7 @@ import { runPinnedWriteHelper } from "../src/pinned-write.js";
 import { replaceFileAtomic } from "../src/replace-file.js";
 import { writeViaSiblingTempPath } from "../src/sibling-temp.js";
 import { sanitizeTempFileName, tempFile } from "../src/temp-target.js";
-import { tempWorkspaceSync } from "../src/private-temp-workspace.js";
+import { tempWorkspace, tempWorkspaceSync } from "../src/private-temp-workspace.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 import { movePathToTrash } from "../src/trash.js";
 
@@ -388,6 +388,19 @@ describe("security finding regressions", () => {
     } finally {
       await target.cleanup();
     }
+  });
+
+  it("accepts safe temp workspace leaf names with spaces and dot prefixes", async () => {
+    await using workspace = await tempWorkspace({
+      rootDir: await tempRoot("fs-safe-workspace-leaf-"),
+      prefix: "work-",
+    });
+
+    await workspace.writeText("report 2026.txt", "ok");
+    await workspace.writeText(".env", "TOKEN=ok");
+
+    await expect(workspace.read("report 2026.txt")).resolves.toEqual(Buffer.from("ok"));
+    await expect(workspace.read(".env")).resolves.toEqual(Buffer.from("TOKEN=ok"));
   });
 
   it.runIf(process.platform !== "win32")("pins sync temp workspace reads against final symlink swaps", async () => {

--- a/test/findings-regression.test.ts
+++ b/test/findings-regression.test.ts
@@ -2,12 +2,15 @@ import fsSync from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import JSZip from "jszip";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { extractArchive } from "../src/archive.js";
 import { configureFsSafePython, root as openRoot } from "../src/index.js";
 import { prepareArchiveDestinationDir, prepareArchiveOutputPath, mergeExtractedTreeIntoDestination } from "../src/archive-staging.js";
 import { fileStore, fileStoreSync } from "../src/file-store.js";
 import { writeJsonSync } from "../src/json.js";
 import { moveJsonDurableQueueEntryToFailed, resolveJsonDurableQueueEntryPaths } from "../src/json-durable-queue.js";
+import { movePathWithCopyFallback } from "../src/move-path.js";
 import { runPinnedWriteHelper } from "../src/pinned-write.js";
 import { replaceFileAtomic } from "../src/replace-file.js";
 import { writeViaSiblingTempPath } from "../src/sibling-temp.js";
@@ -269,6 +272,17 @@ describe("security finding regressions", () => {
     await expect(fsp.readFile(target, "utf8")).resolves.toContain('"ok": true');
   });
 
+  it.runIf(process.platform !== "win32")("does not chmod existing parents during sync JSON writes", async () => {
+    const base = await tempRoot("fs-safe-json-parent-mode-");
+    const parent = path.join(base, "shared");
+    await fsp.mkdir(parent, { mode: 0o755 });
+    await fsp.chmod(parent, 0o755);
+
+    writeJsonSync(path.join(parent, "state.json"), { ok: true });
+
+    expect((await fsp.stat(parent)).mode & 0o777).toBe(0o755);
+  });
+
   it.runIf(process.platform !== "win32")("does not copy atomic fallback through a raced destination symlink", async () => {
     const base = await tempRoot("fs-safe-atomic-fallback-race-");
     const outside = await tempRoot("fs-safe-atomic-fallback-outside-");
@@ -304,6 +318,55 @@ describe("security finding regressions", () => {
 
     await expect(fsp.readFile(outsideFile, "utf8")).resolves.toBe("outside");
     await expect(fsp.readFile(target, "utf8")).resolves.toBe("new");
+  });
+
+  it.runIf(process.platform !== "win32")("stages EXDEV file moves without buffering or chmodding parents", async () => {
+    const base = await tempRoot("fs-safe-move-exdev-mode-");
+    const source = path.join(base, "source.bin");
+    const destDir = path.join(base, "public");
+    const dest = path.join(destDir, "dest.bin");
+    await fsp.mkdir(destDir, { mode: 0o755 });
+    await fsp.chmod(destDir, 0o755);
+    await fsp.writeFile(source, Buffer.alloc(1024 * 1024, 7));
+    const realRename = fsp.rename;
+    const realReadFile = fsp.readFile;
+    vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+      }
+      return await realRename(from, to);
+    });
+    vi.spyOn(fsp, "readFile").mockImplementation(async (target, options) => {
+      if (target === source) {
+        throw new Error("move fallback must not buffer source files");
+      }
+      return await realReadFile(target, options as never);
+    });
+
+    await movePathWithCopyFallback({ from: source, to: dest });
+
+    expect((await fsp.stat(destDir)).mode & 0o777).toBe(0o755);
+    await expect(fsp.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await fsp.readFile(dest)).byteLength).toBe(1024 * 1024);
+  });
+
+  it.runIf(process.platform !== "win32")("preserves public directory modes for zip staging parents", async () => {
+    const oldUmask = process.umask(0o022);
+    try {
+      const base = await tempRoot("fs-safe-zip-dir-mode-");
+      const archivePath = path.join(base, "pkg.zip");
+      const destDir = path.join(base, "dest");
+      await fsp.mkdir(destDir);
+      const zip = new JSZip();
+      zip.file("assets/app.js", "console.log('ok');");
+      await fsp.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+
+      await extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 });
+
+      expect((await fsp.stat(path.join(destDir, "assets"))).mode & 0o777).toBe(0o755);
+    } finally {
+      process.umask(oldUmask);
+    }
   });
 
   it("rejects durable queue ids that are not safe path segments", async () => {

--- a/test/findings-regression.test.ts
+++ b/test/findings-regression.test.ts
@@ -9,8 +9,10 @@ import { fileStore, fileStoreSync } from "../src/file-store.js";
 import { writeJsonSync } from "../src/json.js";
 import { moveJsonDurableQueueEntryToFailed, resolveJsonDurableQueueEntryPaths } from "../src/json-durable-queue.js";
 import { runPinnedWriteHelper } from "../src/pinned-write.js";
+import { replaceFileAtomic } from "../src/replace-file.js";
 import { writeViaSiblingTempPath } from "../src/sibling-temp.js";
 import { sanitizeTempFileName, tempFile } from "../src/temp-target.js";
+import { tempWorkspaceSync } from "../src/private-temp-workspace.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 import { movePathToTrash } from "../src/trash.js";
 
@@ -267,6 +269,43 @@ describe("security finding regressions", () => {
     await expect(fsp.readFile(target, "utf8")).resolves.toContain('"ok": true');
   });
 
+  it.runIf(process.platform !== "win32")("does not copy atomic fallback through a raced destination symlink", async () => {
+    const base = await tempRoot("fs-safe-atomic-fallback-race-");
+    const outside = await tempRoot("fs-safe-atomic-fallback-outside-");
+    const target = path.join(base, "state.txt");
+    const outsideFile = path.join(outside, "outside.txt");
+    await fsp.writeFile(target, "old");
+    await fsp.writeFile(outsideFile, "outside");
+    const originalLstat = fsp.lstat;
+    let swapped = false;
+
+    await replaceFileAtomic({
+      filePath: target,
+      content: "new",
+      copyFallbackOnPermissionError: true,
+      fileSystem: {
+        promises: {
+          ...fsp,
+          rename: async () => {
+            throw Object.assign(new Error("forced EPERM"), { code: "EPERM" });
+          },
+          lstat: async (candidate) => {
+            const stat = await originalLstat(candidate);
+            if (!swapped && candidate === target) {
+              swapped = true;
+              await fsp.rm(target);
+              await fsp.symlink(outsideFile, target, "file");
+            }
+            return stat;
+          },
+        },
+      },
+    });
+
+    await expect(fsp.readFile(outsideFile, "utf8")).resolves.toBe("outside");
+    await expect(fsp.readFile(target, "utf8")).resolves.toBe("new");
+  });
+
   it("rejects durable queue ids that are not safe path segments", async () => {
     const base = await tempRoot("fs-safe-queue-id-");
     expect(() => resolveJsonDurableQueueEntryPaths(base, "../escape")).toThrow();
@@ -285,6 +324,33 @@ describe("security finding regressions", () => {
       expect(target.file("..")).toBe(path.join(target.dir, "download.bin"));
     } finally {
       await target.cleanup();
+    }
+  });
+
+  it.runIf(process.platform !== "win32")("pins sync temp workspace reads against final symlink swaps", async () => {
+    const base = await tempRoot("fs-safe-temp-workspace-sync-read-");
+    const outside = await tempRoot("fs-safe-temp-workspace-sync-outside-");
+    const workspace = tempWorkspaceSync({ rootDir: base, prefix: "ws-" });
+    try {
+      workspace.write("value.bin", Buffer.from([0, 1, 2, 3]));
+      const outsideFile = path.join(outside, "outside.bin");
+      fsSync.writeFileSync(outsideFile, "outside");
+      const targetPath = workspace.path("value.bin");
+      const originalReadFileSync = fsSync.readFileSync;
+      let swapped = false;
+      vi.spyOn(fsSync, "readFileSync").mockImplementation((target, options) => {
+        if (!swapped && typeof target === "number") {
+          swapped = true;
+          fsSync.rmSync(targetPath);
+          fsSync.symlinkSync(outsideFile, targetPath, "file");
+        }
+        return originalReadFileSync.call(fsSync, target, options as never);
+      });
+
+      expect([...workspace.read("value.bin")]).toEqual([0, 1, 2, 3]);
+      expect(fsSync.readFileSync(outsideFile, "utf8")).toBe("outside");
+    } finally {
+      workspace.cleanup();
     }
   });
 

--- a/test/guarded-write-cleanup.test.ts
+++ b/test/guarded-write-cleanup.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafePython } from "../src/pinned-python-config.js";
+import { runPinnedWriteHelper } from "../src/pinned-write.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function replaceParentAfterOpen(params: {
+  targetPath: string;
+  parentPath: string;
+  movedParentPath: string;
+}): Promise<() => void> {
+  const originalOpen = fs.open;
+  let closeSpy: ReturnType<typeof vi.spyOn> | undefined;
+  const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await originalOpen(...args);
+    if (String(args[0]) === params.targetPath) {
+      closeSpy = vi.spyOn(handle, "close");
+      await fs.rename(params.parentPath, params.movedParentPath);
+      await fs.mkdir(params.parentPath);
+    }
+    return handle;
+  });
+  return () => {
+    openSpy.mockRestore();
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  configureFsSafePython({ mode: "auto", pythonPath: undefined });
+  Object.defineProperty(process, "platform", originalPlatformDescriptor);
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+
+describe("guarded fallback write cleanup", () => {
+  it.runIf(process.platform !== "win32")("closes pinned no-overwrite handles when post guards fail", async () => {
+    configureFsSafePython({ mode: "off" });
+    const base = await tempRoot("fs-safe-pinned-post-guard-");
+    const parentPath = path.join(base, "nested");
+    const movedParentPath = path.join(base, "nested-real");
+    const targetPath = path.join(parentPath, "created.txt");
+    await fs.mkdir(parentPath);
+    const assertClosed = await replaceParentAfterOpen({
+      targetPath,
+      parentPath,
+      movedParentPath,
+    });
+
+    await expect(
+      runPinnedWriteHelper({
+        rootPath: base,
+        relativeParentPath: "nested",
+        basename: "created.txt",
+        mkdir: false,
+        mode: 0o600,
+        overwrite: false,
+        input: { kind: "buffer", data: "payload" },
+      }),
+    ).rejects.toBeTruthy();
+
+    assertClosed();
+  });
+
+  it.runIf(process.platform !== "win32")("closes root no-overwrite handles when post guards fail", async () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    const { root: openRoot } = await import("../src/index.js");
+    const base = await tempRoot("fs-safe-root-post-guard-");
+    const parentPath = path.join(base, "nested");
+    const movedParentPath = path.join(base, "nested-real");
+    await fs.mkdir(parentPath);
+    const targetPath = path.join(await fs.realpath(parentPath), "created.txt");
+    const assertClosed = await replaceParentAfterOpen({
+      targetPath,
+      parentPath,
+      movedParentPath,
+    });
+    const scoped = await openRoot(base);
+
+    await expect(scoped.create("nested/created.txt", "payload")).rejects.toBeTruthy();
+
+    assertClosed();
+  });
+});

--- a/test/guarded-write-cleanup.test.ts
+++ b/test/guarded-write-cleanup.test.ts
@@ -17,6 +17,7 @@ async function replaceParentAfterOpen(params: {
   targetPath: string;
   parentPath: string;
   movedParentPath: string;
+  symlinkTargetPath: string;
 }): Promise<() => void> {
   const originalOpen = fs.open;
   let closeSpy: ReturnType<typeof vi.spyOn> | undefined;
@@ -25,7 +26,7 @@ async function replaceParentAfterOpen(params: {
     if (String(args[0]) === params.targetPath) {
       closeSpy = vi.spyOn(handle, "close");
       await fs.rename(params.parentPath, params.movedParentPath);
-      await fs.mkdir(params.parentPath);
+      await fs.symlink(params.symlinkTargetPath, params.parentPath, "dir");
     }
     return handle;
   });
@@ -51,11 +52,15 @@ describe("guarded fallback write cleanup", () => {
     const parentPath = path.join(base, "nested");
     const movedParentPath = path.join(base, "nested-real");
     const targetPath = path.join(parentPath, "created.txt");
+    const outside = await tempRoot("fs-safe-pinned-post-guard-outside-");
+    const outsideFile = path.join(outside, "created.txt");
     await fs.mkdir(parentPath);
+    await fs.writeFile(outsideFile, "outside");
     const assertClosed = await replaceParentAfterOpen({
       targetPath,
       parentPath,
       movedParentPath,
+      symlinkTargetPath: outside,
     });
 
     await expect(
@@ -71,6 +76,7 @@ describe("guarded fallback write cleanup", () => {
     ).rejects.toBeTruthy();
 
     assertClosed();
+    await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("outside");
   });
 
   it.runIf(process.platform !== "win32")("closes root no-overwrite handles when post guards fail", async () => {
@@ -79,17 +85,22 @@ describe("guarded fallback write cleanup", () => {
     const base = await tempRoot("fs-safe-root-post-guard-");
     const parentPath = path.join(base, "nested");
     const movedParentPath = path.join(base, "nested-real");
+    const outside = await tempRoot("fs-safe-root-post-guard-outside-");
+    const outsideFile = path.join(outside, "created.txt");
     await fs.mkdir(parentPath);
+    await fs.writeFile(outsideFile, "outside");
     const targetPath = path.join(await fs.realpath(parentPath), "created.txt");
     const assertClosed = await replaceParentAfterOpen({
       targetPath,
       parentPath,
       movedParentPath,
+      symlinkTargetPath: outside,
     });
     const scoped = await openRoot(base);
 
     await expect(scoped.create("nested/created.txt", "payload")).rejects.toBeTruthy();
 
     assertClosed();
+    await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("outside");
   });
 });

--- a/test/json-durable-queue.test.ts
+++ b/test/json-durable-queue.test.ts
@@ -87,4 +87,11 @@ describe("durable JSON queues", () => {
     ).resolves.toEqual([{ ok: true }]);
     await expect(fs.access(tempPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
+
+  it("rejects whitespace-padded queue ids", async () => {
+    const queueDir = path.join(root, "queue");
+
+    expect(() => resolveJsonDurableQueueEntryPaths(queueDir, "job ")).toThrow();
+    expect(() => resolveJsonDurableQueueEntryPaths(queueDir, " job")).toThrow();
+  });
 });

--- a/test/platform-fallback-coverage.test.ts
+++ b/test/platform-fallback-coverage.test.ts
@@ -72,4 +72,21 @@ describe("platform fallback coverage", () => {
       code: "ENOENT",
     });
   });
+
+  it("prunes empty directories through the Windows remove fallback", async () => {
+    await importRootForPlatform("win32");
+    const { fileStore } = await import("../src/file-store.js");
+    const rootDir = await tempRoot("fs-safe-win-prune-");
+    const store = fileStore({ rootDir });
+    const stalePath = path.join(rootDir, "old", "stale.txt");
+    await fs.mkdir(path.dirname(stalePath), { recursive: true });
+    await fs.writeFile(stalePath, "stale", "utf8");
+    await fs.utimes(stalePath, new Date(0), new Date(0));
+
+    await store.pruneExpired({ ttlMs: 1, recursive: true, pruneEmptyDirs: true });
+
+    // Root.remove's Node fallback must use rmdir for empty directories; fs.rm
+    // without recursive rejects dirs and would silently leave pruneEmptyDirs work.
+    await expect(fs.stat(path.join(rootDir, "old"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes the filesystem race findings with targeted regression tests across root fallbacks, archive merges, store/private writes, JSON fallbacks, temp helpers, durable queue ids, and trash moves.
- Centralizes the repeated safety patterns into shared safe path segment validation, directory guards, guarded mutation wrappers, and pinned temp-workspace reads.
- Adds a static `pnpm lint:fs-boundary` guard so the known raw fallback patterns do not drift back in.

## Validation

- `pnpm check`
- `pnpm test test/findings-regression.test.ts`
