### PR TITLE
feat(filename): suffix Windows reserved names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Suffix Windows reserved basenames with `_` in `sanitizeUntrustedFileName()` while preserving case and extensions on every platform, including dollar names and superscript COM/LPT variants; thanks @SebTardif (#67).
+
 ## 0.5.1 - 2026-08-01
 
 ### Security and Correctness

--- a/docs/filename.md
+++ b/docs/filename.md
@@ -24,7 +24,8 @@ In order:
 3. **Strip non-portable characters.** C0/C1 controls (`0x00`–`0x1f`, `0x7f`–`0x9f`) and the Windows-invalid set `< > : " / \\ | ? *` are removed on every platform.
 4. **Trim again.**
 5. If the result is empty, `"."`, or `".."`, return `fallbackName`.
-6. **Truncate.** If the cleaned segment is longer than 200 characters, take the first 200.
+6. **Suffix Windows reserved basenames.** Compare the part before the first `.` case-insensitively with the Windows device-name set, including `CON`, `PRN`, `AUX`, `NUL`, `CLOCK$`, `CONIN$`, `CONOUT$`, `COM1..9`, `LPT1..9`, and their superscript `¹`, `²`, and `³` variants. A match gains `_` before its extension, preserving the original case and extension on every platform.
+7. **Truncate.** If the cleaned segment is longer than 200 characters, take the first 200.
 
 That's it. The function stays intentionally small: it produces one traversal-free segment whose characters work across the common POSIX and Windows filename surfaces.
 
@@ -38,28 +39,24 @@ sanitizeUntrustedFileName("a\u0000b\tc", "upload");       // "abc"
 sanitizeUntrustedFileName("   ", "fallback");              // "fallback"
 sanitizeUntrustedFileName(".", "fallback");                // "fallback"
 sanitizeUntrustedFileName("..", "fallback");               // "fallback"
-sanitizeUntrustedFileName("a".repeat(300), "x");           // 200-char "aaa..."
+sanitizeUntrustedFileName("CON", "fallback");              // "CON_"
+sanitizeUntrustedFileName("nul.txt", "fallback");          // "nul_.txt"
+sanitizeUntrustedFileName("aux.c", "fallback");            // "aux_.c"
+sanitizeUntrustedFileName("conin$", "fallback");           // "conin$_"
+sanitizeUntrustedFileName("a".repeat(300), "x");          // 200-char "aaa..."
 ```
 
 ## What it does **not** do
 
 The function is deliberately narrow. It will not:
 
-- Reject Windows reserved names (`CON`, `PRN`, `AUX`, `NUL`, `COM1..9`, `LPT1..9`).
 - Replace leading dots (so a name like `.config` stays hidden on POSIX systems).
 - Trim trailing dots or spaces (Windows tolerates them silently).
 - Add an extension or change case.
 - Validate file *content*. To enforce an extension allow-list, check after sanitization.
 - Deduplicate against existing files. Append a random suffix if you need uniqueness.
 
-If your domain needs stricter handling, layer it on top:
-
-```ts
-const trimmed = sanitizeUntrustedFileName(input, "upload");
-const noWindowsReserved = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..+)?$/i.test(trimmed)
-  ? "upload"
-  : trimmed;
-```
+Windows reserved basenames are handled by the default portability pass; callers no longer need to layer a separate reserved-name recipe on top.
 
 ## Common patterns
 

--- a/src/device-path.ts
+++ b/src/device-path.ts
@@ -29,7 +29,7 @@ const POSIX_BLOCKED_DEVICE_PATHS = new Set([
   "/dev/console",
 ]);
 
-const WINDOWS_RESERVED_DEVICE_NAMES = new Set([
+export const WINDOWS_RESERVED_DEVICE_NAMES: ReadonlySet<string> = new Set([
   "CON",
   "PRN",
   "AUX",

--- a/src/filename.ts
+++ b/src/filename.ts
@@ -1,6 +1,17 @@
 import path from "node:path";
+import { WINDOWS_RESERVED_DEVICE_NAMES } from "./device-path.js";
 
 const WINDOWS_INVALID_FILE_NAME_CHARACTERS = new Set('<>:"/\\|?*');
+
+function suffixWindowsReservedDeviceName(fileName: string): string {
+  const extensionIndex = fileName.indexOf(".");
+  const baseNameEnd = extensionIndex < 0 ? fileName.length : extensionIndex;
+  const baseName = fileName.slice(0, baseNameEnd);
+  if (!WINDOWS_RESERVED_DEVICE_NAMES.has(baseName.toUpperCase())) {
+    return fileName;
+  }
+  return `${baseName}_${fileName.slice(baseNameEnd)}`;
+}
 
 export function sanitizeUntrustedFileName(fileName: string, fallbackName: string): string {
   const trimmed = typeof fileName === "string" ? fileName.trim() : "";
@@ -25,6 +36,7 @@ export function sanitizeUntrustedFileName(fileName: string, fallbackName: string
   if (!base || base === "." || base === "..") {
     return fallbackName;
   }
+  base = suffixWindowsReservedDeviceName(base);
   if (base.length > 200) {
     base = base.slice(0, 200);
   }

--- a/test/filename.test.ts
+++ b/test/filename.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { WINDOWS_RESERVED_DEVICE_NAMES } from "../src/device-path.js";
 import { sanitizeUntrustedFileName } from "../src/filename.js";
+
+function mixedCase(value: string): string {
+  return Array.from(value, (character, index) =>
+    index % 2 === 0 ? character : character.toLowerCase()
+  ).join("");
+}
 
 describe("sanitizeUntrustedFileName", () => {
   it("keeps only the basename and strips control characters", () => {
@@ -9,8 +16,11 @@ describe("sanitizeUntrustedFileName", () => {
   });
 
   it("uses fallback for empty or path-alias names", () => {
+    expect(sanitizeUntrustedFileName("", "fallback.bin")).toBe("fallback.bin");
     expect(sanitizeUntrustedFileName(" ", "fallback.bin")).toBe("fallback.bin");
+    expect(sanitizeUntrustedFileName(".", "fallback.bin")).toBe("fallback.bin");
     expect(sanitizeUntrustedFileName("..", "fallback.bin")).toBe("fallback.bin");
+    expect(sanitizeUntrustedFileName("<>", "fallback.bin")).toBe("fallback.bin");
   });
 
   it("strips C1 controls and Windows-invalid characters on every platform", () => {
@@ -18,4 +28,48 @@ describe("sanitizeUntrustedFileName", () => {
       sanitizeUntrustedFileName('re<po>r:t"|?*\u0085\u009f.pdf', "fallback.bin"),
     ).toBe("report.pdf");
   });
+
+  it.each([...WINDOWS_RESERVED_DEVICE_NAMES])(
+    "suffixes reserved basename %s while preserving case and extensions",
+    (reservedName) => {
+      const casedName = mixedCase(reservedName);
+      expect(sanitizeUntrustedFileName(reservedName, "fallback.bin")).toBe(
+        `${reservedName}_`,
+      );
+      expect(sanitizeUntrustedFileName(`${reservedName}.txt`, "fallback.bin")).toBe(
+        `${reservedName}_.txt`,
+      );
+      expect(sanitizeUntrustedFileName(casedName, "fallback.bin")).toBe(`${casedName}_`);
+      expect(sanitizeUntrustedFileName(`${casedName}.TxT`, "fallback.bin")).toBe(
+        `${casedName}_.TxT`,
+      );
+    },
+  );
+
+  it("handles dollar names, superscript variants, and multi-part extensions", () => {
+    expect(sanitizeUntrustedFileName("conin$", "fallback.bin")).toBe("conin$_");
+    expect(sanitizeUntrustedFileName("ConOut$.log", "fallback.bin")).toBe(
+      "ConOut$_.log",
+    );
+    expect(sanitizeUntrustedFileName("com¹.TXT", "fallback.bin")).toBe("com¹_.TXT");
+    expect(sanitizeUntrustedFileName("LpT³.tar.gz", "fallback.bin")).toBe(
+      "LpT³_.tar.gz",
+    );
+  });
+
+  it("suffixes reserved names before applying the 200-character limit", () => {
+    const input = `CON.${"a".repeat(196)}`;
+    const expected = `CON_.${"a".repeat(195)}`;
+    expect(input).toHaveLength(200);
+    expect(expected).toHaveLength(200);
+    expect(sanitizeUntrustedFileName(input, "fallback.bin")).toBe(expected);
+  });
+
+  it.each(["CON", "nul.txt", "CoNiN$.log", "COM¹.dat", "CON_"])(
+    "is idempotent for reserved-name result %s",
+    (input) => {
+      const once = sanitizeUntrustedFileName(input, "fallback.bin");
+      expect(sanitizeUntrustedFileName(once, "fallback.bin")).toBe(once);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- suffix Windows reserved basenames with `_` while preserving original case and extensions on every platform
- share the exported `WINDOWS_RESERVED_DEVICE_NAMES` set between device-path checks and filename sanitization
- cover every shared reserved name, mixed case, extensions, dollar names, superscript variants, truncation ordering, fallback behavior, and idempotence
- update the filename contract documentation and credit @SebTardif's original idea from #67

## Approved contract

Examples:

- `CON` → `CON_`
- `nul.txt` → `nul_.txt`
- `aux.c` → `aux_.c`
- `conin$` → `conin$_`

Detection is case-insensitive, transformation preserves case, the suffix is inserted before the first extension, and the result is then capped at 200 characters. Empty, `.`, and `..` results retain the existing fallback behavior.

## Proof

- Focused: `pnpm exec vitest run test/filename.test.ts test/device-path.test.ts` — 47 passed
- Full gate: `pnpm check` — 645 passed, 25 skipped; packaged-consumer check passed
- Security: `pnpm test:security` — 62 passed
- Docs: `pnpm docs:site` — built successfully
- Built output: `{ CON: 'CON_', 'nul.txt': 'nul_.txt', 'aux.c': 'aux_.c' }`
- Autoreview: clean, no accepted/actionable findings

## Release note

This portability-contract addition makes the next release minor: `0.6.0`. No release is authorized until Peter gives the release word.
