### PR TITLE
feat: bound reads from open file descriptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 .clawpatch/
 .deepsec/
 .vscode
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.2 - Unreleased
 
+- Treat `EPERM` from pinned-write file and directory `fsync` calls as best effort for filesystems that permit the write but reject explicit synchronization.
+
 ### Features
 
 - Add bounded async/sync reads for already-open file descriptors and handles, plus optional byte caps for standalone JSON readers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## 0.4.2 - Unreleased
 
+### Features
+
+- Add bounded async/sync reads for already-open file descriptors and handles, plus optional byte caps for standalone JSON readers.
+
 ### Security and Correctness
 
+- Make capped root, regular-file, secure-file, secret-file, structured JSON, and synchronous store reads incremental so a file that grows after validation cannot trigger an unbounded allocation.
 - Disable `remove-if-unchanged` stale sidecar deletion because a pathname identity check followed by unlink can delete a replacement lock; retain the deprecated recovery inputs for compatibility while all stale locks fail closed.
 
 ## 0.4.1 - 2026-07-01

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ that OpenClaw needs to compose higher-level APIs are grouped under
 | `@openclaw/fs-safe/permissions` | POSIX mode and Windows ACL inspection plus remediation formatting helpers |
 | `@openclaw/fs-safe/walk` | budget-bounded directory walking with symlink policy, filters, and truncation accounting; not root-bounded |
 | `@openclaw/fs-safe/archive` | `extractArchive`, `resolveArchiveKind`, `ArchiveLimitError`, preflight helpers |
-| `@openclaw/fs-safe/advanced` | lower-level composition helpers such as path scopes, root-file open, install paths, filename sanitizing, temp-file targets, sibling-temp writes, local-root readers, regular-file helpers, `pathExists`, and `withTimeout`; less stable than focused public subpaths |
+| `@openclaw/fs-safe/advanced` | lower-level composition helpers such as path scopes, root-file open, bounded descriptor reads, install paths, filename sanitizing, temp-file targets, sibling-temp writes, local-root readers, regular-file helpers, `pathExists`, and `withTimeout`; less stable than focused public subpaths |
 | `@openclaw/fs-safe/errors` | `FsSafeError`, `FsSafeErrorCode` |
 | `@openclaw/fs-safe/types` | shared types: `DirEntry`, `PathStat`, … |
 | `@openclaw/fs-safe/test-hooks` | hooks the test suite uses to inject races; only active under `NODE_ENV=test` |

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -55,12 +55,32 @@ Operational filesystem failures such as permissions or I/O errors are rethrown.
 
 | Export | Page | Notes |
 |---|---|---|
+| `readFileDescriptorBounded`, `readFileDescriptorBoundedSync`, `readFileHandleBounded` | – | Incremental whole-file reads for already-open descriptors/handles. They consume at most `maxBytes + 1`, do not close the input, and throw `FsSafeError("too-large")` on overflow. |
 | `openRootFile`, `openRootFileSync`, `canUseRootFileOpen`, `matchRootFileOpenFailure`, related types | – | Low-level no-follow open routed through the root-file path. |
 | `appendRegularFile`, `appendRegularFileSync`, `readRegularFile`, `readRegularFileSync`, `statRegularFile`, `statRegularFileSync`, `resolveRegularFileAppendFlags`, `AppendRegularFileOptions`, `RegularFileStatResult` | [regular-file.md](regular-file.md) | Type-checked regular-file I/O. |
 | `sameFileIdentity`, `FileIdentityStat` | – | Compare two stats for same-inode equality. |
 | `pathExists`, `pathExistsSync` | – | Boolean existence check that does not throw on `ENOENT`. |
 | `assertNoSymlinkParents`, `assertNoSymlinkParentsSync`, `AssertNoSymlinkParentsOptions` | – | Reject paths whose ancestor chain contains symlinks. |
 | `assertNoHardlinkedFinalPath`, `assertNoPathAliasEscape`, `PATH_ALIAS_POLICIES`, `PathAliasPolicy` | – | Hardlink/alias defense building blocks. |
+
+The bounded descriptor helpers start at the descriptor's current offset and
+leave ownership with the caller. They are intended for the second half of a
+safe read: first open and validate the path using the boundary appropriate to
+your application, then read the already-pinned descriptor without trusting a
+possibly stale size check.
+
+```ts
+import fs from "node:fs";
+import { readFileDescriptorBoundedSync } from "@openclaw/fs-safe/advanced";
+
+const fd = fs.openSync(filePath, "r");
+try {
+  const bytes = readFileDescriptorBoundedSync(fd, 256 * 1024);
+  consume(bytes);
+} finally {
+  fs.closeSync(fd);
+}
+```
 
 ### Local roots and file URLs
 

--- a/docs/json.md
+++ b/docs/json.md
@@ -40,15 +40,22 @@ Use `readJson` when missing-or-malformed is a programmer error you want to surfa
 
 ## Reading
 
-### `readJson<T>(filePath)`
+### `readJson<T>(filePath, options?)`
 
 Async strict reader. Throws `JsonFileReadError` on missing or invalid input. The cast is unchecked — validate the shape with your own schema (zod, valibot, …) if it came from an untrusted source.
 
 ```ts
 const manifest = await readJson<Manifest>("./manifest.json");
+const smallManifest = await readJson<Manifest>("./manifest.json", {
+  maxBytes: 256 * 1024,
+});
 ```
 
-### `readJsonIfExists<T>(filePath)`
+All standalone readers accept `{ maxBytes?: number }`. When set, the read is
+incremental and consumes no more than `maxBytes + 1` bytes before rejecting, so
+file growth after the initial stat cannot cause an unbounded allocation.
+
+### `readJsonIfExists<T>(filePath, options?)`
 
 Async semi-lenient reader. Returns `null` if the file is missing; throws `JsonFileReadError` if the file exists but cannot be parsed.
 
@@ -56,7 +63,7 @@ Async semi-lenient reader. Returns `null` if the file is missing; throws `JsonFi
 const cache = (await readJsonIfExists<Cache>("./cache.json")) ?? freshCache();
 ```
 
-### `tryReadJson<T>(filePath)`
+### `tryReadJson<T>(filePath, options?)`
 
 Async lenient reader. Returns `null` for any failure (missing, unreadable, invalid). The "no fuss" sibling.
 
