### PR TITLE
ci: test all OSes on Node 22 and 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,18 @@ jobs:
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
 
   check:
-    name: Node 22 check (${{ matrix.os }})
+    name: Node ${{ matrix.node }} check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
+        node:
+          - 22
+          - 24
         os:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
     steps:
       - name: Check out
@@ -45,7 +49,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary

- expand the `check` job to run on Ubuntu, macOS, and Windows
- run the full check suite on both Node 22 and Node 24 for each OS
- keep `fail-fast: false` so one platform/version failure does not hide the rest

## Test plan

- [x] `pnpm check`
