### PR TITLE
fix(ci): continue release after registry miss

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,10 +152,8 @@ jobs:
           package_spec="${package_name}@${package_version}"
 
           verify_registry_artifact() {
-            set +e
             registry_integrity="$(npm view "${package_spec}" dist.integrity 2>registry-error.log)"
             view_status=$?
-            set -e
             if [ "${view_status}" -ne 0 ]; then
               if grep -q "E404" registry-error.log; then
                 return 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Add the public repository governance baseline, pinned CodeQL analysis,
   package tarball/import validation, and protected tag-driven npm trusted
   publishing with provenance and changelog-derived GitHub releases.
+- Let tag-driven publishing continue from an expected registry miss into npm
+  trusted publishing instead of exiting before the publish attempt.
 
 ## 0.4.5 - 2026-07-20
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the protected release workflow exited before `npm publish`
when the requested package version was correctly absent from the registry.

The first `v0.4.6` run validated the tag, changelog, package, tests, and tarball,
then failed in the publish/recovery step:
https://github.com/openclaw/fs-safe/actions/runs/30086619672

## Why This Change Was Made

Keep `errexit` control at the two existing call sites. The registry verification
helper no longer re-enables it internally before returning the expected E404
status, so the workflow can proceed into npm trusted publishing.

## User Impact

This unblocks publication of `@openclaw/fs-safe@0.4.6`. Runtime package behavior
is unchanged by this repair.

## Evidence

- Executed the exact embedded publish block with a fake registry:
  E404 before publish, matching integrity and provenance after publish; exit 0.
- `git diff --check`
- Autoreview: clean, no accepted or actionable findings.
- The failed release run completed all validation and package checks before the
  affected publish/recovery step.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
