### PR TITLE
fix: fall back to copy on EPERM/EEXIST rename errors

### DIFF
--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -261,7 +261,11 @@ export async function movePathWithCopyFallback(
     await guardedRename({ from: options.from, to: options.to });
     return;
   } catch (error) {
-    if ((error as NodeJS.ErrnoException | null)?.code !== "EXDEV") {
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    // EXDEV = cross-device move (same filesystem copy fallback)
+    // EPERM/EEXIST = permission denied or file locked (Windows common)
+    // All three should trigger copy fallback instead of failing.
+    if (code !== "EXDEV" && code !== "EPERM" && code !== "EEXIST") {
       throw error;
     }
   }

--- a/test/move-path-regression.test.ts
+++ b/test/move-path-regression.test.ts
@@ -176,4 +176,48 @@ describe("movePathWithCopyFallback regressions", () => {
       await expect(fsp.stat(dest)).rejects.toMatchObject({ code: "ENOENT" });
     },
   );
+
+  it(
+    "falls back to copy on EPERM (Windows file lock)",
+    async () => {
+      const base = await tempRoot("fs-safe-move-eperm-");
+      const source = path.join(base, "source.txt");
+      const dest = path.join(base, "dest.txt");
+      await fsp.writeFile(source, "hello eperm");
+      const realRename = fsp.rename;
+      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
+        if (from === source && to === dest) {
+          throw Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" });
+        }
+        return await realRename(from, to);
+      });
+
+      await movePathWithCopyFallback({ from: source, to: dest });
+
+      await expect(fsp.readFile(dest, "utf8")).resolves.toBe("hello eperm");
+      // Source is cleaned up after successful copy fallback
+      await expect(fsp.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it(
+    "falls back to copy on EEXIST (destination locked)",
+    async () => {
+      const base = await tempRoot("fs-safe-move-eexist-");
+      const source = path.join(base, "source.txt");
+      const dest = path.join(base, "dest.txt");
+      await fsp.writeFile(source, "hello eexist");
+      const realRename = fsp.rename;
+      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
+        if (from === source && to === dest) {
+          throw Object.assign(new Error("EEXIST: file already exists"), { code: "EEXIST" });
+        }
+        return await realRename(from, to);
+      });
+
+      await movePathWithCopyFallback({ from: source, to: dest });
+
+      await expect(fsp.readFile(dest, "utf8")).resolves.toBe("hello eexist");
+    },
+  );
 });


### PR DESCRIPTION
## Problem

`movePathWithCopyFallback` only catches `EXDEV` (cross-device) errors from `guardedRename`. On Windows, files locked by antivirus, other processes, or permission issues throw `EPERM`/`EEXIST`, causing install and update flows to fail unnecessarily.

## Root Cause

The `renameWithRetry` helper already has `copyFallbackOnPermissionError` support that handles EPERM/EEXIST, but `movePathWithCopyFallback` calls `guardedRename` directly, bypassing that logic.

## Fix

Catch `EPERM` and `EEXIST` alongside `EXDEV` in `movePathWithCopyFallback` so the copy fallback path handles Windows permission/lock errors.

## Tests

Added two new test cases:
- `falls back to copy on EPERM (Windows file lock)`
- `falls back to copy on EEXIST (destination locked)`

Both pass with `vitest run`.

## Context

This is the same issue that the local EPERM patch addressed in OpenClaw. The fix belongs in `@openclaw/fs-safe` so all consumers benefit.