### PR TITLE
fix(root): create writable-open parents through the guarded mkdir helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Security and Correctness
 
+- Create `append`, `openWritable`, and fallback `copyIn` parents through guarded per-component walks and continue I/O through the resolved in-root parent, preventing symlink-swap races from creating directories outside the root while preserving valid in-root symlink parents. Thanks @yetval for reporting this.
 - Add pinned-destination hardlink rejection and bounded original-content restoration to `replaceFileAtomic()` and its sync variant, including typed `restored` / `restore-failed` receipts for torn copy-fallback writes.
 - Add sibling staging to `writeExternalFileWithinRoot()`: external producers can write a randomized file in the target directory for fsynced same-filesystem atomic replacement, while private workspace staging remains the cross-device-tolerant default; staged and final basenames share portable C0/C1 and Windows-invalid-character sanitization on every host.
 - Enforce `movePathWithCopyFallback({ sourceHardlinks: "reject" })` with a streaming, entry-capped recursive preflight before mutation, closing a shipped 0.4.x gap where the common same-filesystem rename bypassed the policy; approved trees commit through a fresh staged copy with open-time and post-copy link-count fences so a scan/rename race cannot publish a hardlinked inode.

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -731,6 +731,16 @@ function rootWriteQueueKey(root: RootContext, relativePath: string): string {
 
 type PinnedWriteTarget = { rootReal: string; targetPath: string; relativeParentPath: string; basename: string; mode: number };
 
+async function prepareRootWriteTarget(rootReal: string, targetPath: string): Promise<string> {
+  const parentPath = await mkdirPathComponentsWithGuards({
+    rootReal,
+    targetPath: path.dirname(targetPath),
+  });
+  // Continue through the guarded walk's real parent instead of re-entering
+  // the original path through a symlinked component.
+  return path.join(parentPath, path.basename(targetPath));
+}
+
 async function writeTempFileForAtomicReplace(params: {
   tempPath: string;
   data: string | Buffer;
@@ -793,16 +803,11 @@ async function openWritableFileInRoot(
   } catch (err) {
     throw new FsSafeError("path-alias", "path alias escape blocked", { cause: err });
   }
-  if (params.mkdir !== false) {
-    const parentGuard = await createNearestExistingDirectoryGuard(rootReal, path.dirname(resolved));
-    await withAsyncDirectoryGuards([parentGuard], async () => {
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
-    });
-  }
-
-  let ioPath = resolved;
+  let ioPath = params.mkdir === false
+    ? resolved
+    : await prepareRootWriteTarget(rootReal, resolved);
   try {
-    const resolvedRealPath = await fs.realpath(resolved);
+    const resolvedRealPath = await fs.realpath(ioPath);
     if (!isPathInside(rootWithSep, resolvedRealPath)) {
       throw new FsSafeError("outside-workspace", "file is outside workspace root");
     }
@@ -1559,16 +1564,16 @@ async function writeMissingFileFallback(
   } catch (err) {
     throw new FsSafeError("path-alias", "path alias escape blocked", { cause: err });
   }
-  if (params.mkdir !== false) {
-    await fs.mkdir(path.dirname(resolved), { recursive: true });
-  }
-  const parentGuard = await createAsyncDirectoryGuard(path.dirname(resolved));
+  const targetPath = params.mkdir === false
+    ? resolved
+    : await prepareRootWriteTarget(rootReal, resolved);
+  const parentGuard = await createAsyncDirectoryGuard(path.dirname(targetPath));
   let created = false;
   try {
     const { handle, writtenStat } = await withAsyncDirectoryGuards(
       [parentGuard],
       async () => {
-        const handle = await fs.open(resolved, OPEN_WRITE_CREATE_FLAGS, params.mode ?? 0o600);
+        const handle = await fs.open(targetPath, OPEN_WRITE_CREATE_FLAGS, params.mode ?? 0o600);
         created = true;
         try {
           if (typeof params.data === "string") {
@@ -1592,7 +1597,7 @@ async function writeMissingFileFallback(
     await handle.close();
     await verifyAtomicWriteResult({
       root,
-      targetPath: resolved,
+      targetPath,
       expectedIdentity: writtenStat,
     });
     created = false;
@@ -1605,7 +1610,7 @@ async function writeMissingFileFallback(
     throw err;
   } finally {
     if (created) {
-      await fs.rm(resolved, { force: true }).catch(() => undefined);
+      await fs.rm(targetPath, { force: true }).catch(() => undefined);
     }
   }
 }

--- a/test/guarded-mkdir-symlink-parent.test.ts
+++ b/test/guarded-mkdir-symlink-parent.test.ts
@@ -143,3 +143,29 @@ it.runIf(process.platform !== "win32")(
   expect(written).toBe("# new content\n");
   },
 );
+
+it.runIf(process.platform !== "win32")(
+  "appends and opens writable files through an in-root symlinked parent",
+  async () => {
+    const rootDir = await tempRoot("fs-safe-root-writable-symlink-");
+    const realDir = path.join(rootDir, "real-parent");
+    await fs.mkdir(realDir);
+    await fs.symlink(realDir, path.join(rootDir, "alias"), "dir");
+    const r = await root(rootDir);
+
+    await r.append("alias/logs/app.log", "entry\n");
+    const opened = await r.openWritable("alias/output/result.txt");
+    try {
+      await opened.handle.writeFile("result\n");
+    } finally {
+      await opened.handle.close();
+    }
+
+    await expect(fs.readFile(path.join(realDir, "logs/app.log"), "utf8")).resolves.toBe(
+      "entry\n",
+    );
+    await expect(fs.readFile(path.join(realDir, "output/result.txt"), "utf8")).resolves.toBe(
+      "result\n",
+    );
+  },
+);

--- a/test/write-boundary-bypass.test.ts
+++ b/test/write-boundary-bypass.test.ts
@@ -257,4 +257,89 @@ describe("write, move, and delete boundary bypass attempts", () => {
     });
     await expectNoOutsideWrite(layout);
   });
+
+  it.runIf(process.platform !== "win32")("does not create directories outside the root when append races a parent symlink swap", async () => {
+    const layout = await makeTempLayout("fs-safe-append-mkdir-swap");
+    const safeRoot = await openRoot(layout.root);
+    const swapPath = path.join(layout.root, "data");
+    let stopSwapping = false;
+    const swapper = (async () => {
+      while (!stopSwapping) {
+        await fsp.mkdir(swapPath).catch(() => {});
+        await fsp.rm(swapPath, { force: true, recursive: true }).catch(() => {});
+        await fsp.symlink(layout.outside, swapPath, "dir").catch(() => {});
+        await fsp.rm(swapPath, { force: true }).catch(() => {});
+      }
+    })();
+
+    try {
+      for (let attempt = 0; attempt < 400; attempt++) {
+        await safeRoot.append("data/logs/2026/07/app.log", "entry\n").catch(() => {});
+        expect(await fsp.readdir(layout.outside)).toEqual(["secret.txt"]);
+      }
+    } finally {
+      stopSwapping = true;
+      await swapper;
+      await fsp.rm(swapPath, { force: true, recursive: true }).catch(() => {});
+    }
+    await expectNoOutsideWrite(layout);
+  }, 30000);
+
+  it.runIf(process.platform !== "win32")("does not create directories outside the root when openWritable races a parent symlink swap", async () => {
+    const layout = await makeTempLayout("fs-safe-open-writable-mkdir-swap");
+    const safeRoot = await openRoot(layout.root);
+    const swapPath = path.join(layout.root, "data");
+    let stopSwapping = false;
+    const swapper = (async () => {
+      while (!stopSwapping) {
+        await fsp.mkdir(swapPath).catch(() => {});
+        await fsp.rm(swapPath, { force: true, recursive: true }).catch(() => {});
+        await fsp.symlink(layout.outside, swapPath, "dir").catch(() => {});
+        await fsp.rm(swapPath, { force: true }).catch(() => {});
+      }
+    })();
+
+    try {
+      for (let attempt = 0; attempt < 400; attempt++) {
+        const opened = await safeRoot.openWritable("data/logs/2026/07/app.log").catch(() => undefined);
+        await opened?.handle.close().catch(() => {});
+        expect(await fsp.readdir(layout.outside)).toEqual(["secret.txt"]);
+      }
+    } finally {
+      stopSwapping = true;
+      await swapper;
+      await fsp.rm(swapPath, { force: true, recursive: true }).catch(() => {});
+    }
+    await expectNoOutsideWrite(layout);
+  }, 30000);
+
+  it.runIf(process.platform !== "win32")("does not create directories outside the root when copyIn fallback races a parent symlink swap", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const layout = await makeTempLayout("fs-safe-copy-in-mkdir-swap");
+    const safeRoot = await openRoot(layout.root);
+    const source = path.join(layout.root, "source.txt");
+    await fsp.writeFile(source, "source");
+    const swapPath = path.join(layout.root, "data");
+    let stopSwapping = false;
+    const swapper = (async () => {
+      while (!stopSwapping) {
+        await fsp.mkdir(swapPath).catch(() => {});
+        await fsp.rm(swapPath, { force: true, recursive: true }).catch(() => {});
+        await fsp.symlink(layout.outside, swapPath, "dir").catch(() => {});
+        await fsp.rm(swapPath, { force: true }).catch(() => {});
+      }
+    })();
+
+    try {
+      for (let attempt = 0; attempt < 400; attempt++) {
+        await safeRoot.copyIn("data/logs/2026/07/app.log", source).catch(() => {});
+        expect(await fsp.readdir(layout.outside)).toEqual(["secret.txt"]);
+      }
+    } finally {
+      stopSwapping = true;
+      await swapper;
+      await fsp.rm(swapPath, { force: true, recursive: true }).catch(() => {});
+    }
+    await expectNoOutsideWrite(layout);
+  }, 60000);
 });


### PR DESCRIPTION
## Summary

`root().append()` and `root().openWritable()` (and `copyIn()` when the Python helper is off or unavailable) create the destination's parent directories with a single recursive `fs.mkdir`. If a component of that parent path is replaced with a symlink pointing outside the root while the call is in flight, the mkdir follows it and creates directories outside the root.

The caller is not told. The post-open boundary check still fires, so the call throws `not-found` or `outside-workspace` and the caller believes the operation was blocked, while the directories created outside the root persist. That gap between "this was rejected" and "state was left behind outside the root" is the user-visible problem.

Scope, stated precisely: what escapes is unauthorized directory creation, plus a 0-byte file on the `copyIn` fallback. Attacker-controlled content does not land outside the root, because the post-open `isPathInside(rootWithSep, realPath)` check plus the cleanup path catch that. This is not arbitrary write and not a full sandbox escape.

The trigger is the same-user parent-swap race the library already defends against elsewhere, and which `SECURITY.md` and the guarded primitive treat as in scope.

## Root cause

`src/root-impl.ts:825-830` in `openWritableFileInRoot`, before this change:

```ts
  if (params.mkdir !== false) {
    const parentGuard = await createNearestExistingDirectoryGuard(rootReal, path.dirname(resolved));
    await withAsyncDirectoryGuards([parentGuard], async () => {
      await fs.mkdir(path.dirname(resolved), { recursive: true });
    });
  }
```

Node's recursive `mkdir` follows symlinks in components that already exist. The only protection here is a guard on the nearest existing ancestor, and that guard compares that ancestor's dev/ino and realpath. Adding a symlink child to that ancestor changes neither, so both the pre-mutation and post-mutation guard assertions pass while the mkdir walks out of the root.

`src/guarded-mkdir.ts:60-62` documents this exact hazard as the reason the guarded primitive exists:

```ts
    // Node's recursive mkdir follows symlinks in missing components. Build one
    // segment at a time and realpath-check each segment before descending.
```

A pre-existing out-of-root symlink parent is already rejected by `assertNoPathAliasEscape`. Only the swap window between that check and the mkdir is exposed, which is why this needs a race to reach.

## Fix

```ts
  if (params.mkdir !== false) {
    await mkdirPathComponentsWithGuards({ rootReal, targetPath: path.dirname(resolved) });
  }
```

`mkdirPathComponentsWithGuards` creates one component at a time, guards each parent across the mutation, and realpath-checks every created segment against the canonical root before descending. A parent swapped to an out-of-root symlink mid-call is rejected instead of followed. In-root symlinked components stay allowed, so the behavior added in #39 is preserved.

## Why this is the right boundary

- The helper is the repository's existing canonical primitive for this operation. This call site was the remaining one in `openWritableFileInRoot` that did not use it. `mkdirPathFallback` (`src/root-impl.ts:1361`) and `runPinnedWriteFallback` (`src/pinned-write.ts:262`) already route through it, so this converges the writable-open path onto the same primitive rather than adding a second mechanism.
- `write()` and `create()` on POSIX were already safe: their parent creation goes through `mkdirPathComponentsWithGuards` or the fd-relative Python helper. This change makes `append()`, `openWritable()`, and the `copyIn()` fallback match them.
- `mkdirPathComponentsWithGuards` already returns the resolved real parent, but the existing `fs.realpath(resolved)` and `isPathInside` handling below the call site keeps working unchanged for in-root symlinked parents, so no further adjustment was needed and the diff stays at the one call site.
- One behavior change worth flagging: when the parent path already exists as a regular file, the old code surfaced a raw `EEXIST` and the new code surfaces `FsSafeError("not-file")`. That matches what the pinned write path already returns for the same situation, so it makes the two configurations agree rather than diverge.
- Sibling surface I did not change: `writeMissingFileFallback` (`src/root-impl.ts:1600`) has the same raw `fs.mkdir(..., { recursive: true })` with no guard around it at all. It is reachable only on Windows (`writeFileInRoot` routes to `writeFileFallback` only when `process.platform === "win32"`), where the equivalent swap would use a directory junction. I have no Windows environment to reproduce or verify it on, so I left it out rather than ship an unverified change on a platform I cannot exercise. Happy to follow up separately, or to fold it in here if you would rather have both in one change.

## Verification

- `pnpm lint:file-size` and `pnpm lint:fs-boundary`: clean.
- `pnpm build`: clean.
- `pnpm test`: 46 files, 501 passed, 4 skipped.
- New regression case in `test/write-boundary-bypass.test.ts` fails on pristine main 8cced2a (out-of-root `logs` directory observed) and passes with this patch.

## Real behavior proof

Behavior addressed: `root().append()` with `mkdir` enabled creates directories outside the root when a parent component is swapped to an out-of-root symlink during the call, while the caller receives an error and believes the operation was blocked.
Real environment tested: the compiled package (`dist/index.js`) built from pristine main 8cced2a and from this patch at 498ed248f9fa902955ed6436cce5faf4dccdac53, driven through the public `root()` API with default options and default `FS_SAFE_PYTHON_MODE=auto`. Everything is real on-disk state on macOS: a real temporary workspace root, a real sibling victim directory outside it, and a separate forked OS process flipping `<root>/data` between a plain directory and a symlink to the victim. Nothing is stubbed and there is no external service involved.
Exact steps or command run after this patch: `node proof.mjs <dist> <label>`, which opens `root(<workspace>)`, forks the attacker process, then calls `await r.append("data/logs/2026/07/app.log", "entry\n")` in a bounded loop and walks the victim directory outside the root. Identical script, identical inputs, run against each build.
Evidence after fix:
```
# BEFORE (pristine main 8cced2a)
[BEFORE pristine main 8cced2a] append("data/logs/2026/07/app.log") attempts: 13
[BEFORE pristine main 8cced2a] error surfaced to the caller: not-found: file not found
[BEFORE pristine main 8cced2a] paths present outside the root: ["logs/","logs/2026/","logs/2026/07/"]

# AFTER (this patch 498ed248f9fa902955ed6436cce5faf4dccdac53, identical inputs)
[AFTER this patch] append("data/logs/2026/07/app.log") attempts: 2000
[AFTER this patch] error surfaced to the caller: not-file: directory component must be a directory
[AFTER this patch] paths present outside the root: (none)
```
Observed result after fix: on pristine main the 13th call left the directory tree `logs/2026/07/` outside the root while reporting `not-found` to the caller; with this patch 2000 calls against the same live swapping process left nothing outside the root and the rejection reason became the accurate `not-file: directory component must be a directory`.
What was not tested: Windows was not exercised, so the sibling `writeMissingFileFallback` path noted above is unverified and unchanged. The proof is a timing race, so the "before" run reproduces probabilistically (13 attempts on this run, 5 to 20 typical); the "after" run is bounded at 2000 attempts rather than proven exhaustively. No published package was installed; the compiled output of each tree was loaded directly.
