### PR TITLE
test: make mode assertions umask-aware

### DIFF
--- a/test/findings-regression.test.ts
+++ b/test/findings-regression.test.ts
@@ -355,23 +355,19 @@ describe("security finding regressions", () => {
     expect((await fsp.readFile(dest)).byteLength).toBe(1024 * 1024);
   });
 
-  it.runIf(process.platform !== "win32")("preserves public directory modes for zip staging parents", async () => {
-    const oldUmask = process.umask(0o022);
-    try {
-      const base = await tempRoot("fs-safe-zip-dir-mode-");
-      const archivePath = path.join(base, "pkg.zip");
-      const destDir = path.join(base, "dest");
-      await fsp.mkdir(destDir);
-      const zip = new JSZip();
-      zip.file("assets/app.js", "console.log('ok');");
-      await fsp.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+  it.runIf(process.platform !== "win32")("preserves default directory modes for zip staging parents", async () => {
+    const expectedDirectoryMode = 0o777 & ~process.umask();
+    const base = await tempRoot("fs-safe-zip-dir-mode-");
+    const archivePath = path.join(base, "pkg.zip");
+    const destDir = path.join(base, "dest");
+    await fsp.mkdir(destDir);
+    const zip = new JSZip();
+    zip.file("assets/app.js", "console.log('ok');");
+    await fsp.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
 
-      await extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 });
+    await extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 });
 
-      expect((await fsp.stat(path.join(destDir, "assets"))).mode & 0o777).toBe(0o755);
-    } finally {
-      process.umask(oldUmask);
-    }
+    expect((await fsp.stat(path.join(destDir, "assets"))).mode & 0o777).toBe(expectedDirectoryMode);
   });
 
   it("rejects durable queue ids that are not safe path segments", async () => {

--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -845,6 +845,7 @@ describe("atomic file replacement", () => {
   it("preserves an existing destination mode when requested", async () => {
     const filePath = path.join(root, "preserve-mode.txt");
     await fs.writeFile(filePath, "old", { mode: 0o640 });
+    await fs.chmod(filePath, 0o640);
 
     await replaceFileAtomic({
       filePath,


### PR DESCRIPTION
## Summary

- make the ZIP staging parent mode regression assert the default directory mode for the active process umask instead of temporarily mutating global umask state
- chmod the pre-existing fixture file before testing `preserveExistingMode`, so the fixture actually has mode `0640` under restrictive umasks

Fixes #25.

## Notes

The implementation already preserves the actual existing mode after replacement on `main`; the failing test fixture was created with `writeFile(..., { mode: 0o640 })`, which is still masked by `umask 077` to `0600`. This keeps the PR test-only and avoids changing the archive permission contract.

## Real Behavior Proof

Branch/commit:

```text
branch: fix/umask-mode-tests
commit: 320d6d4c27ffc4875915ec6708bb65d889862185
status: 0 changed file(s) after commit
```

Restrictive-umask targeted tests:

```text
$ umask 077 && pnpm exec vitest run test/new-primitives.test.ts -t "preserves an existing destination mode"

Test Files  1 passed (1)
Tests  1 passed | 53 skipped (54)

$ umask 077 && pnpm exec vitest run test/findings-regression.test.ts -t "preserves default directory modes"

Test Files  1 passed (1)
Tests  1 passed | 18 skipped (19)
```

Security suite under restrictive umask:

```text
$ umask 077 && pnpm test:security

Test Files  5 passed (5)
Tests  59 passed (59)
```

Full check under restrictive umask:

```text
$ umask 077 && pnpm check

Test Files  37 passed (37)
Tests  404 passed | 2 skipped (406)
```

Full check under normal umask:

```text
$ umask 022 && pnpm check

Test Files  37 passed (37)
Tests  404 passed | 2 skipped (406)
```

Audit and whitespace:

```text
$ pnpm audit --prod && pnpm audit
No known vulnerabilities found
No known vulnerabilities found

$ git diff --check
# no output
```
