### PR TITLE
fix(path): reject drive-relative untrusted relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Suffix Windows reserved basenames with `_` in `sanitizeUntrustedFileName()` while preserving case and extensions on every platform, including dollar names and superscript COM/LPT variants; thanks @SebTardif (#67).
 
+### Security and Correctness
+
+- Reject drive-relative segments such as `C:secret.txt` and `a/C:b` in untrusted relative paths with `invalid-path`. `path.win32.isAbsolute()` reports these as relative, so on Windows `path.resolve()` consumed the drive prefix and silently aliased them onto the plain in-root path, letting two distinct store keys resolve to the same file.
+
 ## 0.5.1 - 2026-08-01
 
 ### Security and Correctness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Security and Correctness
 
-- Reject drive-relative segments such as `C:secret.txt` and `a/C:b` in untrusted relative paths with `invalid-path`. `path.win32.isAbsolute()` reports these as relative, so on Windows `path.resolve()` consumed the drive prefix and silently aliased them onto the plain in-root path, letting two distinct store keys resolve to the same file.
+- Reject drive-relative paths such as `C:secret.txt` with `invalid-path` on every `Root` method and on the `fileStore()` keys that delegate to them, and reject drive-relative segments such as `a/C:b` in the resolving path parser. `path.win32.isAbsolute()` reports these as relative, so on Windows `path.resolve()` consumed the drive prefix and silently aliased them onto the plain in-root path, letting two distinct keys resolve to the same file. Drive-absolute inputs such as `C:\root\file.txt` keep working.
 
 ## 0.5.1 - 2026-08-01
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -92,7 +92,7 @@ type FsSafeErrorCode =
 | `helper-failed` | A native mechanism or multi-step operational helper failed. | Inspect `cause` and any operation-specific `details`; retrying may be unsafe if the operation partially completed. |
 | `helper-unavailable` | Required native binding could not be loaded. | Unsupported platform, missing/incompatible bundled binary, or `FS_SAFE_NATIVE_MODE=require`. `auto` falls back where possible; `require` fails closed. |
 | `insecure-permissions` | A secure file or path permission check found a mode/ACL that allows broader access than requested. | File or directory is group/world writable/readable; Windows ACL grants broad read. |
-| `invalid-path` | Input was empty, contained NUL, was an unparseable URL, or otherwise unusable. | Caller didn't validate input; input was a network path on Windows. |
+| `invalid-path` | Input was empty, contained NUL, was an unparseable URL, or otherwise unusable. | Caller didn't validate input; input was a network path on Windows, or a drive-relative path such as `C:name`. |
 | `not-empty` | `remove()` on a non-empty directory. | Use `replaceDirectoryAtomic` or remove children first. |
 | `not-file` | Read or copy targeted a non-regular file. | Target was a directory, FIFO, socket, device. |
 | `not-found` | The target does not exist (or its parent does not, with `mkdir: false`). | Typical missing-file case. |

--- a/docs/root.md
+++ b/docs/root.md
@@ -151,7 +151,7 @@ Every method throws `FsSafeError` with a `code`. Branch on `err.code`, not messa
 
 | Code | When it fires |
 |---|---|
-| `invalid-path` | The input path is malformed, including embedded NUL bytes. |
+| `invalid-path` | The input path is malformed, including embedded NUL bytes and drive-relative spellings such as `C:name`. |
 | `outside-workspace` | The input resolves outside the root, or contains a `..` segment that would escape it. |
 | `not-found` | The target does not exist (or its parent does not, with `mkdir: false`). |
 | `not-file` | A read or copy targeted a non-regular file (directory, FIFO, socket, …). |

--- a/src/path.ts
+++ b/src/path.ts
@@ -15,7 +15,7 @@ export {
 // Windows treats "C:name" as relative to the drive's own working directory, so
 // path.win32.isAbsolute() reports false while path.resolve() still consumes the
 // prefix. Reject the spelling outright rather than let it alias a plain segment.
-const DRIVE_RELATIVE_SEGMENT = /^[A-Za-z]:/;
+const DRIVE_RELATIVE_PREFIX = /^[A-Za-z]:(?![\\/])/;
 const NOT_FOUND_CODES = new Set(["ENOENT", "ENOTDIR"]);
 const SYMLINK_OPEN_CODES = new Set(["ELOOP", "EINVAL", "ENOTSUP"]);
 const POSIX_SEPARATOR_CHAR_CODE = 0x2f;
@@ -139,6 +139,10 @@ export function safeStatSync(targetPath: string): fs.Stats | null {
   }
 }
 
+export function isDriveRelativePath(value: string): boolean {
+  return DRIVE_RELATIVE_PREFIX.test(value);
+}
+
 export function splitSafeRelativePath(relativePath: string): string[] {
   if (relativePath.length === 0 || relativePath === ".") {
     return [];
@@ -160,7 +164,7 @@ export function splitSafeRelativePath(relativePath: string): string[] {
     if (segment === "..") {
       throw new FsSafeError("invalid-path", "relative path must not contain '..'");
     }
-    if (DRIVE_RELATIVE_SEGMENT.test(segment)) {
+    if (isDriveRelativePath(segment)) {
       throw new FsSafeError("invalid-path", "relative path must not contain a drive letter");
     }
   }

--- a/src/path.ts
+++ b/src/path.ts
@@ -12,6 +12,10 @@ export {
   type UnsafeDeviceReadPathReason,
 } from "./device-path.js";
 
+// Windows treats "C:name" as relative to the drive's own working directory, so
+// path.win32.isAbsolute() reports false while path.resolve() still consumes the
+// prefix. Reject the spelling outright rather than let it alias a plain segment.
+const DRIVE_RELATIVE_SEGMENT = /^[A-Za-z]:/;
 const NOT_FOUND_CODES = new Set(["ENOENT", "ENOTDIR"]);
 const SYMLINK_OPEN_CODES = new Set(["ELOOP", "EINVAL", "ENOTSUP"]);
 const POSIX_SEPARATOR_CHAR_CODE = 0x2f;
@@ -155,6 +159,9 @@ export function splitSafeRelativePath(relativePath: string): string[] {
   for (const segment of segments) {
     if (segment === "..") {
       throw new FsSafeError("invalid-path", "relative path must not contain '..'");
+    }
+    if (DRIVE_RELATIVE_SEGMENT.test(segment)) {
+      throw new FsSafeError("invalid-path", "relative path must not contain a drive letter");
     }
   }
   return segments;

--- a/src/root-context.ts
+++ b/src/root-context.ts
@@ -27,6 +27,13 @@ export function assertValidRootRelativePath(relativePath: string): void {
   }
 }
 
+export function assertValidRootPathInput(filePath: string): void {
+  assertNoNulPathInput(filePath, "file path contains a NUL byte");
+  if (isDriveRelativePath(filePath)) {
+    throw new FsSafeError("invalid-path", "file path must not start with a drive letter");
+  }
+}
+
 let cachedHomePath: { raw: string; real: string } | undefined;
 
 export async function expandRelativePathWithHome(relativePath: string): Promise<string> {

--- a/src/root-context.ts
+++ b/src/root-context.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { expandHomePrefix } from "./home-dir.js";
-import { assertNoNulPathInput, isNotFoundPathError, isPathInside } from "./path.js";
+import {
+  assertNoNulPathInput,
+  isDriveRelativePath,
+  isNotFoundPathError,
+  isPathInside,
+} from "./path.js";
 import { ROOT_PATH_ALIAS_POLICIES, resolveRootPath } from "./root-path.js";
 
 export type RootContext = {
@@ -17,6 +22,9 @@ export const ensureTrailingSep = (value: string) =>
 
 export function assertValidRootRelativePath(relativePath: string): void {
   assertNoNulPathInput(relativePath, "relative path contains a NUL byte");
+  if (isDriveRelativePath(relativePath)) {
+    throw new FsSafeError("invalid-path", "relative path must not start with a drive letter");
+  }
 }
 
 let cachedHomePath: { raw: string; real: string } | undefined;

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -36,6 +36,7 @@ import { readOpenedFileSafely, type ReadResult } from "./read-opened-file.js";
 import { pathStatFromStats } from "./path-stat.js";
 import { resolveRootPath } from "./root-path.js";
 import {
+  assertValidRootPathInput,
   assertValidRootRelativePath,
   ensureTrailingSep,
   expandRelativePathWithHome,
@@ -683,6 +684,7 @@ async function readPathInRoot(
     symlinks?: SymlinkPolicy;
   },
 ): Promise<ReadResult> {
+  assertValidRootPathInput(params.filePath);
   const rootDir = root.rootDir;
   const candidatePath = path.isAbsolute(params.filePath)
     ? path.resolve(params.filePath)

--- a/test/api-coverage.test.ts
+++ b/test/api-coverage.test.ts
@@ -257,7 +257,7 @@ describe("path helpers", () => {
     expect(safeStatSync(path.join(root, "missing"))).toBeNull();
     expect(() => assertNoNulPathInput("a\0b")).toThrow("NUL");
     expect(splitSafeRelativePath("./a//b")).toEqual(["a", "b"]);
-    for (const bad of ["../x", "/x", "C:\\x", "a\\b", "a\0b"]) {
+    for (const bad of ["../x", "/x", "C:\\x", "C:evil", "C:..", "a/C:b", "a\\b", "a\0b"]) {
       expect(() => splitSafeRelativePath(bad)).toThrow();
     }
     expect(resolveSafeRelativePath(root, "a/b")).toBe(path.join(root, "a", "b"));

--- a/test/windows-path.test.ts
+++ b/test/windows-path.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it } from "vitest";
 import { fileStore } from "../src/file-store.js";
 import { isWindowsNetworkPath } from "../src/local-file-access.js";
 import {
+  isDriveRelativePath,
   isPathInside,
   normalizeWindowsPathForComparison,
   splitSafeRelativePath,
 } from "../src/path.js";
+import { root as openRoot } from "../src/root.js";
 
 describe("Windows path classification", () => {
   it("distinguishes extended local paths from UNC paths", () => {
@@ -49,11 +51,65 @@ describe("drive-relative relative paths", () => {
     }
   });
 
+  it("separates drive-relative spellings from drive-absolute ones", () => {
+    for (const value of ["C:evil", "c:", "Z:.."]) {
+      expect(isDriveRelativePath(value), value).toBe(true);
+    }
+    for (const value of ["C:\\root\\file.txt", "C:/root/file.txt", "notes/c:file"]) {
+      expect(isDriveRelativePath(value), value).toBe(false);
+    }
+  });
+
   it("keeps accepting ordinary segments that merely contain a colon", () => {
     expect(splitSafeRelativePath("logs/2026-08-02T10:30:00Z.log")).toEqual([
       "logs",
       "2026-08-02T10:30:00Z.log",
     ]);
+  });
+
+  it("rejects a drive-relative key on every root and store entry point", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "fs-safe-drive-relative-delegates-"));
+    try {
+      const store = fileStore({ rootDir });
+      await store.writeText("secret.txt", "real");
+      const root = await openRoot(rootDir);
+      const key = "C:secret.txt";
+
+      const calls: Array<[string, () => Promise<unknown>]> = [
+        ["root.read", () => root.read(key)],
+        ["root.readText", () => root.readText(key)],
+        ["root.open", () => root.open(key)],
+        ["root.stat", () => root.stat(key)],
+        ["root.exists", () => root.exists(key)],
+        ["root.list", () => root.list(key)],
+        ["root.remove", () => root.remove(key)],
+        ["root.write", () => root.write(key, "aliased")],
+        ["root.move", () => root.move(key, "moved.txt")],
+        ["store.readText", () => store.readText(key)],
+        ["store.open", () => store.open(key)],
+        ["store.exists", () => store.exists(key)],
+        ["store.remove", () => store.remove(key)],
+      ];
+      for (const [label, call] of calls) {
+        await expect(call(), label).rejects.toMatchObject({ code: "invalid-path" });
+      }
+
+      await expect(readFile(path.join(rootDir, "secret.txt"), "utf8")).resolves.toBe("real");
+    } finally {
+      await rm(rootDir, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps accepting an absolute path that stays inside the root", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "fs-safe-drive-relative-absolute-"));
+    try {
+      const root = await openRoot(rootDir);
+      await root.write("note.txt", "kept");
+
+      await expect(root.readText(path.join(rootDir, "note.txt"))).resolves.toBe("kept");
+    } finally {
+      await rm(rootDir, { force: true, recursive: true });
+    }
   });
 
   it("stops a drive-relative store key from aliasing a plain key", async () => {

--- a/test/windows-path.test.ts
+++ b/test/windows-path.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -103,7 +103,12 @@ describe("drive-relative relative paths", () => {
   });
 
   it("keeps accepting an absolute path that stays inside the root", async () => {
-    const rootDir = await mkdtemp(path.join(os.tmpdir(), "fs-safe-drive-relative-absolute-"));
+    // The temp dir must be resolved: macOS hands back /var/... for a /private/var/...
+    // root and Windows CI hands back an 8.3 short name, either of which reads as
+    // outside the root once openRoot() resolves it.
+    const rootDir = await realpath(
+      await mkdtemp(path.join(os.tmpdir(), "fs-safe-drive-relative-absolute-")),
+    );
     try {
       const root = await openRoot(rootDir);
       await root.write("note.txt", "kept");

--- a/test/windows-path.test.ts
+++ b/test/windows-path.test.ts
@@ -85,6 +85,8 @@ describe("drive-relative relative paths", () => {
         ["root.remove", () => root.remove(key)],
         ["root.write", () => root.write(key, "aliased")],
         ["root.move", () => root.move(key, "moved.txt")],
+        ["root.readAbsolute", () => root.readAbsolute(key)],
+        ["root.reader", () => root.reader()(key)],
         ["store.readText", () => store.readText(key)],
         ["store.open", () => store.open(key)],
         ["store.exists", () => store.exists(key)],
@@ -107,6 +109,12 @@ describe("drive-relative relative paths", () => {
       await root.write("note.txt", "kept");
 
       await expect(root.readText(path.join(rootDir, "note.txt"))).resolves.toBe("kept");
+      await expect(
+        root.readAbsolute(path.join(rootDir, "note.txt")),
+      ).resolves.toMatchObject({ buffer: Buffer.from("kept") });
+      await expect(root.reader()(path.join(rootDir, "note.txt"))).resolves.toEqual(
+        Buffer.from("kept"),
+      );
     } finally {
       await rm(rootDir, { force: true, recursive: true });
     }

--- a/test/windows-path.test.ts
+++ b/test/windows-path.test.ts
@@ -1,6 +1,14 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { fileStore } from "../src/file-store.js";
 import { isWindowsNetworkPath } from "../src/local-file-access.js";
-import { isPathInside, normalizeWindowsPathForComparison } from "../src/path.js";
+import {
+  isPathInside,
+  normalizeWindowsPathForComparison,
+  splitSafeRelativePath,
+} from "../src/path.js";
 
 describe("Windows path classification", () => {
   it("distinguishes extended local paths from UNC paths", () => {
@@ -30,6 +38,37 @@ describe("Windows comparison normalization", () => {
     expect(normalizeWindowsPathForComparison("\\\\?\\C:\\Users/Public")).toBe(
       "c:\\users\\public",
     );
+  });
+});
+
+describe("drive-relative relative paths", () => {
+  it("rejects drive-letter segments that Windows would resolve away", () => {
+    const inputs = ["C:evil", "c:evil", "C:", "C:..", "C:evil/sub", "a/C:b", "./C:evil", "a/D:b"];
+    for (const input of inputs) {
+      expect(() => splitSafeRelativePath(input)).toThrow("drive letter");
+    }
+  });
+
+  it("keeps accepting ordinary segments that merely contain a colon", () => {
+    expect(splitSafeRelativePath("logs/2026-08-02T10:30:00Z.log")).toEqual([
+      "logs",
+      "2026-08-02T10:30:00Z.log",
+    ]);
+  });
+
+  it("stops a drive-relative store key from aliasing a plain key", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "fs-safe-drive-relative-"));
+    try {
+      const store = fileStore({ rootDir });
+      await store.writeText("secret.txt", "real");
+
+      await expect(store.writeText("C:secret.txt", "aliased")).rejects.toMatchObject({
+        code: "invalid-path",
+      });
+      await expect(readFile(path.join(rootDir, "secret.txt"), "utf8")).resolves.toBe("real");
+    } finally {
+      await rm(rootDir, { force: true, recursive: true });
+    }
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers passing untrusted relative paths through `splitSafeRelativePath()` / `resolveSafeRelativePath()` would have two distinct inputs resolve to the same file on Windows, because a drive-relative spelling such as `C:secret.txt` was accepted as an ordinary segment.

The affected surface is path validation, and through it the file stores. This is a deliberate compatibility change: input that previously resolved silently now throws `invalid-path`. That is called out here rather than at the bottom because `CONTRIBUTING.md` names path handling as a public compatibility surface.

`splitSafeRelativePath()` (`src/path.ts:138-161`) rejects NUL bytes, backslashes, absolute paths, `//` prefixes, and `..` segments. Absolute detection uses `path.win32.isAbsolute()`, which returns `false` for `C:name` — that spelling is relative to the drive's own working directory, not to the root. The segment is therefore returned unchanged, and `resolveSafeRelativePath()` hands it to `path.resolve()`, which does consume the drive prefix.

Measured on Node v22.20.0 / win32:

```
path.win32.resolve("C:\\root", ...segments)

["C:evil"]        -> C:\root\evil     aliases "evil"
["a","C:b"]       -> C:\root\a\b      aliases "a/b"
["x","C:y","z"]   -> C:\root\x\y\z
["a","C:.."]      -> C:\root
["C:.."]          -> C:\              escape, caught later by isPathInside
["a","D:b"]       -> D:\a\b           escape, caught later by isPathInside
```

`path.posix.resolve()` keeps these as literal segments, so the aliasing bites on Windows only — but the divergence between the two platforms is itself the problem for anything replicating store contents across hosts.

Two consequences beyond the aliasing:

- `"C:.."` passes the `..` check as the single segment `C:..`, so the function violated its own postcondition (`relative path must not contain '..'`) and returned a `..`-bearing segment to any caller that joins segments itself. `resolveSafeRelativePath()`'s trailing `isPathInside()` still caught the escape, so this was a contract gap rather than a traversal.
- `src/file-store.ts:111-120` routes untrusted store keys through `assertRelativePath()`, which rewrites `\` to `/` before validation. That makes `"C:\\x"` safe (it becomes `C:/x`, which `path.win32.isAbsolute()` catches) while `"C:evil"` and `"a\\C:b"` pass straight through — so the whole `fileStore` / `fileStoreSync` key surface was affected.

## Why This Change Was Made

One guard in `src/path.ts`: any segment matching `/^[A-Za-z]:/` is rejected with the existing `invalid-path` code.

Design decisions:

- **Per segment, not on the whole string.** `["a","C:b"] -> C:\root\a\b` above: a drive-relative spelling anywhere in the path aliases the whole prefix, and `"./C:evil"` has its `.` filtered out before resolution. A leading-segment-only check would leave the hole open.
- **Existing error code reused.** No change to the `FsSafeErrorCode` union, `docs/types.md`, or any option shape. The message follows its two siblings in the same loop (`relative path must not contain '..'`, `relative path must not be absolute`).
- **Placed after the `..` check** so `"C:.."` reports the drive-letter cause, and the function can no longer return a `..`-bearing segment.
- **Unconditional, not platform-gated.** The function already calls `path.win32.isAbsolute()` on every host, so its contract is "reject what is unsafe on any supported platform." Gating on `process.platform` would make a store key valid on Linux and a boundary violation on Windows, which is worse for anyone syncing store contents across hosts.
- **Linear.** The pattern is anchored with no backtracking, consistent with the linear-time sanitizer work in `ab93382`.

Non-goal: broader colon handling (NTFS alternate data streams, `file.txt:stream`) is a separate concern and is not touched here.

Compatibility scan: `grep -rnE '"[A-Za-z]:[^\\/]' src/ test/ docs/` returns nothing — no in-package caller passes a drive-relative relative path. Externally this would break a consumer deliberately using single-letter-plus-colon filename prefixes as store keys. Those are already illegal filenames on Windows, and on Windows the previous behavior wrote them to the wrong file, so the breakage surfaces a bug rather than removing a working feature.

## User Impact

`fileStore`, `fileStoreSync`, and any direct user of `@openclaw/fs-safe/path` now reject drive-relative keys instead of silently aliasing them:

```ts
const store = fileStore({ rootDir });
await store.writeText("secret.txt", "real");
await store.writeText("C:secret.txt", "aliased"); // now: invalid-path
```

Before this change the second call resolved to the same file and overwrote it. A caller that maintained its own allow/deny bookkeeping per relative path could be fed the `C:`-prefixed spelling to reach a key it had already decided to protect.

No API, option, default, export, or error code was added or removed.

## Evidence

Reproduction on `main`, from the new store-level regression test:

```
FAIL  test/windows-path.test.ts > drive-relative relative paths >
      stops a drive-relative store key from aliasing a plain key
AssertionError: promise resolved
  "'C:\Users\...\fs-safe-drive-relative-fR1Nlm\secret.txt'"
  instead of rejecting
```

The pre-fix run does not merely fail to throw — it returns the path of `secret.txt`, confirming the second write landed on the first key's file.

Regression coverage added to `test/windows-path.test.ts` (three tests) and `test/api-coverage.test.ts` (existing rejection array extended in place, no new lines):

1. rejection of `C:evil`, `c:evil`, `C:`, `C:..`, `C:evil/sub`, `a/C:b`, `./C:evil`, `a/D:b`
2. a no-false-positive case — `logs/2026-08-02T10:30:00Z.log` still parses normally, so the anchored single-letter pattern does not reject timestamped filenames
3. the `mkdtemp` real-disk store case quoted above

None are platform-skipped. The guard is unconditional, so the assertions hold on all six CI matrix legs; only the pre-fix failure mode was Windows-specific.

Validation on Windows 11, Node v22.20.0, pnpm 10.34.5:

```
pnpm check
  lint:file-size    pass
  lint:fs-boundary  pass
  build             pass
  test              Test Files  54 passed | 6 skipped (60)
                    Tests  490 passed | 183 skipped (673)
  check-pack.mjs    exit 0

pnpm test:security  Test Files  5 passed (5)
                    Tests  45 passed | 17 skipped (62)

targeted           test/windows-path.test.ts  8 passed (8)
                   (5 on main before the three new tests)
```

One note on the local run: `test/file-lock-reentrancy.test.ts` failed once with `EPERM` on a `.lock` file during an earlier full-suite pass, then passed 4/4 in isolation and in the clean re-run above. It is unrelated to this change — `src/sidecar-lock.ts` does not use either function touched here — and looks like a Windows file-handle race from the separate-process arbitration test.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included


## Update — `2a10498`

`readAbsolute()` and `reader()` bypassed the guard: `readPathInRoot()` resolved the raw input against the root before validating it, so `C:secret.txt` reached the downstream check already flattened to `secret.txt`.

Fixed by validating the raw input at the top of `readPathInRoot()`, before the first `path.resolve()`. Drive-absolute in-root paths are unaffected.

Pre-fix, on head `7024025` with the two entry points added to the rejection table:

```
FAIL  test/windows-path.test.ts > drive-relative relative paths >
      rejects a drive-relative key on every root and store entry point
AssertionError: promise resolved "{ …(4) }" instead of rejecting
+   "realPath": "<tmp>\fs-safe-drive-relative-delegates-XXXXXX\secret.txt",
```

Coverage now spans 15 entry points, and the positive case pins `readAbsolute()` and `reader()` on an absolute in-root path.

Validation on Windows 11, Node v22.20.0:

```
lint:file-size    pass
lint:fs-boundary  pass
tsc --noEmit      pass
vitest run        Tests  492 passed | 183 skipped (676)
                  1 failure: file-lock-reentrancy.test.ts (pre-existing flake,
                  5 passed | 2 skipped on isolated re-run)
test:security     Tests  45 passed | 17 skipped (62)
targeted          test/windows-path.test.ts  11 passed (11)
```

The portable-versus-Windows-only compatibility decision is still open for the repository owner; see the discussion comment.
