### PR TITLE
chore(repo): harden package and release automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,19 @@
-# Protect ownership and automation rules.
-/.github/CODEOWNERS @openclaw/openclaw-secops
-/.github/workflows/ @openclaw/openclaw-secops
-/package.json @openclaw/openclaw-secops
-/.github/actionlint.yaml @openclaw/openclaw-secops
+# Protect repository governance and automation.
+/.github/ @openclaw/openclaw-secops
 /.agents/skills/ @openclaw/openclaw-secops
 /.crabbox.yaml @openclaw/openclaw-secops
+/AGENTS.md @openclaw/openclaw-secops
+/CLAUDE.md @openclaw/openclaw-secops
+/CONTRIBUTING.md @openclaw/openclaw-secops
+/CODE_OF_CONDUCT.md @openclaw/openclaw-secops
+/SECURITY.md @openclaw/openclaw-secops
+
+# Protect package, release, and filesystem boundary surfaces.
+/CHANGELOG.md @openclaw/openclaw-secops
+/LICENSE @openclaw/openclaw-secops
+/package.json @openclaw/openclaw-secops
+/pnpm-lock.yaml @openclaw/openclaw-secops
+/scripts/ @openclaw/openclaw-secops
+/src/ @openclaw/openclaw-secops
+/test/ @openclaw/openclaw-secops
+/docs/ @openclaw/openclaw-secops

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug report
+description: Report a reproducible filesystem-safety defect or regression.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Report one issue at a time. Redact credentials, private paths, hostnames, and sensitive file contents.
+        Report boundary bypasses and other security issues through the private security advisory link instead.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the observed defect in one or two sentences.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Provide the shortest deterministic reproduction.
+      placeholder: |
+        1. Install @openclaw/fs-safe@...
+        2. Create a root or call...
+        3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Package version or commit
+      placeholder: "@openclaw/fs-safe@0.4.5 or commit SHA"
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - Root-bounded reads or writes
+        - Path, symlink, or hardlink validation
+        - Atomic operations or file locking
+        - JSON, store, or secret-file helpers
+        - Archive extraction
+        - Permissions or ownership
+        - Temp files or external outputs
+        - TypeScript types or package exports
+        - Multiple surfaces
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Node.js version, operating system, filesystem type, and relevant mount options.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Redacted logs or filesystem evidence
+      description: Include only the evidence needed to reproduce and diagnose the issue.
+      render: shell
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: Explain severity, frequency, and affected consumers or systems.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/openclaw/fs-safe/security/advisories/new
+    about: Report vulnerabilities privately.
+  - name: OpenClaw community support
+    url: https://discord.gg/clawd
+    about: Ask usage and integration questions in the OpenClaw community.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,35 @@
 version: 2
+
 updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 2
+    groups:
+      production:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
+    cooldown:
+      default-days: 2
     groups:
-      github-actions:
+      actions:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,65 +1,59 @@
-<!--
-Optional linked context:
-Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
-below this comment.
-
-Required PR title:
-type: user-facing description
-Use a parenthesized scope only when it adds clarity:
-fix(auth): login redirect loops when session cookie is expired
-
-Types: feat, fix, improve, refactor, docs, chore.
-For fixes, describe the user-visible symptom and trigger:
-fix: task list fails to load when user has no environments
-Avoid implementation details such as:
-fix: add null check to task query
--->
-
-<details>
-<summary>Additional instructions</summary>
-
-**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
-can help update the branch when needed.
-
-</details>
-
 ## What Problem This Solves
 
 <!--
-Describe the concrete user, product, or operational problem.
+Describe the concrete problem for consumers of `@openclaw/fs-safe`.
 For fixes, begin with:
-"Fixes an issue where users <do X> would <experience Y> when <condition>."
+"Fixes an issue where consumers <do X> would <experience Y> when <condition>."
 or:
 "Resolves a problem where..."
 
-Name the affected UI surface or workflow. Do not describe the code-level cause here.
+Name the affected filesystem surface: root confinement, path validation,
+identity checks, archive extraction, permissions, atomic operations, stores,
+secrets, exports, packaging, or supported platforms. Do not describe only the
+code-level cause.
 -->
 
 ## Why This Change Was Made
 
 <!--
 In one or two sentences, explain the complete shipped solution, key design
