### PR TITLE
release: 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.5.1 - 2026-08-01
 
 ### Security and Correctness
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "fs-safe-native"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bzip2",
  "flate2",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fs-safe-native"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/openclaw/fs-safe"

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-native-build",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Private build workspace for the native bindings bundled by @openclaw/fs-safe.",
   "private": true,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Capability-style filesystem roots for Node.js apps that handle untrusted relative paths.",
   "keywords": [
     "filesystem",


### PR DESCRIPTION
## Summary

- set the root npm package and private native workspace to `0.5.1`
- set the Rust crate and locked package version to `0.5.1`
- date the accumulated patch changelog for 2026-08-01

## Proof

- `node scripts/release-notes.mjs 0.5.1`
- `pnpm check`: 607 tests passed, 25 skipped; packed consumer check passed
- `node scripts/check-pack.mjs`: passed
- autoreview: clean, no accepted/actionable findings

After this lands, the protected annotated `v0.5.1` tag will invoke the repository-owned trusted publishing workflow.
