### PR TITLE
fix(store): serialize concurrent JSON mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Security and Correctness
 
+- Serialize async `jsonStore` writes and read-modify-write updates in-process by canonical store path before taking the cross-process sidecar lock, preventing overlapping `write`, `update`, and `updateOr` calls from silently losing updates; reject nested same-path mutations with typed `store-reentrant-update` errors. Thanks @yetval for reporting this.
 - Create `append`, `openWritable`, and fallback `copyIn` parents through guarded per-component walks and continue I/O through the resolved in-root parent, preventing symlink-swap races from creating directories outside the root while preserving valid in-root symlink parents. Thanks @yetval for reporting this.
 - Add pinned-destination hardlink rejection and bounded original-content restoration to `replaceFileAtomic()` and its sync variant, including typed `restored` / `restore-failed` receipts for torn copy-fallback writes.
 - Add sibling staging to `writeExternalFileWithinRoot()`: external producers can write a randomized file in the target directory for fsynced same-filesystem atomic replacement, while private workspace staging remains the cross-device-tolerant default; staged and final basenames share portable C0/C1 and Windows-invalid-character sanitization on every host.
@@ -31,6 +32,7 @@
 
 ### Compatibility
 
+- Remove the unsound process-scoped `allowReentrant` async file-lock option. Callers that passed it should delete the property; same-process contention now follows the normal retry and timeout policy, while nested same-file `jsonStore` mutations fail immediately instead of deadlocking.
 - Remove the persistent Python helper and its `pythonPath` configuration. Replace `configureFsSafePython`, `FS_SAFE_PYTHON_MODE`, and the OpenClaw Python aliases with `configureFsSafeNative` and `FS_SAFE_NATIVE_MODE`; 0.5 warns once and maps the former `auto`, `require`, and `off` policies solely as an upgrade bridge for shipped 0.4 consumers.
 - Add `publishFileExclusive({ strategy: "rename-noreplace" })`; this strategy requires the native helper, atomically moves the source, and never replaces an existing destination.
 

--- a/docs/json-store.md
+++ b/docs/json-store.md
@@ -113,7 +113,17 @@ Read, transform, write — under the lock if locking is enabled. Returns the new
 const next = await store.update((prev) => ({ count: (prev?.count ?? 0) + 1 }));
 ```
 
-`run` is async-friendly. The whole `read → run → write` sequence runs inside one `withLock` call, so concurrent updaters from different processes serialize cleanly.
+`run` is async-friendly. The whole `read → run → write` sequence is serialized
+by canonical file path inside the process. With locking enabled, the sidecar
+lock is acquired inside that queue, so concurrent updaters from different
+processes serialize cleanly too.
+
+Do not call `write()`, `update()`, or `updateOr()` for the same file from inside
+an update callback. That nested mutation cannot run until the outer update
+finishes, so `jsonStore` rejects it immediately with
+`FsSafeError("store-reentrant-update")`. Return the complete next value from the
+outer callback instead. The check follows Node async context, including promise
+and `queueMicrotask` boundaries.
 
 Use `update(run)` when missing state is part of your model. Use `updateOr(fallback, run)` when the missing-file case should start from a concrete value and you want to merge into defaults:
 
@@ -137,13 +147,18 @@ const counter = jsonStore<{ count: number }>({
 });
 ```
 
-When `lock` is falsy, `read` / `write` / `update` are unlocked. The `update` shape is still useful — it gives you a single function for the read-modify-write pattern — but it offers no concurrency guarantees if other processes also write to the file.
+When `lock` is falsy, writes and updates still serialize inside this process by
+canonical file path, including across separate `jsonStore` handles. They offer
+no concurrency guarantees if another process also writes to the file.
 
 Process-wide lock defaults from `configureFsSafeLocks()` apply only after locking is explicitly enabled. They do not make JSON stores lock by default.
 
 JSON store locks fail closed on stale sidecars by default. Opt-in `staleRecovery: "remove-if-unchanged"` requires caller approval and uses the same exclusive reclaim guard as the low-level sidecar-lock API.
 
