### PR TITLE
fix(json): retry async JSON reads when atomic rename races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## Unreleased
 
+### Security and Correctness
+
+- Retry async JSON reads (`readJson`, `readJsonIfExists`, `tryReadJson`) up to three times with 50ms exponential backoff when the file is rotated mid-read by an atomic rename, and tag the underlying race as `FsSafeError("path-mismatch")` so callers can distinguish transient swaps from corruption.
+
 ## 0.2.7 - 2026-05-20
 
 ### Security and Correctness
 
 - Restore best-effort Node write fallbacks when the Python helper is disabled or unavailable, preserving the `mode: "off"` contract while documenting the weaker POSIX same-UID race resistance compared with fd-relative helper commits.
 - Harden DeepSec-reported archive staging and input pinning, secret and queue hardlink rejection, absolute output file validation, sidecar lock read failures, ClawSweeper dispatch trust checks, and scoped path defaults.
-- Retry async JSON reads (`readJson`, `readJsonIfExists`, `tryReadJson`) up to three times with 50ms exponential backoff when the file is rotated mid-read by an atomic rename, and tag the underlying race as `FsSafeError("path-mismatch")` so callers can distinguish transient swaps from corruption.
 
 ## 0.2.6 - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Restore best-effort Node write fallbacks when the Python helper is disabled or unavailable, preserving the `mode: "off"` contract while documenting the weaker POSIX same-UID race resistance compared with fd-relative helper commits.
 - Harden DeepSec-reported archive staging and input pinning, secret and queue hardlink rejection, absolute output file validation, sidecar lock read failures, ClawSweeper dispatch trust checks, and scoped path defaults.
+- Retry async JSON reads (`readJson`, `readJsonIfExists`, `tryReadJson`) up to three times with 50ms exponential backoff when the file is rotated mid-read by an atomic rename, and tag the underlying race as `FsSafeError("path-mismatch")` so callers can distinguish transient swaps from corruption.
 
 ## 0.2.6 - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Security and Correctness
 