-decisions, and relevant boundaries or non-goals. Include implementation detail
-only when it helps reviewers understand user-visible behavior or risk.
-Avoid file-by-file narration.
+decisions, and relevant boundaries or non-goals. Call out security,
+compatibility, export, error-shape, default, or platform implications.
 -->
 
 ## User Impact
 
 <!--
-State what users, operators, or developers can now do or expect. Lead with the
-concrete benefit and use user-facing language. If there is no user-visible
-impact, say so plainly.
+State what package consumers can now do or expect. If the change is breaking,
+describe the migration path. If it affects only tooling, tests, or docs and
+ships nothing new in the package, say so plainly.
 -->
 
 ## Evidence
 
 <!--
-Show the most useful proof that this change works. Screenshots, screencasts,
-terminal output, focused tests, CI results, live observations, redacted logs,
-and artifact links are all useful. Include before/after evidence for visual
-changes when it clarifies the result.
+Show the most useful proof that this change works:
 
-Reviewers will inspect the code, tests, and CI. Use this section to make the
-validation easy to understand, not to restate the diff.
+- focused regression or security tests
+- output of `pnpm check`
+- tarball/import proof from `pnpm pack:check`
+- platform or filesystem-specific reproduction
+- CI links or redacted logs
+-->
+
+- [ ] Tests added or updated when behavior changed
+- [ ] Security and compatibility impact considered
+- [ ] `CHANGELOG.md` updated when release-relevant
+- [ ] No credentials, private paths, private hosts, or sensitive contents included
+
+<!--
+Optional linked context:
+Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line.
+
+Required PR title:
+type(scope): user-facing description
+
+Types: feat, fix, improve, refactor, docs, chore.
+Suggested scopes: root, path, archive, atomic, store, secrets, permissions,
+exports, build, ci, deps, docs, tests.
 -->

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "31 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+          - actions
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,247 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: 24
+  PNPM_VERSION: 10.34.5
+
+jobs:
+  publish:
+    name: Publish @openclaw/fs-safe
+    if: github.ref_protected
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate package metadata
+        run: |
+          node <<'NODE'
+          const { readFileSync } = require("node:fs");
+
+          const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+          const expectedName = "@openclaw/fs-safe";
+          const expectedAuthor = "OpenClaw Team <dev@openclaw.ai>";
+          const expectedRepo = "https://github.com/openclaw/fs-safe";
+          const repository = typeof pkg.repository === "string"
+            ? pkg.repository
+            : pkg.repository?.url;
+          const normalize = (value) =>
+            String(value ?? "")
+              .trim()
+              .replace(/^git\+/, "")
+              .replace(/\.git$/i, "")
+              .replace(/\/+$/, "");
+
+          const errors = [];
+          if (pkg.name !== expectedName) {
+            errors.push(`package name must be ${expectedName}; found ${pkg.name ?? "<missing>"}`);
+          }
+          if (pkg.author !== expectedAuthor) {
+            errors.push(`package author must be ${expectedAuthor}; found ${pkg.author ?? "<missing>"}`);
+          }
+          if (normalize(repository) !== expectedRepo) {
+            errors.push(`repository URL must be ${expectedRepo}; found ${normalize(repository) || "<missing>"}`);
+          }
+          if (pkg.private === true) {
+            errors.push("package must not be private");
+          }
+          if (pkg.publishConfig?.access !== "public") {
+            errors.push("publishConfig.access must be public");
+          }
+          if (pkg.publishConfig?.provenance !== true) {
+            errors.push("publishConfig.provenance must be true");
+          }
+          if (errors.length > 0) {
+            for (const error of errors) console.error(error);
+            process.exit(1);
+          }
+          NODE
+
+      - name: Validate release tag and changelog
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+
+          package_version="$(node -p "require('./package.json').version")"
+          expected_tag="v${package_version}"
+          if ! printf '%s\n' "${RELEASE_TAG}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "release tag must match vX.Y.Z; received ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          if [ "${RELEASE_TAG}" != "${expected_tag}" ]; then
+            echo "release tag ${RELEASE_TAG} does not match package version ${package_version}" >&2
+            exit 1
+          fi
+          if [ "$(git cat-file -t "refs/tags/${RELEASE_TAG}")" != "tag" ]; then
+            echo "release tag ${RELEASE_TAG} must be annotated" >&2
+            exit 1
+          fi
+          release_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          git merge-base --is-ancestor "${release_commit}" origin/main
+          node scripts/release-notes.mjs "${package_version}" >/dev/null
+
+      - name: Check
+        run: pnpm check
+
+      - name: Prepare release artifact
+        id: artifact
+        run: |
+          set -euo pipefail
+          mkdir release-artifact
+          npm pack \
+            --json \
+            --ignore-scripts \
+            --pack-destination release-artifact \
+            > release-artifact/pack.json
+          node <<'NODE' >> "${GITHUB_OUTPUT}"
+          const { readFileSync } = require("node:fs");
+          const [artifact] = JSON.parse(readFileSync("release-artifact/pack.json", "utf8"));
+
+          if (!artifact?.filename || !artifact?.integrity) {
+            console.error("npm pack did not return an artifact filename and integrity");
+            process.exit(1);
+          }
+          console.log(`filename=${artifact.filename}`);
+          console.log(`integrity=${artifact.integrity}`);
+          NODE
+
+      - name: Publish or verify npm artifact
+        env:
+          PACKAGE_FILENAME: ${{ steps.artifact.outputs.filename }}
+          PACKAGE_INTEGRITY: ${{ steps.artifact.outputs.integrity }}
+        run: |
+          set -euo pipefail
+          package_name="$(node -p "require('./package.json').name")"
+          package_version="$(node -p "require('./package.json').version")"
+          package_spec="${package_name}@${package_version}"
+
+          verify_registry_artifact() {
+            set +e
+            registry_integrity="$(npm view "${package_spec}" dist.integrity 2>registry-error.log)"
+            view_status=$?
+            set -e
+            if [ "${view_status}" -ne 0 ]; then
+              if grep -q "E404" registry-error.log; then
+                return 2
+              fi
+              cat registry-error.log >&2
+              return 3
+            fi
+            registry_attestation="$(npm view "${package_spec}" dist.attestations.url)"
+            if [ "${registry_integrity}" != "${PACKAGE_INTEGRITY}" ]; then
+              echo "${package_spec} exists with different package bytes." >&2
+              return 1
+            fi
+            if [ -z "${registry_attestation}" ]; then
+              echo "${package_spec} exists without npm provenance." >&2
+              return 1
+            fi
+            echo "verified ${package_spec} integrity and provenance"
+          }
+
+          set +e
+          verify_registry_artifact
+          verify_status=$?
+          set -e
+          case "${verify_status}" in
+            0) exit 0 ;;
+            2) ;;
+            *) exit "${verify_status}" ;;
+          esac
+
+          set +e
+          npm publish \
+            "release-artifact/${PACKAGE_FILENAME}" \
+            --access public \
+            --provenance
+          publish_status=$?
+          set -e
+
+          for attempt in $(seq 1 12); do
+            set +e
+            verify_registry_artifact
+            verify_status=$?
+            set -e
+            if [ "${verify_status}" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "${verify_status}" -eq 3 ]; then
+              exit "${verify_status}"
+            fi
+            echo "registry verification attempt ${attempt}/12 did not confirm the artifact yet"
+            sleep 5
+          done
+
+          echo "npm publish exited ${publish_status}; registry verification never confirmed the artifact." >&2
+          exit 1
+
+  release:
+    name: Publish GitHub Release
+    if: github.ref_protected
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: publish
+    permissions:
+      contents: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          package_version="${RELEASE_TAG#v}"
+          node scripts/release-notes.mjs "${package_version}" > release-notes.md
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "${RELEASE_TAG} already has a GitHub release."
+            exit 0
+          fi
+          gh release create "${RELEASE_TAG}" \
+            --verify-tag \
+            --title "fs-safe ${RELEASE_TAG#v}" \
+            --notes-file release-notes.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 dist/
-node_modules/
+node_modules
 coverage/
 *.tsbuildinfo
 .clawpatch/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# AGENTS.md - @openclaw/fs-safe
