### PR TITLE
fix(root): report documented remove() failure codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Security and Correctness
 
-- Report the documented `remove()` failure codes instead of collapsing every failure to `path-alias`. A missing target now throws `not-found`, a non-empty directory throws `not-empty`, and any other filesystem failure throws `not-removable`, while directory identity drift keeps reporting `path-mismatch`.
+- Report the documented `remove()` failure codes instead of collapsing every failure to `path-alias`. A missing target now throws `not-found`, a non-empty directory throws `not-empty`, and any other filesystem failure throws `not-removable`, while directory identity drift keeps reporting `path-mismatch`. The errno classification covers only the deletion syscalls, so a parent-directory guard failure still fails closed with `path-alias` rather than implying a removal was attempted.
 
 ## 0.5.1 - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Suffix Windows reserved basenames with `_` in `sanitizeUntrustedFileName()` while preserving case and extensions on every platform, including dollar names and superscript COM/LPT variants; thanks @SebTardif (#67).
 
+### Security and Correctness
+
+- Report the documented `remove()` failure codes instead of collapsing every failure to `path-alias`. A missing target now throws `not-found`, a non-empty directory throws `not-empty`, and any other filesystem failure throws `not-removable`, while directory identity drift keeps reporting `path-mismatch`.
+
 ## 0.5.1 - 2026-08-01
 
 ### Security and Correctness

--- a/src/root-errors.ts
+++ b/src/root-errors.ts
@@ -25,6 +25,18 @@ export function normalizePinnedPathError(error: unknown): Error {
   });
 }
 
