### PR TITLE
Reject unsafe device read paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security and Correctness
+
+- Reject known unsafe device and process-fd read paths before opening files, including `/dev/zero`, `/dev/random`, `/dev/fd/*`, `/proc/*/fd/*`, and Windows reserved device names.
+
 ## 0.3.0 - 2026-05-21
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -439,12 +439,12 @@ if (err instanceof FsSafeError) {
 }
 ```
 
-Current `FsSafeErrorCode` values are `already-exists`, `hardlink`, `helper-failed`, `helper-unavailable`, `invalid-path`, `insecure-permissions`, `not-empty`, `not-file`, `not-found`, `not-owned`, `not-removable`, `outside-workspace`, `path-alias`, `path-mismatch`, `permission-unverified`, `symlink`, `timeout`, `too-large`, and `unsupported-platform`.
+Current `FsSafeErrorCode` values are `already-exists`, `denied-path`, `device-path`, `hardlink`, `helper-failed`, `helper-unavailable`, `invalid-path`, `insecure-permissions`, `not-empty`, `not-file`, `not-found`, `not-owned`, `not-removable`, `outside-workspace`, `path-alias`, `path-mismatch`, `permission-unverified`, `symlink`, `timeout`, `too-large`, and `unsupported-platform`.
 
 ## Safety model
 
 - root-bounded APIs resolve paths against a configured root and reject canonical escapes
-- reads open with `O_NOFOLLOW` where available, then verify fd identity matches the path identity before returning the buffer or handle
+- reads reject known unsafe device paths, open with `O_NOFOLLOW` where available, then verify fd identity matches the path identity before returning the buffer or handle
 - writes use pinned parent-directory helpers and atomic replacement on POSIX, with verified post-write identity
 - `remove`, `mkdir`, `move`, `stat`, `list`, and parent-fd writes use one persistent fd-relative Python helper on POSIX, with Node fallbacks when the helper is disabled or unavailable
 - archive extraction stages into a private directory and merges through the same boundary checks used by direct writes

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -31,6 +31,7 @@ class FsSafeError extends Error {
 type FsSafeErrorCode =
   | "already-exists"
   | "denied-path"
+  | "device-path"
   | "hardlink"
   | "helper-failed"
   | "helper-unavailable"
@@ -57,6 +58,7 @@ type FsSafeErrorCode =
 |---|---|---|
 | `already-exists` | `create()`, `createJson()`, `move({ overwrite: false })`. | Target file or directory already at the destination. |
 | `denied-path` | A root mutation matched `denyMutations.paths` or `denyMutations.prefixes`. | Caller configured application-sensitive paths that must not be written, removed, moved, or created. |
+| `device-path` | A read/open target is a known unsafe device or process-fd path. | `/dev/zero`, `/dev/random`, `/dev/stdin`, `/dev/fd/*`, `/proc/*/fd/*`, or a Windows reserved device name. |
 | `hardlink` | Read or copy with `hardlinks: "reject"` saw `nlink > 1`. | File is hardlinked — possibly an alias of an out-of-tree inode. |
 | `helper-failed` | Internal POSIX helper failed after startup. | Inspect `cause`; retrying may be unsafe if the operation may have partially completed. |
 | `helper-unavailable` | Persistent Python helper was disabled or could not be spawned. | `FS_SAFE_PYTHON_MODE=off`, Python missing in PATH, restricted sandbox. `auto` falls back where possible; `require` fails closed. |
@@ -95,6 +97,7 @@ try {
     case "not-found":
       return reply(404, "missing");
     case "symlink":
+    case "device-path":
     case "hardlink":
     case "path-mismatch":
     case "path-alias":

--- a/docs/path.md
+++ b/docs/path.md
@@ -11,6 +11,8 @@ import {
   safeRealpathSync,
   safeStatSync,
   assertNoNulPathInput,
+  assertNoUnsafeDeviceReadPath,
+  isUnsafeDeviceReadPath,
   isNotFoundPathError,
   isSymlinkOpenError,
   hasNodeErrorCode,
@@ -88,6 +90,17 @@ if (!stat?.isFile()) return notFound();
 ### `assertNoNulPathInput(filePath, message?)`
 
 Throws `FsSafeError` with code `invalid-path` when a path string contains an embedded NUL byte. Use it before calling Node `fs` APIs directly; Node's native error can include raw path text in the message.
+
+### `assertNoUnsafeDeviceReadPath(filePath, options?)`
+
+Throws `FsSafeError` with code `device-path` when a read target is a known unsafe device or process-fd path. The built-in read/open helpers call this automatically before opening files; use it only when you are building your own read primitive.
+
+```ts
+assertNoUnsafeDeviceReadPath("/dev/zero"); // throws on POSIX
+isUnsafeDeviceReadPath("/dev/fd/0");       // true on POSIX
+```
+
+The check is intentionally not a normal consumer policy knob. Safe read APIs reject these targets by default because they can block forever, stream indefinitely, or alias process file descriptors.
 
 ## Error inspection
 

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -17,10 +17,11 @@ Regardless of shape, every read goes through the same boundary checks:
 1. Resolve the relative path against the canonical real root.
 2. Reject anything that escapes the root (`outside-workspace`).
 3. Reject `..` segments and absolute inputs (unless via `readAbsolute` with an in-root absolute path).
-4. Open with `O_NOFOLLOW` where available. A symlink in the path triggers `symlink` unless the call's `symlinks` policy is `follow-within-root`.
-5. Stat the open fd and compare to the resolved path's identity (`sameFileIdentity`). A swap mid-call triggers `path-mismatch`.
-6. If `hardlinks: "reject"`, refuse files with `nlink > 1` (`hardlink`).
-7. If `maxBytes` is set, refuse reads larger than the cap (`too-large`).
+4. Reject known unsafe device and process-fd paths before opening (`device-path`).
+5. Open with `O_NOFOLLOW` where available. A symlink in the path triggers `symlink` unless the call's `symlinks` policy is `follow-within-root`.
+6. Stat the open fd and compare to the resolved path's identity (`sameFileIdentity`). A swap mid-call triggers `path-mismatch`.
+7. If `hardlinks: "reject"`, refuse files with `nlink > 1` (`hardlink`).
+8. If `maxBytes` is set, refuse reads larger than the cap (`too-large`).
 
 ## Read shapes
 
@@ -160,6 +161,7 @@ try {
 - **`outside-workspace`** — relative path escaped the root, or `readAbsolute` got an absolute path outside.
 - **`not-found`** — the file is gone.
 - **`not-file`** — you read a directory or a non-regular file (FIFO, socket, …).
+- **`device-path`** — the path targets a known unsafe device or process fd path.
 - **`symlink`** — a path component is a symlink and the policy is `reject`.
 - **`path-mismatch`** — opened fd identity did not match the resolved path. Almost always a TOCTOU swap by something else.
 - **`hardlink`** — `hardlinks: "reject"` saw `nlink > 1`.

--- a/docs/root.md
+++ b/docs/root.md
@@ -139,6 +139,7 @@ Every method throws `FsSafeError` with a `code`. Branch on `err.code`, not messa
 | `outside-workspace` | The input resolves outside the root, or contains a `..` segment that would escape it. |
 | `not-found` | The target does not exist (or its parent does not, with `mkdir: false`). |
 | `not-file` | A read or copy targeted a non-regular file (directory, FIFO, socket, …). |
+| `device-path` | A read/open target is a known unsafe device or process-fd path. |
 | `already-exists` | `create()` or `move()` without `overwrite` hit an existing target. |
 | `denied-path` | A mutation target matched `denyMutations.paths` or `denyMutations.prefixes`. |
 | `symlink` | A path component is a symlink, and the call's `symlinks` policy is `reject`. |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -13,6 +13,7 @@ You hand a `root()` boundary to a piece of code that takes caller-controlled rel
 - replaces a path component with a symlink between check and use (TOCTOU)
 - replaces the destination directory with a symlink right before a write
 - creates a hardlink that aliases an out-of-tree inode and asks you to read or replace it
+- asks a read/open primitive to target a known unsafe device or process-fd path
 - triggers a partial write that leaves a half-written file at the destination
 - ships an archive with `..` paths, absolute paths, or symlinks pointing outside the destination
 
@@ -20,7 +21,7 @@ It does **not** defend against:
 
 - a process running with permissions to write anywhere on the filesystem and choosing to ignore the library
 - another process with the same UID racing to mutate the same directory between two separate `fs-safe` calls — the boundary is per-call, not per-session
-- traversal across filesystem boundaries, bind mounts, device files, `/proc`-style virtual filesystems, or any other path your process can normally access from inside the root
+- arbitrary traversal across filesystem boundaries, bind mounts, or virtual filesystems beyond the known unsafe read device paths
 - container escape, TOCTOU between fork and exec of helpers, or kernel-level vulnerabilities
 - semantic content checks: file types, archive payload schemas, signature verification
 
@@ -83,7 +84,7 @@ The library does not advertise different security guarantees per platform — it
 |---|---|
 | Not ambient authority removal | Code that can import `node:fs` can still bypass the handle. Keep caller-controlled path operations behind `root()` by convention, review, and tests. |
 | Absolute paths are escape hatches | APIs that accept or return absolute paths exist for audit, ingest, and advanced composition. Prefer root-relative names in normal application flow. |
-| Not a mount/device boundary | `root()` keeps path traversal inside the directory tree; it does not make device files, bind mounts, or virtual filesystems safe to expose. |
+| Not a mount boundary | `root()` keeps path traversal inside the directory tree and blocks known unsafe read device paths, but it does not make bind mounts or virtual filesystems safe to expose wholesale. |
 | Per-call, not per-session | Another process with the same privileges can still mutate the tree between two separate calls. Use one verb method for the operation you need to make race-resistant. |
 | Hardlink rejection is best-effort | Link-count checks depend on platform metadata. Treat `hardlinks: "reject"` as a tripwire, not an authorization primitive. |
 | Mode bits are not a full policy engine | `replaceFileAtomic` and secret-file helpers set requested modes, but you should still set umask and inspect modes when policy requires it. |

--- a/docs/types.md
+++ b/docs/types.md
@@ -148,7 +148,8 @@ The two policy unions you'll see throughout. `"reject"` is conservative; `"follo
 
 ```ts
 type FsSafeErrorCode =
-  | "already-exists" | "denied-path" | "hardlink" | "helper-failed"
+  | "already-exists" | "denied-path" | "device-path" | "hardlink"
+  | "helper-failed"
   | "helper-unavailable" | "insecure-permissions" | "invalid-path"
   | "not-empty" | "not-file" | "not-found" | "not-owned"
   | "not-removable" | "outside-workspace" | "path-alias"

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -3,6 +3,14 @@
 // higher-level primitive.
 export { createAsyncLock } from "./async-lock.js";
 export {
+  assertNoUnsafeDeviceReadPath,
+  isUnsafeDeviceReadPath,
+  matchUnsafeDeviceReadPath,
+  type UnsafeDeviceReadPathMatch,
+  type UnsafeDeviceReadPathOptions,
+  type UnsafeDeviceReadPathReason,
+} from "./device-path.js";
+export {
   assertAbsolutePathInput,
   canonicalPathFromExistingAncestor,
   ensureAbsoluteDirectory,

--- a/src/device-path.ts
+++ b/src/device-path.ts
@@ -46,6 +46,9 @@ const WINDOWS_RESERVED_DEVICE_NAMES = new Set([
   "COM7",
   "COM8",
   "COM9",
+  "COM¹",
+  "COM²",
+  "COM³",
   "LPT1",
   "LPT2",
   "LPT3",
@@ -55,6 +58,9 @@ const WINDOWS_RESERVED_DEVICE_NAMES = new Set([
   "LPT7",
   "LPT8",
   "LPT9",
+  "LPT¹",
+  "LPT²",
+  "LPT³",
 ]);
 
 function candidateReadPaths(filePath: string): string[] {

--- a/src/device-path.ts
+++ b/src/device-path.ts
@@ -1,0 +1,146 @@
+import path from "node:path";
+import { FsSafeError } from "./errors.js";
+import { trySafeFileURLToPath } from "./local-file-access.js";
+
+export type UnsafeDeviceReadPathReason =
+  | "posix-device"
+  | "posix-fd"
+  | "windows-device";
+
+export type UnsafeDeviceReadPathMatch = {
+  path: string;
+  reason: UnsafeDeviceReadPathReason;
+};
+
+export type UnsafeDeviceReadPathOptions = {
+  cwd?: string;
+  platform?: NodeJS.Platform;
+};
+
+const POSIX_BLOCKED_DEVICE_PATHS = new Set([
+  "/dev/zero",
+  "/dev/random",
+  "/dev/urandom",
+  "/dev/full",
+  "/dev/stdin",
+  "/dev/stdout",
+  "/dev/stderr",
+  "/dev/tty",
+  "/dev/console",
+]);
+
+const WINDOWS_RESERVED_DEVICE_NAMES = new Set([
+  "CON",
+  "PRN",
+  "AUX",
+  "NUL",
+  "CLOCK$",
+  "CONIN$",
+  "CONOUT$",
+  "COM1",
+  "COM2",
+  "COM3",
+  "COM4",
+  "COM5",
+  "COM6",
+  "COM7",
+  "COM8",
+  "COM9",
+  "LPT1",
+  "LPT2",
+  "LPT3",
+  "LPT4",
+  "LPT5",
+  "LPT6",
+  "LPT7",
+  "LPT8",
+  "LPT9",
+]);
+
+function candidateReadPaths(filePath: string): string[] {
+  if (!filePath.startsWith("file://")) {
+    return [filePath];
+  }
+  const parsed = trySafeFileURLToPath(filePath);
+  return parsed === undefined ? [filePath] : [filePath, parsed];
+}
+
+function normalizePosixPath(filePath: string, cwd?: string): string {
+  if (path.posix.isAbsolute(filePath)) {
+    return path.posix.normalize(filePath);
+  }
+  const base = cwd && path.posix.isAbsolute(cwd) ? cwd : process.cwd();
+  return path.posix.resolve(base, filePath);
+}
+
+function matchPosixDeviceReadPath(
+  filePath: string,
+  cwd?: string,
+): UnsafeDeviceReadPathMatch | undefined {
+  const normalized = normalizePosixPath(filePath, cwd);
+  if (POSIX_BLOCKED_DEVICE_PATHS.has(normalized)) {
+    return { path: normalized, reason: "posix-device" };
+  }
+  if (normalized === "/dev/fd" || normalized.startsWith("/dev/fd/")) {
+    return { path: normalized, reason: "posix-fd" };
+  }
+  if (/^\/proc\/(?:self|thread-self|\d+)\/fd(?:\/|$)/.test(normalized)) {
+    return { path: normalized, reason: "posix-fd" };
+  }
+  return undefined;
+}
+
+function normalizeWindowsDeviceBaseName(filePath: string): string {
+  const normalized = filePath.replace(/\//g, "\\").replace(/[\\]+$/g, "");
+  const lastSegment = normalized.split("\\").filter(Boolean).at(-1) ?? normalized;
+  const withoutStream = lastSegment.split(":")[0] ?? lastSegment;
+  const withoutTrailingIgnoredChars = withoutStream.replace(/[ .]+$/g, "");
+  return (withoutTrailingIgnoredChars.split(".")[0] ?? withoutTrailingIgnoredChars).toUpperCase();
+}
+
+function matchWindowsDeviceReadPath(filePath: string): UnsafeDeviceReadPathMatch | undefined {
+  const normalized = filePath.replace(/\//g, "\\");
+  if (/^\\\\\.\\/.test(normalized) || /^\\\\\?\\GLOBALROOT\\Device\\/i.test(normalized)) {
+    return { path: normalized, reason: "windows-device" };
+  }
+  const baseName = normalizeWindowsDeviceBaseName(filePath);
+  if (WINDOWS_RESERVED_DEVICE_NAMES.has(baseName)) {
+    return { path: normalized, reason: "windows-device" };
+  }
+  return undefined;
+}
+
+export function matchUnsafeDeviceReadPath(
+  filePath: string,
+  options: UnsafeDeviceReadPathOptions = {},
+): UnsafeDeviceReadPathMatch | undefined {
+  const platform = options.platform ?? process.platform;
+  for (const candidate of candidateReadPaths(filePath)) {
+    const match = platform === "win32"
+      ? matchWindowsDeviceReadPath(candidate)
+      : matchPosixDeviceReadPath(candidate, options.cwd);
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+}
+
+export function isUnsafeDeviceReadPath(
+  filePath: string,
+  options?: UnsafeDeviceReadPathOptions,
+): boolean {
+  return matchUnsafeDeviceReadPath(filePath, options) !== undefined;
+}
+
+export function assertNoUnsafeDeviceReadPath(
+  filePath: string,
+  options?: UnsafeDeviceReadPathOptions,
+): void {
+  if (matchUnsafeDeviceReadPath(filePath, options)) {
+    throw new FsSafeError(
+      "device-path",
+      `file reads from unsafe device paths are not allowed: ${filePath}`,
+    );
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,7 @@
 export type FsSafeErrorCode =
   | "already-exists"
   | "denied-path"
+  | "device-path"
   | "hardlink"
   | "helper-failed"
   | "helper-unavailable"

--- a/src/path.ts
+++ b/src/path.ts
@@ -4,6 +4,15 @@ import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.js";
 
+export {
+  assertNoUnsafeDeviceReadPath,
+  isUnsafeDeviceReadPath,
+  matchUnsafeDeviceReadPath,
+  type UnsafeDeviceReadPathMatch,
+  type UnsafeDeviceReadPathOptions,
+  type UnsafeDeviceReadPathReason,
+} from "./device-path.js";
+
 const NOT_FOUND_CODES = new Set(["ENOENT", "ENOTDIR"]);
 const SYMLINK_OPEN_CODES = new Set(["ELOOP", "EINVAL", "ENOTSUP"]);
 const POSIX_SEPARATOR_CHAR_CODE = 0x2f;

--- a/src/pinned-open.ts
+++ b/src/pinned-open.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { isUnsafeDeviceReadPath } from "./device-path.js";
 import { sameFileIdentity as hasSameFileIdentity } from "./file-identity.js";
 
 export type PinnedOpenSyncFailureReason = "path" | "validation" | "io";
@@ -40,6 +41,9 @@ export function openPinnedFileSync(params: {
     (typeof ioFs.constants.O_NOFOLLOW === "number" ? ioFs.constants.O_NOFOLLOW : 0);
   let fd: number | null = null;
   try {
+    if (isUnsafeDeviceReadPath(params.filePath)) {
+      return { ok: false, reason: "validation" };
+    }
     if (params.rejectPathSymlink) {
       const candidateStat = ioFs.lstatSync(params.filePath);
       if (candidateStat.isSymbolicLink()) {
@@ -48,6 +52,9 @@ export function openPinnedFileSync(params: {
     }
 
     const realPath = params.resolvedPath ?? ioFs.realpathSync(params.filePath);
+    if (isUnsafeDeviceReadPath(realPath)) {
+      return { ok: false, reason: "validation" };
+    }
     const preOpenStat = ioFs.lstatSync(realPath);
     if (!isAllowedType(preOpenStat, allowedType)) {
       return { ok: false, reason: "validation" };

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -3,6 +3,7 @@ import fsSync from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { assertNoUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { isNotFoundPathError } from "./path.js";
@@ -130,6 +131,7 @@ export async function readRegularFile(params: {
   filePath: string;
   maxBytes?: number;
 }): Promise<{ buffer: Buffer; stat: Stats }> {
+  assertNoUnsafeDeviceReadPath(params.filePath);
   const result = await statRegularFile(params.filePath);
   if (result.missing) {
     throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });
@@ -227,6 +229,7 @@ export function readRegularFileSync(params: { filePath: string; maxBytes?: numbe
   buffer: Buffer;
   stat: Stats;
 } {
+  assertNoUnsafeDeviceReadPath(params.filePath);
   const result = statRegularFileSync(params.filePath);
   if (result.missing) {
     throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -23,6 +23,7 @@ import { canFallbackFromPythonError, getFsSafePythonConfig } from "./pinned-pyth
 import { assertNoPathAliasEscape, PATH_ALIAS_POLICIES } from "./path-policy.js";
 import {
   assertNoNulPathInput,
+  assertNoUnsafeDeviceReadPath,
   hasNodeErrorCode,
   isNotFoundPathError,
   isPathInside,
@@ -157,10 +158,6 @@ const OPEN_APPEND_CREATE_FLAGS =
 
 export const DEFAULT_ROOT_MAX_BYTES = 16 * 1024 * 1024;
 
-function closeHandleForDispose(handle: FileHandle): Promise<void> {
-  return handle.close().catch(() => undefined);
-}
-
 function openResult(params: {
   handle: FileHandle;
   realPath: string;
@@ -170,9 +167,7 @@ function openResult(params: {
     handle: params.handle,
     realPath: params.realPath,
     stat: params.stat,
-    [Symbol.asyncDispose]: async () => {
-      await closeHandleForDispose(params.handle);
-    },
+    [Symbol.asyncDispose]: () => params.handle.close().catch(() => undefined),
   };
 }
 
@@ -184,6 +179,7 @@ async function openVerifiedLocalFile(
     symlinks?: SymlinkPolicy;
   },
 ): Promise<OpenResult> {
+  assertNoUnsafeDeviceReadPath(filePath);
   const fsSafeTestHooks = getFsSafeTestHooks();
   // Reject directories before opening so we never surface EISDIR to callers (e.g. tool
   // results that get sent to messaging channels). See openclaw/openclaw#31186.
@@ -922,9 +918,7 @@ async function openWritableFileInRoot(
       createdForWrite,
       realPath,
       stat,
-      [Symbol.asyncDispose]: async () => {
-        await closeHandleForDispose(handle);
-      },
+      [Symbol.asyncDispose]: () => handle.close().catch(() => undefined),
     };
   } catch (err) {
     const cleanupCreatedPath = createdForWrite && err instanceof FsSafeError;

--- a/src/secure-file.ts
+++ b/src/secure-file.ts
@@ -4,6 +4,7 @@ import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import { assertNoUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { isWindowsDriveLetterPath, isWindowsNetworkPath } from "./local-file-access.js";
@@ -73,6 +74,7 @@ async function openSecureHandle(options: SecureFileReadOptions): Promise<{
   pathStat: Stats;
   realPath: string;
 }> {
+  assertNoUnsafeDeviceReadPath(options.filePath);
   if (isWindowsNetworkPath(options.filePath, "win32") && !options.trust?.allowNetworkPath) {
     throw new FsSafeError("invalid-path", `${label(options)} must be a local absolute path.`);
   }

--- a/test/device-path.test.ts
+++ b/test/device-path.test.ts
@@ -49,6 +49,8 @@ describe("unsafe device read paths", () => {
       "NUL",
       "C:\\tmp\\NUL.txt",
       "C:\\tmp\\con",
+      "C:\\tmp\\COM¹.txt",
+      "C:\\tmp\\LPT³",
       "logs\\COM1",
       "\\\\.\\NUL",
       "\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1",

--- a/test/device-path.test.ts
+++ b/test/device-path.test.ts
@@ -1,0 +1,116 @@
+import syncFs from "node:fs";
+import fs from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import {
+  isUnsafeDeviceReadPath,
+  matchUnsafeDeviceReadPath,
+} from "../src/path.js";
+import { openPinnedFileSync } from "../src/pinned-open.js";
+import { readRegularFile, readRegularFileSync } from "../src/regular-file.js";
+import { root, readLocalFileSafely } from "../src/root.js";
+import { readSecureFile } from "../src/secure-file.js";
+
+const posixIt = process.platform === "win32" ? it.skip : it;
+
+describe("unsafe device read paths", () => {
+  it("matches POSIX device and fd namespaces", () => {
+    for (const filePath of [
+      "/dev/zero",
+      "/dev/random",
+      "/dev/urandom",
+      "/dev/full",
+      "/dev/stdin",
+      "/dev/stdout",
+      "/dev/stderr",
+      "/dev/tty",
+      "/dev/console",
+      "/dev/fd",
+      "/dev/fd/0",
+      "/dev/fd/99",
+      "/proc/self/fd",
+      "/proc/self/fd/0",
+      "/proc/thread-self/fd/1",
+      "/proc/123/fd/2",
+    ]) {
+      expect(isUnsafeDeviceReadPath(filePath, { platform: "linux" })).toBe(true);
+    }
+  });
+
+  it("does not match ordinary POSIX paths that merely contain device-like names", () => {
+    expect(isUnsafeDeviceReadPath("/tmp/dev/zero", { platform: "linux" })).toBe(false);
+    expect(isUnsafeDeviceReadPath("dev/zero", { cwd: "/tmp/work", platform: "linux" })).toBe(
+      false,
+    );
+    expect(isUnsafeDeviceReadPath("/dev/null", { platform: "linux" })).toBe(false);
+  });
+
+  it("matches Windows reserved device names", () => {
+    for (const filePath of [
+      "NUL",
+      "C:\\tmp\\NUL.txt",
+      "C:\\tmp\\con",
+      "logs\\COM1",
+      "\\\\.\\NUL",
+      "\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1",
+    ]) {
+      expect(matchUnsafeDeviceReadPath(filePath, { platform: "win32" })).toMatchObject({
+        reason: "windows-device",
+      });
+    }
+    expect(isUnsafeDeviceReadPath("C:\\tmp\\normal.txt", { platform: "win32" })).toBe(false);
+  });
+
+  posixIt("blocks async public file read primitives before open", async () => {
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async () => {
+      throw new Error("open should not be called for unsafe device paths");
+    });
+    try {
+      await expect(readLocalFileSafely({ filePath: "/dev/zero" })).rejects.toMatchObject({
+        code: "device-path",
+      });
+      await expect(readRegularFile({ filePath: "/dev/zero" })).rejects.toMatchObject({
+        code: "device-path",
+      });
+      await expect(
+        readSecureFile({
+          filePath: "/dev/zero",
+          permissions: { allowInsecure: true },
+        }),
+      ).rejects.toMatchObject({ code: "device-path" });
+      expect(openSpy).not.toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  posixIt("blocks root reads after resolving relative paths", async () => {
+    const openSpy = vi.spyOn(fs, "open").mockImplementation(async () => {
+      throw new Error("open should not be called for unsafe device paths");
+    });
+    try {
+      const scoped = await root("/");
+      await expect(scoped.read("dev/fd/0")).rejects.toMatchObject({
+        code: "device-path",
+      });
+      expect(openSpy).not.toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  posixIt("blocks sync read helpers before open", () => {
+    const openSpy = vi.spyOn(syncFs, "openSync").mockImplementation(() => {
+      throw new Error("openSync should not be called for unsafe device paths");
+    });
+    try {
+      expect(() => readRegularFileSync({ filePath: "/dev/fd/0" })).toThrowError(
+        /unsafe device paths/,
+      );
+      const opened = openPinnedFileSync({ filePath: "/dev/fd/0" });
+      expect(opened).toMatchObject({ ok: false, reason: "validation" });
+      expect(openSpy).not.toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Summary
- Add a shared unsafe device-read path guard for POSIX device/fd namespaces and Windows reserved device names.
- Enforce the guard before opening files in fs-safe read/open primitives, including root reads, local reads, regular-file reads, secure-file reads, and pinned sync opens.
- Export the guard helpers from the path and advanced surfaces, and document the new device-path FsSafeError code.

Verification
- pnpm check passed: 36 test files, 387 passed, 2 skipped.

Notes
- The full check needs permission to create temporary directories under ~/.Trash because of existing trash-helper tests.