### PR TITLE
docs: repair sidecar recovery link

### DIFF
--- a/docs/writing.md
+++ b/docs/writing.md
@@ -250,7 +250,7 @@ await fs.write("state.json", body); // succeeds on rclone FUSE
 
 **Security note.** `verify-content-with-lock` proves that the bytes observed after rename match the requested write and prevents *cooperating* writers from interleaving. It does **not** prove that the destination still names the temp-file object, retain the Python helper's fd-relative parent pinning, or stop a same-UID process that ignores the advisory lock. Do not use this option on directories writable by untrusted same-UID processes. Strict identity verification remains the default.
 
-Lock recovery is fail-closed. If a process crashes and leaves the root-level `.fs-safe-write-<sha256>.lock`, a later write reports the stale lock instead of deleting it based on a host-local PID. Recover only under external authority that excludes every competing writer; see [File lock](sidecar-lock.md#stale-recovery-is-fail-closed).
+Lock recovery is fail-closed. If a process crashes and leaves the root-level `.fs-safe-write-<sha256>.lock`, a later write reports the stale lock instead of deleting it based on a host-local PID. Recover only under external authority that excludes every competing writer; see [File lock](sidecar-lock.md#stale-recovery-guarded-remove-if-unchanged).
 
 ## See also
 


### PR DESCRIPTION
## Summary

Repair the stale-recovery documentation link that has kept the Pages workflow red since the guarded recovery heading changed in #44.

## Proof

- `node scripts/build-docs-site.mjs` — passed and generated `dist/docs-site`.
- `git diff --check` — passed.
- Canonical AutoReview on the uncommitted patch — clean, no accepted/actionable findings (correctness confidence 0.99).
- Confirms the failure from Pages runs `29674989844` and `29793470914`: `writing.html` previously targeted the removed `sidecar-lock.html#stale-recovery-is-fail-closed` anchor.

No runtime behavior, API, dependencies, or release state changes.
