### PR TITLE
fix: guard stale sidecar recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.4.4 - Unreleased
 
+### Security and Correctness
+
+- Restore opt-in stale sidecar recovery with an exclusive reclaim guard that serializes snapshot verification and unlink, preserving dead-owner recovery without allowing a competing reclaimer to delete a fresh replacement lock.
+
 ## 0.4.3 - 2026-07-18
 
 ### Compatibility

--- a/README.md
+++ b/README.md
@@ -283,9 +283,10 @@ the common merge-into-defaults case. Standalone helpers use options bags
 because they do not carry a bound root and often need multiple authority, path,
 and policy knobs.
 
-Sidecar locks fail closed on stale holders. The legacy `remove-if-unchanged`
-option remains accepted for source compatibility, but it no longer unlinks a
-third-party stale lock during acquisition; see the [file lock docs](docs/sidecar-lock.md).
+Sidecar locks fail closed on stale holders by default. Opt-in `remove-if-unchanged`
+recovery requires caller approval and serializes snapshot verification and unlink
+with an exclusive reclaim guard so a replacement lock cannot be deleted; see the
+[file lock docs](docs/sidecar-lock.md).
 
 Use `fileStore()` for cache/blob/media-style directories where callers
 need safe relative paths, size limits, atomic replacement, stream writes, and