+
+## Purpose
+
+`@openclaw/fs-safe` provides capability-style filesystem roots and related
+primitives for Node.js applications that handle untrusted paths.
+
+Filesystem boundaries, identity checks, archive extraction, permissions, and
+secret handling are security-sensitive public contracts.
+
+## Repository
+
+- GitHub: `https://github.com/openclaw/fs-safe`
+- npm: `https://www.npmjs.com/package/@openclaw/fs-safe`
+- Docs: `https://fs-safe.io`
+- Default branch: `main`
+- Runtime: Node.js `>=22`
+- Package manager: `pnpm`; use the version declared in `package.json`
+- Human contribution guide: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Security policy: [`SECURITY.md`](SECURITY.md)
+
+`CLAUDE.md` is a compatibility symlink to this file. Edit `AGENTS.md` only.
+Shared maintainer skills live in `openclaw/agent-skills`; do not vendor copies
+into this repository unless a repo-specific snapshot is intentionally required.
+
+## Security Boundaries
+
+- Never weaken root confinement, path normalization, symlink or hardlink
+  rejection, post-operation identity checks, or pinned file behavior.
+- Treat pathnames as attacker-controlled unless a public API explicitly says
+  otherwise.
+- Keep unsafe fallback behavior explicit, bounded, and documented.
+- Preserve fail-closed behavior for ambiguous filesystem identity and
+  ownership states.
+- Add focused regression tests for traversal, swap races, archive extraction,
+  permissions, secret files, and platform-specific fallbacks.
+- Do not add raw filesystem primitives that bypass the shared guarded helpers.
+
+## Public Package Contract
+
+- Keep exports, generated declarations, README examples, and docs aligned.
+- Treat exported types, error codes, option defaults, and package subpaths as
+  compatibility surfaces.
+- Update `CHANGELOG.md` under `Unreleased` for public, security, compatibility,
+  package, or operational changes.
+- Never commit generated `dist/` output.
+- Releases are tag-driven from `main` through
+  `.github/workflows/release.yml`; never publish locally or add npm tokens.
+
+## Commands
+
+Use repository scripts rather than invoking underlying tools directly:
+
+```bash
+pnpm build
+pnpm test
+pnpm test:security
+pnpm check
+pnpm pack:check
+```
+
+Run the smallest relevant test while iterating. Run `pnpm check` and
+`git diff --check` before handoff.
+
+## Change Rules
+
+- Keep one logical concern per change.
+- Use conventional commit and pull request titles.
+- Do not edit dependency lockfiles by hand.
+- Never commit credentials, private paths, private hosts, or unredacted logs.
+- Run the shared `autoreview` skill before shipping non-trivial changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.4.6 - Unreleased
 
