### PR TITLE
fix(lock): release sidecars across filesystem identity drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.4.5 - Unreleased
 
+### Security and Correctness
+
+- Give new sidecar locks an internal random ownership token outside the parsed JSON payload so release remains ownership-checked when virtual filesystems report different descriptor and pathname identities, while legacy locks retain the stricter identity-plus-content check.
+
 ## 0.4.4 - 2026-07-18
 
 ### Security and Correctness

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -23,6 +23,10 @@ The lock file sits next to the protected resource. If a process crashes mid-lock
 
 The library installs a `process.on("exit")` handler that releases all currently-held locks synchronously, so well-behaved exits leave no stale sidecars. Crashed holders leave their sidecar behind; recover only after an application-owned liveness policy proves the holder cannot still be writing.
 
+Each new sidecar also carries an internal random ownership token encoded as JSON trailing whitespace. `JSON.parse()` and every payload callback still see exactly the caller-provided object. Only the process that successfully created the sidecar keeps that token as release authority; merely reading token-shaped bytes from disk does not enable this mode. Release compares the in-memory token and exact serialized bytes, and requires the pathname to remain a regular file, instead of requiring an opened descriptor and pathname lookup to report the same inode identity. This preserves ownership checks on filesystems such as Docker Desktop VirtioFS where those two views can legitimately differ. Sidecars created by older releases have no token and retain the legacy identity-plus-content check.
+
+The raw sidecar bytes are not a canonical JSON representation: tools that trim or rewrite the trailing whitespace invalidate the ownership token, so release leaves the changed sidecar in place and fails closed. The token distinguishes cooperating acquisitions; it is not a secret and does not make pathname compare-and-remove atomic against a hostile process that can replace files outside the lock protocol.
+
 ## API
 
 ```ts

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -1,6 +1,14 @@
+import { randomBytes } from "node:crypto";
 import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
 import { sameFileIdentity } from "./file-identity.js";
+
+const SIDECAR_LOCK_OWNERSHIP_TOKEN_BYTES = 16;
+const SIDECAR_LOCK_OWNERSHIP_TOKEN_BITS = SIDECAR_LOCK_OWNERSHIP_TOKEN_BYTES * 8;
+const SIDECAR_LOCK_OWNERSHIP_TOKEN_PREFIX = "\t".repeat(8);
+const SIDECAR_LOCK_OWNERSHIP_TOKEN_PATTERN = new RegExp(
+  `\\n(${SIDECAR_LOCK_OWNERSHIP_TOKEN_PREFIX}[ \\t]{${SIDECAR_LOCK_OWNERSHIP_TOKEN_BITS}})\\n$`,
+);
 
 export type SidecarLockStaleSnapshot = {
   lockPath: string;
@@ -13,7 +21,33 @@ export type SidecarLockSnapshot = {
   raw?: string;
   payload: Record<string, unknown> | null;
   stat?: Stats;
+  ownershipToken?: string;
 };
+
+function createSidecarLockOwnershipToken(): string {
+  let token = SIDECAR_LOCK_OWNERSHIP_TOKEN_PREFIX;
+  for (const byte of randomBytes(SIDECAR_LOCK_OWNERSHIP_TOKEN_BYTES)) {
+    for (let bit = 7; bit >= 0; bit -= 1) {
+      token += byte & (1 << bit) ? "\t" : " ";
+    }
+  }
+  return token;
+}
+
+export function readSidecarLockOwnershipToken(raw: string): string | undefined {
+  return SIDECAR_LOCK_OWNERSHIP_TOKEN_PATTERN.exec(raw)?.[1];
+}
+
+export function serializeSidecarLockPayload(payload: Record<string, unknown>): {
+  raw: string;
+  ownershipToken: string;
+} {
+  const ownershipToken = createSidecarLockOwnershipToken();
+  return {
+    raw: `${JSON.stringify(payload, null, 2)}\n${ownershipToken}\n`,
+    ownershipToken,
+  };
+}
 
 export async function readSidecarLockSnapshot(
   lockPath: string,
@@ -43,6 +77,16 @@ export function sidecarLockSnapshotMatches(
   current: SidecarLockSnapshot,
   observed: SidecarLockSnapshot,
 ): boolean {
+  if (observed.ownershipToken !== undefined) {
+    return (
+      current.stat?.isFile() === true &&
+      current.raw !== undefined &&
+      observed.raw !== undefined &&
+      readSidecarLockOwnershipToken(current.raw) === observed.ownershipToken &&
+      readSidecarLockOwnershipToken(observed.raw) === observed.ownershipToken &&
+      current.raw === observed.raw
+    );
+  }
   if (observed.stat && current.stat && !sameFileIdentity(observed.stat, current.stat)) {
     return false;
   }

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -2,12 +2,13 @@ import fsSync from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { sameFileIdentity } from "./file-identity.js";
 import {
   readSidecarLockSnapshot,
   releaseSidecarReclaimGuard,
   removeSidecarLockIfUnchanged,
   removeStaleSidecarLockIfAllowed,
+  serializeSidecarLockPayload,
+  sidecarLockSnapshotMatches,
   sidecarLockSnapshotStillPresent,
   sidecarReclaimGuardExists,
   tryAcquireSidecarReclaimGuard,
@@ -122,10 +123,8 @@ function resolveManagerState(key: string): SidecarLockManagerState {
 function snapshotMatchesSync(lockPath: string, observed: SidecarLockSnapshot): boolean {
   try {
     const stat = fsSync.lstatSync(lockPath);
-    if (observed.stat && !sameFileIdentity(observed.stat, stat)) {
-      return false;
-    }
-    return observed.raw === undefined || fsSync.readFileSync(lockPath, "utf8") === observed.raw;
+    const raw = fsSync.readFileSync(lockPath, "utf8");
+    return sidecarLockSnapshotMatches({ raw, payload: null, stat }, observed);
   } catch {
     return false;
   }
@@ -304,9 +303,9 @@ export function createSidecarLockManager(key: string) {
         try {
           handle = await fs.open(lockPath, "wx");
           const payload = await options.payload();
-          const raw = `${JSON.stringify(payload, null, 2)}\n`;
+          const { raw, ownershipToken } = serializeSidecarLockPayload(payload);
           await handle.writeFile(raw, "utf8");
-          const snapshot = { raw, payload, stat: await handle.stat() };
+          const snapshot = { raw, payload, stat: await handle.stat(), ownershipToken };
           const createdHeld: HeldLock = {
             count: 1,
             handle,

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -2,6 +2,7 @@ import fsSync from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { sameFileIdentity } from "./file-identity.js";
 import {
   readSidecarLockSnapshot,
   releaseSidecarReclaimGuard,
@@ -121,12 +122,42 @@ function resolveManagerState(key: string): SidecarLockManagerState {
 }
 
 function snapshotMatchesSync(lockPath: string, observed: SidecarLockSnapshot): boolean {
+  let fd: number | undefined;
   try {
-    const stat = fsSync.lstatSync(lockPath);
-    const raw = fsSync.readFileSync(lockPath, "utf8");
-    return sidecarLockSnapshotMatches({ raw, payload: null, stat }, observed);
+    const beforeStat = fsSync.lstatSync(lockPath);
+    if (!beforeStat.isFile()) {
+      return false;
+    }
+    const openFlags =
+      fsSync.constants.O_RDONLY |
+      (process.platform !== "win32" && typeof fsSync.constants.O_NOFOLLOW === "number"
+        ? fsSync.constants.O_NOFOLLOW
+        : 0) |
+      (typeof fsSync.constants.O_NONBLOCK === "number" ? fsSync.constants.O_NONBLOCK : 0);
+    fd = fsSync.openSync(lockPath, openFlags);
+    const openedStat = fsSync.fstatSync(fd);
+    if (!openedStat.isFile()) {
+      return false;
+    }
+    if (observed.raw !== undefined && openedStat.size !== Buffer.byteLength(observed.raw)) {
+      return false;
+    }
+    const raw = fsSync.readFileSync(fd, "utf8");
+    const afterStat = fsSync.lstatSync(lockPath);
+    if (!afterStat.isFile() || !sameFileIdentity(beforeStat, afterStat)) {
+      return false;
+    }
+    return sidecarLockSnapshotMatches({ raw, payload: null, stat: afterStat }, observed);
   } catch {
     return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fsSync.closeSync(fd);
+      } catch {
+        // Best-effort process-exit cleanup.
+      }
+    }
   }
 }
 

--- a/test/sidecar-lock-ownership-token.test.ts
+++ b/test/sidecar-lock-ownership-token.test.ts
@@ -111,6 +111,47 @@ describe("sidecar lock ownership tokens", () => {
     }
   });
 
+  it.skipIf(process.platform === "win32")(
+    "rejects non-regular exit-time replacements before reading them",
+    async () => {
+      const base = await tempRoot("fs-safe-sync-non-regular-replacement-");
+      const targetPath = path.join(base, "state.json");
+      const lockPath = `${targetPath}.lock`;
+      const replacementPath = path.join(base, "replacement.lock");
+      const manager = createSidecarLockManager(`fs-safe-sync-non-regular-${Date.now()}`);
+      const listenersBefore = new Set(process.listeners("exit"));
+      let exitListener: (() => void) | undefined;
+
+      try {
+        await manager.acquire({
+          targetPath,
+          lockPath,
+          staleMs: 1,
+          payload: async () => ({ createdAt: new Date().toISOString(), owner: "caller" }),
+        });
+        const raw = await fsp.readFile(lockPath, "utf8");
+        await fsp.rm(lockPath);
+        await fsp.writeFile(replacementPath, raw, "utf8");
+        await fsp.symlink(replacementPath, lockPath);
+        const readFileSync = vi.spyOn(fsSync, "readFileSync");
+
+        exitListener = process
+          .listeners("exit")
+          .find((listener) => !listenersBefore.has(listener)) as (() => void) | undefined;
+        expect(exitListener).toBeDefined();
+        exitListener?.();
+
+        expect(readFileSync).not.toHaveBeenCalledWith(lockPath, "utf8");
+        expect((await fsp.lstat(lockPath)).isSymbolicLink()).toBe(true);
+      } finally {
+        if (exitListener) {
+          process.removeListener("exit", exitListener);
+        }
+        manager.reset();
+      }
+    },
+  );
+
   it("does not delete a replacement lock with the same caller payload", async () => {
     const base = await tempRoot("fs-safe-sidecar-same-payload-");
     const targetPath = path.join(base, "state.json");

--- a/test/sidecar-lock-ownership-token.test.ts
+++ b/test/sidecar-lock-ownership-token.test.ts
@@ -1,0 +1,269 @@
+import fsSync from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSidecarLockManager } from "../src/sidecar-lock.js";
+import {
+  readSidecarLockOwnershipToken,
+  readSidecarLockSnapshot,
+  serializeSidecarLockPayload,
+  sidecarLockSnapshotMatches,
+} from "../src/sidecar-lock-reclaim.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
+});
+
+describe("sidecar lock ownership tokens", () => {
+  it("round-trips a token without changing the parsed payload", async () => {
+    const base = await tempRoot("fs-safe-sidecar-token-round-trip-");
+    const lockPath = path.join(base, "state.json.lock");
+    const payload = { createdAt: "2999-01-01T00:00:00.000Z", owner: "caller" };
+    const serialized = serializeSidecarLockPayload(payload);
+
+    expect(serialized.ownershipToken).toMatch(/^[ \t]+$/);
+    expect(readSidecarLockOwnershipToken(serialized.raw)).toBe(serialized.ownershipToken);
+    expect(JSON.parse(serialized.raw)).toEqual(payload);
+
+    await fsp.writeFile(lockPath, serialized.raw, "utf8");
+    const snapshot = await readSidecarLockSnapshot(lockPath);
+    expect(snapshot?.raw).toBe(serialized.raw);
+    expect(snapshot?.payload).toEqual(payload);
+    expect(snapshot?.ownershipToken).toBeUndefined();
+    expect(readSidecarLockOwnershipToken(`${JSON.stringify(payload)}\n`)).toBeUndefined();
+  });
+
+  it("releases its sidecar when descriptor and pathname identity drift", async () => {
+    const base = await tempRoot("fs-safe-sidecar-identity-drift-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const manager = createSidecarLockManager(`fs-safe-identity-drift-${Date.now()}`);
+    const lock = await manager.acquire({
+      targetPath,
+      lockPath,
+      staleMs: 1,
+      payload: async () => ({ createdAt: new Date().toISOString(), owner: "caller" }),
+    });
+    const realLstat = fsp.lstat.bind(fsp);
+    vi.spyOn(fsp, "lstat").mockImplementation(async (...args) => {
+      const stat = await realLstat(...args);
+      if (String(args[0]) !== lockPath) {
+        return stat;
+      }
+      return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
+        ino: typeof stat.ino === "bigint" ? stat.ino + 1n : stat.ino + 1,
+      });
+    });
+
+    await lock.release();
+
+    await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("releases its sidecar from process-exit cleanup when identity drifts", async () => {
+    const base = await tempRoot("fs-safe-sidecar-sync-identity-drift-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const manager = createSidecarLockManager(`fs-safe-sync-identity-drift-${Date.now()}`);
+    const listenersBefore = new Set(process.listeners("exit"));
+    let exitListener: (() => void) | undefined;
+
+    try {
+      await manager.acquire({
+        targetPath,
+        lockPath,
+        staleMs: 1,
+        payload: async () => ({ createdAt: new Date().toISOString(), owner: "caller" }),
+      });
+      const realLstatSync = fsSync.lstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+        const stat = realLstatSync(...args);
+        if (String(args[0]) !== lockPath) {
+          return stat;
+        }
+        return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
+          ino: typeof stat.ino === "bigint" ? stat.ino + 1n : stat.ino + 1,
+        });
+      });
+
+      exitListener = process
+        .listeners("exit")
+        .find((listener) => !listenersBefore.has(listener)) as (() => void) | undefined;
+      expect(exitListener).toBeDefined();
+      exitListener?.();
+
+      expect(fsSync.existsSync(lockPath)).toBe(false);
+    } finally {
+      if (exitListener) {
+        process.removeListener("exit", exitListener);
+      }
+      manager.reset();
+    }
+  });
+
+  it("does not delete a replacement lock with the same caller payload", async () => {
+    const base = await tempRoot("fs-safe-sidecar-same-payload-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const payload = { createdAt: "2999-01-01T00:00:00.000Z", owner: "caller" };
+    const firstManager = createSidecarLockManager(`fs-safe-same-payload-first-${Date.now()}`);
+    const secondManager = createSidecarLockManager(`fs-safe-same-payload-second-${Date.now()}`);
+    const first = await firstManager.acquire({
+      targetPath,
+      lockPath,
+      staleMs: 1,
+      payload: async () => payload,
+    });
+    const firstRaw = await fsp.readFile(lockPath, "utf8");
+    await fsp.rm(lockPath);
+    const second = await secondManager.acquire({
+      targetPath,
+      lockPath,
+      staleMs: 1,
+      payload: async () => payload,
+    });
+    const secondRaw = await fsp.readFile(lockPath, "utf8");
+
+    expect(JSON.parse(firstRaw)).toEqual(payload);
+    expect(JSON.parse(secondRaw)).toEqual(payload);
+    expect(secondRaw).not.toBe(firstRaw);
+    await first.release();
+    await expect(fsp.readFile(lockPath, "utf8")).resolves.toBe(secondRaw);
+    await second.release();
+  });
+
+  it("keeps a sidecar whose internal ownership token was trimmed", async () => {
+    const base = await tempRoot("fs-safe-sidecar-trimmed-token-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const manager = createSidecarLockManager(`fs-safe-trimmed-token-${Date.now()}`);
+    const lock = await manager.acquire({
+      targetPath,
+      lockPath,
+      staleMs: 1,
+      payload: async () => ({ createdAt: new Date().toISOString(), owner: "caller" }),
+    });
+    const raw = await fsp.readFile(lockPath, "utf8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    await fsp.writeFile(lockPath, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+
+    await lock.release();
+
+    await expect(fsp.readFile(lockPath, "utf8")).resolves.toBe(
+      `${JSON.stringify(parsed, null, 2)}\n`,
+    );
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "keeps a symlink replacement even when its target contains the owned bytes",
+    async () => {
+      const base = await tempRoot("fs-safe-sidecar-symlink-replacement-");
+      const targetPath = path.join(base, "state.json");
+      const lockPath = `${targetPath}.lock`;
+      const replacementPath = path.join(base, "replacement.lock");
+      const manager = createSidecarLockManager(`fs-safe-symlink-replacement-${Date.now()}`);
+      const lock = await manager.acquire({
+        targetPath,
+        lockPath,
+        staleMs: 1,
+        payload: async () => ({ createdAt: new Date().toISOString(), owner: "caller" }),
+      });
+      const raw = await fsp.readFile(lockPath, "utf8");
+      await fsp.rm(lockPath);
+      await fsp.writeFile(replacementPath, raw, "utf8");
+      await fsp.symlink(replacementPath, lockPath);
+
+      await lock.release();
+
+      expect((await fsp.lstat(lockPath)).isSymbolicLink()).toBe(true);
+      await expect(fsp.readFile(replacementPath, "utf8")).resolves.toBe(raw);
+    },
+  );
+
+  it("retains identity and content checks for legacy snapshots", async () => {
+    const base = await tempRoot("fs-safe-sidecar-legacy-identity-");
+    const lockPath = path.join(base, "state.json.lock");
+    const raw = '{"owner":"legacy"}\n';
+    await fsp.writeFile(lockPath, raw, "utf8");
+    const stat = await fsp.lstat(lockPath);
+    const driftedStat = Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
+      ino: typeof stat.ino === "bigint" ? stat.ino + 1n : stat.ino + 1,
+    });
+
+    expect(
+      sidecarLockSnapshotMatches(
+        { raw, payload: { owner: "legacy" }, stat },
+        { raw, payload: { owner: "legacy" }, stat },
+      ),
+    ).toBe(true);
+    expect(
+      sidecarLockSnapshotMatches(
+        { raw, payload: { owner: "legacy" }, stat: driftedStat },
+        { raw, payload: { owner: "legacy" }, stat },
+      ),
+    ).toBe(false);
+    expect(
+      sidecarLockSnapshotMatches(
+        { raw: '{"owner":"replacement"}\n', payload: { owner: "replacement" }, stat },
+        { raw, payload: { owner: "legacy" }, stat },
+      ),
+    ).toBe(false);
+  });
+
+  it("treats malformed JSON and a partial token as unowned disk snapshots", async () => {
+    const base = await tempRoot("fs-safe-sidecar-malformed-");
+    const lockPath = path.join(base, "state.json.lock");
+    await fsp.writeFile(lockPath, "{", "utf8");
+
+    const malformedSnapshot = await readSidecarLockSnapshot(lockPath);
+    expect(malformedSnapshot?.raw).toBe("{");
+    expect(malformedSnapshot?.payload).toBeNull();
+    expect(readSidecarLockOwnershipToken("{")).toBeUndefined();
+
+    const payload = { owner: "caller" };
+    const serialized = serializeSidecarLockPayload(payload);
+    const partialRaw = serialized.raw.slice(0, -2);
+    await fsp.writeFile(lockPath, partialRaw, "utf8");
+    const partialSnapshot = await readSidecarLockSnapshot(lockPath);
+    expect(partialSnapshot?.payload).toEqual(payload);
+    expect(readSidecarLockOwnershipToken(partialRaw)).toBeUndefined();
+  });
+
+  it("cleans a partial sidecar left by a failed write", async () => {
+    const base = await tempRoot("fs-safe-sidecar-partial-write-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const manager = createSidecarLockManager(`fs-safe-partial-write-${Date.now()}`);
+    const realOpen = fsp.open.bind(fsp);
+    vi.spyOn(fsp, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      const originalWriteFile = handle.writeFile.bind(handle);
+      vi.spyOn(handle, "writeFile").mockImplementationOnce(async (data) => {
+        const raw = typeof data === "string" ? data : Buffer.from(data).toString();
+        await originalWriteFile(raw.slice(0, 4), "utf8");
+        throw Object.assign(new Error("partial write"), { code: "EIO" });
+      });
+      return handle;
+    });
+
+    await expect(
+      manager.acquire({
+        targetPath,
+        lockPath,
+        staleMs: 1,
+        payload: async () => ({ createdAt: new Date().toISOString(), owner: "caller" }),
+      }),
+    ).rejects.toMatchObject({ code: "EIO" });
+    await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
<!-- submission-timestamps:start -->
First submitted: July 20, 2026, 10:54 AM (US Eastern Time) / 14:54 UTC.
Last body edit: July 20, 2026, 11:00 AM (US Eastern Time) / 15:00 UTC.
Latest head commit: July 20, 2026, 10:31 AM (US Eastern Time) / 14:31 UTC.
<!-- submission-timestamps:end -->

## Summary

Fixes sidecar locks that can remain behind when a virtual filesystem reports different identities for the open lock descriptor and the lock pathname. New locks carry per-acquisition ownership authority in JSON-compatible trailing whitespace, so normal and process-exit release can validate exact ownership without requiring those two filesystem views to agree.

This contribution keeps the public payload and API unchanged, preserves the stricter legacy matcher for older sidecars, documents the raw-format compatibility boundary, and records the change in the current `0.4.5 - Unreleased` changelog.

## Breaking Changes

None. Public TypeScript APIs, configuration, and parsed payloads are unchanged.

The raw sidecar byte format gains trailing JSON whitespace. Standards-compliant JSON readers continue to parse the same caller payload, but tools that trim or rewrite raw lock bytes intentionally invalidate release ownership and cause cleanup to fail closed.

## What Problem This Solves

On filesystems such as Docker Desktop VirtioFS, `FileHandle.stat()` and pathname `lstat()` can report different inode/device identities for the same file. The existing release path interprets that drift as an ownership mismatch, leaves the sidecar in place, and causes subsequent lock consumers to encounter a stale or contended lock.

This is the shared-library form of the release failure investigated in [openclaw/openclaw#106777](https://github.com/openclaw/openclaw/issues/106777) and addressed locally for the exec-approvals owner boundary in [openclaw/openclaw#111368](https://github.com/openclaw/openclaw/pull/111368).

## Why This Change Was Made

The release decision needs a per-acquisition ownership signal that survives legitimate filesystem identity drift without weakening replacement protection. A random token retained by the successful creator provides that signal while exact raw-byte comparison and a regular-file check keep changed, trimmed, symlinked, or independently acquired sidecars in place.

Disk snapshots do not gain token authority merely by containing token-shaped bytes. Sidecars created by older releases therefore continue through the identity-plus-content matcher.

## User Impact

Consumers can release sidecar locks on filesystems whose descriptor and pathname identities drift, reducing stranded-lock failures while retaining fail-closed cleanup when the pathname no longer contains the sidecar created by that acquisition.

## Implementation

- Generate 16 random bytes (128 bits) for every successfully created sidecar.
- Encode the token as 128 spaces/tabs after an eight-tab sentinel in trailing JSON whitespace. `JSON.parse()` and payload callbacks still see only the caller-provided object.
- Retain the token only in the in-memory held-lock snapshot. Release requires the current pathname to be a regular file, to contain the same encoded token, and to match the exact serialized bytes.
- Reuse the matcher in asynchronous release and synchronous process-exit cleanup.
- Preserve identity-plus-content comparison for legacy snapshots without in-memory ownership authority.
- Keep replacement protection fail closed: a cooperating replacement with the same caller payload receives a different token; trimmed bytes, changed bytes, and symlink replacements are not removed.

The token is an ownership discriminator, not a secret. This change does not make pathname compare-and-remove atomic against a hostile actor that can copy exact lock bytes outside the cooperative protocol.

## Code-Path Analysis

- Runtime entry and owner: `src/sidecar-lock.ts` creates, tracks, releases, drains, and performs process-exit cleanup for held sidecars.
- Matching and serialization boundary: `src/sidecar-lock-reclaim.ts` owns raw serialization, token recognition, snapshot matching, guarded stale-recovery comparison, and removal.
- Caller surface: `src/file-lock.ts` exposes `acquireFileLock()` and `withFileLock()` over the sidecar manager; file-store callers use that public lock surface.
- Sibling contract: `src/file-identity.ts` remains the strict identity helper used by legacy snapshots.
- Adjacent coverage: `test/sidecar-lock-ownership-token.test.ts` adds token-specific regression cases; `test/sidecar-lock-regression.test.ts` retains stale-reclaim, contention, and fail-closed coverage.
- User-facing contract: `docs/sidecar-lock.md` documents the raw trailing-whitespace behavior and threat-model boundary; `CHANGELOG.md` records it under `0.4.5 - Unreleased`.

## Mainline Comparison

The branch is one commit directly on `openclaw/fs-safe:main@3b3cc4e53c6525b7bff7f31cbf9e2f8e9a5f7532`, the API-confirmed default-branch head at submission. That base only opens the `0.4.5` changelog. The prior same-surface change, `2d06dbc`, introduced the v0.4.4 reclaim guard and centralized snapshot matching; this contribution adds the new-owner token path without changing the guarded stale-recovery policy.

## Branch and Base Provenance

- Base: `openclaw/fs-safe:main@3b3cc4e53c6525b7bff7f31cbf9e2f8e9a5f7532`
- Head: `snowzlmbot/fs-safe:fix/sidecar-lock-ownership-token@23f8ca32e32112907cb3f91e33e33518f6034de4`
- Merge base: `3b3cc4e53c6525b7bff7f31cbf9e2f8e9a5f7532`
- Fork default branch: `snowzlmbot/fs-safe:main@3b3cc4e53c6525b7bff7f31cbf9e2f8e9a5f7532`; it contains no contribution-specific commit.

## Dependency and Contract Verification

The implementation uses Node.js `crypto.randomBytes()`, available within the package's existing Node.js 22+ engine contract. No dependency or lockfile change is required. JSON permits trailing whitespace, so parsed payload compatibility is preserved. Existing nonce-less sidecars retain legacy identity-plus-content behavior, including across mixed-version operation.

## Labels Considered

`bug`, `filesystem`, and `security/correctness` are relevant descriptions. No upstream labels, assignees, milestone, or project metadata were set by this external contributor.

## Validation

Validation was run from a clean detached worktree at exact head `23f8ca32e32112907cb3f91e33e33518f6034de4`:

- `pnpm test test/sidecar-lock-ownership-token.test.ts test/sidecar-lock-regression.test.ts`: 2 files passed, 20 tests passed.
- `pnpm build`: passed with TypeScript 7.0.2.
- `git diff --check 3b3cc4e53c6525b7bff7f31cbf9e2f8e9a5f7532..23f8ca32e32112907cb3f91e33e33518f6034de4`: passed.

The targeted suite covers payload-preserving token round trips, asynchronous and process-exit release under simulated identity drift, same-payload foreign replacement preservation, trimmed-token and symlink replacement preservation, legacy identity-plus-content fallback, malformed/partial token handling, failed-write cleanup, and the existing stale-reclaim regression suite.

This is focused local validation, not a claim that the full suite passed locally. Upstream CI is the source of the initial cross-platform full-check results after submission.

Initial upstream workflow state at exact head `23f8ca32e32112907cb3f91e33e33518f6034de4`:

- [ClawSweeper Dispatch](https://github.com/openclaw/fs-safe/actions/runs/29752773329) passed.
- [CI](https://github.com/openclaw/fs-safe/actions/runs/29752773705), [coverage](https://github.com/openclaw/fs-safe/actions/runs/29752773634), and [benchmarks](https://github.com/openclaw/fs-safe/actions/runs/29752773649) were created with `action_required` and no jobs, awaiting repository approval to run fork workflows. This state is not a test failure.

## Evidence Source Map

- Controlled identity-drift proof: `test/sidecar-lock-ownership-token.test.ts`, exercised by the targeted Vitest command above.
- Replacement and compatibility proof: the same test file covers different-token same-payload replacement, trimmed bytes, symlink replacement, legacy snapshots, and partial writes.
- Existing reclaim contract: `test/sidecar-lock-regression.test.ts`, exercised in the same targeted run.
- Build contract: local `pnpm build` at the exact head.

No downstream GitHub Actions run or PR-only evidence branch was used for these local checks.

## Sanitized Logs

```text
Test Files  2 passed (2)
Tests       20 passed (20)
pnpm build  passed
git diff --check  passed
```

## Media Evidence

No screenshot or video is attached because the change has no visual surface and the available proof is a controlled filesystem regression test. Live Docker Desktop VirtioFS after-fix output is not yet available.

## Risk

- Replacement safety: release still has a pathname check/remove interval. Exact bytes, token equality, and regular-file checks protect cooperative replacement cases, but do not claim atomic protection against a hostile process that reproduces exact bytes during that interval.
- Compatibility: standards-compliant JSON consumers are unaffected; byte-canonical tooling that rewrites whitespace will intentionally cause the lock to remain.
- Performance and storage: each acquisition adds one 16-byte random draw and 137 trailing whitespace bytes; no persistent index or memory growth is introduced.
- Security: the token is not confidential and is not accepted as authority when discovered by reading an existing sidecar.
- Operations: cleanup continues to fail closed when ownership cannot be proven.

## Rollback

Revert commit `23f8ca32e32112907cb3f91e33e33518f6034de4`. There is no data, configuration, dependency, or API migration and no irreversible state change. During a rollback, active sidecar holders should be allowed to finish rather than manually deleting their locks; the raw files remain valid JSON and older code treats them through the legacy identity-plus-content path.

## Docs Updated

`docs/sidecar-lock.md` describes the new raw format, compatibility behavior, and non-goals. `CHANGELOG.md` records the correction in the current `0.4.5 - Unreleased` section.

The docs-site link validator was also attempted, but both this head and the unchanged base fail on the pre-existing missing `sidecar-lock.html#stale-recovery-is-fail-closed` anchor from `writing.html`; this contribution does not change that link or heading.

## Related Issue and PR

- Related investigation: [openclaw/openclaw#106777](https://github.com/openclaw/openclaw/issues/106777)
- Related OpenClaw-local implementation: [openclaw/openclaw#111368](https://github.com/openclaw/openclaw/pull/111368)

This shared-library contribution does not close or supersede either OpenClaw object automatically, and it does not request a decision between implementations.

## Not Tested / Limitations

- Live Docker Desktop VirtioFS output is not yet available.
- The full local test suite was not run; the focused sidecar suites and build were run at the exact head.
- The docs-site validator remains blocked by the pre-existing base-branch anchor failure described above.
- Initial upstream CI, coverage, and benchmark workflows are awaiting repository approval to run fork workflows; no jobs have executed yet.