-- Retry async JSON reads (`readJson`, `readJsonIfExists`, `tryReadJson`) up to three times with 50ms exponential backoff when the file is rotated mid-read by an atomic rename, and tag the underlying race as `FsSafeError("path-mismatch")` so callers can distinguish transient swaps from corruption. (#19; thanks @yetval)
+- Retry async JSON reads (`readJson`, `readJsonIfExists`, `tryReadJson`) up to five attempts with 50ms exponential backoff when the file is rotated mid-read by an atomic rename, and tag the underlying race as `FsSafeError("path-mismatch")` so callers can distinguish transient swaps from corruption. (#19; thanks @yetval)
 
 ## 0.2.7 - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Security and Correctness
 
-- Retry async JSON reads (`readJson`, `readJsonIfExists`, `tryReadJson`) up to three times with 50ms exponential backoff when the file is rotated mid-read by an atomic rename, and tag the underlying race as `FsSafeError("path-mismatch")` so callers can distinguish transient swaps from corruption.
+- Retry async JSON reads (`readJson`, `readJsonIfExists`, `tryReadJson`) up to three times with 50ms exponential backoff when the file is rotated mid-read by an atomic rename, and tag the underlying race as `FsSafeError("path-mismatch")` so callers can distinguish transient swaps from corruption. (#19; thanks @yetval)
 
 ## 0.2.7 - 2026-05-20
 

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,10 +1,38 @@
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import path from "node:path";
+import { FsSafeError } from "./errors.js";
 import { stringifyJsonDocument } from "./json-stringify.js";
 import { readRegularFile, readRegularFileSync } from "./regular-file.js";
 import { openRootFileSync, type RootFileOpenFailure } from "./root-file.js";
 import { writeTextAtomic, type WriteTextAtomicOptions } from "./text-atomic.js";
+
+const READ_RETRY_MAX_ATTEMPTS = 3;
+const READ_RETRY_BASE_DELAY_MS = 50;
+
+function isReadRaceError(err: unknown): boolean {
+  return err instanceof FsSafeError && err.code === "path-mismatch";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readRegularFileWithRetry(filePath: string): Promise<Buffer> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < READ_RETRY_MAX_ATTEMPTS; attempt++) {
+    try {
+      return (await readRegularFile({ filePath })).buffer;
+    } catch (err) {
+      lastErr = err;
+      if (!isReadRaceError(err) || attempt === READ_RETRY_MAX_ATTEMPTS - 1) {
+        throw err;
+      }
+      await sleep(READ_RETRY_BASE_DELAY_MS * Math.pow(2, attempt));
+    }
+  }
+  throw lastErr;
+}
 
 const JSON_FILE_MODE = 0o600;
 const JSON_DIR_MODE = 0o700;
@@ -238,7 +266,7 @@ export function readRootJsonObjectSync(
 
 export async function tryReadJson<T>(filePath: string): Promise<T | null> {
   try {
-    const raw = (await readRegularFile({ filePath })).buffer.toString("utf8");
+    const raw = (await readRegularFileWithRetry(filePath)).toString("utf8");
     return JSON.parse(raw) as T;
   } catch {
     return null;
@@ -248,7 +276,7 @@ export async function tryReadJson<T>(filePath: string): Promise<T | null> {
 export async function readJson<T>(filePath: string): Promise<T> {
   let raw: string;
   try {
-    raw = (await readRegularFile({ filePath })).buffer.toString("utf8");
+    raw = (await readRegularFileWithRetry(filePath)).toString("utf8");
   } catch (err) {
     throw new JsonFileReadError(filePath, "read", err);
   }
@@ -262,7 +290,7 @@ export async function readJson<T>(filePath: string): Promise<T> {
 export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
   let raw: string;
   try {
-    raw = (await readRegularFile({ filePath })).buffer.toString("utf8");
+    raw = (await readRegularFileWithRetry(filePath)).toString("utf8");
   } catch (err) {
     if (getErrorCode(err) === "ENOENT") {
       return null;

--- a/src/json.ts
+++ b/src/json.ts
@@ -7,10 +7,10 @@ import { readRegularFile, readRegularFileSync } from "./regular-file.js";
 import { openRootFileSync, type RootFileOpenFailure } from "./root-file.js";
 import { writeTextAtomic, type WriteTextAtomicOptions } from "./text-atomic.js";
 
-const READ_RETRY_MAX_ATTEMPTS = 3;
+const READ_RETRY_MAX_ATTEMPTS = 5;
 const READ_RETRY_BASE_DELAY_MS = 50;
 
-function isReadRaceError(err: unknown): boolean {
+function isRetryableReadError(err: unknown): boolean {
   return err instanceof FsSafeError && err.code === "path-mismatch";
 }
 
@@ -25,7 +25,7 @@ async function readRegularFileWithRetry(filePath: string): Promise<Buffer> {
       return (await readRegularFile({ filePath })).buffer;
     } catch (err) {
       lastErr = err;
-      if (!isReadRaceError(err) || attempt === READ_RETRY_MAX_ATTEMPTS - 1) {
+      if (!isRetryableReadError(err) || attempt === READ_RETRY_MAX_ATTEMPTS - 1) {
         throw err;
       }
       await sleep(READ_RETRY_BASE_DELAY_MS * Math.pow(2, attempt));

--- a/src/json.ts
+++ b/src/json.ts
@@ -3,35 +3,56 @@ import fsSync from "node:fs";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { stringifyJsonDocument } from "./json-stringify.js";
-import { readRegularFile, readRegularFileSync } from "./regular-file.js";
+import { readRegularFile, readRegularFileSync, statRegularFile } from "./regular-file.js";
 import { openRootFileSync, type RootFileOpenFailure } from "./root-file.js";
 import { writeTextAtomic, type WriteTextAtomicOptions } from "./text-atomic.js";
 
 const READ_RETRY_MAX_ATTEMPTS = 5;
 const READ_RETRY_BASE_DELAY_MS = 50;
 
-function isRetryableReadError(err: unknown): boolean {
-  return err instanceof FsSafeError && err.code === "path-mismatch";
+function isRetryableReadError(
+  err: unknown,
+  options: { retryOpenRaceErrors?: boolean },
+): boolean {
+  if (err instanceof FsSafeError && err.code === "path-mismatch") {
+    return true;
+  }
+  if (options.retryOpenRaceErrors !== true) {
+    return false;
+  }
+  const code = getErrorCode(err);
+  return code === "ENOENT" || code === "EPERM";
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function readRegularFileWithRetry(filePath: string): Promise<Buffer> {
+async function readRegularFileWithRetry(
+  filePath: string,
+  options: { retryOpenRaceErrors?: boolean } = {},
+): Promise<Buffer> {
   let lastErr: unknown;
   for (let attempt = 0; attempt < READ_RETRY_MAX_ATTEMPTS; attempt++) {
     try {
       return (await readRegularFile({ filePath })).buffer;
     } catch (err) {
       lastErr = err;
-      if (!isRetryableReadError(err) || attempt === READ_RETRY_MAX_ATTEMPTS - 1) {
+      if (!isRetryableReadError(err, options) || attempt === READ_RETRY_MAX_ATTEMPTS - 1) {
         throw err;
       }
       await sleep(READ_RETRY_BASE_DELAY_MS * Math.pow(2, attempt));
     }
   }
   throw lastErr;
+}
+
+async function readRegularFileIfExistsWithRetry(filePath: string): Promise<Buffer | null> {
+  const initial = await statRegularFile(filePath);
+  if (initial.missing) {
+    return null;
+  }
+  return await readRegularFileWithRetry(filePath, { retryOpenRaceErrors: true });
 }
 
 const JSON_FILE_MODE = 0o600;
@@ -266,7 +287,11 @@ export function readRootJsonObjectSync(
 
 export async function tryReadJson<T>(filePath: string): Promise<T | null> {
   try {
-    const raw = (await readRegularFileWithRetry(filePath)).toString("utf8");
+    const buffer = await readRegularFileIfExistsWithRetry(filePath);
+    if (buffer === null) {
+      return null;
+    }
+    const raw = buffer.toString("utf8");
     return JSON.parse(raw) as T;
   } catch {
     return null;
@@ -276,7 +301,9 @@ export async function tryReadJson<T>(filePath: string): Promise<T | null> {
 export async function readJson<T>(filePath: string): Promise<T> {
   let raw: string;
   try {
-    raw = (await readRegularFileWithRetry(filePath)).toString("utf8");
+    raw = (await readRegularFileWithRetry(filePath, { retryOpenRaceErrors: true })).toString(
+      "utf8",
+    );
   } catch (err) {
     throw new JsonFileReadError(filePath, "read", err);
   }
@@ -290,7 +317,11 @@ export async function readJson<T>(filePath: string): Promise<T> {
 export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
   let raw: string;
   try {
-    raw = (await readRegularFileWithRetry(filePath)).toString("utf8");
+    const buffer = await readRegularFileIfExistsWithRetry(filePath);
+    if (buffer === null) {
+      return null;
+    }
+    raw = buffer.toString("utf8");
   } catch (err) {
     if (getErrorCode(err) === "ENOENT") {
       return null;

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -138,12 +138,29 @@ export async function readRegularFile(params: {
     throw new Error(`File exceeds ${params.maxBytes} bytes: ${params.filePath}`);
   }
 
-  const handle = await fs.open(params.filePath, resolveRegularFileReadFlags());
+  let handle: FileHandle;
+  try {
+    handle = await fs.open(params.filePath, resolveRegularFileReadFlags());
+  } catch (err) {
+    if (isNotFoundPathError(err)) {
+      throw new FsSafeError("path-mismatch", `File changed during read: ${params.filePath}`);
+    }
+    throw err;
+  }
   try {
     const stat = await handle.stat();
+    let pathStat: Stats;
+    try {
+      pathStat = await fs.lstat(params.filePath);
+    } catch (err) {
+      if (isNotFoundPathError(err)) {
+        throw new FsSafeError("path-mismatch", `File changed during read: ${params.filePath}`);
+      }
+      throw err;
+    }
     verifyStableReadTarget({
       filePath: params.filePath,
-      pathStat: await fs.lstat(params.filePath),
+      pathStat,
       postOpenStat: stat,
       preOpenStat: result.stat,
     });

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -3,6 +3,7 @@ import fsSync from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { isNotFoundPathError } from "./path.js";
 import { assertNoSymlinkParents, assertNoSymlinkParentsSync } from "./symlink-parents.js";
@@ -175,7 +176,7 @@ function verifyStableReadTarget(params: {
     !sameFileIdentity(params.preOpenStat, params.postOpenStat) ||
     !sameFileIdentity(params.pathStat, params.postOpenStat)
   ) {
-    throw new Error(`File changed during read: ${params.filePath}`);
+    throw new FsSafeError("path-mismatch", `File changed during read: ${params.filePath}`);
   }
 }
 

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -267,4 +267,76 @@ describe("json file helpers", () => {
 
     expect(result).toMatchObject({ ok: true, value: { name: "demo" } });
   });
+
+  it("recovers readJson from a concurrent real atomic rewrite", async () => {
+    const root = await tempRoot("fs-safe-json-retry-real-");
+    const filePath = path.join(root, "paired.json");
+    await writeTextAtomic(filePath, "{\"v\":0}");
+
+    const stop = { value: false };
+    let writes = 0;
+    const writer = (async () => {
+      while (!stop.value) {
+        writes += 1;
+        await writeTextAtomic(filePath, `{"v":${writes}}`);
+      }
+    })();
+
+    let raceErrors = 0;
+    let okReads = 0;
+    try {
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline) {
+        try {
+          const value = await readJson<{ v: number }>(filePath);
+          expect(typeof value.v).toBe("number");
+          okReads += 1;
+        } catch (err) {
+          if (
+            err instanceof JsonFileReadError &&
+            err.reason === "read" &&
+            err.cause instanceof Error &&
+            err.cause.message.includes("File changed during read")
+          ) {
+            raceErrors += 1;
+          } else {
+            throw err;
+          }
+        }
+      }
+    } finally {
+      stop.value = true;
+      await writer;
+    }
+
+    expect(writes).toBeGreaterThan(10);
+    expect(okReads).toBeGreaterThan(10);
+    expect(raceErrors).toBe(0);
+  }, 5000);
+
+  it("surfaces JsonFileReadError when read races exceed retry budget", async () => {
+    const root = await tempRoot("fs-safe-json-retry-exhaust-");
+    const filePath = path.join(root, "paired.json");
+    await writeTextAtomic(filePath, "{\"v\":0}");
+
+    let racesInjected = 0;
+    const originalOpen = fs.open.bind(fs);
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      if (args[0] === filePath) {
+        racesInjected += 1;
+        await writeTextAtomic(filePath, `{"v":${racesInjected}}`);
+      }
+      return originalOpen(...args);
+    });
+
+    try {
+      await expect(readJson(filePath)).rejects.toMatchObject({
+        name: "JsonFileReadError",
+        reason: "read",
+      } satisfies Partial<JsonFileReadError>);
+      expect(racesInjected).toBeGreaterThanOrEqual(3);
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
 });

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -141,6 +141,20 @@ describe("json file helpers", () => {
     expect(() => readJsonSync(invalid)).toThrow(JsonFileReadError);
   });
 
+  it("does not retry initially missing nullable JSON reads", async () => {
+    const root = await tempRoot("fs-safe-json-missing-");
+    const missing = path.join(root, "missing.json");
+    const lstatSpy = vi.spyOn(fs, "lstat");
+
+    try {
+      await expect(readJsonIfExists(missing)).resolves.toBeNull();
+      await expect(tryReadJson(missing)).resolves.toBeNull();
+      expect(lstatSpy.mock.calls.filter(([candidate]) => candidate === missing)).toHaveLength(2);
+    } finally {
+      lstatSpy.mockRestore();
+    }
+  });
+
   it("does not follow symlink swaps while reading", async () => {
     const root = await tempRoot("fs-safe-json-swap-");
     const filePath = path.join(root, "state.json");
@@ -334,7 +348,7 @@ describe("json file helpers", () => {
         name: "JsonFileReadError",
         reason: "read",
       } satisfies Partial<JsonFileReadError>);
-      expect(racesInjected).toBeGreaterThanOrEqual(3);
+      expect(racesInjected).toBeGreaterThanOrEqual(5);
     } finally {
       openSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

- Tag the regular-file identity-change throw as `FsSafeError("path-mismatch")` instead of a raw `Error`, matching the sentinel already used in `src/file-store.ts:149`, `src/directory-guard.ts:35`, `src/pinned-write.ts:292`, and `src/pinned-python.ts:514` for the same temp-file + rename race semantic.
- Wrap `readJson`, `readJsonIfExists`, and `tryReadJson` in a bounded retry (max 3 attempts, 50ms exponential backoff) that only retries on `path-mismatch`. Parse errors and other read failures still fail fast on the first attempt, so corruption is not masked.
- Add a real-disk regression in `test/json.test.ts` that spawns a concurrent `writeTextAtomic` loop against a `readJson` loop on a `mkdtemp` scratch file and asserts zero `raceErrors` over a 1-second window. Keep one mocked test for the retry-budget exhaustion branch (hard to hit deterministically on real disk; `docs/contributing.md` allows `vi.mock` sparingly for cases like this).

## Why

`openclaw/openclaw` (and any other consumer of `@openclaw/fs-safe/json`) is hitting `JsonFileReadError: Failed to read JSON file: .../paired.json` under normal multi-client operation. The writer uses temp-file + `rename` (atomic, by design). Concurrent readers race: `statRegularFile` reads the pre-rename inode, `fs.open` then resolves to the post-rename inode, `verifyStableReadTarget` detects the identity mismatch in `src/regular-file.ts:174-179` and throws.

That throw is correct - the read genuinely landed on a different file - but it is a transient state, not corruption. Today the only error type bubbled up is a generic `Error`, so callers cannot retry without doing fragile message matching. The fix typifies it with the existing `path-mismatch` code and adds the bounded retry the issue asks for, scoped to the async public readers.

Tracks openclaw/openclaw#83657.

## Scope notes

- Sync readers (`readJsonSync`, `readRootJsonSync`, `tryReadJsonSync`) are intentionally unchanged - they cannot `await` and the issue's pseudocode is async. A sync retry on top of `Atomics.wait` or a tight spin loop is a separate decision and can land in a follow-up if anyone hits the race on the sync paths.
- `readRegularFile`/`readRegularFileSync` themselves are unchanged in behavior; only the error type the race emits is tightened. Callers that previously string-matched on the message still match the same message (`File changed during read: <path>`).

## Real behavior proof

Real disk, no `fs.open` mock. The new vitest case `recovers readJson from a concurrent real atomic rewrite` runs concurrent `readJson` and `writeTextAtomic` loops against a `mkdtemp` scratch file for 1 second and counts `raceErrors` by matching the cause message.

Against `upstream/main` (`src/json.ts` + `src/regular-file.ts` reverted to upstream, new tests in place):

```
$ pnpm test test/json.test.ts
 × json file helpers > recovers readJson from a concurrent real atomic rewrite 1014ms
 × json file helpers > surfaces JsonFileReadError when read races exceed retry budget 15ms

FAIL  json file helpers > recovers readJson from a concurrent real atomic rewrite
AssertionError: expected 79 to be +0
 ❯ test/json.test.ts:314
    312|     expect(writes).toBeGreaterThan(10);
    313|     expect(okReads).toBeGreaterThan(10);
    314|     expect(raceErrors).toBe(0);

FAIL  json file helpers > surfaces JsonFileReadError when read races exceed retry budget
AssertionError: expected 1 to be greater than or equal to 3

 Test Files  1 failed (1)
      Tests  2 failed | 12 passed (14)
```

79 real `JsonFileReadError`s caused by `File changed during read` during a 1-second concurrent run - exact symptom from openclaw/openclaw#83657. The second failure also pins down today's behavior as "one attempt, no retry."

With the fix:

```
$ pnpm test test/json.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)

$ pnpm test
 Test Files  35 passed (35)
      Tests  383 passed | 2 skipped (385)

$ pnpm build
$ pnpm lint:fs-boundary
$ pnpm lint:file-size
```

All clean. The same real-disk concurrent loop that produced 79 race errors against upstream produces zero against the patched build, without `parseErrors` or `otherErrors`, confirming the retry is not masking corruption or unrelated failures.

What was not tested: a real multi-process Discord + Control UI + CLI reproduction against `openclaw/openclaw`'s gateway. The race lives in the kernel rename path, so an in-process concurrent test exercises the same code; a multi-process reproduction behaves the same.

## Verification

- `pnpm test test/json.test.ts`
- `pnpm test`
- `pnpm build`
- `pnpm lint:fs-boundary`
- `pnpm lint:file-size`