### PR TITLE
fix(permissions): bound Windows ACL commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,6 @@ jobs:
     name: Node ${{ matrix.node }} check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
-    # Keep the ordinary matrix on the shipping JavaScript/command fallback;
-    # native-check owns explicit bundled-binding coverage below.
-    env:
-      FS_SAFE_NATIVE_MODE: off
     strategy:
       fail-fast: false
       matrix:
@@ -60,7 +56,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check
+      # Deliberately do not build a host binding here. On Windows this exercises
+      # the shipping command fallback; native-check covers the bundled binding.
+      - name: Check JavaScript fallback
         run: pnpm check
 
   native-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
     name: Node ${{ matrix.node }} check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    # Keep the ordinary matrix on the shipping JavaScript/command fallback;
+    # native-check owns explicit bundled-binding coverage below.
+    env:
+      FS_SAFE_NATIVE_MODE: off
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,17 @@
 ### Security and Correctness
 
 - Retry a contended file-lock acquisition when Windows denies access to a lock file whose directory entry is still being torn down, including when the native binding performs the exclusive create. Both the exclusive create and the holder's snapshot read reported that transient `EPERM` as a hard failure, so concurrent `acquireFileLock()` calls failed intermittently on Windows even though the very next attempt would have succeeded. Retries stay bounded, so a genuine permission denial still surfaces as `EPERM` rather than a lock timeout; thanks @Yigtwxx for the fix.