-The default `managerKey` namespaces the in-process `FileLockManager` per absolute file path, so two `jsonStore` calls on the same file share lock state automatically.
+The default `managerKey` namespaces the `FileLockManager` per absolute file
+path. The JSON-store queue is independent of the manager key, so separate
+handles and custom lock-manager namespaces still cannot overlap mutations of
+the same canonical file path inside one process.
 
 ## Common patterns
 

--- a/docs/migrating-to-0.5.md
+++ b/docs/migrating-to-0.5.md
@@ -140,6 +140,11 @@ The default directory-error policy remains `throw`. See
 
 - Use `acquireFileLockSync()` only in synchronous boot or migration code; retry
   waits block the thread. Request-serving paths should use `withFileLock()`.
+- Remove `allowReentrant` from async file-lock options. Same-process contention
+  now follows the ordinary retry and timeout policy. Locked and unlocked
+  `jsonStore` mutations serialize by canonical file path; nested same-file
+  mutations from an update callback fail with `store-reentrant-update`, so
+  return the complete value from the outer callback instead.
 - Use `createSecretFileAtomic()` for first-writer-wins credentials and catch
   `secret-exists`; use `writeSecretFileAtomic()` only when replacement is the
   intended protocol.

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -59,7 +59,6 @@ type FileLockAcquireOptions<TPayload extends Record<string, unknown>> = {
   timeoutMs?: number;                    // overall acquire deadline; default unbounded
   retry?: FileLockRetryOptions;
   staleRecovery?: "fail-closed" | "remove-if-unchanged"; // default "fail-closed"
-  allowReentrant?: boolean;              // if this process already holds it, increment a count instead of failing
   payload: () => TPayload | Promise<TPayload>;
   shouldReclaim?: (params: {
     lockPath: string;
@@ -95,6 +94,12 @@ type FileLockRetryOptions = {
 `parsePayload` replaces JSON parsing for legacy or custom sidecars. Its `unknown`
 result is passed to `shouldReclaim` and `shouldRemoveStaleLock`, allowing PID,
 process-start, argv, or role schemas to remain application-owned.
+
+Async lock acquisition is not reentrant. Another acquisition for the same path,
+including one from the same process and manager, follows the normal retry and
+timeout policy until the current holder releases it. Version 0.5 removes the
+unsound process-scoped `allowReentrant` option; callers that passed it should
+delete the property.
 
 Pass `lockRoot` to place sidecar create, read, verification, and removal behind
 an existing `Root` capability. `lockPath` must resolve inside that root.
@@ -213,7 +218,7 @@ const handle = await acquireFileLock(targetPath, {
 });
 ```
 
-`heldByThisProcess` is true when this manager already holds the lock (relevant for the reentrant case). A `true` result marks the observed sidecar as stale; `staleRecovery` then decides whether acquisition fails closed or attempts caller-approved removal.
+`heldByThisProcess` is true when this manager already holds the lock. A `true` result marks the observed sidecar as stale; `staleRecovery` then decides whether acquisition fails closed or attempts caller-approved removal.
 
 ## Stale recovery: guarded `remove-if-unchanged`
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,6 +17,7 @@ export type FsSafeErrorCode =
   | "path-mismatch"
   | "permission-unverified"
   | "secret-exists"
+  | "store-reentrant-update"
   | "symlink"
   | "timeout"
   | "too-large"

--- a/src/json-document-store.ts
+++ b/src/json-document-store.ts
@@ -1,7 +1,13 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { canonicalPathFromExistingAncestor } from "./absolute-path.js";
+import { FsSafeError } from "./errors.js";
 import type { FileLockRetryOptions } from "./file-lock.js";
 import { getFsSafeLockConfig } from "./lock-config.js";
 import { createSidecarLockManager } from "./sidecar-lock.js";
 import type { SidecarLockStaleRecovery } from "./sidecar-lock.js";
+import { serializePathWrite } from "./write-queue.js";
+
+const activeStoreMutations = new AsyncLocalStorage<ReadonlySet<string>>();
 
 export type JsonStoreLockOptions = {
   staleMs?: number;
@@ -80,22 +86,35 @@ export function createJsonStore<T>(
     });
   }
 
-  async function withOptionalLock<R>(run: () => Promise<R>): Promise<R> {
-    if (!locks || !lockOptions) {
-      return await run();
+  async function withSerializedMutation<R>(run: () => Promise<R>): Promise<R> {
+    const canonicalPath = await canonicalPathFromExistingAncestor(adapter.filePath);
+    const activePaths = activeStoreMutations.getStore();
+    if (activePaths?.has(canonicalPath)) {
+      throw new FsSafeError(
+        "store-reentrant-update",
+        `jsonStore cannot write or update ${canonicalPath} from inside its active update callback; return the complete next value from the outer update instead`,
+      );
     }
-    return await locks.withLock(
-      {
-        targetPath: adapter.filePath,
-        staleMs: lockOptions.staleMs,
-        timeoutMs: lockOptions.timeoutMs,
-        retry: lockOptions.retry,
-        staleRecovery: lockOptions.staleRecovery,
-        allowReentrant: true,
-        payload: () => ({ pid: process.pid, createdAt: new Date().toISOString() }),
-      },
-      run,
-    );
+    return await serializePathWrite(`json-store:${canonicalPath}`, async () => {
+      const mutationPaths = new Set(activePaths);
+      mutationPaths.add(canonicalPath);
+      return await activeStoreMutations.run(mutationPaths, async () => {
+        if (!locks || !lockOptions) {
+          return await run();
+        }
+        return await locks.withLock(
+          {
+            targetPath: adapter.filePath,
+            staleMs: lockOptions.staleMs,
+            timeoutMs: lockOptions.timeoutMs,
+            retry: lockOptions.retry,
+            staleRecovery: lockOptions.staleRecovery,
+            payload: () => ({ pid: process.pid, createdAt: new Date().toISOString() }),
+          },
+          run,
+        );
+      });
+    });
   }
 
   return {
@@ -104,18 +123,18 @@ export function createJsonStore<T>(
     readOr,
     readRequired: adapter.readRequired,
     write: async (value) => {
-      await withOptionalLock(async () => {
+      await withSerializedMutation(async () => {
         await write(value);
       });
     },
     update: async (run) =>
-      await withOptionalLock(async () => {
+      await withSerializedMutation(async () => {
         const next = await run(await read());
         await write(next);
         return next;
       }),
     updateOr: async (fallback, run) =>
-      await withOptionalLock(async () => {
+      await withSerializedMutation(async () => {
         const current = await read();
         const next = await run(current === undefined ? cloneFallback(fallback) : current);
         await write(next);

--- a/src/sidecar-lock-types.ts
+++ b/src/sidecar-lock-types.ts
@@ -23,7 +23,6 @@ export type SidecarLockAcquireOptions<TPayload extends Record<string, unknown>> 
   timeoutMs?: number;
   retry?: SidecarLockRetryOptions;
   staleRecovery?: SidecarLockStaleRecovery;
-  allowReentrant?: boolean;
   payload: () => TPayload | Promise<TPayload>;
   shouldReclaim?: (params: {
     lockPath: string;

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -41,7 +41,6 @@ export type {
   WithSidecarLockOptions,
 } from "./sidecar-lock-types.js";
 type HeldLock = {
-  count: number;
   handle: NativeFileHandle;
   lockPath: string;
   snapshot: SidecarLockSnapshot;
@@ -170,19 +169,10 @@ async function releaseHeldLock(
   state: SidecarLockManagerState,
   normalizedTargetPath: string,
   held: HeldLock,
-  opts: { force?: boolean } = {},
 ): Promise<boolean> {
   const current = state.held.get(normalizedTargetPath);
   if (current !== held) {
     return false;
-  }
-  if (opts.force) {
-    held.count = 0;
-  } else {
-    held.count -= 1;
-    if (held.count > 0) {
-      return false;
-    }
   }
   if (held.releasePromise) {
     await held.releasePromise.catch(() => undefined);
@@ -230,24 +220,6 @@ export function createSidecarLockManager(key: string) {
     ensureExitCleanupRegistered();
     const normalizedTargetPath = await resolveNormalizedTargetPath(options.targetPath);
     const lockPath = options.lockPath ?? `${normalizedTargetPath}.lock`;
-    const held = state.held.get(normalizedTargetPath);
-    if (held && options.allowReentrant) {
-      held.count += 1;
-      const release = () =>
-        releaseHeldLock(state, normalizedTargetPath, held).then(() => undefined);
-      const verifyStillHeld = async () =>
-        await sidecarLockSnapshotStillPresent(held.lockPath, held.snapshot, {
-          lockRoot: held.lockRoot,
-          parsePayload: held.parsePayload,
-        });
-      return {
-        lockPath,
-        normalizedTargetPath,
-        verifyStillHeld,
-        release,
-        [Symbol.asyncDispose]: release,
-      };
-    }
 
     const startedAt = Date.now();
     const retry = options.retry ?? {};
@@ -304,7 +276,6 @@ export function createSidecarLockManager(key: string) {
           }
           const snapshot = { raw, payload, stat: await handle.stat(), ownershipToken };
           const createdHeld: HeldLock = {
-            count: 1,
             handle,
             lockPath,
             snapshot,
@@ -319,7 +290,7 @@ export function createSidecarLockManager(key: string) {
               await releaseSidecarReclaimGuard(state.reclaimGuards, reclaimGuardPath);
               ownsReclaimGuard = false;
             } catch (err) {
-              await releaseHeldLock(state, normalizedTargetPath, createdHeld, { force: true });
+              await releaseHeldLock(state, normalizedTargetPath, createdHeld);
               throw err;
             }
           }
@@ -463,7 +434,7 @@ export function createSidecarLockManager(key: string) {
 
   async function drain(): Promise<void> {
     for (const [normalizedTargetPath, held] of Array.from(state.held.entries())) {
-      await releaseHeldLock(state, normalizedTargetPath, held, { force: true }).catch(
+      await releaseHeldLock(state, normalizedTargetPath, held).catch(
         () => undefined,
       );
     }
@@ -479,7 +450,7 @@ export function createSidecarLockManager(key: string) {
       lockPath: held.lockPath,
       acquiredAt: held.acquiredAt,
       metadata: held.metadata,
-      forceRelease: () => releaseHeldLock(state, normalizedTargetPath, held, { force: true }),
+      forceRelease: () => releaseHeldLock(state, normalizedTargetPath, held),
     }));
   }
 

--- a/test/coverage-gaps.test.ts
+++ b/test/coverage-gaps.test.ts
@@ -289,7 +289,7 @@ describe("trash helper", () => {
 });
 
 describe("sidecar lock manager", () => {
-  it("acquires, reenters, lists, force releases, and drains locks", async () => {
+  it("acquires, queues, lists, force releases, and drains locks", async () => {
     const root = await tempRoot("fs-safe-sidecar-");
     const targetPath = path.join(root, "state.json");
     const manager = createSidecarLockManager(`coverage-${Date.now()}-${Math.random()}`);
@@ -297,21 +297,22 @@ describe("sidecar lock manager", () => {
     const lock = await manager.acquire({
       targetPath,
       staleMs: 60_000,
-      allowReentrant: true,
       metadata: { test: true },
       payload: () => ({ owner: "coverage" }),
     });
-    const reentrant = await manager.acquire({
+    const queued = manager.acquire({
       targetPath,
       staleMs: 60_000,
-      allowReentrant: true,
+      timeoutMs: 1_000,
+      retry: { minTimeout: 1, maxTimeout: 2 },
       payload: () => ({ owner: "coverage" }),
     });
     expect(manager.heldEntries()).toHaveLength(1);
     expect(manager.heldEntries()[0]?.metadata).toEqual({ test: true });
-    await reentrant.release();
-    expect(await manager.heldEntries()[0]?.forceRelease()).toBe(true);
     await lock.release();
+    const queuedLock = await queued;
+    expect(await manager.heldEntries()[0]?.forceRelease()).toBe(true);
+    await queuedLock.release();
     expect(manager.heldEntries()).toEqual([]);
 
     const value = await manager.withLock(

--- a/test/json-store-concurrency.test.ts
+++ b/test/json-store-concurrency.test.ts
@@ -1,0 +1,225 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createJsonStore,
+  type JsonStore,
+  type JsonStoreAdapter,
+} from "../src/json-document-store.js";
+import { jsonStore } from "../src/json-store.js";
+
+type State = { count: number };
+type Mutation = "update" | "updateOr" | "write";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
+});
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function runMutation(
+  store: JsonStore<State>,
+  mutation: Mutation,
+  count: number,
+  onUpdate?: () => Promise<void>,
+): Promise<void> {
+  if (mutation === "write") {
+    await store.write({ count });
+    return;
+  }
+  const update = async (current: State | undefined): Promise<State> => {
+    expect(current?.count ?? 0).toBe(count - 1);
+    await onUpdate?.();
+    return { count };
+  };
+  if (mutation === "update") {
+    await store.update(update);
+  } else {
+    await store.updateOr({ count: 0 }, update);
+  }
+}
+
+describe("jsonStore mutation serialization", () => {
+  it("preserves every overlapping update from the issue reproduction", async () => {
+    const root = await tempRoot("fs-safe-json-store-concurrent-");
+    const filePath = path.join(root, "state.json");
+    await jsonStore<State>({ filePath, lock: true }).write({ count: 0 });
+
+    await Promise.all(
+      [0, 1, 2].map(async (index) => {
+        await delay(index * 5);
+        await jsonStore<State>({ filePath, lock: true }).updateOr(
+          { count: 0 },
+          async (current) => {
+            await delay(20);
+            return { count: current.count + 1 };
+          },
+        );
+      }),
+    );
+
+    await expect(jsonStore<State>({ filePath }).readRequired()).resolves.toEqual({ count: 3 });
+  });
+
+  it.each<readonly [Mutation, Mutation]>(
+    (["update", "updateOr", "write"] as const).flatMap((first) =>
+      (["update", "updateOr", "write"] as const).map((second) => [first, second] as const),
+    ),
+  )("serializes overlapping %s then %s calls", async (firstMutation, secondMutation) => {
+    const root = await tempRoot("fs-safe-json-store-pairs-");
+    const filePath = path.join(root, "state.json");
+    let stored: State | undefined = { count: 0 };
+    const firstEntered = deferred();
+    const releaseFirst = deferred();
+    let secondEntered = false;
+
+    const adapter = (
+      onRead: () => Promise<void>,
+      onWrite: () => Promise<void>,
+    ): JsonStoreAdapter<State> => ({
+      filePath,
+      readIfExists: async () => {
+        await onRead();
+        return stored && { ...stored };
+      },
+      readRequired: async () => {
+        await onRead();
+        if (!stored) throw new Error("missing test state");
+        return { ...stored };
+      },
+      write: async (value) => {
+        await onWrite();
+        stored = { ...value };
+      },
+    });
+
+    const firstStore = createJsonStore(
+      adapter(
+        async () => undefined,
+        async () => {
+          if (firstMutation === "write") {
+            firstEntered.resolve();
+            await releaseFirst.promise;
+          }
+        },
+      ),
+      { lock: true },
+    );
+    const secondStore = createJsonStore(
+      adapter(
+        async () => {
+          secondEntered = true;
+        },
+        async () => {
+          secondEntered = true;
+        },
+      ),
+      { lock: true },
+    );
+
+    const first = runMutation(firstStore, firstMutation, 1, async () => {
+      firstEntered.resolve();
+      await releaseFirst.promise;
+    });
+    await firstEntered.promise;
+    const second = runMutation(secondStore, secondMutation, 2);
+    try {
+      await delay(10);
+      expect(secondEntered).toBe(false);
+    } finally {
+      releaseFirst.resolve();
+    }
+    await Promise.all([first, second]);
+    expect(stored).toEqual({ count: 2 });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "shares one queue across canonical parent aliases",
+    async () => {
+      const root = await tempRoot("fs-safe-json-store-alias-");
+      const realDir = path.join(root, "real");
+      const aliasDir = path.join(root, "alias");
+      await fsp.mkdir(realDir);
+      await fsp.symlink(realDir, aliasDir, "dir");
+      let stored: State | undefined = { count: 0 };
+      let aliasRead = false;
+      const firstEntered = deferred();
+      const releaseFirst = deferred();
+      const adapter = (filePath: string, onRead: () => void): JsonStoreAdapter<State> => ({
+        filePath,
+        readIfExists: async () => {
+          onRead();
+          return stored && { ...stored };
+        },
+        readRequired: async () => {
+          onRead();
+          if (!stored) throw new Error("missing test state");
+          return { ...stored };
+        },
+        write: async (value) => {
+          stored = { ...value };
+        },
+      });
+      const realStore = createJsonStore(adapter(path.join(realDir, "state.json"), () => undefined));
+      const aliasStore = createJsonStore(
+        adapter(path.join(aliasDir, "state.json"), () => {
+          aliasRead = true;
+        }),
+      );
+
+      const first = realStore.update(async () => {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+        return { count: 1 };
+      });
+      await firstEntered.promise;
+      const second = aliasStore.update((current) => ({ count: (current?.count ?? 0) + 1 }));
+      try {
+        await delay(10);
+        expect(aliasRead).toBe(false);
+      } finally {
+        releaseFirst.resolve();
+      }
+      await Promise.all([first, second]);
+      expect(stored).toEqual({ count: 2 });
+    },
+  );
+
+  it("rejects nested updates with a typed error across a queueMicrotask boundary", async () => {
+    const root = await tempRoot("fs-safe-json-store-reentrant-");
+    const filePath = path.join(root, "state.json");
+    const store = jsonStore<State>({ filePath, lock: true });
+    await store.write({ count: 0 });
+
+    const nested = store.update(async () =>
+      await new Promise<State>((resolve, reject) => {
+        queueMicrotask(() => {
+          void store.update((current) => ({ count: (current?.count ?? 0) + 1 })).then(resolve, reject);
+        });
+      }),
+    );
+
+    await expect(nested).rejects.toMatchObject({
+      name: "FsSafeError",
+      code: "store-reentrant-update",
+      message: expect.stringContaining("return the complete next value from the outer update"),
+    });
+    await expect(store.readRequired()).resolves.toEqual({ count: 0 });
+  });
+});

--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -1021,19 +1021,20 @@ describe("file locks", () => {
 
     const lock = await manager.acquire(targetPath, {
       staleMs: 60_000,
-      allowReentrant: true,
       metadata: { suite: "new-primitives" },
       payload: () => ({ owner: "manager" }),
     });
-    const reentrant = await manager.acquire(targetPath, {
+    const queued = manager.acquire(targetPath, {
       staleMs: 60_000,
-      allowReentrant: true,
+      timeoutMs: 1_000,
+      retry: { minTimeout: 1, maxTimeout: 2 },
       payload: () => ({ owner: "manager" }),
     });
     expect(manager.heldEntries()).toHaveLength(1);
     expect(manager.heldEntries()[0]?.metadata).toEqual({ suite: "new-primitives" });
-    await reentrant.release();
     await lock.release();
+    const queuedLock = await queued;
+    await queuedLock.release();
     expect(manager.heldEntries()).toEqual([]);
 
     await expect(


### PR DESCRIPTION
## Summary

- serialize every async `jsonStore` mutation in-process by canonical file path, with the cross-process sidecar acquired inside that queue
- remove the process-scoped `allowReentrant` lock option and reject nested same-file store mutations with typed `store-reentrant-update`
- document the 0.5 compatibility/migration change and add regression coverage for every `update` / `updateOr` / `write` pairing

Refs #60.

## Reproduction-derived proof

The issue's staggered three-updater scenario now persists `{ "count": 3 }` through the packaged public API. The same workload split across three child processes also persists `{ "count": 3 }`, confirming cross-process arbitration is unchanged.

The regression suite additionally proves all nine ordered pairs of overlapping `update`, `updateOr`, and `write` calls serialize across separate store handles, canonical parent aliases share one queue, and nested re-entry across `queueMicrotask` rejects with `FsSafeError` code `store-reentrant-update` without changing the stored value.

## Validation

- `pnpm check` — 56 files, 615 passed, 7 skipped; package check included
- `pnpm test:security` — 62 passed
- `pnpm docs:site`
- packaged-artifact behavior validation — same-process count 3, cross-process count 3, nested typed rejection, and `allowReentrant` rejected by TypeScript with TS2353
- autoreview — clean, no accepted/actionable findings

`pnpm native:test` could not run locally because this host has no `cargo` binary; native code is untouched, and hosted Rust CI is required before merge.
