### PR TITLE
fix: fail closed on stale lock recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.4.2 - Unreleased
 
+### Security and Correctness
+
+- Disable `remove-if-unchanged` stale sidecar deletion because a pathname identity check followed by unlink can delete a replacement lock; retain the deprecated recovery inputs for compatibility while all stale locks fail closed.
+
 ## 0.4.1 - 2026-07-01
 
 ### Security and Correctness

--- a/README.md
+++ b/README.md
@@ -283,7 +283,9 @@ the common merge-into-defaults case. Standalone helpers use options bags
 because they do not carry a bound root and often need multiple authority, path,
 and policy knobs.
 
-Sidecar locks fail closed on stale holders by default. Use the [file lock docs](docs/sidecar-lock.md) for the lower-level `remove-if-unchanged` recovery mode when your application can prove the old owner is gone.
+Sidecar locks fail closed on stale holders. The legacy `remove-if-unchanged`
+option remains accepted for source compatibility, but it no longer unlinks a
+third-party stale lock during acquisition; see the [file lock docs](docs/sidecar-lock.md).
 
 Use `fileStore()` for cache/blob/media-style directories where callers
 need safe relative paths, size limits, atomic replacement, stream writes, and

--- a/docs/config.md
+++ b/docs/config.md
@@ -56,7 +56,7 @@ Return the effective configuration: programmatic overrides win, then env vars, t
 function configureFsSafeLocks(config: Partial<FsSafeLockConfig>): void;
 
 type FsSafeLockConfig = {
-  staleRecovery: "fail-closed" | "remove-if-unchanged";
+  staleRecovery: "fail-closed" | "remove-if-unchanged"; // legacy value also fails closed
   staleMs?: number;
   timeoutMs?: number;
   retry?: FileLockRetryOptions;
@@ -65,7 +65,7 @@ type FsSafeLockConfig = {
 
 Set process-wide defaults for sidecar lock options. This does **not** turn locking on globally; callers still need to pass `lock: true` or a lock options object for the specific JSON store/resource that needs cross-process coordination.
 
-`staleRecovery` defaults to `"fail-closed"`. `"remove-if-unchanged"` is available for callers that also pass `shouldRemoveStaleLock`; fs-safe re-reads the observed sidecar and removes it only when the raw content and file identity still match.
+`staleRecovery` defaults to `"fail-closed"`. The deprecated `"remove-if-unchanged"` value remains accepted for source and configuration compatibility, but behaves as `"fail-closed"`. fs-safe never removes a stale third-party lock during acquisition because a pathname recheck followed by unlink cannot prevent deleting a replacement lock.
 
 ## `getFsSafeLockConfig()`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ await fs.remove("notes/archive/today.txt");
 | [`extractArchive`](archive.md) | ZIP/TAR extraction with size, count, link, and traversal limits. |
 | [Secret files](secret-file.md) | Mode-0600 credentials with size and TOCTOU defense. |
 | [Permissions](permissions.md) | POSIX mode and Windows ACL inspection/remediation helpers. |
-| [`acquireFileLock`](sidecar-lock.md) | Cross-process file lock with retry, fail-closed stale-lock handling, and opt-in caller-approved stale removal. |
+| [`acquireFileLock`](sidecar-lock.md) | Cross-process file lock with retry and fail-closed stale-lock handling. |
 | [`FsSafeError`](errors.md) | Closed code union (with `policy` / `operational` category) you can branch on. |
 | [`pathScope()`](path-scope.md) | Lower-level absolute-path boundary helper; lives behind `@openclaw/fs-safe/advanced`. |
 | [`@openclaw/fs-safe/advanced`](advanced.md) | Directory of lower-level composition helpers (path scopes, regular-file I/O, install paths, sibling-temp writes, …). |

--- a/docs/json-store.md
+++ b/docs/json-store.md
@@ -53,7 +53,7 @@ type JsonStoreLockOptions = {
   staleMs?: number;     // default 30_000
   timeoutMs?: number;   // default 30_000
   retry?: FileLockRetryOptions;
-  staleRecovery?: "fail-closed" | "remove-if-unchanged";
+  staleRecovery?: "fail-closed" | "remove-if-unchanged"; // legacy value also fails closed
   managerKey?: string;  // default `fs-safe.json-store:<filePath>`
 };
 
@@ -141,7 +141,7 @@ When `lock` is falsy, `read` / `write` / `update` are unlocked. The `update` sha
 
 Process-wide lock defaults from `configureFsSafeLocks()` apply only after locking is explicitly enabled. They do not make JSON stores lock by default.
 
-JSON store locks do not expose `shouldRemoveStaleLock`, so `staleRecovery: "remove-if-unchanged"` cannot remove a stale sidecar by itself. Use the lower-level [file lock](sidecar-lock.md) API when your application needs custom owner-liveness checks and caller-approved stale-lock removal.
+JSON store locks always fail closed on stale sidecars. The deprecated `staleRecovery: "remove-if-unchanged"` value remains accepted for compatibility, but it behaves as `"fail-closed"` and never removes the lock.
 
 The default `managerKey` namespaces the in-process `FileLockManager` per absolute file path, so two `jsonStore` calls on the same file share lock state automatically.
 

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -51,7 +51,7 @@ type FileLockAcquireOptions<TPayload extends Record<string, unknown>> = {
   staleMs?: number;                      // default 30_000
   timeoutMs?: number;                    // overall acquire deadline; default unbounded
   retry?: FileLockRetryOptions;
-  staleRecovery?: "fail-closed" | "remove-if-unchanged"; // default "fail-closed"
+  staleRecovery?: "fail-closed" | "remove-if-unchanged"; // legacy value also fails closed
   allowReentrant?: boolean;              // if this process already holds it, increment a count instead of failing
   payload: () => TPayload | Promise<TPayload>;
   shouldReclaim?: (params: {
@@ -62,7 +62,7 @@ type FileLockAcquireOptions<TPayload extends Record<string, unknown>> = {
     nowMs: number;
     heldByThisProcess: boolean;
   }) => boolean | Promise<boolean>;
-  shouldRemoveStaleLock?: (snapshot: {
+  shouldRemoveStaleLock?: (snapshot: {          // deprecated; retained but not invoked
     lockPath: string;
     normalizedTargetPath: string;
     raw: string;
@@ -170,40 +170,24 @@ const handle = await acquireFileLock(targetPath, {
 });
 ```
 
-`heldByThisProcess` is true when this manager already holds the lock (relevant for the reentrant case). A `true` result marks the observed sidecar as stale; `staleRecovery` then decides whether acquisition fails closed or tries caller-approved removal.
+`heldByThisProcess` is true when this manager already holds the lock (relevant for the reentrant case). A `true` result marks the observed sidecar as stale and acquisition throws an error with code `file_lock_stale`.
 
-## Stale recovery: `remove-if-unchanged`
+## Stale recovery is fail-closed
 
-The default `staleRecovery: "fail-closed"` never removes third-party sidecars. Use `staleRecovery: "remove-if-unchanged"` only when your app has a reliable owner-liveness policy and can prove a stale owner cannot still be writing.
+fs-safe never removes a stale third-party sidecar during acquisition. Checking a pathname's content and identity before unlinking it is not atomic: another process can replace the lock between the final check and the unlink. Every stale result therefore fails closed with error code `file_lock_stale`.
 
-```ts
-const handle = await acquireFileLock(targetPath, {
-  staleMs: 60_000,
-  staleRecovery: "remove-if-unchanged",
-  payload: () => ({ pid: process.pid, createdAt: new Date().toISOString() }),
-  shouldReclaim: ({ payload }) => {
-    const pid = Number(payload?.pid);
-    return Number.isInteger(pid) && pid > 0 && ownerIsDefinitelyDead(pid);
-  },
-  shouldRemoveStaleLock: ({ payload }) => {
-    const pid = Number(payload?.pid);
-    return Number.isInteger(pid) && pid > 0 && ownerIsDefinitelyDead(pid);
-  },
-});
-```
-
-`shouldRemoveStaleLock` receives the exact lock snapshot that `fs-safe` inspected. `fs-safe` re-reads the sidecar and removes it only if the raw content and file identity are unchanged. If the callback is missing, returns false, or the file changed, acquisition fails closed or keeps retrying according to the normal retry policy.
+The `"remove-if-unchanged"` value and `shouldRemoveStaleLock` callback remain accepted as deprecated compatibility inputs. They are ignored and the callback is not invoked. To recover, stop or otherwise exclude every process that can acquire the lock, remove the confirmed stale sidecar under that external authority, and retry acquisition.
 
 ## What sidecar locks defend against
 
 - **Two processes writing the same file at once.** `acquire` serializes the critical section.
-- **Accidentally deleting a fresh lock during stale recovery.** Stale third-party locks fail closed by default. Opt-in removal rechecks the observed snapshot before unlinking.
+- **Accidentally deleting a fresh lock during stale recovery.** Stale third-party locks always fail closed and are never unlinked during acquisition.
 - **Race between simultaneous acquire attempts.** `O_CREAT | O_EXCL` ensures one wins.
 
 ## What they do **not** defend against
 
 - **Misbehaving holders that ignore the lock.** Locks are advisory — only callers that go through `acquire` are bound.
-- **Automatic stale lock deletion.** If a process crashes, use the payload and your own supervisor/process table to decide when removal is safe, then opt into `remove-if-unchanged`.
+- **Automatic stale lock deletion.** If a process crashes, recover only under external authority that excludes every competing lock acquirer.
 - **Multi-host coordination over network filesystems.** Behavior depends on the underlying filesystem's `O_EXCL` semantics; treat as best-effort.
 
 ## Common patterns

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -250,7 +250,7 @@ await fs.write("state.json", body); // succeeds on rclone FUSE
 
 **Security note.** `verify-content-with-lock` proves that the bytes observed after rename match the requested write and prevents *cooperating* writers from interleaving. It does **not** prove that the destination still names the temp-file object, retain the Python helper's fd-relative parent pinning, or stop a same-UID process that ignores the advisory lock. Do not use this option on directories writable by untrusted same-UID processes. Strict identity verification remains the default.
 
-Lock recovery is fail-closed. If a process crashes and leaves the root-level `.fs-safe-write-<sha256>.lock`, a later write reports the stale lock instead of deleting it based on a host-local PID. Remove a stale sidecar only after proving that its holder can no longer write, using the application-owned recovery guidance in [File lock](sidecar-lock.md#stale-recovery-remove-if-unchanged).
+Lock recovery is fail-closed. If a process crashes and leaves the root-level `.fs-safe-write-<sha256>.lock`, a later write reports the stale lock instead of deleting it based on a host-local PID. Recover only under external authority that excludes every competing writer; see [File lock](sidecar-lock.md#stale-recovery-is-fail-closed).
 
 ## See also
 

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -13,8 +13,12 @@ export type SidecarLockRetryOptions = {
   randomize?: boolean;
 };
 
-export type SidecarLockStaleRecovery = "fail-closed" | "remove-if-unchanged";
+export type SidecarLockStaleRecovery =
+  | "fail-closed"
+  /** @deprecated Stale locks now always fail closed. */
+  | "remove-if-unchanged";
 
+/** @deprecated Stale-removal callbacks are retained for source compatibility but are not invoked. */
 export type SidecarLockStaleSnapshot = {
   lockPath: string;
   normalizedTargetPath: string;
@@ -39,6 +43,7 @@ export type SidecarLockAcquireOptions<TPayload extends Record<string, unknown>> 
     nowMs: number;
     heldByThisProcess: boolean;
   }) => boolean | Promise<boolean>;
+  /** @deprecated Stale locks now always fail closed; this callback is not invoked. */
   shouldRemoveStaleLock?: (
     snapshot: SidecarLockStaleSnapshot,
   ) => boolean | Promise<boolean>;
@@ -165,45 +170,6 @@ async function lockSnapshotStillPresent(
 ): Promise<boolean> {
   const current = await readLockSnapshot(lockPath);
   return !!current && !!observed && snapshotMatches(current, observed);
-}
-
-async function removeStaleLockIfAllowed(params: {
-  lockPath: string;
-  normalizedTargetPath: string;
-  snapshot: LockSnapshot;
-  shouldRemoveStaleLock?: (
-    snapshot: SidecarLockStaleSnapshot,
-  ) => boolean | Promise<boolean>;
-}): Promise<"removed" | "changed" | "not-approved"> {
-  if (!params.shouldRemoveStaleLock) {
-    return "not-approved";
-  }
-  if (params.snapshot.raw === undefined) {
-    return "not-approved";
-  }
-  if (
-    !(await params.shouldRemoveStaleLock({
-      lockPath: params.lockPath,
-      normalizedTargetPath: params.normalizedTargetPath,
-      raw: params.snapshot.raw,
-      payload: params.snapshot.payload,
-    }))
-  ) {
-    return "not-approved";
-  }
-  const current = await readLockSnapshot(params.lockPath);
-  if (!current || !snapshotMatches(current, params.snapshot)) {
-    return "changed";
-  }
-  try {
-    await fs.rm(params.lockPath, { force: true });
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return "changed";
-    }
-    return "not-approved";
-  }
-  return "removed";
 }
 
 function snapshotMatchesSync(lockPath: string, observed: LockSnapshot): boolean {
@@ -406,18 +372,9 @@ export function createSidecarLockManager(key: string) {
           if (!(await lockSnapshotStillPresent(lockPath, snapshot))) {
             continue;
           }
-          const staleRecovery = options.staleRecovery ?? "fail-closed";
-          if (staleRecovery === "remove-if-unchanged") {
-            const removal = await removeStaleLockIfAllowed({
-              lockPath,
-              normalizedTargetPath,
-              snapshot,
-              shouldRemoveStaleLock: options.shouldRemoveStaleLock,
-            });
-            if (removal === "removed" || removal === "changed") {
-              continue;
-            }
-          }
+          // A pathname recheck followed by unlink is not atomic: a fresh lock
+          // can replace the observed file in between. Legacy recovery inputs
+          // remain accepted, but third-party stale locks always fail closed.
           throw Object.assign(new Error(`file lock stale for ${normalizedTargetPath}`), {
             code: "file_lock_stale",
             lockPath,

--- a/test/sidecar-lock-regression.test.ts
+++ b/test/sidecar-lock-regression.test.ts
@@ -128,108 +128,29 @@ describe("sidecar lock regressions", () => {
     }
   });
 
-  it("removes stale sidecar locks only when the caller approves the observed snapshot", async () => {
+  it("fails closed even when legacy stale-removal inputs approve the snapshot", async () => {
     const base = await tempRoot("fs-safe-sidecar-remove-");
     const targetPath = path.join(base, "state.json");
     const lockPath = `${targetPath}.lock`;
     const manager = createSidecarLockManager(`fs-safe-remove-test-${Date.now()}`);
     await fsp.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
-    const normalizedTargetPath = await fsp.realpath(targetPath).catch(async () =>
-      path.join(await fsp.realpath(path.dirname(targetPath)), path.basename(targetPath)),
-    );
 
-    const seen: Array<Record<string, unknown> | null> = [];
-    const lock = await manager.acquire({
-      targetPath,
-      lockPath,
-      staleMs: 1,
-      staleRecovery: "remove-if-unchanged",
-      payload: async () => ({ createdAt: new Date().toISOString(), owner: "next" }),
-      shouldReclaim: async () => true,
-      shouldRemoveStaleLock: async (snapshot) => {
-        expect(snapshot.lockPath).toBe(lockPath);
-        expect(snapshot.normalizedTargetPath).toBe(normalizedTargetPath);
-        expect(snapshot.raw).toContain("2000-01-01T00:00:00.000Z");
-        seen.push(snapshot.payload);
-        return true;
-      },
-    });
-    try {
-      await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("next");
-      expect(seen).toEqual([{ createdAt: "2000-01-01T00:00:00.000Z" }]);
-    } finally {
-      await lock.release();
-    }
-  });
-
-  it("fails closed when stale sidecar removal is not explicitly approved", async () => {
-    const base = await tempRoot("fs-safe-sidecar-refuse-");
-    const targetPath = path.join(base, "state.json");
-    const lockPath = `${targetPath}.lock`;
-    const manager = createSidecarLockManager(`fs-safe-refuse-test-${Date.now()}`);
-    await fsp.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
-
+    const shouldRemoveStaleLock = vi.fn(async () => true);
     await expect(
       manager.acquire({
         targetPath,
         lockPath,
         staleMs: 1,
-        timeoutMs: 1,
-        retry: { retries: 0 },
         staleRecovery: "remove-if-unchanged",
-        payload: async () => ({ createdAt: new Date().toISOString() }),
-        shouldReclaim: async ({ payload }) => payload?.createdAt === "2000-01-01T00:00:00.000Z",
-        shouldRemoveStaleLock: async () => false,
-      }),
-    ).rejects.toMatchObject({ code: "file_lock_stale" });
-    await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("2000-01-01T00:00:00.000Z");
-
-    await expect(
-      manager.acquire({
-        targetPath,
-        lockPath,
-        staleMs: 1,
-        timeoutMs: 1,
-        retry: { retries: 0 },
-        staleRecovery: "remove-if-unchanged",
-        payload: async () => ({ createdAt: new Date().toISOString() }),
+        payload: async () => ({ createdAt: new Date().toISOString(), owner: "next" }),
         shouldReclaim: async () => true,
+        shouldRemoveStaleLock,
       }),
     ).rejects.toMatchObject({ code: "file_lock_stale" });
-    await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("2000-01-01T00:00:00.000Z");
-  });
-
-  it("preserves a sidecar that changes after stale removal approval", async () => {
-    const base = await tempRoot("fs-safe-sidecar-changed-");
-    const targetPath = path.join(base, "state.json");
-    const lockPath = `${targetPath}.lock`;
-    const manager = createSidecarLockManager(`fs-safe-changed-test-${Date.now()}`);
-    await fsp.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
-
-    let replaced = false;
-    await expect(
-      manager.acquire({
-        targetPath,
-        lockPath,
-        staleMs: 1,
-        timeoutMs: 1,
-        retry: { retries: 0 },
-        staleRecovery: "remove-if-unchanged",
-        payload: async () => ({ createdAt: new Date().toISOString() }),
-        shouldReclaim: async ({ payload }) => payload?.createdAt === "2000-01-01T00:00:00.000Z",
-        shouldRemoveStaleLock: async () => {
-          if (!replaced) {
-            replaced = true;
-            await fsp.writeFile(
-              lockPath,
-              JSON.stringify({ createdAt: "2999-01-01T00:00:00.000Z" }),
-            );
-          }
-          return true;
-        },
-      }),
-    ).rejects.toMatchObject({ code: "file_lock_timeout" });
-    await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("2999");
+    expect(shouldRemoveStaleLock).not.toHaveBeenCalled();
+    await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain(
+      "2000-01-01T00:00:00.000Z",
+    );
   });
 
   it("cleans failed sidecar locks and preserves stale corrupt locks", async () => {


### PR DESCRIPTION
## What Problem This Solves

The opt-in `remove-if-unchanged` stale-lock recovery path re-read a sidecar's content and file identity before deleting it by pathname. That check and unlink are separate operations, so another process could replace the observed stale sidecar between them and have its fresh lock deleted, breaking mutual exclusion.

## Why This Change Was Made

Node's pathname-based unlink cannot bind deletion to the file object that was inspected. Caller-provided owner-liveness checks do not close that race.

Stale sidecars now always fail closed with `file_lock_stale`. The shipped `remove-if-unchanged` value and `shouldRemoveStaleLock` callback remain accepted as deprecated compatibility inputs, but they are ignored. Recovery must happen under external authority that excludes every competing lock acquirer.

## User Impact

Fresh replacement locks can no longer be deleted by automatic stale recovery.

Callers using the legacy recovery mode will now receive `file_lock_stale` and must explicitly recover after proving that no process can acquire or hold the lock. Existing TypeScript and configuration inputs continue to parse.

## Evidence

- `pnpm test test/sidecar-lock-regression.test.ts` — 7 passed
- `pnpm test` — 421 passed, 3 skipped
- `pnpm build`
- `pnpm lint:file-size`
- `pnpm lint:fs-boundary`
- Regression coverage verifies that legacy approval callbacks are not invoked and stale sidecars remain unchanged.
- README, configuration, JSON-store, writing, and sidecar-lock documentation now describe the fail-closed contract.
