### PR TITLE
fix(workspace): add packages field so pnpm prepare succeeds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
+packages: []
+
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
## Summary

- `pnpm-workspace.yaml` only contained `allowBuilds` with no `packages:` field.
- Recent pnpm rejects that with `ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION` (`packages field missing or empty`) during the prepare step it runs inside any consumer that pulls `@openclaw/fs-safe` from a github tarball.
- Net effect: any downstream repo that pins a commit (e.g. the `openclaw` repo) currently fails its `pnpm install` with `ERR_PNPM_PREPARE_PACKAGE`.
- Adding `packages: []` keeps the file a valid (empty) workspace root while preserving the `allowBuilds: { esbuild: true }` directive.

## Verification

- [x] Extracted working tree to a clean directory and ran `pnpm install` — completes without error (previously failed with `ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION`).
- [ ] Will verify end-to-end against the consumer (`openclaw`) by bumping its commit pin to this branch's head SHA once it merges to `main`.
