### PR TITLE
fix: restore regular-file overflow compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.4.3 - Unreleased
 
+### Compatibility
+
+- Restore the pre-0.4.2 `readRegularFile` and `readRegularFileSync` overflow error message while retaining allocation-bounded reads and the structured `too-large` error on the new low-level bounded-read primitives.
+
 ## 0.4.2 - 2026-07-18
 
 ### Features

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -48,6 +48,17 @@ function resolveRegularFileReadFlags(): number {
   );
 }
 
+function regularFileTooLargeError(filePath: string, maxBytes: number, cause?: unknown): FsSafeError {
+  return new FsSafeError("too-large", `File exceeds ${maxBytes} bytes: ${filePath}`, { cause });
+}
+
+function translateBoundedReadOverflow(error: unknown, filePath: string, maxBytes: number): never {
+  if (error instanceof FsSafeError && error.code === "too-large") {
+    throw regularFileTooLargeError(filePath, maxBytes, error);
+  }
+  throw error;
+}
+
 export async function statRegularFile(filePath: string): Promise<RegularFileStatResult> {
   let stat: Stats;
   try {
@@ -90,10 +101,7 @@ export async function readRegularFile(params: {
     throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });
   }
   if (params.maxBytes !== undefined && result.stat.size > params.maxBytes) {
-    throw new FsSafeError(
-      "too-large",
-      `file exceeds limit of ${params.maxBytes} bytes (got ${result.stat.size})`,
-    );
+    throw regularFileTooLargeError(params.filePath, params.maxBytes);
   }
 
   let handle: FileHandle;
@@ -123,17 +131,22 @@ export async function readRegularFile(params: {
       preOpenStat: result.stat,
     });
     if (params.maxBytes !== undefined && stat.size > params.maxBytes) {
-      throw new FsSafeError(
-        "too-large",
-        `file exceeds limit of ${params.maxBytes} bytes (got ${stat.size})`,
-      );
+      throw regularFileTooLargeError(params.filePath, params.maxBytes);
     }
     // With a byte cap, avoid readFile(): a raced file growth would allocate
     // the oversized content before the post-read check could reject it.
-    const buffer =
-      params.maxBytes === undefined
-        ? await handle.readFile()
-        : await readFileHandleBounded(handle, params.maxBytes);
+    let buffer: Buffer;
+    try {
+      buffer =
+        params.maxBytes === undefined
+          ? await handle.readFile()
+          : await readFileHandleBounded(handle, params.maxBytes);
+    } catch (error) {
+      if (params.maxBytes !== undefined) {
+        translateBoundedReadOverflow(error, params.filePath, params.maxBytes);
+      }
+      throw error;
+    }
     return { buffer, stat };
   } finally {
     await handle.close();
@@ -171,17 +184,22 @@ function readOpenedRegularFileSync(params: {
     preOpenStat: params.preOpenStat,
   });
   if (params.maxBytes !== undefined && stat.size > params.maxBytes) {
-    throw new FsSafeError(
-      "too-large",
-      `file exceeds limit of ${params.maxBytes} bytes (got ${stat.size})`,
-    );
+    throw regularFileTooLargeError(params.filePath, params.maxBytes);
   }
   // Keep capped sync reads incremental for the same reason as async reads:
   // readFileSync(fd) would buffer a raced oversized file before throwing.
-  const buffer =
-    params.maxBytes === undefined
-      ? fsSync.readFileSync(params.fd)
-      : readFileDescriptorBoundedSync(params.fd, params.maxBytes);
+  let buffer: Buffer;
+  try {
+    buffer =
+      params.maxBytes === undefined
+        ? fsSync.readFileSync(params.fd)
+        : readFileDescriptorBoundedSync(params.fd, params.maxBytes);
+  } catch (error) {
+    if (params.maxBytes !== undefined) {
+      translateBoundedReadOverflow(error, params.filePath, params.maxBytes);
+    }
+    throw error;
+  }
   return { buffer, stat };
 }
 
@@ -195,10 +213,7 @@ export function readRegularFileSync(params: { filePath: string; maxBytes?: numbe
     throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });
   }
   if (params.maxBytes !== undefined && result.stat.size > params.maxBytes) {
-    throw new FsSafeError(
-      "too-large",
-      `file exceeds limit of ${params.maxBytes} bytes (got ${result.stat.size})`,
-    );
+    throw regularFileTooLargeError(params.filePath, params.maxBytes);
   }
 
   const fd = fsSync.openSync(params.filePath, resolveRegularFileReadFlags());

--- a/test/regular-file-compat.test.ts
+++ b/test/regular-file-compat.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FsSafeError } from "../src/errors.js";
+import { readRegularFile, readRegularFileSync } from "../src/regular-file.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("regular-file overflow compatibility", () => {
+  it("preserves the pre-0.4.2 async overflow message with a structured code", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-regular-compat-"));
+    tempDirs.push(root);
+    const filePath = path.join(root, "input.txt");
+    await fs.writeFile(filePath, "abc", "utf8");
+
+    await expect(readRegularFile({ filePath, maxBytes: 2 })).rejects.toMatchObject({
+      code: "too-large",
+      message: `File exceeds 2 bytes: ${filePath}`,
+      constructor: FsSafeError,
+    });
+  });
+
+  it("preserves the pre-0.4.2 sync overflow message with a structured code", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-regular-compat-"));
+    tempDirs.push(root);
+    const filePath = path.join(root, "input.txt");
+    await fs.writeFile(filePath, "abc", "utf8");
+
+    expect(() => readRegularFileSync({ filePath, maxBytes: 2 })).toThrow(
+      expect.objectContaining({
+        code: "too-large",
+        message: `File exceeds 2 bytes: ${filePath}`,
+        constructor: FsSafeError,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Related: openclaw/openclaw#111104

## What Problem This Solves

Fixes an issue where users of `readRegularFile` or `readRegularFileSync` would receive a different overflow message after upgrading from fs-safe 0.4.1 to 0.4.2. Downstream callers that preserve or test the established `File exceeds <limit> bytes: <path>` message regressed even though 0.4.2 was a patch release.

## Why This Change Was Made

The existing regular-file APIs now translate the new allocation-bounded primitive's `too-large` error back to their pre-0.4.2 message. They retain the structured `FsSafeError` code, and the new low-level bounded descriptor/handle APIs keep their richer diagnostic message.

## User Impact

Existing callers regain their established overflow text without losing the memory-safety improvement or structured `too-large` classification introduced in 0.4.2.

## Evidence

- `pnpm check` passes: file-size guard, filesystem-boundary guard, TypeScript build, 41 test files, 437 passed tests, and 3 platform skips.
- New async and sync compatibility tests assert both the exact pre-0.4.2 message and the structured `too-large` code.
- OpenClaw exact-head CI exposed the regression across its regular-file consumers; its production build and the new fs-safe bounded-read primitives otherwise passed.
- Fresh Codex autoreview reported no accepted/actionable findings with correctness confidence 0.96.
- `git diff --check` passes.

AI-assisted: yes. The compatibility contract, implementation, and tests were reviewed manually and with autoreview.
