### PR TITLE
chore(repo): add feature request form

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,8 @@ body:
     attributes:
       value: |
         Describe the capability and contract, not only an implementation idea.
-        Report boundary bypasses and other security issues through the private security advisory link instead.
+        Report boundary bypasses and other security issues through the
+        [private security advisory](https://github.com/openclaw/fs-safe/security/advisories/new) instead.
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Propose a new filesystem-safety capability or public API change.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the capability and contract, not only an implementation idea.
+        Report boundary bypasses and other security issues through the private security advisory link instead.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What concrete filesystem problem cannot be solved safely with the current public API?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API or behavior
+      description: Describe the desired contract, including inputs, outputs, errors, and security boundaries.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Explain existing workarounds and why they are insufficient.
+    validations:
+      required: true
+  - type: checkboxes
+    id: surfaces
+    attributes:
+      label: Affected surfaces
+      options:
+        - label: Root-bounded reads or writes
+        - label: Path, symlink, or hardlink validation
+        - label: Atomic operations or file locking
+        - label: JSON, store, or secret-file helpers
+        - label: Archive extraction
+        - label: Permissions or ownership
+        - label: Temp files or external outputs
+        - label: TypeScript types or package exports
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Security and compatibility considerations
+      description: Note traversal, identity, race, migration, platform, or breaking-change concerns.
+    validations:
+      required: true


### PR DESCRIPTION
## What Problem This Solves

The repository baseline added a bug form but omitted the companion feature-request form used by the other TypeScript library repositories, leaving GitHub community health at 87%.

## Why This Change Was Made

Adds a focused feature form for filesystem-safety API proposals, with explicit security and compatibility prompts.

## User Impact

No package or runtime change. Contributors get a structured route for feature proposals.

## Evidence

- YAML parsing passed
- `git diff --check` passed
- `enhancement` label exists

- [x] Tests added or updated when behavior changed (no runtime behavior changed)
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant (covered by the existing 0.4.6 repository-baseline entry)
- [x] No credentials, private paths, private hosts, or sensitive contents included
