### PR TITLE
chore(release): open 0.4.8 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.4.8 - Unreleased
+
 ## 0.4.7 - 2026-07-24
 
 ### Features


### PR DESCRIPTION
## What Problem This Solves

Opens the next patch changelog section after the verified `0.4.7` release.

## Why This Change Was Made

Keeps new release notes under an explicit unreleased version instead of appending them to the published `0.4.7` section.

## User Impact

Release metadata only; no package behavior changes.

## Evidence

- `0.4.7` is published on npm with matching integrity and provenance.
- GitHub Release `v0.4.7` and its tag workflow are complete.
- `git diff --check` passed.

- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
