### PR TITLE
chore(release): v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.4.6 - Unreleased
+## 0.4.6 - 2026-07-24
+
+### Highlights
+
+- Reject foreign-owned or unverifiable Windows files in secure reads while
+  preserving supported trusted local owners and exact extended drive paths.
 
 ### Security and Correctness
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Capability-style filesystem roots for Node.js apps that handle untrusted relative paths.",
   "keywords": [
     "filesystem",


### PR DESCRIPTION
## What Problem This Solves

The Windows ownership hardening merged after `v0.4.5`, but the npm package and
GitHub release still expose `0.4.5`.

## Why This Change Was Made

Bump the package to `0.4.6` and date the existing release notes so the protected
tag workflow can publish the already-merged security fix. This PR changes release
metadata only.

## User Impact

Consumers can install a release that rejects foreign-owned or unverifiable
Windows files during secure reads while preserving trusted local owners and
exact extended drive paths.

## Evidence

- `pnpm check`: 43 files passed; 461 tests passed, 4 skipped; build, lint,
  tarball, and import checks passed.
- `pnpm test:security`: 5 files and 59 tests passed.
- Native Windows release proof on Node `24.15.0` and pnpm `10.34.5`:
  60 focused tests passed, 11 skipped; Administrators-owned normal and exact
  `\\?\` paths were accepted; Builtin Users ownership was rejected with
  `not-owned`.
- Crabbox run: https://crabbox.openclaw.ai/portal/runs/run_1bd53888f6c7
- Autoreview: clean, no accepted or actionable findings.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included

Related: #48