--- a/docs/config.md
+++ b/docs/config.md
@@ -56,7 +56,7 @@ Return the effective configuration: programmatic overrides win, then env vars, t
 function configureFsSafeLocks(config: Partial<FsSafeLockConfig>): void;
 
 type FsSafeLockConfig = {
-  staleRecovery: "fail-closed" | "remove-if-unchanged"; // legacy value also fails closed
+  staleRecovery: "fail-closed" | "remove-if-unchanged";
   staleMs?: number;
   timeoutMs?: number;
   retry?: FileLockRetryOptions;
@@ -65,7 +65,7 @@ type FsSafeLockConfig = {
 
 Set process-wide defaults for sidecar lock options. This does **not** turn locking on globally; callers still need to pass `lock: true` or a lock options object for the specific JSON store/resource that needs cross-process coordination.
 
-`staleRecovery` defaults to `"fail-closed"`. The deprecated `"remove-if-unchanged"` value remains accepted for source and configuration compatibility, but behaves as `"fail-closed"`. fs-safe never removes a stale third-party lock during acquisition because a pathname recheck followed by unlink cannot prevent deleting a replacement lock.
+`staleRecovery` defaults to `"fail-closed"`. The opt-in `"remove-if-unchanged"` mode requires caller approval and serializes the final snapshot check and unlink with an exclusive `.reclaim` guard. A reclaim guard left by a killed reclaimer fails closed and requires externally coordinated cleanup.
 
 ## `getFsSafeLockConfig()`
 

--- a/docs/json-store.md
+++ b/docs/json-store.md
@@ -53,7 +53,7 @@ type JsonStoreLockOptions = {
   staleMs?: number;     // default 30_000
   timeoutMs?: number;   // default 30_000
   retry?: FileLockRetryOptions;
-  staleRecovery?: "fail-closed" | "remove-if-unchanged"; // legacy value also fails closed
+  staleRecovery?: "fail-closed" | "remove-if-unchanged";
   managerKey?: string;  // default `fs-safe.json-store:<filePath>`
 };
 
@@ -141,7 +141,7 @@ When `lock` is falsy, `read` / `write` / `update` are unlocked. The `update` sha
 
 Process-wide lock defaults from `configureFsSafeLocks()` apply only after locking is explicitly enabled. They do not make JSON stores lock by default.
 
-JSON store locks always fail closed on stale sidecars. The deprecated `staleRecovery: "remove-if-unchanged"` value remains accepted for compatibility, but it behaves as `"fail-closed"` and never removes the lock.
+JSON store locks fail closed on stale sidecars by default. Opt-in `staleRecovery: "remove-if-unchanged"` requires caller approval and uses the same exclusive reclaim guard as the low-level sidecar-lock API.
 
 The default `managerKey` namespaces the in-process `FileLockManager` per absolute file path, so two `jsonStore` calls on the same file share lock state automatically.
 

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -21,7 +21,7 @@ try {
 
 The lock file sits next to the protected resource. If a process crashes mid-lock, the next acquirer notices the held entry, inspects its payload (PID, host, acquired-at timestamp), and decides — via `shouldReclaim` (defaulting to "is the lock older than `staleMs`?") — whether it should keep waiting or fail.
 
-The library installs a `process.on("exit")` handler that releases all currently-held locks synchronously, so well-behaved exits leave no stale sidecars. Crashed holders leave their sidecar behind; remove those through an application-owned recovery path after you have proved the holder cannot still be writing.
+The library installs a `process.on("exit")` handler that releases all currently-held locks synchronously, so well-behaved exits leave no stale sidecars. Crashed holders leave their sidecar behind; recover only after an application-owned liveness policy proves the holder cannot still be writing.
 
 ## API
 
@@ -51,7 +51,7 @@ type FileLockAcquireOptions<TPayload extends Record<string, unknown>> = {
   staleMs?: number;                      // default 30_000
   timeoutMs?: number;                    // overall acquire deadline; default unbounded
   retry?: FileLockRetryOptions;
-  staleRecovery?: "fail-closed" | "remove-if-unchanged"; // legacy value also fails closed
+  staleRecovery?: "fail-closed" | "remove-if-unchanged"; // default "fail-closed"
   allowReentrant?: boolean;              // if this process already holds it, increment a count instead of failing
   payload: () => TPayload | Promise<TPayload>;
   shouldReclaim?: (params: {
@@ -62,7 +62,7 @@ type FileLockAcquireOptions<TPayload extends Record<string, unknown>> = {
     nowMs: number;
     heldByThisProcess: boolean;
   }) => boolean | Promise<boolean>;
-  shouldRemoveStaleLock?: (snapshot: {          // deprecated; retained but not invoked
+  shouldRemoveStaleLock?: (snapshot: {
     lockPath: string;
     normalizedTargetPath: string;
     raw: string;
@@ -170,24 +170,28 @@ const handle = await acquireFileLock(targetPath, {
 });
 ```
 
-`heldByThisProcess` is true when this manager already holds the lock (relevant for the reentrant case). A `true` result marks the observed sidecar as stale and acquisition throws an error with code `file_lock_stale`.
+`heldByThisProcess` is true when this manager already holds the lock (relevant for the reentrant case). A `true` result marks the observed sidecar as stale; `staleRecovery` then decides whether acquisition fails closed or attempts caller-approved removal.
 
-## Stale recovery is fail-closed
+## Stale recovery: guarded `remove-if-unchanged`
 
-fs-safe never removes a stale third-party sidecar during acquisition. Checking a pathname's content and identity before unlinking it is not atomic: another process can replace the lock between the final check and the unlink. Every stale result therefore fails closed with error code `file_lock_stale`.
+The default `staleRecovery: "fail-closed"` never removes third-party sidecars. Use `staleRecovery: "remove-if-unchanged"` only when your app has a reliable owner-liveness policy and can prove a stale owner cannot still be writing.
 
-The `"remove-if-unchanged"` value and `shouldRemoveStaleLock` callback remain accepted as deprecated compatibility inputs. They are ignored and the callback is not invoked. To recover, stop or otherwise exclude every process that can acquire the lock, remove the confirmed stale sidecar under that external authority, and retry acquisition.
+Opt-in recovery creates an exclusive `<lockPath>.reclaim` directory before the final snapshot check and unlink. Every compliant acquirer waits while that guard exists, so two reclaimers cannot perform the check/unlink race that could delete a fresh replacement lock. If another acquirer creates the replacement during the handoff, its exclusive create wins and the reclaimer leaves it untouched.
+
+`shouldRemoveStaleLock` receives the exact lock snapshot that fs-safe inspected. The callback must approve that owner as definitely stale. If the callback is missing, returns false, or the file changed, acquisition fails closed or keeps retrying according to the normal retry policy.
+
+A process killed during the short reclaim section can leave the empty `.reclaim` directory behind. That ambiguous state intentionally fails closed; remove the guard only under external authority that excludes every competing lock acquirer.
 
 ## What sidecar locks defend against
 
 - **Two processes writing the same file at once.** `acquire` serializes the critical section.
-- **Accidentally deleting a fresh lock during stale recovery.** Stale third-party locks always fail closed and are never unlinked during acquisition.
+- **Accidentally deleting a fresh lock during stale recovery.** Opt-in removal is serialized by the reclaim guard and rechecks the approved snapshot before unlinking.
 - **Race between simultaneous acquire attempts.** `O_CREAT | O_EXCL` ensures one wins.
 
 ## What they do **not** defend against
 
 - **Misbehaving holders that ignore the lock.** Locks are advisory — only callers that go through `acquire` are bound.
-- **Automatic stale lock deletion.** If a process crashes, recover only under external authority that excludes every competing lock acquirer.
+- **Unapproved stale lock deletion.** If a process crashes, use the payload and your own liveness policy before opting into guarded recovery.
 - **Multi-host coordination over network filesystems.** Behavior depends on the underlying filesystem's `O_EXCL` semantics; treat as best-effort.
 
 ## Common patterns

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -1,0 +1,145 @@
+import type { Stats } from "node:fs";
+import fs from "node:fs/promises";
+import { sameFileIdentity } from "./file-identity.js";
+
+export type SidecarLockStaleSnapshot = {
+  lockPath: string;
+  normalizedTargetPath: string;
+  raw: string;
+  payload: Record<string, unknown> | null;
+};
+
+export type SidecarLockSnapshot = {
+  raw?: string;
+  payload: Record<string, unknown> | null;
+  stat?: Stats;
+};
+
+export async function readSidecarLockSnapshot(
+  lockPath: string,
+): Promise<SidecarLockSnapshot | null> {
+  try {
+    const stat = await fs.lstat(lockPath);
+    const raw = await fs.readFile(lockPath, "utf8");
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      const payload =
+        parsed && typeof parsed === "object" && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : null;
+      return { raw, payload, stat };
+    } catch {
+      return { raw, payload: null, stat };
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+export function sidecarLockSnapshotMatches(
+  current: SidecarLockSnapshot,
+  observed: SidecarLockSnapshot,
+): boolean {
+  if (observed.stat && current.stat && !sameFileIdentity(observed.stat, current.stat)) {
+    return false;
+  }
+  if (observed.raw !== undefined) {
+    return current.raw === observed.raw;
+  }
+  return observed.stat !== undefined && current.stat !== undefined;
+}
+
+export async function removeSidecarLockIfUnchanged(
+  lockPath: string,
+  observed: SidecarLockSnapshot | null,
+): Promise<boolean> {
+  const current = await readSidecarLockSnapshot(lockPath);
+  if (!current || !observed || !sidecarLockSnapshotMatches(current, observed)) {
+    return false;
+  }
+  await fs.rm(lockPath, { force: true }).catch(() => undefined);
+  return true;
+}
+
+export async function sidecarLockSnapshotStillPresent(
+  lockPath: string,
+  observed: SidecarLockSnapshot | null,
+): Promise<boolean> {
+  const current = await readSidecarLockSnapshot(lockPath);
+  return !!current && !!observed && sidecarLockSnapshotMatches(current, observed);
+}
+
+export async function sidecarReclaimGuardExists(pathname: string): Promise<boolean> {
+  try {
+    await fs.lstat(pathname);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export async function tryAcquireSidecarReclaimGuard(
+  reclaimGuards: Set<string>,
+  reclaimGuardPath: string,
+): Promise<boolean> {
+  try {
+    await fs.mkdir(reclaimGuardPath);
+    reclaimGuards.add(reclaimGuardPath);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export async function releaseSidecarReclaimGuard(
+  reclaimGuards: Set<string>,
+  reclaimGuardPath: string,
+): Promise<void> {
+  await fs.rmdir(reclaimGuardPath);
+  reclaimGuards.delete(reclaimGuardPath);
+}
+
+export async function removeStaleSidecarLockIfAllowed(params: {
+  lockPath: string;
+  normalizedTargetPath: string;
+  snapshot: SidecarLockSnapshot;
+  shouldRemoveStaleLock?: (snapshot: SidecarLockStaleSnapshot) => boolean | Promise<boolean>;
+}): Promise<"removed" | "changed" | "not-approved"> {
+  if (!params.shouldRemoveStaleLock || params.snapshot.raw === undefined) {
+    return "not-approved";
+  }
+  if (!(await sidecarLockSnapshotStillPresent(params.lockPath, params.snapshot))) {
+    return "changed";
+  }
+  if (
+    !(await params.shouldRemoveStaleLock({
+      lockPath: params.lockPath,
+      normalizedTargetPath: params.normalizedTargetPath,
+      raw: params.snapshot.raw,
+      payload: params.snapshot.payload,
+    }))
+  ) {
+    return "not-approved";
+  }
+  if (!(await sidecarLockSnapshotStillPresent(params.lockPath, params.snapshot))) {
+    return "changed";
+  }
+  try {
+    await fs.rm(params.lockPath);
+    return "removed";
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return "changed";
+    }
+    throw err;
+  }
+}

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -1,9 +1,21 @@
 import fsSync from "node:fs";
-import type { Stats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { sameFileIdentity } from "./file-identity.js";
+import {
+  readSidecarLockSnapshot,
+  releaseSidecarReclaimGuard,
+  removeSidecarLockIfUnchanged,
+  removeStaleSidecarLockIfAllowed,
+  sidecarLockSnapshotStillPresent,
+  sidecarReclaimGuardExists,
+  tryAcquireSidecarReclaimGuard,
+  type SidecarLockSnapshot,
+  type SidecarLockStaleSnapshot,
+} from "./sidecar-lock-reclaim.js";
+
+export type { SidecarLockStaleSnapshot } from "./sidecar-lock-reclaim.js";
 
 export type SidecarLockRetryOptions = {
   retries?: number;
@@ -13,18 +25,7 @@ export type SidecarLockRetryOptions = {
   randomize?: boolean;
 };
 
-export type SidecarLockStaleRecovery =
-  | "fail-closed"
-  /** @deprecated Stale locks now always fail closed. */
-  | "remove-if-unchanged";
-
-/** @deprecated Stale-removal callbacks are retained for source compatibility but are not invoked. */
-export type SidecarLockStaleSnapshot = {
-  lockPath: string;
-  normalizedTargetPath: string;
-  raw: string;
-  payload: Record<string, unknown> | null;
-};
+export type SidecarLockStaleRecovery = "fail-closed" | "remove-if-unchanged";
 
 export type SidecarLockAcquireOptions<TPayload extends Record<string, unknown>> = {
   targetPath: string;
@@ -43,10 +44,7 @@ export type SidecarLockAcquireOptions<TPayload extends Record<string, unknown>> 
     nowMs: number;
     heldByThisProcess: boolean;
   }) => boolean | Promise<boolean>;
-  /** @deprecated Stale locks now always fail closed; this callback is not invoked. */
-  shouldRemoveStaleLock?: (
-    snapshot: SidecarLockStaleSnapshot,
-  ) => boolean | Promise<boolean>;
+  shouldRemoveStaleLock?: (snapshot: SidecarLockStaleSnapshot) => boolean | Promise<boolean>;
   metadata?: Record<string, unknown>;
 };
 
@@ -76,7 +74,7 @@ type HeldLock = {
   count: number;
   handle: FileHandle;
   lockPath: string;
-  snapshot: LockSnapshot;
+  snapshot: SidecarLockSnapshot;
   acquiredAt: number;
   metadata: Record<string, unknown>;
   releasePromise?: Promise<void>;
@@ -85,6 +83,8 @@ type HeldLock = {
 type SidecarLockManagerState = {
   cleanupRegistered: boolean;
   held: Map<string, HeldLock>;
+  reclaimCleanupRegistered: boolean;
+  reclaimGuards: Set<string>;
 };
 
 const GLOBAL_STATE_KEY = Symbol.for("fsSafe.sidecarLockManagers");
@@ -103,76 +103,23 @@ function resolveManagerState(key: string): SidecarLockManagerState {
   const managers = getGlobalManagers();
   let state = managers.get(key);
   if (!state) {
-    state = { cleanupRegistered: false, held: new Map() };
+    state = {
+      cleanupRegistered: false,
+      held: new Map(),
+      reclaimCleanupRegistered: false,
+      reclaimGuards: new Set(),
+    };
     managers.set(key, state);
+  } else {
+    // The global manager symbol is shared across package copies and hot reloads.
+    // Backfill state created by fs-safe versions that predate reclaim guards.
+    state.reclaimCleanupRegistered ??= false;
+    state.reclaimGuards ??= new Set();
   }
   return state;
 }
 
-type LockSnapshot = {
-  raw?: string;
-  payload: Record<string, unknown> | null;
-  stat?: Stats;
-};
-
-async function readLockSnapshot(lockPath: string): Promise<LockSnapshot | null> {
-  try {
-    const stat = await fs.lstat(lockPath);
-    const raw = await fs.readFile(lockPath, "utf8");
-    try {
-      const parsed = JSON.parse(raw) as unknown;
-      const payload =
-        parsed && typeof parsed === "object" && !Array.isArray(parsed)
-          ? (parsed as Record<string, unknown>)
-          : null;
-      return { raw, payload, stat };
-    } catch {
-      return { raw, payload: null, stat };
-    }
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw err;
-  }
-}
-
-function snapshotMatches(current: LockSnapshot, observed: LockSnapshot): boolean {
-  if (observed.stat && current.stat && !sameFileIdentity(observed.stat, current.stat)) {
-    return false;
-  }
-  if (observed.raw !== undefined) {
-    return current.raw === observed.raw;
-  }
-  return observed.stat !== undefined && current.stat !== undefined;
-}
-
-async function removeLockIfUnchanged(
-  lockPath: string,
-  observed: LockSnapshot | null,
-): Promise<boolean> {
-  const current = await readLockSnapshot(lockPath);
-  if (!current || !observed) {
-    return false;
-  }
-  if (!snapshotMatches(current, observed)) {
-    // The lock changed after we decided it was stale. Leave the fresh holder's
-    // file alone; deleting by path here would break mutual exclusion.
-    return false;
-  }
-  await fs.rm(lockPath, { force: true }).catch(() => undefined);
-  return true;
-}
-
-async function lockSnapshotStillPresent(
-  lockPath: string,
-  observed: LockSnapshot | null,
-): Promise<boolean> {
-  const current = await readLockSnapshot(lockPath);
-  return !!current && !!observed && snapshotMatches(current, observed);
-}
-
-function snapshotMatchesSync(lockPath: string, observed: LockSnapshot): boolean {
+function snapshotMatchesSync(lockPath: string, observed: SidecarLockSnapshot): boolean {
   try {
     const stat = fsSync.lstatSync(lockPath);
     if (observed.stat && !sameFileIdentity(observed.stat, stat)) {
@@ -223,6 +170,17 @@ async function defaultShouldReclaim(params: {
   }
 }
 
+function releaseAllReclaimGuardsSync(state: SidecarLockManagerState): void {
+  for (const reclaimGuardPath of state.reclaimGuards) {
+    try {
+      fsSync.rmdirSync(reclaimGuardPath);
+      state.reclaimGuards.delete(reclaimGuardPath);
+    } catch {
+      // Best-effort process-exit cleanup. A surviving guard fails closed.
+    }
+  }
+}
+
 function releaseAllLocksSync(state: SidecarLockManagerState): void {
   for (const [normalizedTargetPath, held] of state.held) {
     void held.handle.close().catch(() => undefined);
@@ -235,6 +193,7 @@ function releaseAllLocksSync(state: SidecarLockManagerState): void {
     }
     state.held.delete(normalizedTargetPath);
   }
+  releaseAllReclaimGuardsSync(state);
 }
 
 async function releaseHeldLock(
@@ -262,7 +221,7 @@ async function releaseHeldLock(
   state.held.delete(normalizedTargetPath);
   held.releasePromise = (async () => {
     await held.handle.close().catch(() => undefined);
-    await removeLockIfUnchanged(held.lockPath, held.snapshot);
+    await removeSidecarLockIfUnchanged(held.lockPath, held.snapshot);
   })();
   try {
     await held.releasePromise;
@@ -276,11 +235,16 @@ export function createSidecarLockManager(key: string) {
   const state = resolveManagerState(key);
 
   function ensureExitCleanupRegistered(): void {
-    if (state.cleanupRegistered) {
+    if (!state.cleanupRegistered) {
+      state.cleanupRegistered = true;
+      state.reclaimCleanupRegistered = true;
+      process.on("exit", () => releaseAllLocksSync(state));
       return;
     }
-    state.cleanupRegistered = true;
-    process.on("exit", () => releaseAllLocksSync(state));
+    if (!state.reclaimCleanupRegistered) {
+      state.reclaimCleanupRegistered = true;
+      process.on("exit", () => releaseAllReclaimGuardsSync(state));
+    }
   }
 
   async function acquire<TPayload extends Record<string, unknown>>(
@@ -292,7 +256,8 @@ export function createSidecarLockManager(key: string) {
     const held = state.held.get(normalizedTargetPath);
     if (held && options.allowReentrant) {
       held.count += 1;
-      const release = () => releaseHeldLock(state, normalizedTargetPath, held).then(() => undefined);
+      const release = () =>
+        releaseHeldLock(state, normalizedTargetPath, held).then(() => undefined);
       return {
         lockPath,
         normalizedTargetPath,
@@ -304,103 +269,150 @@ export function createSidecarLockManager(key: string) {
     const startedAt = Date.now();
     const retry = options.retry ?? {};
     const maxRetries = options.timeoutMs === Number.POSITIVE_INFINITY ? undefined : retry.retries;
+    const reclaimGuardPath = `${lockPath}.reclaim`;
+    let ownsReclaimGuard = false;
     let attempt = 0;
-    while (true) {
-      let handle: FileHandle | null = null;
-      try {
-        handle = await fs.open(lockPath, "wx");
-        const payload = await options.payload();
-        const raw = `${JSON.stringify(payload, null, 2)}\n`;
-        await handle.writeFile(raw, "utf8");
-        const snapshot = { raw, payload, stat: await handle.stat() };
-        const createdHeld: HeldLock = {
-          count: 1,
-          handle,
-          lockPath,
-          snapshot,
-          acquiredAt: Date.now(),
-          metadata: options.metadata ?? {},
-        };
-        state.held.set(normalizedTargetPath, createdHeld);
-        const release = () =>
-          releaseHeldLock(state, normalizedTargetPath, createdHeld).then(() => undefined);
-        return {
+    const waitForRetry = async (): Promise<void> => {
+      const elapsed = Date.now() - startedAt;
+      if (
+        (options.timeoutMs !== undefined &&
+          options.timeoutMs !== Number.POSITIVE_INFINITY &&
+          elapsed >= options.timeoutMs) ||
+        (maxRetries !== undefined && attempt >= maxRetries)
+      ) {
+        throw Object.assign(new Error(`file lock timeout for ${normalizedTargetPath}`), {
+          code: "file_lock_timeout",
           lockPath,
           normalizedTargetPath,
-          release,
-          [Symbol.asyncDispose]: release,
-        };
-      } catch (err) {
-        if (handle) {
-          const failedSnapshot: LockSnapshot = { payload: null };
-          try {
-            failedSnapshot.stat = await handle.stat();
-          } catch {
-            // Best-effort cleanup of a failed exclusive create.
-          }
-          const current = state.held.get(normalizedTargetPath);
-          if (current?.handle === handle) {
-            state.held.delete(normalizedTargetPath);
-          }
-          // If payload serialization/write fails, the file may be empty or
-          // partial JSON, so remove while our exclusive handle is still open.
-          await fs.rm(lockPath, { force: true }).catch(() => undefined);
-          await handle.close().catch(() => undefined);
-          // Windows can refuse removing an open file; retry after close but
-          // only if the path still points at the file identity we created.
-          await removeLockIfUnchanged(lockPath, failedSnapshot);
-        }
-        if ((err as { code?: unknown }).code !== "EEXIST") {
-          throw err;
-        }
-        const nowMs = Date.now();
-        const snapshot = await readLockSnapshot(lockPath);
-        if (!snapshot) {
+        });
+      }
+      const remaining =
+        options.timeoutMs === undefined || options.timeoutMs === Number.POSITIVE_INFINITY
+          ? Number.POSITIVE_INFINITY
+          : Math.max(0, options.timeoutMs - elapsed);
+      const delay = Math.min(computeDelayMs(retry, attempt), remaining);
+      attempt += 1;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    };
+    try {
+      while (true) {
+        if (!ownsReclaimGuard && (await sidecarReclaimGuardExists(reclaimGuardPath))) {
+          await waitForRetry();
           continue;
         }
-        const shouldReclaim = options.shouldReclaim ?? defaultShouldReclaim;
-        if (
-          await shouldReclaim({
+        let handle: FileHandle | null = null;
+        try {
+          handle = await fs.open(lockPath, "wx");
+          const payload = await options.payload();
+          const raw = `${JSON.stringify(payload, null, 2)}\n`;
+          await handle.writeFile(raw, "utf8");
+          const snapshot = { raw, payload, stat: await handle.stat() };
+          const createdHeld: HeldLock = {
+            count: 1,
+            handle,
+            lockPath,
+            snapshot,
+            acquiredAt: Date.now(),
+            metadata: options.metadata ?? {},
+          };
+          state.held.set(normalizedTargetPath, createdHeld);
+          if (ownsReclaimGuard) {
+            try {
+              await releaseSidecarReclaimGuard(state.reclaimGuards, reclaimGuardPath);
+              ownsReclaimGuard = false;
+            } catch (err) {
+              await releaseHeldLock(state, normalizedTargetPath, createdHeld, { force: true });
+              throw err;
+            }
+          }
+          const release = () =>
+            releaseHeldLock(state, normalizedTargetPath, createdHeld).then(() => undefined);
+          return {
             lockPath,
             normalizedTargetPath,
-            payload: snapshot?.payload ?? null,
-            staleMs: options.staleMs,
-            nowMs,
-            heldByThisProcess: state.held.has(normalizedTargetPath),
-          })
-        ) {
-          if (!(await lockSnapshotStillPresent(lockPath, snapshot))) {
+            release,
+            [Symbol.asyncDispose]: release,
+          };
+        } catch (err) {
+          if (handle) {
+            const failedSnapshot: SidecarLockSnapshot = { payload: null };
+            try {
+              failedSnapshot.stat = await handle.stat();
+            } catch {
+              // Best-effort cleanup of a failed exclusive create.
+            }
+            const current = state.held.get(normalizedTargetPath);
+            if (current?.handle === handle) {
+              state.held.delete(normalizedTargetPath);
+            }
+            // If payload serialization/write fails, the file may be empty or
+            // partial JSON, so remove while our exclusive handle is still open.
+            await fs.rm(lockPath, { force: true }).catch(() => undefined);
+            await handle.close().catch(() => undefined);
+            // Windows can refuse removing an open file; retry after close but
+            // only if the path still points at the file identity we created.
+            await removeSidecarLockIfUnchanged(lockPath, failedSnapshot);
+          }
+          if ((err as { code?: unknown }).code !== "EEXIST") {
+            throw err;
+          }
+          if (ownsReclaimGuard) {
+            await releaseSidecarReclaimGuard(state.reclaimGuards, reclaimGuardPath);
+            ownsReclaimGuard = false;
             continue;
           }
-          // A pathname recheck followed by unlink is not atomic: a fresh lock
-          // can replace the observed file in between. Legacy recovery inputs
-          // remain accepted, but third-party stale locks always fail closed.
-          throw Object.assign(new Error(`file lock stale for ${normalizedTargetPath}`), {
-            code: "file_lock_stale",
-            lockPath,
-            normalizedTargetPath,
-          });
+          const nowMs = Date.now();
+          const snapshot = await readSidecarLockSnapshot(lockPath);
+          if (!snapshot) {
+            continue;
+          }
+          const shouldReclaim = options.shouldReclaim ?? defaultShouldReclaim;
+          if (
+            await shouldReclaim({
+              lockPath,
+              normalizedTargetPath,
+              payload: snapshot?.payload ?? null,
+              staleMs: options.staleMs,
+              nowMs,
+              heldByThisProcess: state.held.has(normalizedTargetPath),
+            })
+          ) {
+            if (!(await sidecarLockSnapshotStillPresent(lockPath, snapshot))) {
+              continue;
+            }
+            const staleRecovery = options.staleRecovery ?? "fail-closed";
+            if (staleRecovery === "remove-if-unchanged") {
+              if (!(await tryAcquireSidecarReclaimGuard(state.reclaimGuards, reclaimGuardPath))) {
+                await waitForRetry();
+                continue;
+              }
+              ownsReclaimGuard = true;
+              const removal = await removeStaleSidecarLockIfAllowed({
+                lockPath,
+                normalizedTargetPath,
+                snapshot,
+                shouldRemoveStaleLock: options.shouldRemoveStaleLock,
+              });
+              if (removal === "removed" || removal === "changed") {
+                continue;
+              }
+              await releaseSidecarReclaimGuard(state.reclaimGuards, reclaimGuardPath);
+              ownsReclaimGuard = false;
+            }
+            throw Object.assign(new Error(`file lock stale for ${normalizedTargetPath}`), {
+              code: "file_lock_stale",
+              lockPath,
+              normalizedTargetPath,
+            });
+          }
+          await waitForRetry();
         }
-        const elapsed = Date.now() - startedAt;
-        if (
-          (options.timeoutMs !== undefined &&
-            options.timeoutMs !== Number.POSITIVE_INFINITY &&
-            elapsed >= options.timeoutMs) ||
-          (maxRetries !== undefined && attempt >= maxRetries)
-        ) {
-          throw Object.assign(new Error(`file lock timeout for ${normalizedTargetPath}`), {
-            code: "file_lock_timeout",
-            lockPath,
-            normalizedTargetPath,
-          });
-        }
-        const remaining =
-          options.timeoutMs === undefined || options.timeoutMs === Number.POSITIVE_INFINITY
-            ? Number.POSITIVE_INFINITY
-            : Math.max(0, options.timeoutMs - elapsed);
-        const delay = Math.min(computeDelayMs(retry, attempt), remaining);
-        attempt += 1;
-        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    } finally {
+      if (ownsReclaimGuard) {
+        await releaseSidecarReclaimGuard(state.reclaimGuards, reclaimGuardPath).catch(
+          () => undefined,
+        );
       }
     }
   }

--- a/test/sidecar-lock-regression.test.ts
+++ b/test/sidecar-lock-regression.test.ts
@@ -55,7 +55,10 @@ describe("sidecar lock regressions", () => {
         shouldReclaim: async () => {
           if (!replaced) {
             replaced = true;
-            await fsp.writeFile(lockPath, JSON.stringify({ createdAt: "2999-01-01T00:00:00.000Z" }));
+            await fsp.writeFile(
+              lockPath,
+              JSON.stringify({ createdAt: "2999-01-01T00:00:00.000Z" }),
+            );
             return true;
           }
           return false;
@@ -128,29 +131,165 @@ describe("sidecar lock regressions", () => {
     }
   });
 
-  it("fails closed even when legacy stale-removal inputs approve the snapshot", async () => {
+  it("removes a stale sidecar only after caller approval under the reclaim guard", async () => {
     const base = await tempRoot("fs-safe-sidecar-remove-");
     const targetPath = path.join(base, "state.json");
     const lockPath = `${targetPath}.lock`;
     const manager = createSidecarLockManager(`fs-safe-remove-test-${Date.now()}`);
     await fsp.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
 
-    const shouldRemoveStaleLock = vi.fn(async () => true);
+    const seen: Array<Record<string, unknown> | null> = [];
+    const lock = await manager.acquire({
+      targetPath,
+      lockPath,
+      staleMs: 1,
+      staleRecovery: "remove-if-unchanged",
+      payload: async () => ({ createdAt: new Date().toISOString(), owner: "next" }),
+      shouldReclaim: async () => true,
+      shouldRemoveStaleLock: async (snapshot) => {
+        expect(snapshot.lockPath).toBe(lockPath);
+        expect(snapshot.raw).toContain("2000-01-01T00:00:00.000Z");
+        seen.push(snapshot.payload);
+        return true;
+      },
+    });
+    try {
+      expect(seen).toEqual([{ createdAt: "2000-01-01T00:00:00.000Z" }]);
+      await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("next");
+      await expect(fsp.stat(`${lockPath}.reclaim`)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await lock.release();
+    }
+  });
+
+  it("fails closed when stale removal is not explicitly approved", async () => {
+    const base = await tempRoot("fs-safe-sidecar-refuse-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const manager = createSidecarLockManager(`fs-safe-refuse-test-${Date.now()}`);
+    await fsp.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
+
     await expect(
       manager.acquire({
         targetPath,
         lockPath,
         staleMs: 1,
+        retry: { retries: 0 },
         staleRecovery: "remove-if-unchanged",
-        payload: async () => ({ createdAt: new Date().toISOString(), owner: "next" }),
+        payload: async () => ({ createdAt: new Date().toISOString() }),
         shouldReclaim: async () => true,
-        shouldRemoveStaleLock,
       }),
     ).rejects.toMatchObject({ code: "file_lock_stale" });
-    expect(shouldRemoveStaleLock).not.toHaveBeenCalled();
-    await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain(
-      "2000-01-01T00:00:00.000Z",
-    );
+    await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("2000");
+    await expect(fsp.stat(`${lockPath}.reclaim`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("serializes stale reclaimers so a replacement lock cannot be deleted", async () => {
+    const base = await tempRoot("fs-safe-sidecar-reclaim-guard-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    await fsp.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
+
+    let approveFirst!: () => void;
+    const firstApproval = new Promise<void>((resolve) => {
+      approveFirst = resolve;
+    });
+    let firstEnteredApproval!: () => void;
+    const firstApprovalEntered = new Promise<void>((resolve) => {
+      firstEnteredApproval = resolve;
+    });
+    const firstManager = createSidecarLockManager(`fs-safe-first-reclaimer-${Date.now()}`);
+    const secondManager = createSidecarLockManager(`fs-safe-second-reclaimer-${Date.now()}`);
+    const secondRemoval = vi.fn(async () => true);
+
+    const firstAcquire = firstManager.acquire({
+      targetPath,
+      lockPath,
+      staleMs: 1,
+      staleRecovery: "remove-if-unchanged",
+      payload: async () => ({ createdAt: "2999-01-01T00:00:00.000Z", owner: "first" }),
+      shouldReclaim: async ({ payload }) => payload?.createdAt === "2000-01-01T00:00:00.000Z",
+      shouldRemoveStaleLock: async () => {
+        firstEnteredApproval();
+        await firstApproval;
+        return true;
+      },
+    });
+    await firstApprovalEntered;
+
+    const secondAcquire = secondManager.acquire({
+      targetPath,
+      lockPath,
+      staleMs: 1,
+      timeoutMs: 50,
+      retry: { retries: 20, minTimeout: 1, maxTimeout: 2 },
+      staleRecovery: "remove-if-unchanged",
+      payload: async () => ({ createdAt: new Date().toISOString(), owner: "second" }),
+      shouldReclaim: async ({ payload }) => payload?.createdAt === "2000-01-01T00:00:00.000Z",
+      shouldRemoveStaleLock: secondRemoval,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(secondRemoval).not.toHaveBeenCalled();
+    approveFirst();
+    const firstLock = await firstAcquire;
+    await expect(secondAcquire).rejects.toMatchObject({ code: "file_lock_timeout" });
+    expect(secondRemoval).not.toHaveBeenCalled();
+    await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("first");
+    await firstLock.release();
+  });
+
+  it("fails closed when a crashed reclaimer leaves its guard behind", async () => {
+    const base = await tempRoot("fs-safe-sidecar-reclaim-guard-stale-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const reclaimGuardPath = `${lockPath}.reclaim`;
+    await fsp.mkdir(reclaimGuardPath);
+
+    const manager = createSidecarLockManager(`fs-safe-stale-reclaim-guard-${Date.now()}`);
+    await expect(
+      manager.acquire({
+        targetPath,
+        lockPath,
+        staleMs: 1,
+        timeoutMs: 5,
+        retry: { retries: 1, minTimeout: 1, maxTimeout: 1 },
+        staleRecovery: "remove-if-unchanged",
+        payload: async () => ({ createdAt: new Date().toISOString() }),
+        shouldReclaim: async () => true,
+        shouldRemoveStaleLock: async () => true,
+      }),
+    ).rejects.toMatchObject({ code: "file_lock_timeout" });
+    expect((await fsp.stat(reclaimGuardPath)).isDirectory()).toBe(true);
+    await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("backfills reclaim state created by an older package copy", async () => {
+    const base = await tempRoot("fs-safe-sidecar-legacy-manager-state-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    await fsp.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
+
+    const managerKey = `fs-safe-legacy-manager-state-${Date.now()}`;
+    const managers = Reflect.get(globalThis, Symbol.for("fsSafe.sidecarLockManagers")) as Map<
+      string,
+      { cleanupRegistered: boolean; held: Map<string, unknown> }
+    >;
+    managers.set(managerKey, { cleanupRegistered: true, held: new Map() });
+
+    const manager = createSidecarLockManager(managerKey);
+    const lock = await manager.acquire({
+      targetPath,
+      lockPath,
+      staleMs: 1,
+      staleRecovery: "remove-if-unchanged",
+      payload: async () => ({ createdAt: new Date().toISOString(), owner: "next" }),
+      shouldReclaim: async () => true,
+      shouldRemoveStaleLock: async () => true,
+    });
+    await lock.release();
+    managers.delete(managerKey);
+    await expect(fsp.stat(`${lockPath}.reclaim`)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("cleans failed sidecar locks and preserves stale corrupt locks", async () => {


### PR DESCRIPTION
## What Problem This Solves

The 0.4.2 fail-closed stale-lock change removed an unsafe compare-then-unlink race, but it also disabled the established opt-in dead-owner recovery contract. OpenClaw exact-head CI exposed that compatibility break across its session, registry, and plugin file-lock callers.

Simply restoring the old implementation would let two reclaimers race: one can replace a stale lock while the other still holds the old snapshot, allowing the second unlink to delete the fresh lock.

## Why This Change Was Made

Opt-in `remove-if-unchanged` recovery now creates an exclusive `<lockPath>.reclaim` directory before final snapshot approval and removal. Every compliant acquirer waits while that guard exists, so only one reclaimer can unlink the verified stale sidecar. If another acquirer creates a replacement during the handoff, its exclusive create wins and the guarded reclaimer leaves it untouched.

The default remains `fail-closed`. Removal still requires both `shouldReclaim` and `shouldRemoveStaleLock` approval. A reclaim guard left by a killed reclaimer also fails closed and requires externally coordinated cleanup.

Snapshot and reclaim mechanics moved into a focused internal module so the main lock manager remains within the repository's file-size budget. The global manager state is normalized for older package copies and hot reloads before any guard is created, including versioned exit cleanup for the new guard set.

## User Impact

Existing opt-in callers regain dead-owner recovery without regaining the fresh-replacement deletion race. Default callers continue to fail closed exactly as in 0.4.2 and 0.4.3.

## Evidence

- `pnpm check`: 41 test files passed; 441 tests passed and 3 platform-specific tests skipped.
- Regression coverage proves caller-approved recovery, missing-approval failure, two-reclaimer serialization, crash-left guard failure, fresh replacement preservation, and mixed-version global-state normalization.
- File-size guard, filesystem-boundary guard, TypeScript build, and `git diff --check` passed.
- Fresh whole-change autoreview reported no accepted/actionable findings with correctness confidence 0.91 after fixing its mixed-version state finding.

AI-assisted: yes. I reviewed the lock protocol, compatibility boundary, documentation, and exact downstream failures.
