### PR TITLE
test(permissions): budget the Windows ACL tests for the no-native path

### DIFF
--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -239,7 +239,7 @@ describe("secure file reads", () => {
         ownerTrusted: true,
       });
     },
-    15_000,
+    60_000,
   );
 
   it.runIf(process.platform === "win32")(
@@ -268,7 +268,7 @@ describe("secure file reads", () => {
         ownerTrusted: true,
       });
     },
-    15_000,
+    60_000,
   );
 
   it("rejects symlinks and files outside trusted dirs", async () => {


### PR DESCRIPTION
## What Problem This Solves

`new-primitives.test.ts > secure file reads > reads from a validated Windows ACL and owner` times out at 15s on Windows CI. It has failed that way on #82, #85 and #87, always on one Node version while the other passes on the identical commit. The affected surface is test reliability for the Windows permissions fallback — nothing ships differently.

The cause is that the `Node N check` job never runs `pnpm native:build`, so these tests run the *command* fallback rather than the native `readOwnerAndDacl()`. Instrumenting `defaultPermissionExec` shows the cost:

```
SPAWNS inspect=2 total=4 ms=546
LOG ["powershell.exe -NoLogo -NoProfile -NonInteractive -Enco",
     "icacls.exe C:\...\secret.json",
     "powershell.exe -NoLogo -NoProfile -NonInteractive -Enco",
     "icacls.exe C:\...\secret.json"]
```

Each `inspectPathPermissions()` spawns `powershell.exe` for the owner query (`inspectWindowsOwner`) plus `icacls.exe` for the ACL. Each test pays **six process spawns**: two `icacls` in `secureWindowsTestFile`, then two inspecting calls at two spawns each.

## Why This Change Was Made

This is a timing budget for a spawn-bound test, not a slow assertion, so the budget is the thing that is wrong. Both Windows ACL tests do identical work and both move from 15s to 60s.

Cold process starts dominate on a Windows runner. The same failing run showed the machine five to ten times slower than local across unrelated suites — `api-coverage` at 6833ms and `archive` at 5306ms — and a test whose cost is almost entirely `CreateProcess` scales worse than wall-clock I/O does. Locally these tests take 561ms.

Non-goals: this does not change the library. `permissions.ts` still prefers `inspectWindowsPermissionsNative()`, which performs no spawns, and only falls back to the commands when no binding is loaded. Jobs that do build the binding never pay this cost.

## User Impact

None for package consumers. Test-only change.

## Evidence

Local run of the affected file, all green:

```
Test Files  1 passed (1)
     Tests  59 passed | 11 skipped (70)
```

Full local verification: `vitest run` 487 passed / 183 skipped, `tsc --noEmit` clean, `scripts/check-file-size.mjs` and `scripts/check-fs-boundary-primitives.mjs` both exit 0.

The spawn counts above come from temporarily instrumenting `defaultPermissionExec` to record each command; that instrumentation is not part of this diff.

### Separate finding, not fixed here

`defaultPermissionExec` in `src/permissions.ts` calls `execFileAsync` with no `timeout`, and so does `secureWindowsTestFile`. A wedged `icacls.exe` or `powershell.exe` would hang `inspectPathPermissions()` indefinitely for a consumer, not just in tests. That is a real robustness gap but it is a behaviour change to public API, so I have left it out of a test-only PR. Happy to open it separately if you want it bounded.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [ ] `CHANGELOG.md` updated when release-relevant — test-only, nothing ships
- [x] No credentials, private paths, private hosts, or sensitive contents included
