### PR TITLE
fix(ci): publish the local release tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
 
           set +e
           npm publish \
-            "release-artifact/${PACKAGE_FILENAME}" \
+            "./release-artifact/${PACKAGE_FILENAME}" \
             --access public \
             --provenance
           publish_status=$?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   publishing with provenance and changelog-derived GitHub releases.
 - Let tag-driven publishing continue from an expected registry miss into npm
   trusted publishing instead of exiting before the publish attempt.
+- Publish the generated tarball through an explicit relative path so npm treats
+  it as a local artifact instead of GitHub repository shorthand.
 
 ## 0.4.5 - 2026-07-20
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the release workflow passed the generated tarball to npm
without an explicit relative-path prefix. npm interpreted
`release-artifact/openclaw-fs-safe-0.4.6.tgz` as GitHub repository shorthand and
attempted an SSH clone instead of publishing the local artifact.

Failed release run:
https://github.com/openclaw/fs-safe/actions/runs/30086956227

## Why This Change Was Made

Publish `./release-artifact/${PACKAGE_FILENAME}` so npm unambiguously receives a
local tarball. The package, trusted-publisher configuration, and provenance
requirements are unchanged.

## User Impact

This unblocks publication of `@openclaw/fs-safe@0.4.6`. Runtime package behavior
is unchanged by this repair.

## Evidence

- Packed the release artifact and ran real
  `npm publish --dry-run --ignore-scripts ./release-artifact/<tarball>
  --access public`; npm recognized `@openclaw/fs-safe@0.4.6` and prepared the
  public publish.
- `git diff --check`
- Autoreview: clean, no accepted or actionable findings.
- The failed workflow log shows npm attempting
  `git ls-remote ssh://git@github.com/release-artifact/...tgz.git` with the old
  path.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
