### PR TITLE
feat(walk): report unreadable directories in failedDirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Features
-
-- Add `WalkDirectoryResult.failedDirs` to `walkDirectory`/`walkDirectorySync`, recording every directory whose `realpath`/`readdir` threw so destructive callers can tell an incomplete scan from an empty directory instead of treating a transient `readdir` failure as mass deletion. (#29; thanks @amknight)
-
 ### Compatibility
 
 - Require Node.js 22 or newer for the npm package and docs, matching the maintained CI matrix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add `WalkDirectoryResult.failedDirs` to `walkDirectory`/`walkDirectorySync`, recording every directory whose `realpath`/`readdir` threw so destructive callers can tell an incomplete scan from an empty directory instead of treating a transient `readdir` failure as mass deletion. (#29; thanks @amknight)
+
 ### Compatibility
 
 - Require Node.js 22 or newer for the npm package and docs, matching the maintained CI matrix.

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ for (const file of scan.entries) {
 }
 ```
 
-Check `scan.truncated` before treating the result as complete.
+Check `scan.truncated` before treating the result as complete, and `scan.failedDirs` to tell an incomplete scan (a directory that could not be read) from an empty one before pruning state from the listing.
 
 ## Archive extraction
 

--- a/docs/walk.md
+++ b/docs/walk.md
@@ -25,6 +25,7 @@ type WalkDirectoryResult = {
   entries: WalkDirectoryEntry[];
   scannedEntryCount: number;
   truncated: boolean;
+  failedDirs: WalkDirectoryFailure[];
 };
 
 type WalkDirectoryEntry = {
@@ -35,9 +36,18 @@ type WalkDirectoryEntry = {
   kind: "file" | "directory" | "symlink" | "other";
   dirent: import("node:fs").Dirent;
 };
+
+type WalkDirectoryFailure = {
+  path: string;
+  relativePath: string;
+  depth: number;
+  error: unknown;
+};
 ```
 
 `depth` starts at `1` for direct children of `rootDir`. `relativePath` is always relative to the supplied root. `scannedEntryCount` counts directory entries examined, including entries filtered out by `include`.
+
+`failedDirs` lists every directory whose `realpath`/`readdir` threw, so its contents are absent from `entries`. `error` is the thrown value (a `NodeJS.ErrnoException` at runtime), so callers can distinguish a benign missing-directory race (`ENOENT`) from a real read failure (`EACCES`, `EIO`, `ESTALE`, …). The walk-root entry has an empty `relativePath`. Failures resolving a symlink's target kind are not reported here.
 
 ## Options
 
@@ -55,7 +65,7 @@ type WalkDirectoryOptions = {
 
 `include` controls which entries are returned. `descend` controls which directory entries are traversed. A skipped directory can still be returned if `include` accepts it.
 
-Unreadable directories are skipped. This makes the helper suitable for best-effort inventories and pruning jobs; use a stricter root-bounded operation when every entry must be accounted for.
+Unreadable directories are skipped rather than throwing, but every skipped directory is recorded in `failedDirs`. This keeps the helper suitable for best-effort inventories while letting pruning jobs tell an incomplete scan from an empty one: a destructive reconcile that deletes state for paths missing from `entries` must first confirm `failedDirs` holds no real read failures, or a transient `EIO`/`EACCES` blip would be mistaken for mass deletion. Use a stricter root-bounded operation when every entry must be accounted for.
 
 ## See also
 

--- a/docs/walk.md
+++ b/docs/walk.md
@@ -25,7 +25,7 @@ type WalkDirectoryResult = {
   entries: WalkDirectoryEntry[];
   scannedEntryCount: number;
   truncated: boolean;
-  failedDirs: WalkDirectoryFailure[];
+  failedDirs?: WalkDirectoryFailure[];
 };
 
 type WalkDirectoryEntry = {
@@ -47,7 +47,7 @@ type WalkDirectoryFailure = {
 
 `depth` starts at `1` for direct children of `rootDir`. `relativePath` is always relative to the supplied root. `scannedEntryCount` counts directory entries examined, including entries filtered out by `include`.
 
-`failedDirs` lists every directory whose `realpath`/`readdir` threw, so its contents are absent from `entries`. `error` is the thrown value (a `NodeJS.ErrnoException` at runtime), so callers can distinguish a benign missing-directory race (`ENOENT`) from a real read failure (`EACCES`, `EIO`, `ESTALE`, …). The walk-root failure has an empty `relativePath` and `depth: 0`. Failures resolving a symlink's target kind are not reported here.
+`walkDirectory()` and `walkDirectorySync()` always return `failedDirs`; the property remains optional on the exported `WalkDirectoryResult` type so existing callers that manually construct the legacy result shape remain source-compatible. It lists every directory whose `realpath`/`readdir` threw, so its contents are absent from `entries`. `error` is the thrown value (a `NodeJS.ErrnoException` at runtime), so callers can distinguish a benign missing-directory race (`ENOENT`) from a real read failure (`EACCES`, `EIO`, `ESTALE`, …). The walk-root failure has an empty `relativePath` and `depth: 0`. Failures resolving a symlink's target kind are not reported here.
 
 ## Options
 

--- a/docs/walk.md
+++ b/docs/walk.md
@@ -47,7 +47,7 @@ type WalkDirectoryFailure = {
 
 `depth` starts at `1` for direct children of `rootDir`. `relativePath` is always relative to the supplied root. `scannedEntryCount` counts directory entries examined, including entries filtered out by `include`.
 
-`failedDirs` lists every directory whose `realpath`/`readdir` threw, so its contents are absent from `entries`. `error` is the thrown value (a `NodeJS.ErrnoException` at runtime), so callers can distinguish a benign missing-directory race (`ENOENT`) from a real read failure (`EACCES`, `EIO`, `ESTALE`, …). The walk-root entry has an empty `relativePath`. Failures resolving a symlink's target kind are not reported here.
+`failedDirs` lists every directory whose `realpath`/`readdir` threw, so its contents are absent from `entries`. `error` is the thrown value (a `NodeJS.ErrnoException` at runtime), so callers can distinguish a benign missing-directory race (`ENOENT`) from a real read failure (`EACCES`, `EIO`, `ESTALE`, …). The walk-root failure has an empty `relativePath` and `depth: 0`. Failures resolving a symlink's target kind are not reported here.
 
 ## Options
 

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -80,7 +80,13 @@ function recordFailedDir(
   depth: number,
   error: unknown,
 ): void {
-  result.failedDirs.push({ path: dir, relativePath: path.relative(root, dir), depth, error });
+  const relativePath = path.relative(root, dir);
+  result.failedDirs.push({
+    path: dir,
+    relativePath,
+    depth: relativePath === "" ? 0 : depth - 1,
+    error,
+  });
 }
 
 function resolveSyncKind(fullPath: string, dirent: fsSync.Dirent, symlinks: WalkSymlinkPolicy): WalkEntryKind | null {

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -22,10 +22,25 @@ export type WalkDirectoryOptions = {
   descend?: (entry: WalkDirectoryEntry) => boolean;
 };
 
+export type WalkDirectoryFailure = {
+  path: string;
+  relativePath: string;
+  depth: number;
+  error: unknown;
+};
+
 export type WalkDirectoryResult = {
   entries: WalkDirectoryEntry[];
   scannedEntryCount: number;
   truncated: boolean;
+  // Directories the walk could not enumerate because realpath/readdir threw,
+  // so their contents are absent from `entries`. `error` is the thrown value
+  // (a NodeJS.ErrnoException at runtime). A non-empty failedDirs means the
+  // listing is incomplete, not authoritative: callers reconciling destructive
+  // state from `entries` must skip (after filtering benign missing-dir races
+  // via the error code) rather than treat unseen paths as deleted. Failures
+  // resolving a symlink's target kind are not recorded here.
+  failedDirs: WalkDirectoryFailure[];
 };
 
 function kindForDirent(dirent: fsSync.Dirent): WalkEntryKind {
@@ -56,6 +71,16 @@ function buildEntry(params: {
     kind: params.kind ?? kindForDirent(params.dirent),
     dirent: params.dirent,
   };
+}
+
+function recordFailedDir(
+  result: WalkDirectoryResult,
+  root: string,
+  dir: string,
+  depth: number,
+  error: unknown,
+): void {
+  result.failedDirs.push({ path: dir, relativePath: path.relative(root, dir), depth, error });
 }
 
 function resolveSyncKind(fullPath: string, dirent: fsSync.Dirent, symlinks: WalkSymlinkPolicy): WalkEntryKind | null {
@@ -94,7 +119,12 @@ export function walkDirectorySync(
 ): WalkDirectoryResult {
   const root = path.resolve(rootDir);
   const symlinks = options.symlinks ?? "skip";
-  const result: WalkDirectoryResult = { entries: [], scannedEntryCount: 0, truncated: false };
+  const result: WalkDirectoryResult = {
+    entries: [],
+    scannedEntryCount: 0,
+    truncated: false,
+    failedDirs: [],
+  };
   const visitedDirs = new Set<string>();
 
   function visit(dir: string, depth: number): void {
@@ -102,7 +132,8 @@ export function walkDirectorySync(
     let realDir: string;
     try {
       realDir = fsSync.realpathSync(dir);
-    } catch {
+    } catch (error) {
+      recordFailedDir(result, root, dir, depth, error);
       return;
     }
     if (visitedDirs.has(realDir)) return;
@@ -111,7 +142,8 @@ export function walkDirectorySync(
     let entries: fsSync.Dirent[];
     try {
       entries = fsSync.readdirSync(dir, { withFileTypes: true });
-    } catch {
+    } catch (error) {
+      recordFailedDir(result, root, dir, depth, error);
       return;
     }
     for (const dirent of entries) {
@@ -148,7 +180,12 @@ export async function walkDirectory(
 ): Promise<WalkDirectoryResult> {
   const root = path.resolve(rootDir);
   const symlinks = options.symlinks ?? "skip";
-  const result: WalkDirectoryResult = { entries: [], scannedEntryCount: 0, truncated: false };
+  const result: WalkDirectoryResult = {
+    entries: [],
+    scannedEntryCount: 0,
+    truncated: false,
+    failedDirs: [],
+  };
   const visitedDirs = new Set<string>();
 
   async function visit(dir: string, depth: number): Promise<void> {
@@ -156,7 +193,8 @@ export async function walkDirectory(
     let realDir: string;
     try {
       realDir = await fs.realpath(dir);
-    } catch {
+    } catch (error) {
+      recordFailedDir(result, root, dir, depth, error);
       return;
     }
     if (visitedDirs.has(realDir)) return;
@@ -165,7 +203,8 @@ export async function walkDirectory(
     let entries: fsSync.Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
+    } catch (error) {
+      recordFailedDir(result, root, dir, depth, error);
       return;
     }
     for (const dirent of entries) {

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -33,13 +33,12 @@ export type WalkDirectoryResult = {
   entries: WalkDirectoryEntry[];
   scannedEntryCount: number;
   truncated: boolean;
-  // Directories the walk could not enumerate because realpath/readdir threw,
-  // so their contents are absent from `entries`. `error` is the thrown value
-  // (a NodeJS.ErrnoException at runtime). A non-empty failedDirs means the
-  // listing is incomplete, not authoritative: callers reconciling destructive
-  // state from `entries` must skip (after filtering benign missing-dir races
-  // via the error code) rather than treat unseen paths as deleted. Failures
-  // resolving a symlink's target kind are not recorded here.
+  // Always present on values returned by the walkers. Optional so existing
+  // callers can continue constructing the legacy result shape.
+  failedDirs?: WalkDirectoryFailure[];
+};
+
+type WalkDirectoryResultWithFailures = WalkDirectoryResult & {
   failedDirs: WalkDirectoryFailure[];
 };
 
@@ -74,7 +73,7 @@ function buildEntry(params: {
 }
 
 function recordFailedDir(
-  result: WalkDirectoryResult,
+  result: WalkDirectoryResultWithFailures,
   root: string,
   dir: string,
   depth: number,
@@ -122,10 +121,10 @@ async function resolveAsyncKind(fullPath: string, dirent: fsSync.Dirent, symlink
 export function walkDirectorySync(
   rootDir: string,
   options: WalkDirectoryOptions = {},
-): WalkDirectoryResult {
+): WalkDirectoryResultWithFailures {
   const root = path.resolve(rootDir);
   const symlinks = options.symlinks ?? "skip";
-  const result: WalkDirectoryResult = {
+  const result: WalkDirectoryResultWithFailures = {
     entries: [],
     scannedEntryCount: 0,
     truncated: false,
@@ -183,10 +182,10 @@ export function walkDirectorySync(
 export async function walkDirectory(
   rootDir: string,
   options: WalkDirectoryOptions = {},
-): Promise<WalkDirectoryResult> {
+): Promise<WalkDirectoryResultWithFailures> {
   const root = path.resolve(rootDir);
   const symlinks = options.symlinks ?? "skip";
-  const result: WalkDirectoryResult = {
+  const result: WalkDirectoryResultWithFailures = {
     entries: [],
     scannedEntryCount: 0,
     truncated: false,

--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -42,7 +42,11 @@ import {
   summarizeWindowsAcl,
 } from "../src/permissions.js";
 import { readSecureFile } from "../src/secure-file.js";
-import { walkDirectory, walkDirectorySync } from "../src/walk.js";
+import {
+  walkDirectory,
+  walkDirectorySync,
+  type WalkDirectoryResult,
+} from "../src/walk.js";
 
 let root: string;
 
@@ -490,6 +494,16 @@ describe("secure file reads", () => {
 });
 
 describe("directory walking", () => {
+  it("keeps the legacy result shape source-compatible", () => {
+    const result: WalkDirectoryResult = {
+      entries: [],
+      scannedEntryCount: 0,
+      truncated: false,
+    };
+
+    expect(result.failedDirs).toBeUndefined();
+  });
+
   it("walks bounded trees and reports truncation", async () => {
     await fs.mkdir(path.join(root, "a", "b"), { recursive: true });
     await fs.writeFile(path.join(root, "a", "one.txt"), "1");

--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -555,6 +555,7 @@ describe("directory walking", () => {
         );
         // ...but the failure is reported, not silently swallowed.
         expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual(["blocked"]);
+        expect(scan.failedDirs[0]).toMatchObject({ path: blocked, depth: 1 });
         expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
       } finally {
         await fs.chmod(blocked, 0o755);
@@ -574,6 +575,7 @@ describe("directory walking", () => {
 
         expect(scan.entries).toEqual([]);
         expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual([""]);
+        expect(scan.failedDirs[0]).toMatchObject({ path: scanRoot, depth: 0 });
         expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
       } finally {
         await fs.chmod(scanRoot, 0o755);
@@ -596,6 +598,29 @@ describe("directory walking", () => {
           path.join("readable", "ok.txt"),
         );
         expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual(["blocked"]);
+        expect(scan.failedDirs[0]).toMatchObject({ path: blocked, depth: 1 });
+        expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
+      } finally {
+        await fs.chmod(blocked, 0o755);
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "reports nested failed directory depth relative to the walk root",
+    async () => {
+      const parent = path.join(root, "parent");
+      const blocked = path.join(parent, "blocked");
+      await fs.mkdir(blocked, { recursive: true });
+      await fs.writeFile(path.join(blocked, "hidden.txt"), "secret");
+      await fs.chmod(blocked, 0o000);
+      try {
+        const scan = await walkDirectory(root);
+
+        expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual([
+          path.join("parent", "blocked"),
+        ]);
+        expect(scan.failedDirs[0]).toMatchObject({ path: blocked, depth: 2 });
         expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
       } finally {
         await fs.chmod(blocked, 0o755);

--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -524,6 +524,84 @@ describe("directory walking", () => {
       path.join("a", "loop"),
     ]);
   });
+
+  it("leaves failedDirs empty when every directory is readable", async () => {
+    await fs.mkdir(path.join(root, "a", "b"), { recursive: true });
+    await fs.writeFile(path.join(root, "a", "one.txt"), "1");
+
+    expect((await walkDirectory(root)).failedDirs).toEqual([]);
+    expect(walkDirectorySync(root).failedDirs).toEqual([]);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "reports an unreadable subtree in failedDirs without dropping readable siblings",
+    async () => {
+      await fs.mkdir(path.join(root, "readable"), { recursive: true });
+      await fs.writeFile(path.join(root, "readable", "ok.txt"), "1");
+      const blocked = path.join(root, "blocked");
+      await fs.mkdir(blocked, { recursive: true });
+      await fs.writeFile(path.join(blocked, "hidden.txt"), "secret");
+      await fs.chmod(blocked, 0o000);
+      try {
+        const scan = await walkDirectory(root, { include: (entry) => entry.kind === "file" });
+
+        // The readable sibling is still enumerated.
+        expect(scan.entries.map((entry) => entry.relativePath)).toContain(
+          path.join("readable", "ok.txt"),
+        );
+        // The unreadable subtree contributes no entries.
+        expect(scan.entries.map((entry) => entry.relativePath)).not.toContain(
+          path.join("blocked", "hidden.txt"),
+        );
+        // ...but the failure is reported, not silently swallowed.
+        expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual(["blocked"]);
+        expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
+      } finally {
+        await fs.chmod(blocked, 0o755);
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "reports an unreadable walk root in failedDirs with an empty listing",
+    async () => {
+      const scanRoot = path.join(root, "scan");
+      await fs.mkdir(scanRoot, { recursive: true });
+      await fs.writeFile(path.join(scanRoot, "file.txt"), "1");
+      await fs.chmod(scanRoot, 0o000);
+      try {
+        const scan = await walkDirectory(scanRoot);
+
+        expect(scan.entries).toEqual([]);
+        expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual([""]);
+        expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
+      } finally {
+        await fs.chmod(scanRoot, 0o755);
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "reports unreadable directories from the synchronous walk too",
+    async () => {
+      await fs.mkdir(path.join(root, "readable"), { recursive: true });
+      await fs.writeFile(path.join(root, "readable", "ok.txt"), "1");
+      const blocked = path.join(root, "blocked");
+      await fs.mkdir(blocked, { recursive: true });
+      await fs.chmod(blocked, 0o000);
+      try {
+        const scan = walkDirectorySync(root, { include: (entry) => entry.kind === "file" });
+
+        expect(scan.entries.map((entry) => entry.relativePath)).toContain(
+          path.join("readable", "ok.txt"),
+        );
+        expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual(["blocked"]);
+        expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
+      } finally {
+        await fs.chmod(blocked, 0o755);
+      }
+    },
+  );
 });
 
 describe("private file store mode", () => {


### PR DESCRIPTION
## Summary

`walkDirectory()` / `walkDirectorySync()` swallow `realpath`/`readdir` errors at **every** level — including the walk root — with a bare `catch { return; }`, then return a partial or empty `entries` list. A caller that reconciles destructive state from the listing (stale-row pruning, exported-corpus reconciliation, etc.) cannot tell a transient `EIO`/`EACCES`/`ESTALE` read failure from a genuinely empty directory, so a single blip looks like a mass deletion.

This adds **`WalkDirectoryResult.failedDirs`**: every directory the walk could not enumerate is recorded with its absolute `path`, root-relative `relativePath`, `depth`, and the thrown `error`. Callers can now classify a benign missing-directory race (`ENOENT`) versus a real read failure and skip destructive work when the scan was not authoritative.

Behaviour is otherwise unchanged — unreadable directories are still skipped, and entries from the readable parts of the tree are still returned. The field is additive; existing consumers that ignore it are unaffected.

```ts
type WalkDirectoryFailure = { path: string; relativePath: string; depth: number; error: unknown };
type WalkDirectoryResult = { entries; scannedEntryCount; truncated; failedDirs: WalkDirectoryFailure[] };
```

## Motivation

OpenClaw's memory index treats a directory listing as the source of truth for destructive maintenance (stale-row pruning of its search index). Because `walkDirectory` swallows `realpath`/`readdir` errors, a transient `EIO`/`EACCES`/`ESTALE` blip currently yields an empty/partial listing that the prune treats as mass deletion — a live index-wipe hazard on `main`.

A pending OpenClaw fix guards this by adding an explicit `readdir` probe on each scan root *before* walking it, but that costs a second full `readdir` per root on networked filesystems and still only covers the root, leaving sub-tree read failures invisible. With `failedDirs`, that fix can detect an incomplete scan straight from the walk result — no probe, one `readdir` per directory — and catch failures anywhere in the tree, not just at the root.

## What changed

- `src/walk.ts`: new `WalkDirectoryFailure` type and `failedDirs` on `WalkDirectoryResult`; both walkers record the `realpath`/`readdir` catch sites via a shared `recordFailedDir` helper. Symlink-target kind-resolution failures are intentionally **not** recorded (they are not directory-enumeration failures).
- `test/new-primitives.test.ts`: unreadable sub-tree (readable siblings preserved + failure reported with `EACCES`), unreadable walk root (empty listing + reported), the synchronous walker, and the empty-`failedDirs` contract for a fully readable tree.
- `docs/walk.md`, `README.md`: document `failedDirs` and the incomplete-vs-empty distinction for pruning callers.

## Verification

Run on macOS, Node 25, `pnpm check` (lint:file-size + lint:fs-boundary + build + test):

- `pnpm check` — **green**: both lints pass, `tsc` builds clean, **412 passed | 3 skipped (415)** across 37 files.
- New directory-walking tests: **6 passed** (4 new + 2 pre-existing), and confirmed RED first (each new test failed with `failedDirs` undefined before the implementation).
