### PR TITLE
chore: open v0.4.7 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.4.7 - Unreleased
+
 ## 0.4.6 - 2026-07-24
 
 ### Highlights


### PR DESCRIPTION
## What Problem This Solves

The `v0.4.6` release consumed the current changelog section, leaving no
unreleased section for subsequent changes.

## Why This Change Was Made

Open the next `0.4.7 - Unreleased` section using the repository's established
post-release pattern. The package version remains `0.4.6`.

## User Impact

No package behavior changes. Future release notes have the correct collection
section.

## Evidence

- `git diff --check`
- Matches the post-`v0.4.5` changelog pattern.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
