### PR TITLE
fix(path): reject Windows reserved basenames in sanitizeUntrustedFileName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Security and Correctness
+
+- **Security — `sanitizeUntrustedFileName()`:** Reject Windows reserved device basenames (`CON`, `PRN`, `AUX`, `NUL`, `COM1`–`COM9`, `LPT1`–`LPT9`, and variants with extensions or trailing spaces/dots) and return the caller fallback, matching the reserved-name rules already used by device-path read guards. Prevents staging/output helpers from accepting untrusted names that open devices on Windows.
+
 ## 0.5.0 - 2026-07-26
 
 ### Highlights

--- a/src/device-path.ts
+++ b/src/device-path.ts
@@ -104,6 +104,11 @@ function normalizeWindowsDeviceBaseName(filePath: string): string {
   return (withoutTrailingIgnoredChars.split(".")[0] ?? withoutTrailingIgnoredChars).toUpperCase();
 }
 
+/** True when the basename is a Windows reserved device name (CON, NUL, COM1, …). */
+export function isWindowsReservedDeviceBaseName(fileName: string): boolean {
+  return WINDOWS_RESERVED_DEVICE_NAMES.has(normalizeWindowsDeviceBaseName(fileName));
+}
+
 function matchWindowsDeviceReadPath(filePath: string): UnsafeDeviceReadPathMatch | undefined {
   const normalized = filePath.replace(/\//g, "\\");
   if (/^\\\\\.\\/.test(normalized) || /^\\\\\?\\GLOBALROOT\\Device\\/i.test(normalized)) {

--- a/src/filename.ts
+++ b/src/filename.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { isWindowsReservedDeviceBaseName } from "./device-path.js";
 
 const WINDOWS_INVALID_FILE_NAME_CHARACTERS = new Set('<>:"/\\|?*');
 
@@ -23,6 +24,12 @@ export function sanitizeUntrustedFileName(fileName: string, fallbackName: string
   }
   base = cleaned.trim();
   if (!base || base === "." || base === "..") {
+    return fallbackName;
+  }
+  // Windows treats these basenames as devices even with an extension
+  // (NUL.txt opens the NUL device). Refuse them so staging/output helpers
+  // never create reserved paths from untrusted names.
+  if (isWindowsReservedDeviceBaseName(base)) {
     return fallbackName;
   }
   if (base.length > 200) {

--- a/test/filename.test.ts
+++ b/test/filename.test.ts
@@ -18,4 +18,16 @@ describe("sanitizeUntrustedFileName", () => {
       sanitizeUntrustedFileName('re<po>r:t"|?*\u0085\u009f.pdf', "fallback.bin"),
     ).toBe("report.pdf");
   });
+
+  it("rejects Windows reserved device basenames", () => {
+    expect(sanitizeUntrustedFileName("CON", "fallback.bin")).toBe("fallback.bin");
+    expect(sanitizeUntrustedFileName("nul.txt", "fallback.bin")).toBe("fallback.bin");
+    expect(sanitizeUntrustedFileName("COM1", "fallback.bin")).toBe("fallback.bin");
+    expect(sanitizeUntrustedFileName("LPT9.doc", "fallback.bin")).toBe("fallback.bin");
+    expect(sanitizeUntrustedFileName("aux ", "fallback.bin")).toBe("fallback.bin");
+    expect(sanitizeUntrustedFileName("PRN.backup", "fallback.bin")).toBe("fallback.bin");
+    // Not reserved: longer names that only contain reserved tokens as a prefix/suffix.
+    expect(sanitizeUntrustedFileName("console.txt", "fallback.bin")).toBe("console.txt");
+    expect(sanitizeUntrustedFileName("null.pdf", "fallback.bin")).toBe("null.pdf");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers using `sanitizeUntrustedFileName()` (via staging, external output, and sibling-temp helpers) would accept Windows reserved device basenames such as `CON`, `NUL.txt`, or `COM1` from untrusted input. On Windows those names open devices rather than ordinary files, which breaks portable name sanitization already used for C0/C1 and Windows-invalid characters on every host.

## Why This Change Was Made

Reuse the reserved-name set and normalization already used by the device-path read guards (`isWindowsReservedDeviceBaseName`) inside `sanitizeUntrustedFileName()`. Reserved basenames (including extensions and trailing spaces/dots) return the caller-supplied fallback. Non-goals: changing path resolution or read guards; only the untrusted basename sanitizer.

## User Impact

Callers that pass reserved basenames now receive the same fallback they already get for empty, `.`, or `..` names. Valid names such as `console.txt` and `null.pdf` are unchanged. No public API signature changes.

## Evidence

### Red / green

- **Red:** `pnpm exec vitest run test/filename.test.ts` failed with `expected 'CON' to be 'fallback.bin'` before the production change.
- **Green:** same file, 4/4 tests pass after the fix; full `pnpm check` (598 passed, 22 skipped).

### Runtime sample (built `dist/`)

```console
"CON" -> fallback.bin
"nul.txt" -> fallback.bin
"COM1" -> fallback.bin
"LPT9.doc" -> fallback.bin
"aux " -> fallback.bin
"console.txt" -> console.txt
"report.pdf" -> report.pdf
```

### Checklist

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included

### Related

- Same-repo reserved-name read guards: [#22](https://github.com/openclaw/fs-safe/pull/22)
- Hardened staging / portable basename sanitization: [#62](https://github.com/openclaw/fs-safe/pull/62)
- Node.js path reserved-name edge cases: [nodejs/node#64266](https://github.com/nodejs/node/pull/64266)

## Real behavior proof

- **Behavior or issue addressed:** Untrusted basenames that are Windows reserved devices must not pass through `sanitizeUntrustedFileName`; they must fall back.
- **Real environment tested:** macOS arm64, Node from repo toolchain, `@openclaw/fs-safe` branch `fix/windows-reserved-basenames` after `pnpm build`.
- **Exact steps or command run after this patch:**

  ```bash
  pnpm install --frozen-lockfile
  pnpm exec vitest run test/filename.test.ts
  pnpm build
  node --input-type=module -e "import { sanitizeUntrustedFileName } from './dist/filename.js';
  for (const c of ['CON','nul.txt','console.txt']) console.log(c, '->', sanitizeUntrustedFileName(c, 'fallback.bin'));"
  pnpm check
  ```

- **Evidence after fix:** reserved cases map to `fallback.bin`; non-reserved `console.txt` kept; full check green.
- **Observed result after fix:** `sanitizeUntrustedFileName('CON', 'fallback.bin') === 'fallback.bin'` and siblings; staging helpers inherit the safer basename policy.
- **What was not tested:** Live Windows NTFS create of reserved names (behavior is documented OS semantics; this PR blocks the name before open).
