### PR TITLE
fix(path): keep whitespace in Windows comparison paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Stop trimming surrounding whitespace when normalizing Windows paths for comparison, so a space-padded root no longer compares equal to its unpadded sibling and `isPathInside` keeps reporting outside paths as outside.
 - Replace backtracking-prone path-segment, temp-name, and Windows device-path sanitizers with linear scans to keep attacker-controlled inputs from causing excessive CPU use.
 
 ### Docs and Tooling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Security and Correctness
 
 - Stop trimming surrounding whitespace when normalizing Windows paths for comparison, so a space-padded root no longer compares equal to its unpadded sibling and `isPathInside` keeps reporting outside paths as outside.
+- Apply `denyMutations` prefixes to the directory they name on Windows. A prefix with trailing whitespace previously compared equal to its unpadded sibling, so the named directory stayed writable while the sibling was blocked; the two `preserves trailing whitespace` deny-mutation cases now run on Windows instead of being skipped.
 - Replace backtracking-prone path-segment, temp-name, and Windows device-path sanitizers with linear scans to keep attacker-controlled inputs from causing excessive CPU use.
 
 ### Docs and Tooling

--- a/src/path.ts
+++ b/src/path.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { FsSafeError } from "./errors.js";
-import { normalizeLowercaseStringOrEmpty } from "./string-coerce.js";
 
 export {
   assertNoUnsafeDeviceReadPath,
@@ -25,7 +24,9 @@ export function normalizeWindowsPathForComparison(input: string): string {
       normalized = `\\\\${normalized.slice(4)}`;
     }
   }
-  return normalizeLowercaseStringOrEmpty(normalized.replaceAll("/", "\\"));
+  // Lowercase only: this value feeds Windows containment math, so surrounding
+  // whitespace is part of the path and must not be trimmed away.
+  return normalized.replaceAll("/", "\\").toLowerCase();
 }
 
 export function isNodeError(value: unknown): value is NodeJS.ErrnoException {

--- a/test/deny-mutations.test.ts
+++ b/test/deny-mutations.test.ts
@@ -116,7 +116,7 @@ describe("root denyMutations policies", () => {
     ).rejects.toMatchObject({ code: "invalid-path" });
   });
 