+### Docs and Tooling
+
+- Add the public repository governance baseline, pinned CodeQL analysis,
+  package tarball/import validation, and protected tag-driven npm trusted
+  publishing with provenance and changelog-derived GitHub releases.
+
 ## 0.4.5 - 2026-07-20
 
 ### Highlights

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our Commitment
+
+We are committed to making participation in this project a respectful,
+harassment-free experience for everyone.
+
+## Expected Behavior
+
+- Be respectful, direct, and constructive.
+- Focus criticism on ideas and code, not people.
+- Accept responsibility, apologize when needed, and learn from mistakes.
+- Respect privacy and avoid publishing another person's private information.
+
+## Unacceptable Behavior
+
+- Harassment, threats, discrimination, or sexualized language
+- Trolling, personal attacks, or sustained disruption
+- Publishing private information without permission
+- Any conduct that would be inappropriate in a professional setting
+
+## Enforcement
+
+Report unacceptable behavior privately to `security@openclaw.ai`. Maintainers
+will review reports promptly, protect reporter privacy where possible, and may
+remove, edit, reject, or ban contributions or participants when necessary.
+
+## Attribution
+
+This policy is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to @openclaw/fs-safe
+
+Thanks for helping improve the filesystem safety primitives used by OpenClaw
+and other Node.js applications.
+
+By participating, you agree to follow the
+[Code of Conduct](CODE_OF_CONDUCT.md). Report security issues privately as
+described in [SECURITY.md](SECURITY.md).
+
+## Before You Start
+
+- Bugs and small fixes can go directly to a focused pull request.
+- Discuss breaking API changes or new security-policy behavior in an issue
+  before implementation.
+- Search existing issues and pull requests before opening a duplicate.
+
+## Development Setup
+
+Use the Node.js and pnpm versions declared by the repository.
+
+```bash
+pnpm install --frozen-lockfile
+pnpm check
+```
+
+Use the smallest relevant command while iterating:
+
+```bash
+pnpm build
+pnpm test
+pnpm test:security
+pnpm pack:check
+```
+
+The complete development and documentation guide lives at
+[`docs/contributing.md`](docs/contributing.md).
+
+## Pull Requests
+
+- Keep one logical change per pull request.
+- Use a conventional title such as
+  `fix(root): reject replaced parent directory`.
+- Explain the problem, chosen solution, and security or compatibility impact.
+- Add focused regression tests for behavior changes.
+- Update docs and exports together for new public APIs.
+- Update `CHANGELOG.md` for public, security, compatibility, package, or
+  operational changes.
+- Run `pnpm check` and report the exact validation performed.
+
+Path handling, filesystem identity, exported types, error codes, option
+defaults, and package subpaths are public compatibility surfaces. Prefer
+additive changes and call out deliberate breaks explicitly.
+
+## Reporting Bugs
+
+Use the bug report template and include:
+
+- the exact package version or commit
+- Node.js version, operating system, and filesystem type
+- a minimal reproduction
+- expected and actual behavior
+- relevant redacted logs or filesystem observations
+
+Never include credentials, private hostnames, personal paths, or sensitive file
+contents.
+
+## Release Process
+
+Maintainers publish from a protected `vX.Y.Z` tag on `main` through the trusted
+publishing workflow. The tag, package version, and dated `CHANGELOG.md` section
+must match. Do not publish locally or add an npm automation token.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,45 @@
 # Security Policy
 