+export function normalizeRemoveGuardError(error: unknown): Error {
+  if (error instanceof FsSafeError) {
+    return error;
+  }
+  if (isNotFoundPathError(error)) {
+    return new FsSafeError("not-found", "file not found", {
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+  return normalizePinnedPathError(error);
+}
+
 export function normalizeRemovePathError(error: unknown): Error {
   if (error instanceof FsSafeError) {
     return error;

--- a/src/root-errors.ts
+++ b/src/root-errors.ts
@@ -1,5 +1,7 @@
 import { FsSafeError } from "./errors.js";
-import { hasNodeErrorCode } from "./path.js";
+import { hasNodeErrorCode, isNodeError, isNotFoundPathError } from "./path.js";
+
+const REMOVE_NOT_EMPTY_CODES = new Set(["ENOTEMPTY", "EEXIST"]);
 
 export function isAlreadyExistsError(error: unknown): boolean {
   return hasNodeErrorCode(error, "EEXIST") || /File exists|EEXIST/i.test(String(error));
@@ -21,4 +23,21 @@ export function normalizePinnedPathError(error: unknown): Error {
   return new FsSafeError("path-alias", "path is not under root", {
     cause: error instanceof Error ? error : undefined,
   });
+}
+
+export function normalizeRemovePathError(error: unknown): Error {
+  if (error instanceof FsSafeError) {
+    return error;
+  }
+  if (!isNodeError(error) || typeof error.code !== "string") {
+    return normalizePinnedPathError(error);
+  }
+  const cause = error instanceof Error ? error : undefined;
+  if (isNotFoundPathError(error)) {
+    return new FsSafeError("not-found", "file not found", { cause });
+  }
+  if (REMOVE_NOT_EMPTY_CODES.has(error.code)) {
+    return new FsSafeError("not-empty", "directory is not empty", { cause });
+  }
+  return new FsSafeError("not-removable", "path could not be removed", { cause });
 }

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -47,6 +47,7 @@ import {
   isAlreadyExistsError,
   normalizePinnedPathError,
   normalizePinnedWriteError,
+  normalizeRemovePathError,
 } from "./root-errors.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
 import { stringifyJsonDocument } from "./json-stringify.js";
@@ -988,7 +989,7 @@ async function removePathInRoot(
   try {
     await removePathFallback(resolved);
   } catch (error) {
-    throw normalizePinnedPathError(error);
+    throw normalizeRemovePathError(error);
   }
 }
 

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -47,6 +47,7 @@ import {
   isAlreadyExistsError,
   normalizePinnedPathError,
   normalizePinnedWriteError,
+  normalizeRemoveGuardError,
   normalizeRemovePathError,
 } from "./root-errors.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
@@ -989,7 +990,7 @@ async function removePathInRoot(
   try {
     await removePathFallback(resolved);
   } catch (error) {
-    throw normalizeRemovePathError(error);
+    throw normalizePinnedPathError(error);
   }
 }
 
@@ -1325,11 +1326,24 @@ async function resolvePinnedRootPathInRoot(
   };
 }
 
+async function prepareRemoveGuard(targetPath: string) {
+  try {
+    const guard = await createAsyncDirectoryGuard(path.dirname(targetPath));
+    await getFsSafeTestHooks()?.beforeRootFallbackMutation?.("remove", targetPath);
+    await assertAsyncDirectoryGuard(guard);
+    return guard;
+  } catch (error) {
+    throw normalizeRemoveGuardError(error);
+  }
+}
+
 async function removePathFallback(resolved: { resolved: string }): Promise<void> {
-  const guard = await createAsyncDirectoryGuard(path.dirname(resolved.resolved));
-  await getFsSafeTestHooks()?.beforeRootFallbackMutation?.("remove", resolved.resolved);
-  await assertAsyncDirectoryGuard(guard);
-  await ((await fs.lstat(resolved.resolved)).isDirectory() ? fs.rmdir(resolved.resolved) : fs.rm(resolved.resolved));
+  const guard = await prepareRemoveGuard(resolved.resolved);
+  try {
+    await ((await fs.lstat(resolved.resolved)).isDirectory() ? fs.rmdir(resolved.resolved) : fs.rm(resolved.resolved));
+  } catch (error) {
+    throw normalizeRemovePathError(error);
+  }
   await assertAsyncDirectoryGuard(guard).catch(() => undefined);
 }
 

--- a/test/edge-coverage.test.ts
+++ b/test/edge-coverage.test.ts
@@ -20,6 +20,7 @@ import {
   isAlreadyExistsError,
   normalizePinnedPathError,
   normalizePinnedWriteError,
+  normalizeRemovePathError,
 } from "../src/root-errors.js";
 import { movePathToTrash } from "../src/trash.js";
 
@@ -59,6 +60,27 @@ describe("root error helpers", () => {
       message: "path is not under root",
     });
     expect(normalizePinnedPathError("raw string")).toMatchObject({ code: "path-alias" });
+  });
+
+  it("maps remove syscall failures without swallowing boundary errors", () => {
+    const drift = new FsSafeError("path-mismatch", "directory changed during operation");
+    expect(normalizeRemovePathError(drift)).toBe(drift);
+
+    const mappings = [
+      ["ENOENT", "not-found"],
+      ["ENOTDIR", "not-found"],
+      ["ENOTEMPTY", "not-empty"],
+      ["EEXIST", "not-empty"],
+      ["EACCES", "not-removable"],
+      ["EBUSY", "not-removable"],
+    ] as const;
+    for (const [errno, code] of mappings) {
+      const error = Object.assign(new Error(errno), { code: errno });
+      expect(normalizeRemovePathError(error)).toMatchObject({ code });
+    }
+
+    expect(normalizeRemovePathError(new Error("raw"))).toMatchObject({ code: "path-alias" });
+    expect(normalizeRemovePathError("raw string")).toMatchObject({ code: "path-alias" });
   });
 });
 

--- a/test/edge-coverage.test.ts
+++ b/test/edge-coverage.test.ts
@@ -16,12 +16,15 @@ import {
   safePathSegmentHashed,
 } from "../src/install-path.js";
 import { replaceDirectoryAtomic } from "../src/replace-directory.js";
+import { root as openRoot } from "../src/root.js";
 import {
   isAlreadyExistsError,
   normalizePinnedPathError,
   normalizePinnedWriteError,
+  normalizeRemoveGuardError,
   normalizeRemovePathError,
 } from "../src/root-errors.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 import { movePathToTrash } from "../src/trash.js";
 
 const tempDirs = new Set<string>();
@@ -81,6 +84,39 @@ describe("root error helpers", () => {
 
     expect(normalizeRemovePathError(new Error("raw"))).toMatchObject({ code: "path-alias" });
     expect(normalizeRemovePathError("raw string")).toMatchObject({ code: "path-alias" });
+  });
+
+  it("keeps guard-stage failures fail-closed instead of reporting a removal outcome", () => {
+    const drift = new FsSafeError("path-mismatch", "directory changed during operation");
+    expect(normalizeRemoveGuardError(drift)).toBe(drift);
+
+    for (const errno of ["ENOENT", "ENOTDIR"]) {
+      const error = Object.assign(new Error(errno), { code: errno });
+      expect(normalizeRemoveGuardError(error), errno).toMatchObject({ code: "not-found" });
+    }
+    for (const errno of ["ELOOP", "EACCES", "EBUSY", "ENOTEMPTY", "EEXIST"]) {
+      const error = Object.assign(new Error(errno), { code: errno });
+      expect(normalizeRemoveGuardError(error), errno).toMatchObject({ code: "path-alias" });
+    }
+    expect(normalizeRemoveGuardError(new Error("raw"))).toMatchObject({ code: "path-alias" });
+  });
+
+  it("does not map a guard-stage filesystem failure to a removal code", async () => {
+    const rootPath = await tempRoot("fs-safe-remove-guard-");
+    const scoped = await openRoot(rootPath);
+    await scoped.write("target.txt", "keep");
+
+    __setFsSafeTestHooksForTest({
+      beforeRootFallbackMutation() {
+        throw Object.assign(new Error("ELOOP"), { code: "ELOOP" });
+      },
+    });
+    try {
+      await expect(scoped.remove("target.txt")).rejects.toMatchObject({ code: "path-alias" });
+    } finally {
+      __setFsSafeTestHooksForTest(undefined);
+    }
+    await expect(fs.readFile(path.join(rootPath, "target.txt"), "utf8")).resolves.toBe("keep");
   });
 });
 