-  it.skipIf(skipOnWindows)("preserves trailing whitespace in denied paths", async () => {
+  it("preserves trailing whitespace in denied paths", async () => {
     const rootPath = await tempRoot("fs-safe-deny-space-");
     const deniedName = "secret ";
     const trimmedName = "secret";
@@ -131,7 +131,7 @@ describe("root denyMutations policies", () => {
     await expect(readFile(path.join(rootPath, trimmedName), "utf8")).resolves.toBe("allowed");
   });
 
-  it.skipIf(skipOnWindows)("preserves trailing whitespace in denied prefixes", async () => {
+  it("preserves trailing whitespace in denied prefixes", async () => {
     const rootPath = await tempRoot("fs-safe-deny-prefix-space-");
     const deniedDir = path.join(rootPath, "private ");
     const trimmedDir = path.join(rootPath, "private");

--- a/test/windows-path.test.ts
+++ b/test/windows-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { isWindowsNetworkPath } from "../src/local-file-access.js";
+import { isPathInside, normalizeWindowsPathForComparison } from "../src/path.js";
 
 describe("Windows path classification", () => {
   it("distinguishes extended local paths from UNC paths", () => {
@@ -11,5 +12,33 @@ describe("Windows path classification", () => {
     ).toBe(true);
     expect(isWindowsNetworkPath("\\\\?\\Volume{abc}\\secrets\\token", "win32")).toBe(true);
     expect(isWindowsNetworkPath("\\\\.\\pipe\\service", "win32")).toBe(true);
+  });
+});
+
+describe("Windows comparison normalization", () => {
+  it("keeps surrounding whitespace so padded paths stay distinct", () => {
+    expect(normalizeWindowsPathForComparison("C:\\root ")).toBe("c:\\root ");
+    expect(normalizeWindowsPathForComparison("C:\\root\u00a0")).toBe(
+      "c:\\root\u00a0",
+    );
+  });
+
+  it("still lowercases, normalizes separators, and strips the extended-length prefix", () => {
+    expect(normalizeWindowsPathForComparison("\\\\?\\UNC\\Server\\Share\\A/../B")).toContain(
+      "\\\\server\\share",
+    );
+    expect(normalizeWindowsPathForComparison("\\\\?\\C:\\Users/Public")).toBe(
+      "c:\\users\\public",
+    );
+  });
+});
+
+describe.skipIf(process.platform !== "win32")("Windows containment with padded roots", () => {
+  it("does not report a sibling directory as inside a space-padded root", () => {
+    expect(isPathInside("C:\\root ", "C:\\root\\secret.txt")).toBe(false);
+  });
+
+  it("still reports genuine descendants as inside", () => {
+    expect(isPathInside("C:\\root", "C:\\root\\secret.txt")).toBe(true);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers relying on root confinement would have an outside path reported as inside the root when the root string carries surrounding whitespace. The affected surface is Windows path validation and root confinement: `isPathInside` is the predicate other guards build on, and on `win32` its only normalization step is `normalizeWindowsPathForComparison`.

That function ends by delegating to `normalizeLowercaseStringOrEmpty` (`src/string-coerce.ts:31`), which is a free-text string coercion helper — the same module also normalizes fast-mode flags and thread values. Its chain reaches `normalizeNullableString` (`src/string-coerce.ts:5-11`), which calls `value.trim()`. So a path used for containment math is trimmed before it is lowercased, and leading or trailing whitespace silently disappears from the comparison key.

Whitespace is a legal part of a Windows path component, so trimming merges two genuinely different directories into one comparison key: `C:\root ` and `C:\root` both become `c:\root`.

## Why This Change Was Made

The final step now lowercases in place instead of routing the path through the free-text coercion helper. Separator normalization and extended-length (`\\?\`, `\\?\UNC\`) handling are untouched, so the only behavior that shifts is that surrounding whitespace is preserved. Case folding is deliberately left exactly as it was, since it is the documented comparison semantic and is covered by an existing assertion in `test/api-coverage.test.ts`.

Non-goal, stated explicitly: this change does not alter the Unicode case-folding behavior. `toLowerCase()` is not injective — on a Turkish-language Windows install, `"İstanbul"` folds to a 9-code-point string that never round-trips back, so two distinct NTFS names can still collapse onto one comparison key. Deciding whether comparison should move to an ASCII-only or locale-invariant fold changes behavior for every non-ASCII path, which reads as an owner decision rather than a bug fix. I left it out of this PR and can follow up separately if you want it addressed.

## User Impact

Consumers that derive a root from configuration or environment input — where a stray trailing space is easy to introduce — no longer get a false `true` from `isPathInside` for files that live outside that root. Paths without surrounding whitespace are unaffected, and no export, error shape, or default changes.

## Evidence

Reproduction on Windows 11 with Node 24.15.0, using the real exported functions:

```
BEFORE (src/path.ts @ main ab93382)
  normalizeWindowsPathForComparison("C:\\root ")  -> "c:\\root"
  isPathInside("C:\\root ", "C:\\root\\secret.txt") -> true      <- outside path reported as inside

AFTER (this branch)
  normalizeWindowsPathForComparison("C:\\root ")  -> "c:\\root "
  isPathInside("C:\\root ", "C:\\root\\secret.txt") -> false
  isPathInside("C:\\root",  "C:\\root\\secret.txt") -> true      <- genuine descendants unaffected
```

Regression tests were added to `test/windows-path.test.ts`: one platform-independent case for the normalizer (trailing space and a NBSP), one `win32`-only pair for `isPathInside` covering both the padded root and a genuine descendant, plus an assertion that lowercasing, separator normalization, and extended-length stripping still behave as before.

The new tests are load-bearing. Stashing only `src/path.ts` and re-running the file against the unmodified normalizer:

```
BEFORE (fix reverted, tests kept)
  FAIL  Windows comparison normalization > keeps surrounding whitespace so padded paths stay distinct
  FAIL  Windows containment with padded roots > does not report a sibling directory as inside a space-padded root
        Tests  2 failed | 3 passed (5)

AFTER
        Tests  5 passed (5)
```

### What the other `isPathInside` callers do with this change

The review asks for the intended Windows contract across boundary layers, so I inventoried every
in-package caller rather than reasoning about it:

| call site | root argument | effect of preserving whitespace |
|---|---|---|
| `src/archive-staging.ts:124,221,290,321,368` | `destinationRealDir` / `sourceRootReal` (realpath results) | none in practice; exactness is the fail-closed direction |
| `src/file-store-boundary.ts:64,192` · `src/file-store-prune.ts:54` · `src/file-store.ts:431` | `rootReal` / `scopedRoot.rootWithSep` (realpath results) | same |
| `src/file-store.ts:124` | store `rootDir` | same |
| `src/install-path.ts:67` | `path.resolve(baseDir)` | same |
| `src/deny-mutations.ts:49,96,109,110` | **user-supplied `denyMutations` policy entries** | behavior changes — see below |

A realpath result carries the on-disk spelling, so for every confinement caller the change is
either invisible or the intended fail-closed correction. `deny-mutations` is the one caller that
compares free-text configuration, and there the current Windows behavior is worse than "lenient".

### The deny-list case: Windows applies the policy to the wrong directory

The package already pins the intended contract, on POSIX, with two committed tests —
`test/deny-mutations.test.ts` `preserves trailing whitespace in denied paths` and
`… in denied prefixes`. Both carry `it.skipIf(skipOnWindows)`, which is what the trimming
normalizer forced. Driving those same two scenarios through the public `root()` API on Windows 11
(Node 24.15.0), with only `src/path.ts` swapped between runs:

```
denied prefixes entry: "private "        (both "private " and "private" exist on disk)

  main ab93382     write("private /file.txt") -> ALLOWED        <- the denied directory is writable
                   write("private/file.txt")  -> BLOCKED        <- an undenied sibling is blocked

  this branch      write("private /file.txt") -> BLOCKED
                   write("private/file.txt")  -> ALLOWED
```

So on Windows the deny list is not merely approximate today, it is applied to the wrong directory:
the protected path stays writable while its unprotected sibling is refused. The branch produces the
POSIX behavior the repository already documents.

With that established, the two cases no longer need the Windows skip, and they are load-bearing
there:

```
test/deny-mutations.test.ts on Windows
  this branch    Tests  10 passed | 1 skipped (11)
  main path.ts   Tests   2 failed | 8 passed | 1 skipped (11)   <- exactly the two unskipped cases
```

Full suite on Windows moves from `447 passed | 185 skipped` to `449 passed | 183 skipped` — the two
cases that started running, and nothing else. CI already covers `windows-latest` on Node 22 and 24,
so this is enforced rather than local-only. The remaining `skipIf` in that file (symlink ancestors)
is unrelated and untouched.

Validation performed on this branch:

- `pnpm exec vitest run test/windows-path.test.ts` — 5 passed
- `pnpm exec vitest run` (full suite) — 447 passed, 185 skipped (632); 54 files passed, 6 skipped
- `pnpm lint:file-size` — passed
- `pnpm lint:fs-boundary` — passed
- `pnpm build` (`tsc -p tsconfig.json`) — passed
- `git diff --check` — clean

`CHANGELOG.md` has an entry under `Unreleased` -> `Security and Correctness`.

Related: `openclaw/openclaw#109823`, where this normalizer's lowercasing had to be worked around downstream; that PR documents the same helper being copied to obtain a case-preserving variant.

- [x] Tests cover the change
- [x] `pnpm check` gates run locally
- [x] `CHANGELOG.md` updated when release-relevant
- [x] Docs updated when behavior or API changed (no documented behavior changed; the trimming was undocumented)

