### PR TITLE
chore(release): open 0.5.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.5.1 - 2026-08-01
 
 ### Security and Correctness


### PR DESCRIPTION
## Summary

- reopen the changelog with an empty `Unreleased` section after the verified 0.5.1 release

## Proof

- `git diff --check`
- autoreview clean with no accepted/actionable findings
