### PR TITLE
fix(lock): retry Windows lock files denied mid-teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security and Correctness
+
+- Retry a contended file-lock acquisition when Windows denies access to a lock file whose directory entry is still being torn down. Both the exclusive create and the holder's snapshot read reported that transient `EPERM` as a hard failure, so concurrent `acquireFileLock()` calls failed intermittently on Windows even though the very next attempt would have succeeded. Retries stay bounded, so a genuine permission denial still surfaces as `EPERM` rather than a lock timeout.
+
 ### Features
 
 - Suffix Windows reserved basenames with `_` in `sanitizeUntrustedFileName()` while preserving case and extensions on every platform, including dollar names and superscript COM/LPT variants; thanks @SebTardif (#67).

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -7,9 +7,10 @@ const LINE_BUDGETS = new Map([
   ["src/permissions.ts", 566],
   ["src/root-impl.ts", 1750],
   ["src/root-path.ts", 862],
-  ["src/sidecar-lock.ts", 525],
+  ["src/sidecar-lock.ts", 540],
   ["test/api-coverage.test.ts", 983],
   ["test/new-primitives.test.ts", 1500],
+  ["test/sidecar-lock-regression.test.ts", 540],
 ]);
 
 function walk(dir) {

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -7,7 +7,7 @@ const LINE_BUDGETS = new Map([
   ["src/permissions.ts", 566],
   ["src/root-impl.ts", 1750],
   ["src/root-path.ts", 862],
-  ["src/sidecar-lock.ts", 520],
+  ["src/sidecar-lock.ts", 525],
   ["test/api-coverage.test.ts", 983],
   ["test/new-primitives.test.ts", 1500],
 ]);

--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -7,6 +7,7 @@ const LINE_BUDGETS = new Map([
   ["src/permissions.ts", 566],
   ["src/root-impl.ts", 1750],
   ["src/root-path.ts", 862],
+  ["src/sidecar-lock.ts", 520],
   ["test/api-coverage.test.ts", 983],
   ["test/new-primitives.test.ts", 1500],
 ]);

--- a/src/sidecar-lock-policy.ts
+++ b/src/sidecar-lock-policy.ts
@@ -14,11 +14,14 @@ export function computeSidecarLockDelayMs(retry: SidecarLockRetryOptions, attemp
 // is still being torn down, so a contended acquire sees EPERM on a name that is
 // already gone -- both when creating it exclusively and when reading the
 // holder's snapshot. The next attempt succeeds, so this is contention rather
-// than a permission failure.
+// than a permission failure. The error must name the lock file itself: the
+// exclusive-create helper opens the parent directory first, and a denial from
+// that setup step carries no teardown evidence and has to reach the caller.
 export const maxTransientLockDenials = 8;
 
-export function isTransientLockFileDenial(error: unknown): boolean {
-  return process.platform === "win32" && (error as NodeJS.ErrnoException | null)?.code === "EPERM";
+export function isTransientLockFileDenial(error: unknown, lockPath: string): boolean {
+  const denial = error as NodeJS.ErrnoException | null;
+  return process.platform === "win32" && denial?.code === "EPERM" && denial.path === lockPath;
 }
 
 export function sidecarLockPayloadIsStale(

--- a/src/sidecar-lock-policy.ts
+++ b/src/sidecar-lock-policy.ts
@@ -10,6 +10,17 @@ export function computeSidecarLockDelayMs(retry: SidecarLockRetryOptions, attemp
   return Math.min(maxTimeout, Math.round(base * jitter));
 }
 
+// Windows denies access to a lock file while a just-unlinked directory entry
+// is still being torn down, so a contended acquire sees EPERM on a name that is
+// already gone -- both when creating it exclusively and when reading the
+// holder's snapshot. The next attempt succeeds, so this is contention rather
+// than a permission failure.
+export const maxTransientLockDenials = 8;
+
+export function isTransientLockFileDenial(error: unknown): boolean {
+  return process.platform === "win32" && (error as NodeJS.ErrnoException | null)?.code === "EPERM";
+}
+
 export function sidecarLockPayloadIsStale(
   payload: unknown,
   staleMs: number,

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -266,6 +266,17 @@ export function createSidecarLockManager(key: string) {
     // Bounded so a genuine denial still surfaces as EPERM, not a lock timeout.
     let transientDenials = 0;
     const withinDenialBudget = (): boolean => ++transientDenials <= maxTransientLockDenials;
+    // Waiting can fail on the caller's own retry or deadline limits. Classifying
+    // a denial as contention must not cost them the original diagnosis, so hand
+    // the denial back when no further attempt can be scheduled.
+    const retryOrRethrowDenial = async (denial: unknown): Promise<void> => {
+      try {
+        await waitForRetry();
+      } catch (waitError) {
+        if ((waitError as NodeJS.ErrnoException).code === "file_lock_timeout") throw denial;
+        throw waitError;
+      }
+    };
     const waitForRetry = async (): Promise<void> => {
       const elapsed = Date.now() - startedAt;
       if (
@@ -383,7 +394,7 @@ export function createSidecarLockManager(key: string) {
             });
           }
           if (lockFileCreateDenied && withinDenialBudget()) {
-            await waitForRetry();
+            await retryOrRethrowDenial(err);
             continue;
           }
           if ((err as { code?: unknown }).code !== "EEXIST") {
@@ -404,7 +415,7 @@ export function createSidecarLockManager(key: string) {
           } catch (readErr) {
             if (!isTransientLockFileDenial(readErr, lockPath) || !withinDenialBudget())
               throw readErr;
-            await waitForRetry();
+            await retryOrRethrowDenial(readErr);
             continue;
           }
           if (!snapshot) {

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -315,7 +315,7 @@ export function createSidecarLockManager(key: string) {
               handle =
                 (await createNativeExclusiveFile(lockPath, 0o600)) ?? (await fs.open(lockPath, "wx"));
             } catch (createError) {
-              lockFileCreateDenied = isTransientLockFileDenial(createError);
+              lockFileCreateDenied = isTransientLockFileDenial(createError, lockPath);
               throw createError;
             }
             await handle.writeFile(raw, "utf8");
@@ -402,7 +402,8 @@ export function createSidecarLockManager(key: string) {
               parsePayload: options.parsePayload,
             });
           } catch (readErr) {
-            if (!isTransientLockFileDenial(readErr) || !withinDenialBudget()) throw readErr;
+            if (!isTransientLockFileDenial(readErr, lockPath) || !withinDenialBudget())
+              throw readErr;
             await waitForRetry();
             continue;
           }

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -30,6 +30,8 @@ import type {
 import {
   computeSidecarLockDelayMs,
   defaultSidecarLockShouldReclaim,
+  isTransientLockFileDenial,
+  maxTransientLockDenials,
 } from "./sidecar-lock-policy.js";
 export type { SidecarLockStaleSnapshot } from "./sidecar-lock-reclaim.js";
 export type {
@@ -261,6 +263,10 @@ export function createSidecarLockManager(key: string) {
     const reclaimGuardPath = `${lockPath}.reclaim`;
     let ownsReclaimGuard = false;
     let attempt = 0;
+    // Bounded so a genuine denial still surfaces as EPERM, not a lock timeout.
+    let transientDenials = 0;
+    const isRetryableDenial = (error: unknown): boolean =>
+      isTransientLockFileDenial(error) && ++transientDenials <= maxTransientLockDenials;
     const waitForRetry = async (): Promise<void> => {
       const elapsed = Date.now() - startedAt;
       if (
@@ -370,6 +376,10 @@ export function createSidecarLockManager(key: string) {
               parsePayload: options.parsePayload,
             });
           }
+          if (isRetryableDenial(err)) {
+            await waitForRetry();
+            continue;
+          }
           if ((err as { code?: unknown }).code !== "EEXIST") {
             throw err;
           }
@@ -379,10 +389,17 @@ export function createSidecarLockManager(key: string) {
             continue;
           }
           const nowMs = Date.now();
-          const snapshot = await readSidecarLockSnapshot(lockPath, {
-            lockRoot: options.lockRoot,
-            parsePayload: options.parsePayload,
-          });
+          let snapshot: SidecarLockSnapshot | null;
+          try {
+            snapshot = await readSidecarLockSnapshot(lockPath, {
+              lockRoot: options.lockRoot,
+              parsePayload: options.parsePayload,
+            });
+          } catch (readErr) {
+            if (!isRetryableDenial(readErr)) throw readErr;
+            await waitForRetry();
+            continue;
+          }
           if (!snapshot) {
             continue;
           }

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -265,8 +265,7 @@ export function createSidecarLockManager(key: string) {
     let attempt = 0;
     // Bounded so a genuine denial still surfaces as EPERM, not a lock timeout.
     let transientDenials = 0;
-    const isRetryableDenial = (error: unknown): boolean =>
-      isTransientLockFileDenial(error) && ++transientDenials <= maxTransientLockDenials;
+    const withinDenialBudget = (): boolean => ++transientDenials <= maxTransientLockDenials;
     const waitForRetry = async (): Promise<void> => {
       const elapsed = Date.now() - startedAt;
       if (
@@ -296,6 +295,7 @@ export function createSidecarLockManager(key: string) {
           continue;
         }
         let handle: SidecarFileHandle | null = null;
+        let lockFileCreateDenied = false;
         try {
           const payload = await options.payload();
           const { raw, ownershipToken } = serializeSidecarLockPayload(payload);
@@ -311,7 +311,13 @@ export function createSidecarLockManager(key: string) {
             }
             handle = (await options.lockRoot.open(relativeLockPath)).handle;
           } else {
-            handle = (await createNativeExclusiveFile(lockPath, 0o600)) ?? await fs.open(lockPath, "wx");
+            try {
+              handle =
+                (await createNativeExclusiveFile(lockPath, 0o600)) ?? (await fs.open(lockPath, "wx"));
+            } catch (createError) {
+              lockFileCreateDenied = isTransientLockFileDenial(createError);
+              throw createError;
+            }
             await handle.writeFile(raw, "utf8");
           }
           const snapshot = { raw, payload, stat: await handle.stat(), ownershipToken };
@@ -376,7 +382,7 @@ export function createSidecarLockManager(key: string) {
               parsePayload: options.parsePayload,
             });
           }
-          if (isRetryableDenial(err)) {
+          if (lockFileCreateDenied && withinDenialBudget()) {
             await waitForRetry();
             continue;
           }
@@ -396,7 +402,7 @@ export function createSidecarLockManager(key: string) {
               parsePayload: options.parsePayload,
             });
           } catch (readErr) {
-            if (!isRetryableDenial(readErr)) throw readErr;
+            if (!isTransientLockFileDenial(readErr) || !withinDenialBudget()) throw readErr;
             await waitForRetry();
             continue;
           }

--- a/test/sidecar-lock-regression.test.ts
+++ b/test/sidecar-lock-regression.test.ts
@@ -38,7 +38,7 @@ describe("sidecar lock regressions", () => {
         );
 
   it.runIf(process.platform === "win32")("retries an exclusive create denied mid-teardown", async () => {
-    const base = await tempRoot("fs-safe-sidecar-eperm-create-");
+    const base = await fsp.realpath(await tempRoot("fs-safe-sidecar-eperm-create-"));
     const targetPath = path.join(base, "state.json");
     const lockPath = `${targetPath}.lock`;
     configureFsSafeNative({ mode: "off" });
@@ -66,7 +66,7 @@ describe("sidecar lock regressions", () => {
   });
 
   it.runIf(process.platform === "win32")("retries a contended snapshot read denied mid-teardown", async () => {
-    const base = await tempRoot("fs-safe-sidecar-eperm-read-");
+    const base = await fsp.realpath(await tempRoot("fs-safe-sidecar-eperm-read-"));
     const targetPath = path.join(base, "state.json");
     const lockPath = `${targetPath}.lock`;
     configureFsSafeNative({ mode: "off" });

--- a/test/sidecar-lock-regression.test.ts
+++ b/test/sidecar-lock-regression.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { fileStore } from "../src/file-store.js";
 import { acquireFileLock } from "../src/file-lock.js";
 import { configureFsSafeLocks, getFsSafeLockConfig } from "../src/lock-config.js";
+import { configureFsSafeNative } from "../src/native-config.js";
 import { createSidecarLockManager } from "../src/sidecar-lock.js";
 
 const tempDirs: string[] = [];
@@ -17,6 +18,7 @@ async function tempRoot(prefix: string): Promise<string> {
 
 afterEach(async () => {
   vi.restoreAllMocks();
+  configureFsSafeNative({ mode: "auto" });
   configureFsSafeLocks({
     retry: undefined,
     staleMs: undefined,
@@ -27,6 +29,73 @@ afterEach(async () => {
 });
 
 describe("sidecar lock regressions", () => {
+  // Windows denies access to a lock file while a just-unlinked directory entry is
+  // still being torn down. Both touch points below observed it in CI as EPERM.
+  const denial = (lockPath: string) =>
+    Object.assign(
+          new Error(`EPERM: operation not permitted, open '${lockPath}'`),
+          { code: "EPERM", errno: -4048, syscall: "open", path: lockPath },
+        );
+
+  it.runIf(process.platform === "win32")("retries an exclusive create denied mid-teardown", async () => {
+    const base = await tempRoot("fs-safe-sidecar-eperm-create-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    configureFsSafeNative({ mode: "off" });
+    const realOpen = fsp.open.bind(fsp) as typeof fsp.open;
+    let injected = 0;
+    vi.spyOn(fsp, "open").mockImplementation((async (...args: Parameters<typeof fsp.open>) => {
+      if (args[0] === lockPath && args[1] === "wx" && injected === 0) {
+        injected += 1;
+        throw denial(lockPath);
+      }
+      return await realOpen(...args);
+    }) as typeof fsp.open);
+
+    const lock = await acquireFileLock(targetPath, {
+      managerKey: `eperm-create-${Date.now()}-${Math.random()}`,
+      staleMs: 60_000,
+      timeoutMs: 1_000,
+      retry: { minTimeout: 1, maxTimeout: 2 },
+      payload: async () => ({ pid: process.pid }),
+    });
+    await lock.release();
+
+    expect(injected).toBe(1);
+    await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(process.platform === "win32")("retries a contended snapshot read denied mid-teardown", async () => {
+    const base = await tempRoot("fs-safe-sidecar-eperm-read-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    configureFsSafeNative({ mode: "off" });
+    await fsp.writeFile(lockPath, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }));
+    const realReadFile = fsp.readFile.bind(fsp) as typeof fsp.readFile;
+    let injected = 0;
+    vi.spyOn(fsp, "readFile").mockImplementation((async (...args: Parameters<typeof fsp.readFile>) => {
+      if (args[0] === lockPath && injected === 0) {
+        injected += 1;
+        // The holder's unlink lands while the reader is being denied.
+        await fsp.rm(lockPath, { force: true });
+        throw denial(lockPath);
+      }
+      return await realReadFile(...args);
+    }) as typeof fsp.readFile);
+
+    const lock = await acquireFileLock(targetPath, {
+      managerKey: `eperm-read-${Date.now()}-${Math.random()}`,
+      staleMs: 60_000,
+      timeoutMs: 1_000,
+      retry: { minTimeout: 1, maxTimeout: 2 },
+      payload: async () => ({ pid: process.pid }),
+    });
+    await lock.release();
+
+    expect(injected).toBe(1);
+    await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("does not delete a fresh sidecar lock during stale reclaim or old release", async () => {
     const base = await tempRoot("fs-safe-sidecar-token-");
     const targetPath = path.join(base, "state.json");

--- a/test/sidecar-lock-regression.test.ts
+++ b/test/sidecar-lock-regression.test.ts
@@ -37,6 +37,36 @@ describe("sidecar lock regressions", () => {
           { code: "EPERM", errno: -4048, syscall: "open", path: lockPath },
         );
 
+  it.runIf(process.platform === "win32")("propagates an EPERM that names the lock parent", async () => {
+    // createNativeExclusiveFile() opens dirname(lockPath) before the exclusive
+    // create, so a denial can name the parent. Only the teardown window on the
+    // lock file itself is contention; a parent denial must reach the caller.
+    const base = await fsp.realpath(await tempRoot("fs-safe-sidecar-eperm-parent-"));
+    const targetPath = path.join(base, "state.json");
+    configureFsSafeNative({ mode: "off" });
+    const realOpen = fsp.open.bind(fsp) as typeof fsp.open;
+    let payloadCalls = 0;
+
+    vi.spyOn(fsp, "open").mockImplementation((async (...args: Parameters<typeof fsp.open>) => {
+      if (args[0] === `${targetPath}.lock` && args[1] === "wx") throw denial(base);
+      return await realOpen(...args);
+    }) as typeof fsp.open);
+
+    await expect(
+      acquireFileLock(targetPath, {
+        managerKey: `eperm-parent-${Date.now()}-${Math.random()}`,
+        staleMs: 60_000,
+        timeoutMs: 1_000,
+        retry: { retries: 0 },
+        payload: async () => {
+          payloadCalls += 1;
+          return { pid: process.pid };
+        },
+      }),
+    ).rejects.toMatchObject({ code: "EPERM", path: base });
+    expect(payloadCalls).toBe(1);
+  });
+
   it.runIf(process.platform === "win32")("propagates an EPERM raised outside the lock file", async () => {
     // Only the lock-file create and snapshot read see the teardown window. An
     // EPERM from the caller's payload must reach the caller unchanged instead

--- a/test/sidecar-lock-regression.test.ts
+++ b/test/sidecar-lock-regression.test.ts
@@ -37,6 +37,32 @@ describe("sidecar lock regressions", () => {
           { code: "EPERM", errno: -4048, syscall: "open", path: lockPath },
         );
 
+  it.runIf(process.platform === "win32")("keeps the lock-file EPERM when no retry is left", async () => {
+    // Classifying the denial as contention must not cost the caller the
+    // diagnosis: with no retry budget the original EPERM has to survive
+    // instead of being replaced by the loop's timeout error.
+    const base = await fsp.realpath(await tempRoot("fs-safe-sidecar-eperm-exhausted-"));
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    configureFsSafeNative({ mode: "off" });
+    const realOpen = fsp.open.bind(fsp) as typeof fsp.open;
+
+    vi.spyOn(fsp, "open").mockImplementation((async (...args: Parameters<typeof fsp.open>) => {
+      if (args[0] === lockPath && args[1] === "wx") throw denial(lockPath);
+      return await realOpen(...args);
+    }) as typeof fsp.open);
+
+    await expect(
+      acquireFileLock(targetPath, {
+        managerKey: `eperm-exhausted-${Date.now()}-${Math.random()}`,
+        staleMs: 60_000,
+        timeoutMs: 1_000,
+        retry: { retries: 0 },
+        payload: async () => ({ pid: process.pid }),
+      }),
+    ).rejects.toMatchObject({ code: "EPERM", path: lockPath });
+  });
+
   it.runIf(process.platform === "win32")("propagates an EPERM that names the lock parent", async () => {
     // createNativeExclusiveFile() opens dirname(lockPath) before the exclusive
     // create, so a denial can name the parent. Only the teardown window on the

--- a/test/sidecar-lock-regression.test.ts
+++ b/test/sidecar-lock-regression.test.ts
@@ -37,6 +37,30 @@ describe("sidecar lock regressions", () => {
           { code: "EPERM", errno: -4048, syscall: "open", path: lockPath },
         );
 
+  it.runIf(process.platform === "win32")("propagates an EPERM raised outside the lock file", async () => {
+    // Only the lock-file create and snapshot read see the teardown window. An
+    // EPERM from the caller's payload must reach the caller unchanged instead
+    // of being retried, which would rerun the callback and hide the error.
+    const base = await fsp.realpath(await tempRoot("fs-safe-sidecar-eperm-payload-"));
+    const targetPath = path.join(base, "state.json");
+    configureFsSafeNative({ mode: "off" });
+    let payloadCalls = 0;
+
+    await expect(
+      acquireFileLock(targetPath, {
+        managerKey: `eperm-payload-${Date.now()}-${Math.random()}`,
+        staleMs: 60_000,
+        timeoutMs: 1_000,
+        retry: { retries: 0 },
+        payload: async () => {
+          payloadCalls += 1;
+          throw denial(`${targetPath}.lock`);
+        },
+      }),
+    ).rejects.toMatchObject({ code: "EPERM" });
+    expect(payloadCalls).toBe(1);
+  });
+
   it.runIf(process.platform === "win32")("retries an exclusive create denied mid-teardown", async () => {
     const base = await fsp.realpath(await tempRoot("fs-safe-sidecar-eperm-create-"));
     const targetPath = path.join(base, "state.json");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers taking a contended file lock on Windows would see `acquireFileLock()` reject with `EPERM` when the previous holder released the lock at the same moment. The affected surface is the sidecar file lock (`acquireFileLock`, `withFileLock`, `createFileLockManager`).

Windows denies access to a lock file while a just-unlinked directory entry is still being torn down. In that window the name is already gone but a fresh exclusive create is refused with `ERROR_ACCESS_DENIED`, which libuv reports as `EPERM` (errno `-4048`). The next attempt succeeds, so this is contention, not a permission failure.

`acquire()` treated only `EEXIST` as contention, so the transient `EPERM` escaped from two touch points:

1. the exclusive create, `fs.open(lockPath, "wx")`
2. `readSidecarLockSnapshot()`, which maps only `ENOENT` to a vanished lock

Instrumenting the failure showed the state directly — at the moment of the `EPERM`, the lock file is already gone and a zero-delay retry opens it:

```
EPERM-DIAG {"attempt":2,"lstat":"ENOENT","siblings":["state.json"],"retryAfterMs":0}
```

## Why This Change Was Made

Both touch points now classify a Windows `EPERM` on the lock file as contention and re-enter the existing retry loop. The retry budget is bounded (8 denials), so a genuine permission denial still surfaces as `EPERM` instead of degrading into a `file_lock_timeout` and losing the diagnosis.

The classification is gated to `win32`, matching the equivalence this repository already applies elsewhere — `isPermissionRenameError` in `src/replace-file.ts`, `renameJsonFileWithFallback` in `src/json.ts`, and `windows-rename-denied` in `src/move-path.ts`. `src/sidecar-lock.ts` was the outlier. No public API, error shape, or POSIX behaviour changes.

`src/sidecar-lock.ts` sat at 498 lines against the default 500-line budget, so the predicate lives in `src/sidecar-lock-policy.ts` and the file gets a `LINE_BUDGETS` entry. Happy to split the module instead if you would rather not raise the budget.

## User Impact

Concurrent lock acquisition on Windows no longer fails intermittently when one holder releases while another is waiting. Consumers on POSIX are unaffected. Nothing is added to or removed from the public API.

## Evidence

Two regression tests inject the transient denial at each touch point and assert the acquire still completes. Both fail on `main` and pass with this change:

```
FAIL  test/sidecar-lock-regression.test.ts > retries an exclusive create denied mid-teardown
FAIL  test/sidecar-lock-regression.test.ts > retries a contended snapshot read denied mid-teardown
Tests  2 failed | 11 passed (13)
```

Repeated runs of the real suites on Windows 11 (Node 22), `test/file-lock-reentrancy.test.ts` plus `test/new-primitives.test.ts`:

| | runs | failures |
|---|---|---|
| before | 85 | 8 (~9%) |
| after | 110 | 0 |

The rate before the fix moves with machine load, so a single green run does not demonstrate anything here — the loop does.

Full local verification: `vitest run` 489 passed / 183 skipped, `tsc --noEmit` clean, `scripts/check-file-size.mjs` and `scripts/check-fs-boundary-primitives.mjs` both exit 0.

### Note on the flake reports

This is the defect behind the `file-lock-reentrancy` and `new-primitives > file locks` failures that have been rotating across Windows legs. `src/sidecar-lock.ts` last changed in #65, so it predates the #79 dependency refresh — that bump only shifted timing enough to expose an existing race.

It does not explain `move-path-regression.test.ts > publishes a fresh inode when hardlink rejection is enabled`, which is a different symptom and is still open.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