-`@openclaw/fs-safe` is a filesystem-safety library, so potential boundary bypasses should be reported privately first.
+If you believe you found a security issue in `@openclaw/fs-safe`, report it
+privately.
 
-Email security reports to Peter Steinberger at `steipete@gmail.com` with:
+## Reporting
 
-- affected version or commit
-- platform and filesystem details
-- minimal reproduction steps
-- expected impact
+Open a private report through
+[GitHub Security Advisories](https://github.com/openclaw/fs-safe/security/advisories/new)
+or email `security@openclaw.ai`.
 
-Please do not open a public issue for traversal, symlink, hardlink, archive extraction, or credential-file bugs until we have coordinated disclosure.
+Include:
+
+1. affected version or commit
+2. Node.js version, operating system, filesystem, and mount details
+3. minimal reproduction
+4. demonstrated impact
+5. suggested remediation, if known
+
+Do not open a public issue until maintainers have coordinated disclosure.
+
+## Scope
+
+Security issues in scope generally include:
+
+- traversal or root-confinement bypasses
+- symlink, hardlink, rename, or identity-swap races that cross a documented
+  filesystem boundary
+- archive extraction outside the intended destination
+- unsafe secret-file, permission, ownership, or temporary-file behavior
+- package or release-pipeline compromise affecting the published package
+
+Reports must demonstrate a concrete boundary bypass or impact. Applications
+remain responsible for operating-system isolation, authorization, and choosing
+trusted root directories unless this package documents and fails to enforce a
+specific invariant.
+
+## Operational Guidance
+
+- Keep `@openclaw/fs-safe`, Node.js, and optional archive dependencies current.
+- Treat pathnames and archive contents as untrusted.
+- Use OS-level sandboxing when the threat model includes a hostile process.
+- Pin and review dependency updates before publishing.
+
+There is currently no paid bug bounty program.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,7 +10,8 @@ cd fs-safe
 pnpm install
 ```
 
-Node 22 or newer. The dev toolchain uses pnpm; `npm install` works too but pnpm is what the lockfile is keyed against.
+Node 22 or newer. The dev toolchain and lockfile use pnpm; use the package
+manager version declared in `package.json`.
 
 ## Build
 
@@ -34,9 +35,16 @@ pnpm test test/archive.test.ts
 
 Use `vi.mock` sparingly. Most tests should drive real disk operations in a `mkdtemp`-created scratch directory, asserting on observable behavior. The library has [test hooks](testing.md) for the rare cases where you need to inject a TOCTOU race deterministically.
 
-## Format and types
+## Checks
 
-The repo doesn't ship a separate lint config; `tsc --noEmit` (run by `pnpm build`) is the type gate. Format with your editor's TypeScript Language Server defaults — keep diffs tight.
+Run the complete repository gate before handoff:
+
+```bash
+pnpm check
+```
+
+This runs the filesystem boundary checks, build, tests, and package
+tarball/import validation.
 
 ## Docs
 
@@ -69,7 +77,14 @@ Small, focused PRs land faster. The general shape:
 
 ## Releases
 
-Release process lives in the maintainer's runbook. External contributors don't need to do anything beyond getting the PR merged.
+Maintainers publish from a protected `vX.Y.Z` tag on `main` through
+`.github/workflows/release.yml`. The workflow requires the package version and a
+dated `CHANGELOG.md` section to match the tag, then publishes with npm trusted
+publishing and provenance before creating the GitHub release.
+
+External contributors do not need to do anything beyond getting the pull
+request merged. Maintainers must not publish locally or add npm automation
+tokens.
 
 ## Reporting security issues
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,26 @@
   "name": "@openclaw/fs-safe",
   "version": "0.4.5",
   "description": "Capability-style filesystem roots for Node.js apps that handle untrusted relative paths.",
+  "keywords": [
+    "filesystem",
+    "openclaw",
+    "path-traversal",
+    "security",
+    "typescript"
+  ],
+  "homepage": "https://fs-safe.io",
+  "bugs": {
+    "url": "https://github.com/openclaw/fs-safe/issues"
+  },
   "license": "MIT",
+  "author": "OpenClaw Team <dev@openclaw.ai>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openclaw/fs-safe.git"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "dist/**/*.js",
@@ -95,7 +111,8 @@
     "./test-hooks": {
       "types": "./dist/test-hooks.d.ts",
       "default": "./dist/test-hooks.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "benchmark": "node scripts/benchmark.mjs",
@@ -106,9 +123,11 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:security": "vitest run test/fs-safe.test.ts test/read-boundary-bypass.test.ts test/write-boundary-bypass.test.ts test/additional-boundary-bypass.test.ts test/adversarial-boundary-payloads.test.ts",
-    "check": "pnpm lint:file-size && pnpm lint:fs-boundary && pnpm build && pnpm test",
+    "check": "pnpm lint:file-size && pnpm lint:fs-boundary && pnpm build && pnpm test && node scripts/check-pack.mjs",
     "docs:site": "node scripts/build-docs-site.mjs",
+    "pack:check": "pnpm build && node scripts/check-pack.mjs",
     "check:changed": "pnpm run check",
+    "release:notes": "node scripts/release-notes.mjs",
     "test:changed": "pnpm run test",
     "crabbox:hydrate": "crabbox actions hydrate",
     "crabbox:run": "crabbox run",

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -1,0 +1,122 @@
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+
+const workdir = mkdtempSync(join(tmpdir(), "fs-safe-pack-"));
+const npmCommand = resolveNpmCli();
+const npmEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.toLowerCase().startsWith("npm_config_")),
+);
+
+/**
+ * @param {string[]} args
+ * @param {import("node:child_process").ExecFileSyncOptionsWithStringEncoding} options
+ * @returns {string}
+ */
+function runNpm(args, options) {
+  return execFileSync(process.execPath, [npmCommand, ...args], {
+    ...options,
+    env: npmEnv,
+  });
+}
+
+function resolveNpmCli() {
+  const candidates = [
+    process.env.npm_execpath,
+    join(dirname(process.execPath), "..", "lib", "node_modules", "npm", "bin", "npm-cli.js"),
+    join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js"),
+  ];
+  if (process.platform !== "win32") {
+    try {
+      candidates.push(realpathSync(execFileSync("which", ["npm"], { encoding: "utf8" }).trim()));
+    } catch {
+      // The standard bundled paths remain valid on supported non-Windows Node installations.
+    }
+  }
+  const npmCli = candidates.find(
+    (candidate) => candidate && basename(candidate) === "npm-cli.js" && existsSync(candidate),
+  );
+  if (!npmCli) {
+    throw new Error("could not resolve npm-cli.js from the current Node installation");
+  }
+  return npmCli;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+function collectExportTargets(value) {
+  if (typeof value === "string") {
+    return value.startsWith("./") ? [value.slice(2)] : [];
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  return Object.values(value).flatMap(collectExportTargets);
+}
+
+try {
+  const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+  const output = runNpm(["pack", "--json", "--ignore-scripts", "--pack-destination", workdir], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  /** @type {Array<{ filename: string; files: Array<{ path: string }> }>} */
+  const pack = JSON.parse(output);
+  const [{ filename, files }] = pack;
+  const paths = new Set(files.map((file) => file.path));
+  const expected = new Set([
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md",
+    "SECURITY.md",
+    "package.json",
+    ...collectExportTargets(pkg.exports),
+  ]);
+  const missing = [...expected].filter((path) => !paths.has(path)).toSorted();
+  if (missing.length > 0) {
+    throw new Error(`packed package is missing: ${missing.join(", ")}`);
+  }
+
+  const forbidden = [...paths].filter((path) =>
+    /^(?:\.agents|\.github|scripts|src|test)\//.test(path),
+  );
+  if (forbidden.length > 0) {
+    throw new Error(`packed package contains repository-only files: ${forbidden.join(", ")}`);
+  }
+  if (pkg.name !== "@openclaw/fs-safe") {
+    throw new Error(`unexpected package name: ${pkg.name}`);
+  }
+
+  const archive = join(workdir, filename);
+  writeFileSync(join(workdir, "package.json"), '{"private":true,"type":"module"}\n');
+  runNpm(["install", "--ignore-scripts", "--no-audit", "--no-fund", "--no-package-lock", archive], {
+    cwd: workdir,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+
+  const specifiers = Object.keys(pkg.exports)
+    .filter((subpath) => subpath !== "./package.json")
+    .map((subpath) => (subpath === "." ? pkg.name : `${pkg.name}/${subpath.slice(2)}`));
+  execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      `await Promise.all(${JSON.stringify(specifiers)}.map((specifier) => import(specifier)));`,
+    ],
+    { cwd: workdir, stdio: "pipe" },
+  );
+} finally {
+  rmSync(workdir, { force: true, recursive: true });
+}

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+const version = process.argv[2] ?? pkg.version;
+
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  throw new Error(`release version must match X.Y.Z; received ${version || "<missing>"}`);
+}
+
+const lines = readFileSync("CHANGELOG.md", "utf8").split(/\r?\n/);
+const prefix = `## ${version} - `;
+const start = lines.findIndex((line) => line.startsWith(prefix));
+if (start < 0) {
+  throw new Error(`CHANGELOG.md has no section for ${version}`);
+}
+
+const date = lines[start].slice(prefix.length).trim();
+if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+  throw new Error(`CHANGELOG.md section ${version} must have a release date`);
+}
+
+const next = lines.findIndex((line, index) => index > start && line.startsWith("## "));
+const body = lines.slice(start + 1, next < 0 ? undefined : next).join("\n").trim();
+if (!body) {
+  throw new Error(`CHANGELOG.md section ${version} has no release notes`);
+}
+
+process.stdout.write(`${body}\n`);


### PR DESCRIPTION
## What Problem This Solves

The repository had no complete public-library baseline for governance, security analysis, package verification, or repeatable npm releases. Releases were manual, packed exports were not validated as installed consumer artifacts, and repository security/update coverage was incomplete.

## Why This Change Was Made

Adds repository standards, CodeQL and dependency coverage, and a changelog-driven protected-tag release workflow using npm trusted publishing and provenance. The release path validates metadata, annotated tags, main ancestry, release notes, tarball contents/imports, and ambiguous npm publish recovery through registry integrity and provenance checks.

## User Impact

No runtime API or behavior changes. Package consumers gain verified public exports and provenance on future releases; maintainers gain a documented, fail-closed release process and standard contribution/security surfaces.

## Evidence

- `pnpm check`: 42 files passed; 451 tests passed, 3 skipped
- `pnpm test:security`: 5 files and 59 tests passed
- clean-dist `pnpm pack:check`: tarball contents and every public export import passed
- `pnpm docs:site`, actionlint, YAML parsing, and `git diff --check` passed
- fresh autoreview reported no accepted/actionable findings
- protected release-tag ruleset and npm trusted-publisher mapping verified before merge

- [x] Tests added or updated when behavior changed (no runtime behavior changed)
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