@@ -64,11 +71,11 @@ Async lenient reader. Returns `null` for any failure (missing, unreadable, inval
 const optional = (await tryReadJson<Settings>("./settings.json")) ?? defaults;
 ```
 
-### `readJsonSync<T>(filePath)`
+### `readJsonSync<T>(filePath, options?)`
 
 Synchronous strict reader. Throws `JsonFileReadError` on missing or invalid input, matching the async `readJson` contract.
 
-### `tryReadJsonSync<T>(pathname)`
+### `tryReadJsonSync<T>(pathname, options?)`
 
 Synchronous, generic, lenient. Returns `T | null`. Useful in boot paths where you want a typed result without async.
 
@@ -83,6 +90,7 @@ const result = readRootJsonObjectSync({
   rootDir: "/safe/workspace",
   relativePath: "plugin/openclaw.plugin.json",
   boundaryLabel: "plugin manifest",
+  maxBytes: 256 * 1024,
 });
 
 if (!result.ok) {

--- a/docs/regular-file.md
+++ b/docs/regular-file.md
@@ -32,14 +32,14 @@ type RegularFileStatResult =
   | { missing: false; stat: Stats };
 ```
 
-A non-regular file (directory, FIFO, …) returns `{ missing: false }` with a `stat` whose `isFile()` is false — the helper does not throw, you decide what to do.
+A non-regular file (directory, FIFO, symlink, …) throws. Missing paths return
+`{ missing: true }`; existing regular files return `{ missing: false, stat }`.
 
 ```ts
 import { statRegularFile } from "@openclaw/fs-safe/advanced";
 
 const r = await statRegularFile("/var/log/app.log");
 if (r.missing) return;
-if (!r.stat.isFile()) throw new Error("expected a regular file");
 console.log(`size=${r.stat.size}`);
 ```
 
@@ -60,19 +60,11 @@ const result = await readRegularFile({
   filePath: "/var/log/app.log",
   maxBytes: 4 * 1024 * 1024,
 });
-if (result.missing) return null;
-if (!result.regular) throw new Error("not a regular file");
 processLog(result.buffer);
 ```
 
-Result shape:
-
-```ts
-type Result =
-  | { missing: true }
-  | { missing: false; regular: false; stat: Stats }
-  | { missing: false; regular: true; stat: Stats; buffer: Buffer };
-```
+The result is `{ buffer, stat }`. Missing files preserve the normal `ENOENT`
+shape; non-regular targets throw.
 
 Throws `FsSafeError` with code `too-large` if the file exceeds `maxBytes`. Other I/O errors propagate as `NodeJS.ErrnoException`.
 
@@ -91,9 +83,8 @@ import { appendRegularFile } from "@openclaw/fs-safe/advanced";
 
 await appendRegularFile({
   filePath: "/var/log/app.log",
-  data: `[${new Date().toISOString()}] ${line}\n`,
+  content: `[${new Date().toISOString()}] ${line}\n`,
   encoding: "utf8",
-  prependNewlineIfNeeded: true,
 });
 ```
 
@@ -102,28 +93,30 @@ await appendRegularFile({
 ```ts
 type AppendRegularFileOptions = {
   filePath: string;
-  data: string | Buffer;
-  encoding?: BufferEncoding;             // default utf8 when data is string
-  prependNewlineIfNeeded?: boolean;      // insert "\n" if file does not end with one
-  flags?: number;                         // raw open flags; default O_WRONLY | O_APPEND
-  mode?: number;                          // default 0o644 if file is created
+  content: string | Uint8Array;
+  encoding?: BufferEncoding; // default utf8 when content is string
+  maxFileBytes?: number;     // skip if the resulting file would exceed this
+  mode?: number;             // default 0o600
+  rejectSymlinkParents?: boolean;
 };
 ```
 
-`prependNewlineIfNeeded` reads the trailing byte of the existing file and prepends a `\n` to your data if it isn't already present. Useful for log appenders that want to preserve line boundaries even when callers forget the newline.
+The helper refuses symlink and hardlinked final targets. With
+`rejectSymlinkParents: true`, it also rejects symlinked ancestor directories.
 
 ### `appendRegularFileSync(options)`
 
 Synchronous. Same options.
 
-### `resolveRegularFileAppendFlags(append, truncateExisting)`
+### `resolveRegularFileAppendFlags()`
 
-Helper that returns the right open-flag bitmask for combinations of "append" / "truncate". Use it when you're building your own open path and want to match the append helpers' behavior:
+Helper that returns the append helpers' `O_WRONLY | O_APPEND | O_CREAT` flags,
+plus `O_NOFOLLOW` where the platform provides it:
 
 ```ts
 import { resolveRegularFileAppendFlags } from "@openclaw/fs-safe/advanced";
 
-const flags = resolveRegularFileAppendFlags(true, false); // O_WRONLY | O_APPEND | O_CREAT
+const flags = resolveRegularFileAppendFlags();
 ```
 
 ## Difference from `Root` methods
@@ -131,9 +124,9 @@ const flags = resolveRegularFileAppendFlags(true, false); // O_WRONLY | O_APPEND
 | `regular-file` | `Root` |
 |---|---|
 | Absolute paths only. | Relative to the root. |
-| No identity check post-open. | Identity check on every read/write. |
+| Verifies path and descriptor identity around reads. | Enforces the same checks within a trusted root. |
 | Caller must be confident the path is trusted. | Boundary check is automatic. |
-| Returns explicit `{missing, regular}` shape. | Throws `FsSafeError` with `code`. |
+| Stat reports missing explicitly; reads throw on missing/non-file. | Throws `FsSafeError` with `code`. |
 
 If your call site already trusts the path (it came from your own config, not a caller), `regular-file` is a thinner, faster surface. If the path is caller-influenced, prefer `root()` or wrap in [`pathScope()`](path-scope.md).
 
@@ -142,13 +135,15 @@ If your call site already trusts the path (it came from your own config, not a c
 ### Read a config file if it's there, else seed
 
 ```ts
-const r = await readRegularFile({ filePath: "/etc/app/config.json", maxBytes: 64 * 1024 });
-if (r.missing) {
+const info = await statRegularFile("/etc/app/config.json");
+if (info.missing) {
   await writeJson("/etc/app/config.json", defaultConfig);
-} else if (r.regular) {
-  applyConfig(JSON.parse(r.buffer.toString("utf8")));
 } else {
-  throw new Error("/etc/app/config.json is not a regular file");
+  const r = await readRegularFile({
+    filePath: "/etc/app/config.json",
+    maxBytes: 64 * 1024,
+  });
+  applyConfig(JSON.parse(r.buffer.toString("utf8")));
 }
 ```
 
@@ -156,7 +151,7 @@ if (r.missing) {
 
 ```ts
 const r = await statRegularFile(p);
-if (r.missing || !r.stat.isFile()) return false;
+if (r.missing) return false;
 return true;
 ```
 
@@ -164,7 +159,6 @@ return true;
 
 ```ts
 const r = await readRegularFile({ filePath: logPath, maxBytes: 1 * 1024 * 1024 });
-if (r.missing || !r.regular) return [];
 return r.buffer.toString("utf8").split("\n").slice(-100);
 ```
 

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -3,6 +3,11 @@
 // higher-level primitive.
 export { createAsyncLock } from "./async-lock.js";
 export {
+  readFileDescriptorBounded,
+  readFileDescriptorBoundedSync,
+  readFileHandleBounded,
+} from "./bounded-read.js";
+export {
   assertNoUnsafeDeviceReadPath,
   isUnsafeDeviceReadPath,
   matchUnsafeDeviceReadPath,

--- a/src/bounded-read.ts
+++ b/src/bounded-read.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import { FsSafeError } from "./errors.js";
+
+const READ_CHUNK_BYTES = 64 * 1024;
+
+type ReadableFileHandle = Pick<FileHandle, "read">;
+
+function assertMaxBytes(maxBytes: number): void {
+  if (maxBytes === Number.POSITIVE_INFINITY) {
+    return;
+  }
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new RangeError("maxBytes must be a non-negative safe integer or Infinity");
+  }
+}
+
+function createScratchBuffer(maxBytes: number): Buffer {
+  const initialReadBytes = Number.isFinite(maxBytes)
+    ? Math.min(READ_CHUNK_BYTES, maxBytes + 1)
+    : READ_CHUNK_BYTES;
+  return Buffer.allocUnsafe(Math.max(1, initialReadBytes));
+}
+
+function nextReadLength(total: number, maxBytes: number, capacity: number): number {
+  return Number.isFinite(maxBytes)
+    ? Math.min(capacity, maxBytes - total + 1)
+    : capacity;
+}
+
+function appendChunk(params: {
+  chunks: Buffer[];
+  scratch: Buffer;
+  bytesRead: number;
+  total: number;
+  maxBytes: number;
+}): number {
+  const total = params.total + params.bytesRead;
+  if (total > params.maxBytes) {
+    throw new FsSafeError(
+      "too-large",
+      `file exceeds limit of ${params.maxBytes} bytes (got at least ${total})`,
+    );
+  }
+  params.chunks.push(Buffer.from(params.scratch.subarray(0, params.bytesRead)));
+  return total;
+}
+
+async function readBoundedAsync(
+  maxBytes: number,
+  readChunk: (scratch: Buffer, length: number) => Promise<number>,
+): Promise<Buffer> {
+  assertMaxBytes(maxBytes);
+  const chunks: Buffer[] = [];
+  const scratch = createScratchBuffer(maxBytes);
+  let total = 0;
+  while (true) {
+    const length = nextReadLength(total, maxBytes, scratch.length);
+    const bytesRead = await readChunk(scratch, length);
+    if (bytesRead === 0) {
+      return Buffer.concat(chunks, total);
+    }
+    total = appendChunk({ chunks, scratch, bytesRead, total, maxBytes });
+  }
+}
+
+/**
+ * Reads from the handle's current offset without closing it. A bounded read
+ * consumes at most maxBytes + 1 bytes so growth after an earlier stat cannot
+ * force an unbounded allocation.
+ */
+export async function readFileHandleBounded(
+  handle: ReadableFileHandle,
+  maxBytes: number,
+): Promise<Buffer> {
+  return await readBoundedAsync(maxBytes, async (scratch, length) => {
+    return (await handle.read(scratch, 0, length, null)).bytesRead;
+  });
+}
+
+function readDescriptorChunk(fd: number, scratch: Buffer, length: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    fs.read(fd, scratch, 0, length, null, (error, bytesRead) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(bytesRead);
+    });
+  });
+}
+
+/** Async bounded read from a numeric descriptor. The caller owns the descriptor. */
+export async function readFileDescriptorBounded(fd: number, maxBytes: number): Promise<Buffer> {
+  return await readBoundedAsync(maxBytes, async (scratch, length) => {
+    return await readDescriptorChunk(fd, scratch, length);
+  });
+}
+
+/** Sync bounded read from a numeric descriptor. The caller owns the descriptor. */
+export function readFileDescriptorBoundedSync(fd: number, maxBytes: number): Buffer {
+  assertMaxBytes(maxBytes);
+  const chunks: Buffer[] = [];
+  const scratch = createScratchBuffer(maxBytes);
+  let total = 0;
+  while (true) {
+    const length = nextReadLength(total, maxBytes, scratch.length);
+    const bytesRead = fs.readSync(fd, scratch, 0, length, null);
+    if (bytesRead === 0) {
+      return Buffer.concat(chunks, total);
+    }
+    total = appendChunk({ chunks, scratch, bytesRead, total, maxBytes });
+  }
+}

--- a/src/file-store.ts
+++ b/src/file-store.ts
@@ -3,6 +3,7 @@ import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { Readable } from "node:stream";
+import { readFileDescriptorBoundedSync } from "./bounded-read.js";
 import { createSyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import {
@@ -554,8 +555,11 @@ export function fileStoreSync(options: FileStoreOptions): FileStoreSync {
       }
       try {
         assertMaxBytes(opened.stat.size, readOptions?.maxBytes ?? maxBytes);
-        const raw = syncFs.readFileSync(opened.fd, "utf8");
-        assertMaxBytes(Buffer.byteLength(raw, "utf8"), readOptions?.maxBytes ?? maxBytes);
+        const limit = readOptions?.maxBytes ?? maxBytes;
+        const raw =
+          limit === undefined
+            ? syncFs.readFileSync(opened.fd, "utf8")
+            : readFileDescriptorBoundedSync(opened.fd, limit).toString("utf8");
         return raw;
       } finally {
         syncFs.closeSync(opened.fd);

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import path from "node:path";
+import { readFileDescriptorBoundedSync } from "./bounded-read.js";
 import { FsSafeError } from "./errors.js";
 import { stringifyJsonDocument } from "./json-stringify.js";
 import { readRegularFile, readRegularFileSync, statRegularFile } from "./regular-file.js";
@@ -30,12 +31,12 @@ function sleep(ms: number): Promise<void> {
 
 async function readRegularFileWithRetry(
   filePath: string,
-  options: { retryOpenRaceErrors?: boolean } = {},
+  options: { maxBytes?: number; retryOpenRaceErrors?: boolean } = {},
 ): Promise<Buffer> {
   let lastErr: unknown;
   for (let attempt = 0; attempt < READ_RETRY_MAX_ATTEMPTS; attempt++) {
     try {
-      return (await readRegularFile({ filePath })).buffer;
+      return (await readRegularFile({ filePath, maxBytes: options.maxBytes })).buffer;
     } catch (err) {
       lastErr = err;
       if (!isRetryableReadError(err, options) || attempt === READ_RETRY_MAX_ATTEMPTS - 1) {
@@ -47,12 +48,18 @@ async function readRegularFileWithRetry(
   throw lastErr;
 }
 
-async function readRegularFileIfExistsWithRetry(filePath: string): Promise<Buffer | null> {
+async function readRegularFileIfExistsWithRetry(
+  filePath: string,
+  options: ReadJsonOptions = {},
+): Promise<Buffer | null> {
   const initial = await statRegularFile(filePath);
   if (initial.missing) {
     return null;
   }
-  return await readRegularFileWithRetry(filePath, { retryOpenRaceErrors: true });
+  return await readRegularFileWithRetry(filePath, {
+    maxBytes: options.maxBytes,
+    retryOpenRaceErrors: true,
+  });
 }
 
 const JSON_FILE_MODE = 0o600;
@@ -143,9 +150,19 @@ function writeTempJsonFile(pathname: string, payload: string) {
   }
 }
 
-export function tryReadJsonSync<T = unknown>(pathname: string): T | null {
+export type ReadJsonOptions = {
+  maxBytes?: number;
+};
+
+export function tryReadJsonSync<T = unknown>(
+  pathname: string,
+  options: ReadJsonOptions = {},
+): T | null {
   try {
-    const raw = readRegularFileSync({ filePath: pathname }).buffer.toString("utf8");
+    const raw = readRegularFileSync({
+      filePath: pathname,
+      maxBytes: options.maxBytes,
+    }).buffer.toString("utf8");
     return JSON.parse(raw) as T;
   } catch {
     return null;
@@ -239,7 +256,11 @@ export function readRootStructuredFileSync<T>(
   }
 
   try {
-    const parsed = options.parse(fsSync.readFileSync(opened.fd, "utf8"));
+    const raw =
+      options.maxBytes === undefined
+        ? fsSync.readFileSync(opened.fd, "utf8")
+        : readFileDescriptorBoundedSync(opened.fd, options.maxBytes).toString("utf8");
+    const parsed = options.parse(raw);
     if (options.validate && !options.validate(parsed)) {
       return {
         ok: false,
@@ -285,9 +306,12 @@ export function readRootJsonObjectSync(
   });
 }
 
-export async function tryReadJson<T>(filePath: string): Promise<T | null> {
+export async function tryReadJson<T>(
+  filePath: string,
+  options: ReadJsonOptions = {},
+): Promise<T | null> {
   try {
-    const buffer = await readRegularFileIfExistsWithRetry(filePath);
+    const buffer = await readRegularFileIfExistsWithRetry(filePath, options);
     if (buffer === null) {
       return null;
     }
@@ -298,12 +322,15 @@ export async function tryReadJson<T>(filePath: string): Promise<T | null> {
   }
 }
 
-export async function readJson<T>(filePath: string): Promise<T> {
+export async function readJson<T>(filePath: string, options: ReadJsonOptions = {}): Promise<T> {
   let raw: string;
   try {
-    raw = (await readRegularFileWithRetry(filePath, { retryOpenRaceErrors: true })).toString(
-      "utf8",
-    );
+    raw = (
+      await readRegularFileWithRetry(filePath, {
+        maxBytes: options.maxBytes,
+        retryOpenRaceErrors: true,
+      })
+    ).toString("utf8");
   } catch (err) {
     throw new JsonFileReadError(filePath, "read", err);
   }
@@ -314,10 +341,13 @@ export async function readJson<T>(filePath: string): Promise<T> {
   }
 }
 
-export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
+export async function readJsonIfExists<T>(
+  filePath: string,
+  options: ReadJsonOptions = {},
+): Promise<T | null> {
   let raw: string;
   try {
-    const buffer = await readRegularFileIfExistsWithRetry(filePath);
+    const buffer = await readRegularFileIfExistsWithRetry(filePath, options);
     if (buffer === null) {
       return null;
     }
@@ -335,10 +365,13 @@ export async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
   }
 }
 
-export function readJsonSync<T = unknown>(filePath: string): T {
+export function readJsonSync<T = unknown>(
+  filePath: string,
+  options: ReadJsonOptions = {},
+): T {
   let raw: string;
   try {
-    raw = readRegularFileSync({ filePath }).buffer.toString("utf8");
+    raw = readRegularFileSync({ filePath, maxBytes: options.maxBytes }).buffer.toString("utf8");
   } catch (err) {
     throw new JsonFileReadError(filePath, "read", err);
   }

--- a/src/pinned-python.ts
+++ b/src/pinned-python.ts
@@ -6,15 +6,11 @@ import { getFsSafePythonConfig } from "./pinned-python-config.js";
 const PINNED_PYTHON_WORKER_SOURCE = String.raw`
 import base64, errno, json, os, secrets, stat, sys
 DIR_FLAGS = os.O_RDONLY
-if hasattr(os, "O_DIRECTORY"):
-    DIR_FLAGS |= os.O_DIRECTORY
-if hasattr(os, "O_NOFOLLOW"):
-    DIR_FLAGS |= os.O_NOFOLLOW
+if hasattr(os, "O_DIRECTORY"): DIR_FLAGS |= os.O_DIRECTORY
+if hasattr(os, "O_NOFOLLOW"): DIR_FLAGS |= os.O_NOFOLLOW
 READ_FLAGS = os.O_RDONLY
-if hasattr(os, "O_NONBLOCK"):
-    READ_FLAGS |= os.O_NONBLOCK
-if hasattr(os, "O_NOFOLLOW"):
-    READ_FLAGS |= os.O_NOFOLLOW
+if hasattr(os, "O_NONBLOCK"): READ_FLAGS |= os.O_NONBLOCK
+if hasattr(os, "O_NOFOLLOW"): READ_FLAGS |= os.O_NOFOLLOW
 WRITE_FLAGS = os.O_WRONLY | os.O_CREAT | os.O_EXCL
 if hasattr(os, "O_NOFOLLOW"):
     WRITE_FLAGS |= os.O_NOFOLLOW
@@ -94,6 +90,10 @@ def write_all(fd, data):
         if written <= 0:
             raise OSError(errno.EIO, "short write")
         view = view[written:]
+def fsync_best_effort(fd):
+    try: os.fsync(fd)
+    except OSError as error:
+        if error.errno != errno.EPERM: raise
 def link_unsupported(exc):
     unsupported = (errno.EPERM, errno.EOPNOTSUPP, getattr(errno, "ENOTSUP", errno.EOPNOTSUPP))
     return getattr(exc, "errno", None) in unsupported
@@ -299,13 +299,13 @@ def write_path(root_fd, payload):
         temp_name, temp_fd = create_temp_file(parent_fd, basename, mode)
         os.fchmod(temp_fd, mode)
         write_all(temp_fd, data)
-        os.fsync(temp_fd)
+        fsync_best_effort(temp_fd)
         temp_stat = os.fstat(temp_fd)
         os.close(temp_fd)
         temp_fd = None
         result_stat = commit_temp_file(parent_fd, temp_name, basename, overwrite, mode, temp_stat)
         temp_name = None
-        os.fsync(parent_fd)
+        fsync_best_effort(parent_fd)
         return {"dev": result_stat.st_dev, "ino": result_stat.st_ino}
     finally:
         if temp_fd is not None:

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -51,6 +51,16 @@ function assertWithinMaxBytes(bytes: number, maxBytes: number | undefined): void
   }
 }
 
+async function syncFileBestEffort(handle: FileHandle): Promise<void> {
+  try {
+    await handle.sync();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== "EPERM") {
+      throw error;
+    }
+  }
+}
+
 async function writeStreamToHandle(
   stream: Readable,
   handle: FileHandle,
@@ -289,7 +299,7 @@ async function runPinnedWriteFallback(params: {
       } else {
         await writeStreamToHandle(params.input.stream, handle, params.maxBytes);
       }
-      await handle.sync();
+      await syncFileBestEffort(handle);
       const stat = await handle.stat();
       await handle.close().catch(() => undefined);
       await syncDirectoryBestEffort(parentPath);
@@ -336,7 +346,7 @@ async function runPinnedWriteFallback(params: {
       throw new FsSafeError("path-mismatch", "fallback temp path changed during write");
     }
     const expectedTempStat = tempStat;
-    await handle.sync();
+    await syncFileBestEffort(handle);
     await handle.close().catch(() => undefined);
     handle = undefined;
     await withAsyncDirectoryGuards([parentGuard], async () => {

--- a/src/read-opened-file.ts
+++ b/src/read-opened-file.ts
@@ -1,5 +1,6 @@
 import type { Stats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
+import { readFileHandleBounded } from "./bounded-read.js";
 import { FsSafeError } from "./errors.js";
 
 export type ReadResult = {
@@ -24,13 +25,10 @@ export async function readOpenedFileSafely(params: {
       `file exceeds limit of ${params.maxBytes} bytes (got ${params.opened.stat.size})`,
     );
   }
-  const buffer = await params.opened.handle.readFile();
-  if (params.maxBytes !== undefined && buffer.byteLength > params.maxBytes) {
-    throw new FsSafeError(
-      "too-large",
-      `file exceeds limit of ${params.maxBytes} bytes (got ${buffer.byteLength})`,
-    );
-  }
+  const buffer =
+    params.maxBytes === undefined
+      ? await params.opened.handle.readFile()
+      : await readFileHandleBounded(params.opened.handle, params.maxBytes);
   return {
     buffer,
     realPath: params.opened.realPath,

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -3,6 +3,7 @@ import fsSync from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { readFileDescriptorBoundedSync, readFileHandleBounded } from "./bounded-read.js";
 import { assertNoUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
@@ -47,54 +48,6 @@ function resolveRegularFileReadFlags(): number {
   );
 }
 
-async function readFileHandleBounded(params: {
-  handle: FileHandle;
-  filePath: string;
-  maxBytes?: number;
-}): Promise<Buffer> {
-  if (params.maxBytes === undefined) {
-    return await params.handle.readFile();
-  }
-  const chunks: Buffer[] = [];
-  const scratch = Buffer.allocUnsafe(Math.min(64 * 1024, Math.max(1, params.maxBytes + 1)));
-  let total = 0;
-  while (true) {
-    const { bytesRead } = await params.handle.read(scratch, 0, scratch.length, null);
-    if (bytesRead === 0) {
-      return Buffer.concat(chunks, total);
-    }
-    total += bytesRead;
-    if (total > params.maxBytes) {
-      throw new Error(`File exceeds ${params.maxBytes} bytes: ${params.filePath}`);
-    }
-    chunks.push(Buffer.from(scratch.subarray(0, bytesRead)));
-  }
-}
-
-function readFileDescriptorBounded(params: {
-  fd: number;
-  filePath: string;
-  maxBytes?: number;
-}): Buffer {
-  if (params.maxBytes === undefined) {
-    return fsSync.readFileSync(params.fd);
-  }
-  const chunks: Buffer[] = [];
-  const scratch = Buffer.allocUnsafe(Math.min(64 * 1024, Math.max(1, params.maxBytes + 1)));
-  let total = 0;
-  while (true) {
-    const bytesRead = fsSync.readSync(params.fd, scratch, 0, scratch.length, null);
-    if (bytesRead === 0) {
-      return Buffer.concat(chunks, total);
-    }
-    total += bytesRead;
-    if (total > params.maxBytes) {
-      throw new Error(`File exceeds ${params.maxBytes} bytes: ${params.filePath}`);
-    }
-    chunks.push(Buffer.from(scratch.subarray(0, bytesRead)));
-  }
-}
-
 export async function statRegularFile(filePath: string): Promise<RegularFileStatResult> {
   let stat: Stats;
   try {
@@ -137,7 +90,10 @@ export async function readRegularFile(params: {
     throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });
   }
   if (params.maxBytes !== undefined && result.stat.size > params.maxBytes) {
-    throw new Error(`File exceeds ${params.maxBytes} bytes: ${params.filePath}`);
+    throw new FsSafeError(
+      "too-large",
+      `file exceeds limit of ${params.maxBytes} bytes (got ${result.stat.size})`,
+    );
   }
 
   let handle: FileHandle;
@@ -167,15 +123,17 @@ export async function readRegularFile(params: {
       preOpenStat: result.stat,
     });
     if (params.maxBytes !== undefined && stat.size > params.maxBytes) {
-      throw new Error(`File exceeds ${params.maxBytes} bytes: ${params.filePath}`);
+      throw new FsSafeError(
+        "too-large",
+        `file exceeds limit of ${params.maxBytes} bytes (got ${stat.size})`,
+      );
     }
     // With a byte cap, avoid readFile(): a raced file growth would allocate
     // the oversized content before the post-read check could reject it.
-    const buffer = await readFileHandleBounded({
-      handle,
-      filePath: params.filePath,
-      maxBytes: params.maxBytes,
-    });
+    const buffer =
+      params.maxBytes === undefined
+        ? await handle.readFile()
+        : await readFileHandleBounded(handle, params.maxBytes);
     return { buffer, stat };
   } finally {
     await handle.close();
@@ -213,15 +171,17 @@ function readOpenedRegularFileSync(params: {
     preOpenStat: params.preOpenStat,
   });
   if (params.maxBytes !== undefined && stat.size > params.maxBytes) {
-    throw new Error(`File exceeds ${params.maxBytes} bytes: ${params.filePath}`);
+    throw new FsSafeError(
+      "too-large",
+      `file exceeds limit of ${params.maxBytes} bytes (got ${stat.size})`,
+    );
   }
   // Keep capped sync reads incremental for the same reason as async reads:
   // readFileSync(fd) would buffer a raced oversized file before throwing.
-  const buffer = readFileDescriptorBounded({
-    fd: params.fd,
-    filePath: params.filePath,
-    maxBytes: params.maxBytes,
-  });
+  const buffer =
+    params.maxBytes === undefined
+      ? fsSync.readFileSync(params.fd)
+      : readFileDescriptorBoundedSync(params.fd, params.maxBytes);
   return { buffer, stat };
 }
 
@@ -235,7 +195,10 @@ export function readRegularFileSync(params: { filePath: string; maxBytes?: numbe
     throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });
   }
   if (params.maxBytes !== undefined && result.stat.size > params.maxBytes) {
-    throw new Error(`File exceeds ${params.maxBytes} bytes: ${params.filePath}`);
+    throw new FsSafeError(
+      "too-large",
+      `file exceeds limit of ${params.maxBytes} bytes (got ${result.stat.size})`,
+    );
   }
 
   const fd = fsSync.openSync(params.filePath, resolveRegularFileReadFlags());

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { readFileDescriptorBoundedSync } from "./bounded-read.js";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard, type AsyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError, type FsSafeErrorCode } from "./errors.js";
 import { sameFileIdentity, type FileIdentityStat } from "./file-identity.js";
@@ -123,7 +124,7 @@ function readSecretFileOutcomeSync(
   }
 
   try {
-    const raw = fs.readFileSync(opened.fd, "utf8");
+    const raw = readFileDescriptorBoundedSync(opened.fd, maxBytes).toString("utf8");
     const secret = raw.trim();
     if (!secret) {
       return {
@@ -137,7 +138,10 @@ function readSecretFileOutcomeSync(
     const normalized = normalizeSecretReadError(error);
     return {
       ok: false,
-      code: "invalid-path",
+      code:
+        error instanceof FsSafeError && error.code === "too-large"
+          ? "too-large"
+          : "invalid-path",
       error: normalized,
       message: `Failed to read ${label} file at ${resolvedPath}: ${String(normalized)}`,
     };

--- a/src/secure-file.ts
+++ b/src/secure-file.ts
@@ -4,6 +4,7 @@ import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import { readFileHandleBounded } from "./bounded-read.js";
 import { assertNoUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
@@ -202,14 +203,17 @@ async function assertSecurePermissions(
 async function readHandleWithTimeout(
   handle: FileHandle,
   timeoutMs: number | undefined,
+  maxBytes: number | undefined,
 ): Promise<Buffer> {
+  const read = () =>
+    maxBytes === undefined ? handle.readFile() : readFileHandleBounded(handle, maxBytes);
   if (timeoutMs === undefined || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return await handle.readFile();
+    return await read();
   }
   let timeout: NodeJS.Timeout | undefined;
   try {
     return await Promise.race([
-      handle.readFile(),
+      read(),
       new Promise<never>((_resolve, reject) => {
         timeout = setTimeout(() => {
           void handle.close().catch(() => undefined);
@@ -229,10 +233,11 @@ export async function readSecureFile(
   try {
     await assertTrustedDirs(options, opened.realPath);
     const permissions = await assertSecurePermissions(options, opened.pathStat, opened.realPath);
-    const buffer = await readHandleWithTimeout(opened.handle, options.io?.timeoutMs);
-    if (options.io?.maxBytes !== undefined && buffer.byteLength > options.io.maxBytes) {
-      throw new FsSafeError("too-large", `${label(options)} exceeded maxBytes (${options.io.maxBytes}).`);
-    }
+    const buffer = await readHandleWithTimeout(
+      opened.handle,
+      options.io?.timeoutMs,
+      options.io?.maxBytes,
+    );
     return { buffer, realPath: opened.realPath, stat: opened.pathStat, permissions };
   } finally {
     await opened.handle.close().catch(() => undefined);

--- a/test/bounded-read.test.ts
+++ b/test/bounded-read.test.ts
@@ -1,0 +1,170 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import * as advanced from "../src/advanced.js";
+import {
+  readFileDescriptorBounded,
+  readFileDescriptorBoundedSync,
+  readFileHandleBounded,
+} from "../src/bounded-read.js";
+import { FsSafeError } from "../src/errors.js";
+import { readJson, readJsonSync } from "../src/json.js";
+import { root } from "../src/root.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+
+const tempDirs = new Set<string>();
+
+async function tempFile(content: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-bounded-read-"));
+  tempDirs.add(dir);
+  const filePath = path.join(dir, "input.txt");
+  await fs.writeFile(filePath, content);
+  return filePath;
+}
+
+afterEach(async () => {
+  __setFsSafeTestHooksForTest(undefined);
+  await Promise.all(
+    [...tempDirs].map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+  tempDirs.clear();
+});
+
+describe("bounded descriptor reads", () => {
+  it("exports the descriptor and handle primitives from the advanced surface", () => {
+    expect(advanced.readFileDescriptorBounded).toBe(readFileDescriptorBounded);
+    expect(advanced.readFileDescriptorBoundedSync).toBe(readFileDescriptorBoundedSync);
+    expect(advanced.readFileHandleBounded).toBe(readFileHandleBounded);
+  });
+
+  it("reads an exact-size file and leaves a sync descriptor open", async () => {
+    const filePath = await tempFile("abcd");
+    const fd = fsSync.openSync(filePath, "r");
+    try {
+      expect(readFileDescriptorBoundedSync(fd, 4).toString("utf8")).toBe("abcd");
+      expect(fsSync.fstatSync(fd).isFile()).toBe(true);
+    } finally {
+      fsSync.closeSync(fd);
+    }
+  });
+
+  it("consumes only maxBytes + 1 before rejecting a sync descriptor", async () => {
+    const filePath = await tempFile("abcdef");
+    const fd = fsSync.openSync(filePath, "r");
+    try {
+      expect(() => readFileDescriptorBoundedSync(fd, 2)).toThrowError(
+        expect.objectContaining({ code: "too-large" }),
+      );
+      const next = Buffer.alloc(1);
+      expect(fsSync.readSync(fd, next, 0, 1, null)).toBe(1);
+      expect(next.toString("utf8")).toBe("d");
+    } finally {
+      fsSync.closeSync(fd);
+    }
+  });
+
+  it("reads numeric descriptors asynchronously without taking ownership", async () => {
+    const filePath = await tempFile("abcd");
+    const fd = fsSync.openSync(filePath, "r");
+    try {
+      await expect(readFileDescriptorBounded(fd, 4)).resolves.toEqual(Buffer.from("abcd"));
+      expect(fsSync.fstatSync(fd).isFile()).toBe(true);
+    } finally {
+      fsSync.closeSync(fd);
+    }
+  });
+
+  it("rejects handle growth beyond the stat-time budget without buffering the file", async () => {
+    const filePath = await tempFile("abcd");
+    const handle = await fs.open(filePath, "r");
+    try {
+      expect((await handle.stat()).size).toBe(4);
+      await fs.appendFile(filePath, "efghijkl");
+      await expect(readFileHandleBounded(handle, 4)).rejects.toMatchObject({
+        constructor: FsSafeError,
+        code: "too-large",
+      });
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it("keeps Root reads bounded when a file grows after the verified open", async () => {
+    const filePath = await tempFile("abcd");
+    const scoped = await root(path.dirname(filePath), { maxBytes: 4 });
+    __setFsSafeTestHooksForTest({
+      afterOpen(_openedPath, handle) {
+        const originalRead = handle.read.bind(handle);
+        let grown = false;
+        Object.defineProperty(handle, "read", {
+          configurable: true,
+          value: async (
+            buffer: Buffer,
+            offset: number,
+            length: number,
+            position: number | null,
+          ) => {
+            if (!grown) {
+              grown = true;
+              fsSync.appendFileSync(filePath, "efghijkl");
+            }
+            return await originalRead(buffer, offset, length, position);
+          },
+        });
+      },
+    });
+
+    await expect(scoped.read("input.txt")).rejects.toMatchObject({ code: "too-large" });
+  });
+
+  it("applies maxBytes to standalone async and sync JSON readers", async () => {
+    const filePath = await tempFile(JSON.stringify({ value: "large" }));
+    const asyncError = await readJson(filePath, { maxBytes: 4 }).catch((error) => error);
+    expect(asyncError).toMatchObject({ reason: "read" });
+    expect((asyncError as Error).cause).toMatchObject({ code: "too-large" });
+
+    let syncError: unknown;
+    try {
+      readJsonSync(filePath, { maxBytes: 4 });
+    } catch (error) {
+      syncError = error;
+    }
+    expect(syncError).toMatchObject({ reason: "read" });
+    expect((syncError as Error).cause).toMatchObject({ code: "too-large" });
+  });
+
+  it("supports zero-byte and explicitly unbounded reads", async () => {
+    const emptyPath = await tempFile("");
+    const empty = await fs.open(emptyPath, "r");
+    try {
+      await expect(readFileHandleBounded(empty, 0)).resolves.toEqual(Buffer.alloc(0));
+    } finally {
+      await empty.close();
+    }
+
+    const contentPath = await tempFile("content");
+    const content = await fs.open(contentPath, "r");
+    try {
+      await expect(readFileHandleBounded(content, Number.POSITIVE_INFINITY)).resolves.toEqual(
+        Buffer.from("content"),
+      );
+    } finally {
+      await content.close();
+    }
+  });
+
+  it.each([-1, 1.5, Number.NaN, Number.NEGATIVE_INFINITY])(
+    "rejects invalid maxBytes value %s",
+    async (maxBytes) => {
+      const filePath = await tempFile("x");
+      const fd = fsSync.openSync(filePath, "r");
+      try {
+        expect(() => readFileDescriptorBoundedSync(fd, maxBytes)).toThrow(RangeError);
+      } finally {
+        fsSync.closeSync(fd);
+      }
+    },
+  );
+});

--- a/test/pinned-write-fallback-coverage.test.ts
+++ b/test/pinned-write-fallback-coverage.test.ts
@@ -32,6 +32,7 @@ async function tempRoot(prefix: string): Promise<string> {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   if (originalPlatform) {
     Object.defineProperty(process, "platform", originalPlatform);
   }

--- a/test/pinned-write-fsync.test.ts
+++ b/test/pinned-write-fsync.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafePython, root as openRoot } from "../src/index.js";
+import { __resetPinnedPythonWorkerForTest } from "../src/pinned-python.js";
+import { runPinnedWriteHelper } from "../src/pinned-write.js";
+
+const tempDirs = new Set<string>();
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.add(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  configureFsSafePython({ mode: "auto", pythonPath: undefined });
+  __resetPinnedPythonWorkerForTest();
+  await Promise.all([...tempDirs].map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  tempDirs.clear();
+});
+
+describe("pinned write fsync compatibility", () => {
+  it.runIf(process.platform !== "win32")(
+    "treats EPERM from fallback file sync as best effort",
+    async () => {
+      configureFsSafePython({ mode: "off" });
+      const root = await tempRoot("fs-safe-pinned-write-fsync-eperm-");
+      const realOpen = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const handle = await realOpen(...args);
+        vi.spyOn(handle, "sync").mockRejectedValueOnce(
+          Object.assign(new Error("operation not permitted"), { code: "EPERM" }),
+        );
+        return handle;
+      });
+
+      await expect(
+        runPinnedWriteHelper({
+          rootPath: root,
+          relativeParentPath: "",
+          basename: "created.txt",
+          mkdir: true,
+          mode: 0o600,
+          overwrite: true,
+          input: { kind: "buffer", data: "created", encoding: "utf8" },
+        }),
+      ).resolves.toMatchObject({ dev: expect.any(Number), ino: expect.any(Number) });
+      await expect(fs.readFile(path.join(root, "created.txt"), "utf8")).resolves.toBe("created");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "treats EPERM from Python helper file sync as best effort",
+    async () => {
+      const rootDir = await tempRoot("fs-safe-python-fsync-eperm-");
+      const wrapperPath = path.join(rootDir, "python-wrapper.mjs");
+      await fs.writeFile(
+        wrapperPath,
+        `#!/usr/bin/env node
+import { spawn } from "node:child_process";
+
+const args = process.argv.slice(2);
+const sourceIndex = args.indexOf("-c") + 1;
+if (sourceIndex <= 0 || sourceIndex >= args.length) process.exit(64);
+const source = args[sourceIndex];
+args[sourceIndex] = source.replace(
+  "    try: os.fsync(fd)",
+  "    try: raise OSError(errno.EPERM, 'test fsync permission failure')",
+);
+if (args[sourceIndex] === source) process.exit(65);
+const child = spawn("python3", args, { stdio: "inherit" });
+child.on("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exit(code ?? 1);
+});
+`,
+        { mode: 0o700 },
+      );
+      await fs.chmod(wrapperPath, 0o700);
+      configureFsSafePython({ mode: "require", pythonPath: wrapperPath });
+      const scoped = await openRoot(rootDir);
+
+      await expect(scoped.write("created.txt", "payload")).resolves.toBeUndefined();
+      await expect(fs.readFile(path.join(rootDir, "created.txt"), "utf8")).resolves.toBe(
+        "payload",
+      );
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where callers that capped whole-file reads could still allocate an oversized file when it grew after the initial stat but before the read completed. OpenClaw also had to maintain its own async and sync descriptor loops for already-pinned files because fs-safe did not expose that primitive.

OpenClaw additionally carries a downstream patch for filesystems that complete pinned writes but reject explicit `fsync` with `EPERM`. This PR absorbs that compatibility behavior into fs-safe source so the downstream patch can be deleted with the dependency update.

Related: openclaw/openclaw#110594
Related: openclaw/openclaw#110591
Related: openclaw/openclaw#110592
Related: openclaw/openclaw#110516

## Why This Change Was Made

This adds three advanced helpers for bounded reads from an already-open `FileHandle` or numeric descriptor. They read incrementally from the current offset, consume at most `maxBytes + 1`, leave descriptor ownership with the caller, and report overflow as `FsSafeError("too-large")`.

The same primitive now backs fs-safe's capped root, regular-file, secure-file, secret-file, synchronous structured JSON, and synchronous store reads. Standalone JSON readers gain an additive `{ maxBytes }` option. Uncapped call sites keep their existing whole-file behavior.

Pinned-write file and directory synchronization now treats only `EPERM` as best effort in both the Node fallback and Python helper. Other synchronization errors still propagate.

## User Impact

Consumers can compose path validation/opening with a reusable allocation-bounded read instead of reimplementing descriptor loops. Existing capped fs-safe reads now enforce the cap during allocation even if the file grows after validation.

The advanced helpers do not open, validate, seek, or close descriptors; those responsibilities remain explicit at the call site.

Pinned writes continue to succeed on filesystems that permit writes but reject explicit synchronization with `EPERM`, without weakening handling for other failures.

## Evidence

- `pnpm test test/bounded-read.test.ts` — 12/12 passed, including exact-limit, `maxBytes + 1`, descriptor ownership/current-offset, stat-to-read growth, Root integration, JSON options, zero-byte, Infinity, and invalid-limit cases.
- Focused bounded-read affected suites — 80/80 passed across root, JSON, secret-file, root-file, API coverage, and sync file-store validation.
- `pnpm test test/pinned-write-fsync.test.ts` — 2/2 passed, exercising injected `EPERM` in both the Node fallback and real pinned Python helper.
- `pnpm check` — build and both repository lints passed; 40 test files passed with 435 tests passing and 3 platform skips.
- `pnpm docs:site` and `git diff --check` passed.
- Fresh Codex autoreview reported no accepted/actionable findings (correctness confidence 0.94).