+- Apply `replaceFileAtomic()` and `replaceFileAtomicSync()` modes through pinned temp-file descriptors before rename, and through pinned copy-fallback descriptors, so a post-rename symlink swap cannot redirect `chmod` to an unrelated file while exact modes remain independent of umask; thanks @yetval for reporting this (#86).
+- Bound fallback Windows owner and ACL command execution to 10 seconds per process and report owner-query failures as unverified instead of returning a partial permission classification; thanks @Yigtwxx for the diagnosis.
+
+### Compatibility
+
 - Report access-denied failures from native Windows operations as `EPERM` rather than `EACCES`, matching Node/libuv and the JavaScript fallback. Consumers that matched the previous native-only `EACCES` code should accept `EPERM` as well when supporting older package versions.
+- Add an optional `fchmodSync` operation to the injectable synchronous atomic-replacement filesystem type. Async adapters need no new member because their required `open()` returns a mode-capable `FileHandle`; custom sync adapters that pass `mode` or `preserveExistingMode` now fail before mutation when `fchmodSync` is absent, while adapters that request neither option remain compatible.
 
 ### Features
 
 - Suffix Windows reserved basenames with `_` in `sanitizeUntrustedFileName()` while preserving case and extensions on every platform, including dollar names and superscript COM/LPT variants; thanks @SebTardif (#67).
-
-### Security and Correctness
-
-- Apply `replaceFileAtomic()` and `replaceFileAtomicSync()` modes through pinned temp-file descriptors before rename, and through pinned copy-fallback descriptors, so a post-rename symlink swap cannot redirect `chmod` to an unrelated file while exact modes remain independent of umask; thanks @yetval for reporting this (#86).
-
-### Compatibility
-
-- Add an optional `fchmodSync` operation to the injectable synchronous atomic-replacement filesystem type. Async adapters need no new member because their required `open()` returns a mode-capable `FileHandle`; custom sync adapters that pass `mode` or `preserveExistingMode` now fail before mutation when `fchmodSync` is absent, while adapters that request neither option remain compatible.
 
 ## 0.5.1 - 2026-08-01
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -67,6 +67,10 @@ resolveWindowsUserPrincipal(env);
 The fallback Windows inspector calls `icacls.exe <path>` using its supported
 path-only inspection syntax and classifies principals as trusted, world, or
 group. Trusted defaults include the current user, SYSTEM, and Administrators.
+Built-in PowerShell, `icacls.exe`, and `whoami.exe` invocations have a fixed
+10-second per-process deadline. A command failure or timeout returns an
+unverified result (`source: "unknown"`) so callers fail closed. Advanced callers
+that inject a custom `exec` implementation own that executor's deadline.
 The parser is on the advanced surface so tests and CLIs can process captured
 `icacls` output without spawning a process.
 

--- a/src/permission-exec.ts
+++ b/src/permission-exec.ts
@@ -1,0 +1,36 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_PERMISSION_EXEC_TIMEOUT_MS = 10_000;
+
+export async function executePermissionCommand(
+  command: string,
+  args: string[],
+  timeoutMs = DEFAULT_PERMISSION_EXEC_TIMEOUT_MS,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return (await execFileAsync(command, args, {
+      encoding: "utf8",
+      windowsHide: true,
+      maxBuffer: 1024 * 1024,
+      timeout: timeoutMs,
+      killSignal: "SIGKILL",
+    })) as { stdout: string; stderr: string };
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "killed" in err &&
+      err.killed === true &&
+      "signal" in err &&
+      err.signal === "SIGKILL"
+    ) {
+      throw new Error(`Windows permission inspection timed out after ${timeoutMs}ms`, {
+        cause: err,
+      });
+    }
+    throw err;
+  }
+}

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,8 +1,7 @@
-import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
+import { executePermissionCommand } from "./permission-exec.js";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.js";
 import { inspectWindowsPermissionsNative } from "./windows-permissions-native.js";
 import { resolveWindowsSystemCommand } from "./windows-command.js";
@@ -11,7 +10,6 @@ import {
   resolveWindowsCurrentUserSid,
   resolveWindowsPrincipalSids,
 } from "./windows-owner.js";
-const execFileAsync = promisify(execFile);
 export type PermissionExec = (
   command: string,
   args: string[],
@@ -116,13 +114,7 @@ const TRUSTED_BASE_ASCII = new Set([...TRUSTED_BASE].map(stripDiacritics));
 const normalize = (value: string) => normalizeLowercaseStringOrEmpty(value);
 const defaultWindowsUserInfo: WindowsUserInfoProvider = () => os.userInfo();
 
-function defaultPermissionExec(command: string, args: string[]) {
-  return execFileAsync(command, args, {
-    encoding: "utf8",
-    windowsHide: true,
-    maxBuffer: 1024 * 1024,
-  }) as Promise<{ stdout: string; stderr: string }>;
-}
+const defaultPermissionExec: PermissionExec = executePermissionCommand;
 
 export async function safeStat(targetPath: string): Promise<SafeStatResult> {
   try {
@@ -188,11 +180,27 @@ export async function inspectPathPermissions(
       targetPath, stat: st, effectiveIsDir, effectiveMode, bits,
     });
     if (native) return native;
+    const unverified: PermissionCheck = {
+      ok: true,
+      isSymlink: st.isSymlink,
+      isDir: effectiveIsDir,
+      mode: effectiveMode,
+      bits,
+      source: "unknown",
+      worldWritable: false,
+      groupWritable: false,
+      worldReadable: false,
+      groupReadable: false,
+    };
     const owner = await inspectWindowsOwner({
       targetPath,
       env: opts?.env,
       exec: opts?.exec ?? defaultPermissionExec,
     });
+    if (owner.error) {
+      const error = `Windows owner inspection failed: ${owner.error}`;
+      return { ...unverified, ownerError: owner.error, error };
+    }
     const acl = await inspectWindowsAcl(targetPath, {
       env: opts?.env,
       exec: opts?.exec,
@@ -207,16 +215,7 @@ export async function inspectPathPermissions(
     };
     if (!acl.ok) {
       return {
-        ok: true,
-        isSymlink: st.isSymlink,
-        isDir: effectiveIsDir,
-        mode: effectiveMode,
-        bits,
-        source: "unknown",
-        worldWritable: false,
-        groupWritable: false,
-        worldReadable: false,
-        groupReadable: false,
+        ...unverified,
         ...ownerFields,
         error: acl.error,
       };

--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -221,12 +221,6 @@ describe("secure file reads", () => {
       await fs.writeFile(filePath, '{"token":"ok"}', { mode: 0o600 });
       await secureWindowsTestFile(filePath);
 
-      const permissions = await inspectPathPermissions(filePath);
-      expect(permissions, permissions.ownerError ?? JSON.stringify(permissions)).toMatchObject({
-        source: "windows-acl",
-        ownerTrusted: true,
-      });
-
       const result = await readSecureFile({
         filePath,
         label: "test secret",
@@ -249,12 +243,6 @@ describe("secure file reads", () => {
       await fs.writeFile(filePath, '{"token":"ok"}', { mode: 0o600 });
       await secureWindowsTestFile(filePath);
       const extendedPath = `\\\\?\\${path.resolve(filePath)}`;
-
-      const permissions = await inspectPathPermissions(extendedPath);
-      expect(permissions, permissions.ownerError ?? JSON.stringify(permissions)).toMatchObject({
-        source: "windows-acl",
-        ownerTrusted: true,
-      });
 
       const result = await readSecureFile({
         filePath: extendedPath,
@@ -559,9 +547,20 @@ describe("secure file reads", () => {
   it("reports broad Windows SID writes as world-writable", async () => {
     const target = path.join(root, "windows-acl-token.txt");
     await fs.writeFile(target, "secret", { mode: 0o600 });
-    const exec = vi.fn().mockResolvedValue({
-      stdout: `${target} *S-1-5-18:(F)\n *S-1-5-7:(F)\n`,
-      stderr: "",
+    const exec = vi.fn(async (command: string) => {
+      if (command.toLowerCase().endsWith("powershell.exe")) {
+        return {
+          stdout: JSON.stringify({
+            ownerSid: "S-1-5-7",
+            currentUserSid: "S-1-5-7",
+          }),
+          stderr: "",
+        };
+      }
+      return {
+        stdout: `${target} *S-1-5-18:(F)\n *S-1-5-7:(F)\n`,
+        stderr: "",
+      };
     });
 
     const result = await inspectPathPermissions(target, {
@@ -696,10 +695,12 @@ describe("secure file reads", () => {
       exec,
     });
 
-    expect(result.source).toBe("windows-acl");
+    expect(result.source).toBe("unknown");
     expect(result.ownerSid).toBeUndefined();
     expect(result.ownerTrusted).toBeUndefined();
     expect(result.ownerError).toContain("owner lookup failed");
+    expect(result.error).toContain("Windows owner inspection failed");
+    expect(exec).toHaveBeenCalledTimes(1);
   });
 
   it("fails Windows ACL verification closed when a principal SID cannot be translated", async () => {

--- a/test/permissions-exec.test.ts
+++ b/test/permissions-exec.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_PERMISSION_EXEC_TIMEOUT_MS,
+  executePermissionCommand,
+} from "../src/permission-exec.js";
+import { inspectPathPermissions } from "../src/permissions.js";
+import { readSecureFile } from "../src/secure-file.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("Windows permission command execution", () => {
+  it("terminates a wedged child process on a deterministic deadline", async () => {
+    const timeoutMs = 100;
+    const startedAt = performance.now();
+
+    await expect(
+      executePermissionCommand(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], timeoutMs),
+    ).rejects.toThrow(`Windows permission inspection timed out after ${timeoutMs}ms`);
+
+    expect(performance.now() - startedAt).toBeLessThan(3_000);
+    expect(DEFAULT_PERMISSION_EXEC_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it("fails closed without starting an ACL query when owner inspection fails", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-permission-timeout-"));
+    tempDirs.push(dir);
+    const target = path.join(dir, "secret.json");
+    await fs.writeFile(target, "{}", { mode: 0o600 });
+    const exec = vi.fn().mockRejectedValue(new Error("owner query timed out"));
+
+    const result = await inspectPathPermissions(target, {
+      platform: "win32",
+      env: { SystemRoot: "C:\\Windows" },
+      exec,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      source: "unknown",
+      ownerError: "Error: owner query timed out",
+      error: expect.stringContaining("Windows owner inspection failed"),
+    });
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it("inspects permissions once for one secure read", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-permission-count-"));
+    tempDirs.push(dir);
+    const target = path.join(dir, "secret.json");
+    await fs.writeFile(target, "{}", { mode: 0o600 });
+    const exec = vi.fn(async (command: string, args: string[]) => {
+      if (command.toLowerCase().endsWith("powershell.exe")) {
+        return {
+          stdout: JSON.stringify({
+            ownerSid: "S-1-5-21-42",
+            currentUserSid: "S-1-5-21-42",
+            principalSids: [{ name: "S-1-5-21-42", sid: "S-1-5-21-42" }],
+            principalTranslationFailed: false,
+            remote: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: `${args[0]} *S-1-5-21-42:(F)\n`, stderr: "" };
+    });
+
+    const result = await readSecureFile({
+      filePath: target,
+      inject: {
+        platform: "win32",
+        env: { SystemRoot: "C:\\Windows" },
+        exec,
+      },
+    });
+
+    expect(result.permissions).toMatchObject({ source: "windows-acl", ownerTrusted: true });
+    expect(exec).toHaveBeenCalledTimes(2);
+    expect(exec.mock.calls.map(([command]) => path.win32.basename(command))).toEqual([
+      "powershell.exe",
+      "icacls.exe",
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed

- Bound each built-in Windows permission command to 10 seconds and terminate a timed-out child with a hard kill.
- Return an explicit unverified permission result when owner inspection fails, without starting a follow-up ACL command.
- Remove duplicate direct permission inspections from the two Windows secure-read integration tests; the secure-read result already carries the same verified permission record.
- Keep the ordinary Node matrix deliberately on the shipping JavaScript/command fallback, while the native job retains bundled-binding coverage.

This supersedes #88. Credit to @Yigtwxx for the careful diagnosis of the missing native build, the six-spawn test shape, and the unbounded production executor.

## Why

The timeout increase in #88 treated runner latency rather than the underlying issues. Without the native binding, each permission inspection launches PowerShell for owner facts and icacls for ACL facts. The affected tests inspected once directly and then repeated that work through the secure read. More importantly, the production executor had no deadline, so a wedged system command could hang a caller indefinitely.

The ordinary matrix intentionally remains a fallback test rather than building native everywhere. That preserves real Windows coverage of shipping fallback code. Removing the duplicate inspection cuts each affected test from six real process launches to four, including its two ACL setup commands.

## Proof

- `pnpm check`: 648 passed, 25 skipped
- `pnpm test:security`: 62 passed
- `git diff --check`
- Focused timeout/count suite: 71 passed, 2 skipped
- Autoreview: clean, no accepted/actionable findings
- CI: https://github.com/openclaw/fs-safe/actions/runs/30766951579

On macOS, a fake PowerShell executable that sleeps indefinitely left the pre-change public inspection call running beyond 2.00 seconds. With this change, `inspectPathPermissions()` returned `source: "unknown"` with an explicit timeout error in 10.07 seconds.

Both real Windows fallback jobs are green. `reads from a validated Windows ACL and owner` completed in 3.962 seconds on Node 22 and 4.367 seconds on Node 24; the extended-path case completed in 439 ms and 430 ms. The deterministic wedged-child regression passed in the same jobs as part of the 157 ms / 155 ms permission-executor suite.