--- a/test/fs-safe.test.ts
+++ b/test/fs-safe.test.ts
@@ -396,6 +396,22 @@ describe("@openclaw/fs-safe", () => {
     });
   });
 
+  it("reports documented failure codes when remove cannot unlink the target", async () => {
+    const rootPath = await tempRoot("fs-safe-remove-codes-");
+    const root = await openRoot(rootPath);
+    await root.mkdir("full/child");
+
+    await expect(root.remove("missing.txt")).rejects.toMatchObject({
+      code: expectedFsSafeCode("not-found"),
+    });
+    await expect(root.remove("missing-dir/missing.txt")).rejects.toMatchObject({
+      code: expectedFsSafeCode("not-found"),
+    });
+    await expect(root.remove("full")).rejects.toMatchObject({
+      code: expectedFsSafeCode("not-empty"),
+    });
+  });
+
   it("opens a file handle for fast reads when kernel fd path validation is available", async () => {
     const root = await openRoot(await tempRoot("fs-safe-open-"));
     await root.write("file.txt", "fast");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers calling `Root.remove()` would receive the boundary-violation code `path-alias` ("path is not under root") when the target was simply missing or the directory was simply not empty.

The affected surface is root confinement error reporting. `removePathInRoot()` routes every failure through `normalizePinnedPathError()`, which rewrites any non-`FsSafeError` into `path-alias`. Because `removePathFallback()` reaches the filesystem through plain `fs.lstat` / `fs.rmdir` / `fs.rm`, an `ENOENT` and an `ENOTEMPTY` both surface as boundary violations.

The documentation already specifies the intended behavior in six places:

- `docs/writing.md:130,135` and `docs/writing.md:193,194` — non-empty directories throw `not-empty`, `not-removable` covers other unlink/rmdir failures
- `docs/errors.md:96,100` — same two codes, with `not-found` at `docs/errors.md:98`
- `docs/file-store.md:135` — "non-empty dirs throw `not-empty`"
- `docs/root.md:156` — `not-found` for a missing target

`not-empty` and `not-removable` are declared in the exported `FsSafeErrorCode` union (`src/errors.ts:10,14`) and listed in `docs/types.md:156-157`, but before this change they were constructed nowhere in `src/` and asserted nowhere in `test/`. The documentation was already correct; the implementation was not.

## Why This Change Was Made

A new `normalizeRemovePathError()` in `src/root-errors.ts` classifies the failure at the `remove()` call site: `ENOENT`/`ENOTDIR` to `not-found`, `ENOTEMPTY`/`EEXIST` to `not-empty`, and any other errno to `not-removable`. Anything that is not errno-shaped still falls back to `normalizePinnedPathError()`, so today's `path-alias` behavior is preserved for genuinely unclassifiable throws.

Three boundaries were deliberate:

- **Directory guard signals are untouched.** `createAsyncDirectoryGuard()` and `assertAsyncDirectoryGuard()` already throw `FsSafeError` (`not-file` and `path-mismatch`), so the leading `instanceof FsSafeError` check returns them unchanged. TOCTOU identity drift still reports `path-mismatch` — that is covered by a unit assertion.
- **`normalizePinnedPathError()` itself is unchanged.** `mkdirPathInRoot()` shares it and is out of scope for this PR, and `test/edge-coverage.test.ts` pins its current contract.
- **`EEXIST` maps to `not-empty`** because POSIX permits `rmdir` to report `EEXIST` for a non-empty directory. The package already treats the pair as equivalent in `src/move-path.ts:346` and `src/trash.ts:12`.

Compatibility: error codes are a public compatibility surface, and this is a deliberate behavior change. A consumer branching on `path-alias` around `remove()` will observe the new codes. Consumers written against the documented contract are fixed by this change; consumers written against the previous behavior were treating a routine `ENOTEMPTY` as a containment failure, which is the more dangerous of the two readings. No internal caller depends on the old code — `src/file-store-prune.ts:89,95` is the only in-package consumer and it discards remove errors.

Non-goal: `mkdirPathInRoot()` shares the same normalizer and has its own error-shape questions. Left alone to keep this to one concern; happy to open a follow-up.

## User Impact

`Root.remove()` and `FileStore.remove()` now report the codes their documentation already promised:

```ts
await fs.remove("missing.txt");        // not-found     (was: path-alias)
await fs.remove("snapshots/full-dir"); // not-empty     (was: path-alias)
// permissions, device busy, read-only fs -> not-removable (was: path-alias)
```

Directory identity drift during the remove still reports `path-mismatch`, unchanged. No API, option, default, or export changed; no migration is needed beyond widening a `path-alias` catch if one was written against the previous behavior.

## Evidence

Reproduction on `main` before the fix, using the new regression test:

```
FAIL  test/fs-safe.test.ts > @openclaw/fs-safe > reports documented failure codes
      when remove cannot unlink the target
AssertionError: expected FsSafeError: path is not under root { …(3) } to match
object { code: 'not-found' }
- { "code": "not-found",
+ FsSafeError { "code": "path-alias", }
 ❯ test/fs-safe.test.ts:507:45
```

Regression coverage added:

- `test/fs-safe.test.ts` — real-disk `mkdtemp` root exercising `not-found` for a missing target, `not-found` for a missing parent, and `not-empty` for a populated directory. Not platform-skipped: `removePathInRoot()` has no platform branch, so it runs on all six CI matrix legs.
- `test/edge-coverage.test.ts` — unit assertions over the six errno mappings, the `FsSafeError` pass-through for `path-mismatch`, and the non-errno fallback to `path-alias`.

`not-removable` is covered at the unit level rather than end to end on purpose: forcing `EACCES` needs a `chmod` that is a no-op for root in container CI and is ignored on Windows, and forcing `EBUSY` only works on Windows. A platform-skipped end-to-end case would assert less than the unit test does on every platform.

Validation on Windows 11, Node v22.20.0, pnpm 10.34.5:

```
pnpm check
  lint:file-size    pass
  lint:fs-boundary  pass
  build             pass
  test              Test Files  54 passed | 6 skipped (60)
                    Tests  489 passed | 183 skipped (672)
  check-pack.mjs    exit 0

pnpm test:security  Test Files  5 passed (5)
                    Tests  46 passed | 17 skipped (63)

targeted           Tests  21 passed | 13 skipped (34)
                   (test/fs-safe.test.ts, test/edge-coverage.test.ts;
                    19 passed on main before the two new tests)
```

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included


## Update — `e96eb9c`

The errno mapping wrapped the whole fallback, and the parent-directory guard runs inside it, so a raw guard error such as `ELOOP` became `not-removable` although no deletion was attempted.

The guard stage now sits in `prepareRemoveGuard()` with its own normalizer, and the errno mapping wraps only the `lstat`/`rmdir`/`rm` calls on the target. `removePathInRoot()` is back to `normalizePinnedPathError()`, unchanged from `main`.

`normalizeRemoveGuardError()` keeps `FsSafeError` unchanged, maps `ENOENT`/`ENOTDIR` to `not-found` — the parent does not exist, so the target is definitionally absent and nothing mutated — and fails closed with `path-alias` for every other raw error.

Pre-fix, on head `44cc206` with the new regression:

```
FAIL  test/edge-coverage.test.ts > root error helpers >
      does not map a guard-stage filesystem failure to a removal code
AssertionError: expected FsSafeError: path could not be removed { …(3) } to match
object { code: 'path-alias' }
- Expected
+ Received
- {
-   "code": "path-alias",
+ FsSafeError {
+   "code": "not-removable",
```

Coverage added: an end-to-end case driving an errno-shaped guard failure through the existing `beforeRootFallbackMutation` hook, so it is deterministic on all six CI legs, plus unit assertions over every branch of the new normalizer.

Validation on Windows 11, Node v22.20.0:

```
lint:file-size    pass
lint:fs-boundary  pass
tsc --noEmit      pass
vitest run        Test Files  54 passed | 6 skipped (60)
                  Tests  491 passed | 183 skipped (674)
test:security     Test Files  5 passed (5)
                  Tests  46 passed | 17 skipped (63)
```
