### PR TITLE
fix(release): harden published artifact verification (#81)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,10 +228,46 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  draft-release:
+    name: Create draft GitHub Release
+    if: github.ref_protected
+    needs: collect
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          package_version="${RELEASE_TAG#v}"
+          node scripts/release-notes.mjs "${package_version}" > release-notes.md
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "${RELEASE_TAG}" --json isDraft >/dev/null 2>&1; then
+            echo "${RELEASE_TAG} already has a GitHub release."
+            exit 0
+          fi
+          gh release create "${RELEASE_TAG}" \
+            --verify-tag \
+            --draft \
+            --title "fs-safe ${RELEASE_TAG#v}" \
+            --notes-file release-notes.md
+
   publish:
     name: Publish @openclaw/fs-safe
     if: github.ref_protected
-    needs: collect
+    needs: draft-release
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -241,11 +277,22 @@ jobs:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Update npm
         run: npm install --global npm@${{ env.NPM_VERSION }}
@@ -260,11 +307,11 @@ jobs:
         run: node scripts/publish-or-verify.mjs --package "@openclaw/fs-safe" --artifacts release-artifacts
 
   release:
-    name: Publish GitHub Release
+    name: Verify and promote GitHub Release
     if: github.ref_protected
     needs: publish
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:
@@ -273,10 +320,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Download release package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -292,16 +350,29 @@ jobs:
           node scripts/release-notes.mjs "${package_version}" > release-notes.md
           node scripts/append-release-proof.mjs release-notes.md release-artifacts/manifest.json "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}"
 
-      - name: Publish release
+      - name: Upload release proof
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-proof-${{ github.run_id }}-${{ github.run_attempt }}
+          path: release-notes.md
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Promote draft release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
-            echo "${RELEASE_TAG} already has a GitHub release."
+          release_state="$(gh release view "${RELEASE_TAG}" --json isDraft)"
+          if [ "$(printf '%s' "${release_state}" | jq -r '.isDraft')" != "true" ]; then
+            echo "${RELEASE_TAG} is already public."
             exit 0
           fi
-          gh release create "${RELEASE_TAG}" \
-            --verify-tag \
-            --title "fs-safe ${RELEASE_TAG#v}" \
-            --notes-file release-notes.md
+          gh release edit "${RELEASE_TAG}" \
+            --notes-file release-notes.md \
+            --draft=false
+          published_state="$(gh release view "${RELEASE_TAG}" --json isDraft)"
+          if [ "$(printf '%s' "${published_state}" | jq -r '.isDraft')" != "false" ]; then
+            echo "${RELEASE_TAG} did not become public." >&2
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Retry a contended file-lock acquisition when Windows denies access to a lock file whose directory entry is still being torn down, including when the native binding performs the exclusive create. Both the exclusive create and the holder's snapshot read reported that transient `EPERM` as a hard failure, so concurrent `acquireFileLock()` calls failed intermittently on Windows even though the very next attempt would have succeeded. Retries stay bounded, so a genuine permission denial still surfaces as `EPERM` rather than a lock timeout; thanks @Yigtwxx for the fix.
 - Apply `replaceFileAtomic()` and `replaceFileAtomicSync()` modes through pinned temp-file descriptors before rename, and through pinned copy-fallback descriptors, so a post-rename symlink swap cannot redirect `chmod` to an unrelated file while exact modes remain independent of umask; thanks @yetval for reporting this (#86).
 - Bound fallback Windows owner and ACL command execution to 10 seconds per process and report owner-query failures as unverified instead of returning a partial permission classification; thanks @Yigtwxx for the diagnosis.
+- Verify published npm bytes directly when registry integrity metadata conflicts, and cryptographically verify the registry signature plus Sigstore provenance against the package digest and the trusted fs-safe release workflow (#81).
 - Report the documented `remove()` failure codes instead of collapsing every failure to `path-alias`. A missing target now throws `not-found`, a non-empty directory throws `not-empty`, and any other filesystem failure throws `not-removable`, while directory identity drift keeps reporting `path-mismatch`; thanks @Yigtwxx for the fix.
 
 ### Compatibility
@@ -18,6 +19,10 @@
 ### Features
 
 - Suffix Windows reserved basenames with `_` in `sanitizeUntrustedFileName()` while preserving case and extensions on every platform, including dollar names and superscript COM/LPT variants; thanks @SebTardif (#67).
+
+### Docs and Tooling
+
+- Create GitHub Releases as drafts before npm publication, then attach immutable verification proof and promote them only after the published package passes the shared registry verifier, avoiding stranded releases during registry propagation incidents (#81).
 
 ## 0.5.1 - 2026-08-01
 

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@napi-rs/cli": "3.8.1",
     "@types/node": "^26.1.2",
     "@vitest/coverage-v8": "4.1.10",
+    "sigstore": "5.0.0",
     "typescript": "^7.0.2",
     "vite": "8.2.0",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.10
         version: 4.1.10(vitest@4.1.10)
+      sigstore:
+        specifier: 5.0.0
+        version: 5.0.0
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -241,6 +244,10 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@inquirer/ansi@2.0.7':
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
@@ -744,6 +751,18 @@ packages:
     resolution: {integrity: sha512-VjHyKEqXAwYZK+HY7iJctYvRm3TFEbaQxeZwvAG1QRkoo1a39phMY8J6x9tUEqJI03W6MysB8F2jacI6wvcx+w==}
     engines: {node: '>= 12.22.0'}
 
+  '@npmcli/agent@5.0.2':
+    resolution: {integrity: sha512-EkzGmEsgbQ1rqWkRJe2P0oQHx/ylZozDUNPMXCklLuSFL3GY+QyEfBUjhjCsgGXzh4OGpnHvkboSQgczjP/jJg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/fs@6.0.0':
+    resolution: {integrity: sha512-AheOs4swKka/XLtht6xxJDPezlQ7K2IYQ9Y8lST4JLDjnralnWuMM9AE2CdVcgQJ5omrXhsRzM7F7aYmeZBvKQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@npmcli/redact@5.0.0':
+    resolution: {integrity: sha512-3zcN5Q3yEmeyxXBzqB6fXPQFzYa2ROsGFSr69W0ArXIAGJqxl/aFECOVPD2kbkYPm0U/EHxFKgclK3UA9WQg5A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
     engines: {node: '>= 20'}
@@ -896,8 +915,40 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@sigstore/bundle@5.0.0':
+    resolution: {integrity: sha512-wefjygudENbzbQMks1t5u34EP0fFoD0XvaEP7DOUP/sXKvogzEJYFw5E6pegGyp3onGWzVEYKVa3bNZWyTYX+A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/core@4.0.1':
+    resolution: {integrity: sha512-9v5hRjujn5NXq8o7XFEUgLyAtdr5Iisb4pzM05u3K61IS5q3hP3luWAndk0RkPPLTUFoTbg7Vb84UQ1ZQeajWQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/protobuf-specs@0.5.1':
+    resolution: {integrity: sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@sigstore/sign@5.0.0':
+    resolution: {integrity: sha512-DSFivqz9/i5AkwZ5fq0YdjaJlc4o1WeS2Zffon0kqtChx0vy4W9NOjkEet9bF2vkzOufX72eVH8kZBIGtcBp1w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/tuf@5.0.0':
+    resolution: {integrity: sha512-Zyqg9tcHps3uRAlKHLNmsW4ohsUZAjb9G+31r7lg0ICh/JOcadzmJsIRdjKljlRHpaR0K4aJ2kXXIdywdcdMlA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  '@sigstore/verify@4.1.0':
+    resolution: {integrity: sha512-p/s720RiWxLG8XtmfdPfEJOlATA6H/2knFqmtQbFkHKN3IrhWGUwPfpQAf1UnQIEES9IaH6zzhfjkrhTfeSdZw==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tufjs/canonical-json@2.0.0':
+    resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  '@tufjs/models@5.0.0':
+    resolution: {integrity: sha512-U4mVcdFGOi6pt8n38LdWZp67Svn7ppnU1Pj8SGOVaBi1X4gm+G4ztQlLfkoJbKSHfjA6WeaiJp2A4V83AJF6nQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -1072,6 +1123,10 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  agent-base@9.0.0:
+    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
+    engines: {node: '>= 20'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1082,8 +1137,20 @@ packages:
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  cacache@21.0.1:
+    resolution: {integrity: sha512-pTwz/uj3Jyp6WXdJ6fWhR+7LVxVs6RyroQSn7KJwHsSxXuyGSp0pcMVcwSwTpCFq1X2YG8QBe0W+vN+cr0SwzA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1175,10 +1242,18 @@ packages:
       picomatch:
         optional: true
 
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1186,6 +1261,17 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==}
+    engines: {node: '>= 20'}
+
+  https-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==}
+    engines: {node: '>= 20'}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -1196,6 +1282,10 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
+    engines: {node: '>= 12'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -1302,6 +1392,10 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1311,6 +1405,38 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-fetch-happen@16.0.1:
+    resolution: {integrity: sha512-uUv1yxHzaKVVEPfcFeGSNov/Cehjv08ovlY8ImTljgL7Q+SiA0dAYLQ6SYVa2kkKqNj4Y3aZEI7xv2teadie0A==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-fetch@6.0.0:
+    resolution: {integrity: sha512-AWI8bKapGmgx/J0E6IGYSKj8TiHebZkmKWSs8raPSw8KXwgEAJ+Bw3+LSdXHR6T/RHKAWCOYk2MiLrYluaUU6w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@2.0.0:
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -1332,6 +1458,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -1340,8 +1470,16 @@ packages:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
+  p-map@7.0.6:
+    resolution: {integrity: sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==}
+    engines: {node: '>=18'}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1357,8 +1495,21 @@ packages:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  proc-log@7.0.0:
+    resolution: {integrity: sha512-FYgfaA69XZ93zaXLoMNQ+ViDXGGBgR8aLh03txzcFhV+9xOXx7+8DLCULrKKpR9+GsH9ZfHm82aSUPpozX0Ztg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  proxy-agent-negotiate@1.1.0:
+    resolution: {integrity: sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      kerberos: ^2.0.0
+    peerDependenciesMeta:
+      kerberos:
+        optional: true
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -1389,9 +1540,29 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sigstore@5.0.0:
+    resolution: {integrity: sha512-hJqJfoG/e4qFQaauQL00c6J6FrHLBGKtkFvW3JbTSIEFOhLrSjdSM/gWd/yUOfYo/gsERehTXGC1VZWX+9X4Dg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@10.1.0:
+    resolution: {integrity: sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==}
+    engines: {node: '>= 20'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  ssri@14.0.0:
+    resolution: {integrity: sha512-jQxKI0yx0ZnTKrqjKkLDV2DXkBQn3k49JVmVqDGcDwKDtGDbImD/GXsq04KD0VVzCQQ9wZJYal3RwR1GzWTSow==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -1427,6 +1598,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tuf-js@6.0.0:
+    resolution: {integrity: sha512-zlJVOIO68hmgo1//X4ENEcTGfuOTAtDPi8PsTsG+FyxD85E/ww1ZnwBbWo/yCEExGpI+Kilg7Z3qCdHX2BoJTQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   typanion@3.14.0:
     resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
@@ -1538,6 +1713,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -1685,6 +1863,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@gar/promise-retry@1.0.3': {}
 
   '@inquirer/ansi@2.0.7': {}
 
@@ -2085,6 +2265,23 @@ snapshots:
       '@napi-rs/wasm-tools-win32-ia32-msvc': 1.1.0
       '@napi-rs/wasm-tools-win32-x64-msvc': 1.1.0
 
+  '@npmcli/agent@5.0.2':
+    dependencies:
+      agent-base: 9.0.0
+      http-proxy-agent: 9.1.0
+      https-proxy-agent: 9.1.0
+      lru-cache: 11.5.2
+      socks-proxy-agent: 10.1.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
+  '@npmcli/fs@6.0.0':
+    dependencies:
+      semver: 7.8.5
+
+  '@npmcli/redact@5.0.0': {}
+
   '@octokit/auth-token@6.0.0': {}
 
   '@octokit/core@7.0.6':
@@ -2201,7 +2398,47 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@sigstore/bundle@5.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.1
+
+  '@sigstore/core@4.0.1': {}
+
+  '@sigstore/protobuf-specs@0.5.1': {}
+
+  '@sigstore/sign@5.0.0':
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@sigstore/bundle': 5.0.0
+      '@sigstore/core': 4.0.1
+      '@sigstore/protobuf-specs': 0.5.1
+      make-fetch-happen: 16.0.1
+      proc-log: 7.0.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
+  '@sigstore/tuf@5.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.1
+      tuf-js: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/verify@4.1.0':
+    dependencies:
+      '@sigstore/bundle': 5.0.0
+      '@sigstore/core': 4.0.1
+      '@sigstore/protobuf-specs': 0.5.1
+
   '@standard-schema/spec@1.1.0': {}
+
+  '@tufjs/canonical-json@2.0.0': {}
+
+  '@tufjs/models@5.0.0':
+    dependencies:
+      '@tufjs/canonical-json': 2.0.0
+      minimatch: 10.2.6
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -2336,6 +2573,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  agent-base@9.0.0: {}
+
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
@@ -2346,7 +2585,26 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  balanced-match@4.0.4: {}
+
   before-after-hook@4.0.0: {}
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  cacache@21.0.1:
+    dependencies:
+      '@npmcli/fs': 6.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.6
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.6
+      ssri: 14.0.0
 
   chai@6.2.2: {}
 
@@ -2432,12 +2690,42 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.3
+
   fsevents@2.3.3:
     optional: true
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   has-flag@4.0.0: {}
 
   html-escaper@2.0.2: {}
+
+  http-cache-semantics@4.2.0: {}
+
+  http-proxy-agent@9.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      proxy-agent-negotiate: 1.1.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
+  https-proxy-agent@9.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      proxy-agent-negotiate: 1.1.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
 
   iconv-lite@0.7.3:
     dependencies:
@@ -2448,6 +2736,8 @@ snapshots:
 
   inherits@2.0.4:
     optional: true
+
+  ip-address@10.4.0: {}
 
   isarray@1.0.0:
     optional: true
@@ -2535,6 +2825,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
+  lru-cache@11.5.2: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2549,13 +2841,61 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  minipass@7.1.3:
-    optional: true
+  make-fetch-happen@16.0.1:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/agent': 5.0.2
+      '@npmcli/redact': 5.0.0
+      cacache: 21.0.1
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.3
+      minipass-fetch: 6.0.0
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 7.0.0
+      ssri: 14.0.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass-fetch@6.0.0:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 2.0.0
+      minizlib: 3.1.0
+    optionalDependencies:
+      iconv-lite: 0.7.3
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@2.0.0:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
-    optional: true
 
   ms@2.1.3: {}
 
@@ -2563,12 +2903,21 @@ snapshots:
 
   nanoid@3.3.16: {}
 
+  negotiator@1.0.0: {}
+
   obug@2.1.3: {}
 
   obug@2.1.4: {}
 
+  p-map@7.0.6: {}
+
   pako@1.0.11:
     optional: true
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -2582,8 +2931,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  proc-log@7.0.0: {}
+
   process-nextick-args@2.0.1:
     optional: true
+
+  proxy-agent-negotiate@1.1.0: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -2631,7 +2984,38 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sigstore@5.0.0:
+    dependencies:
+      '@sigstore/bundle': 5.0.0
+      '@sigstore/core': 4.0.1
+      '@sigstore/protobuf-specs': 0.5.1
+      '@sigstore/sign': 5.0.0
+      '@sigstore/tuf': 5.0.0
+      '@sigstore/verify': 4.1.0
+    transitivePeerDependencies:
+      - kerberos
+      - supports-color
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@10.1.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.4.0
+      smart-buffer: 4.2.0
+
   source-map-js@1.2.1: {}
+
+  ssri@14.0.0:
+    dependencies:
+      minipass: 7.1.3
 
   stackback@0.0.2: {}
 
@@ -2668,6 +3052,14 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  tuf-js@6.0.0:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@tufjs/models': 5.0.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   typanion@3.14.0: {}
 
@@ -2747,6 +3139,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yallist@4.0.0: {}
 
   yallist@5.0.0:
     optional: true

--- a/scripts/append-release-proof.mjs
+++ b/scripts/append-release-proof.mjs
@@ -1,33 +1,67 @@
-import { execFileSync } from "node:child_process";
 import { appendFileSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { verifyPublishedPackage } from "./npm-registry-verification.mjs";
 
-const [notesPath, manifestPath, repository, runId] = process.argv.slice(2);
-if (!notesPath || !manifestPath || !repository || !runId) {
-  throw new Error("usage: append-release-proof <notes> <manifest> <repository> <run-id>");
+export function parseArguments(argv) {
+  const [notesPath, manifestPath, repository, runId] = argv;
+  if (!notesPath || !manifestPath || !repository || !runId || argv.length !== 4) {
+    throw new Error("usage: append-release-proof <notes> <manifest> <repository> <run-id>");
+  }
+  return { manifestPath, notesPath, repository, runId };
 }
-const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-const lines = [
-  "",
-  "### Published packages",
-  "",
-  "| Package | Registry tarball | Integrity | Provenance |",
-  "|---|---|---|---|",
-];
-for (const artifact of manifest) {
-  const spec = `${artifact.name}@${artifact.version}`;
-  const dist = JSON.parse(execFileSync("npm", ["view", spec, "dist", "--json"], {
-    encoding: "utf8",
-  }));
-  if (dist.integrity !== artifact.integrity || !dist.tarball || !dist.attestations?.url) {
-    throw new Error(`${spec} registry proof is incomplete or does not match the release artifact`);
+
+export async function appendReleaseProof({
+  appendFile = appendFileSync,
+  fetchImpl = fetch,
+  log = console.log,
+  manifestPath,
+  notesPath,
+  readFile = readFileSync,
+  repository,
+  retryDelaysMs,
+  runId,
+  verifyBundle,
+  verifyPackage = verifyPublishedPackage,
+  wait,
+}) {
+  const manifest = JSON.parse(readFile(manifestPath, "utf8"));
+  if (!Array.isArray(manifest) || manifest.length === 0) {
+    throw new Error("release manifest must be a non-empty array");
+  }
+  const lines = [
+    "",
+    "### Published packages",
+    "",
+    "| Package | Registry tarball | Verified integrity | Provenance |",
+    "|---|---|---|---|",
+  ];
+  const proofs = [];
+  for (const artifact of manifest) {
+    const proof = await verifyPackage(artifact, {
+      fetchImpl,
+      log,
+      retryDelaysMs,
+      verifyBundle,
+      wait,
+    });
+    proofs.push(proof);
+    lines.push(
+      `| [${proof.spec}](https://www.npmjs.com/package/${artifact.name}/v/${artifact.version}) | ` +
+        `[tgz](${proof.tarballUrl}) | \`${proof.integrity}\` | ` +
+        `[verified attestation](${proof.attestationUrl}) |`,
+    );
   }
   lines.push(
-    `| [${spec}](https://www.npmjs.com/package/${artifact.name}/v/${artifact.version}) | [tgz](${dist.tarball}) | \`${dist.integrity}\` | [attestation](${dist.attestations.url}) |`,
+    "",
+    `Release proof: [GitHub Actions run](https://github.com/${repository}/actions/runs/${runId}).`,
+    "",
   );
+  appendFile(notesPath, `${lines.join("\n")}\n`);
+  return proofs;
 }
-lines.push(
-  "",
-  `Release proof: [GitHub Actions run](https://github.com/${repository}/actions/runs/${runId}).`,
-  "",
-);
-appendFileSync(notesPath, `${lines.join("\n")}\n`);
+
+const entryPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined;
+if (entryPath === import.meta.url) {
+  await appendReleaseProof(parseArguments(process.argv.slice(2)));
+}

--- a/scripts/npm-registry-verification.mjs
+++ b/scripts/npm-registry-verification.mjs
@@ -1,0 +1,554 @@
+import { createHash, createPublicKey, verify as verifySignature } from "node:crypto";
+import { verify as verifySigstoreBundle } from "sigstore";
+
+export const NPM_REGISTRY_ORIGIN = "https://registry.npmjs.org";
+export const NPM_PROVENANCE_PREDICATE_TYPE = "https://slsa.dev/provenance/v1";
+export const REGISTRY_RETRY_DELAYS_MS = [
+  5_000,
+  10_000,
+  20_000,
+  30_000,
+  45_000,
+  60_000,
+  60_000,
+  60_000,
+  60_000,
+  60_000,
+  60_000,
+  60_000,
+];
+
+const NPM_PROVENANCE_REPOSITORY = "https://github.com/openclaw/fs-safe";
+const NPM_PROVENANCE_WORKFLOW_PATH = ".github/workflows/release.yml";
+const NPM_PROVENANCE_CERTIFICATE_ISSUER = "https://token.actions.githubusercontent.com";
+const NPM_PROVENANCE_BUILDER_ID = "https://github.com/actions/runner/github-hosted";
+const REGISTRY_REQUEST_TIMEOUT_MS = 30_000;
+const REGISTRY_JSON_MAX_BYTES = 4 * 1024 * 1024;
+const REGISTRY_TARBALL_MAX_BYTES = 128 * 1024 * 1024;
+const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u;
+const PACKAGE_VERSION_PATTERN =
+  /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u;
+const SHA512_INTEGRITY_PATTERN = /^sha512-[A-Za-z0-9+/]{86}==$/u;
+
+export class RegistryVerificationError extends Error {
+  constructor(message, { code, retryable, cause } = {}) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = "RegistryVerificationError";
+    this.code = code;
+    this.retryable = retryable;
+  }
+}
+
+export class RetryableRegistryError extends RegistryVerificationError {
+  constructor(message, { code, cause } = {}) {
+    super(message, { code, retryable: true, cause });
+    this.name = "RetryableRegistryError";
+  }
+}
+
+export class FatalRegistryError extends RegistryVerificationError {
+  constructor(message, { code, cause } = {}) {
+    super(message, { code, retryable: false, cause });
+    this.name = "FatalRegistryError";
+  }
+}
+
+export function sha512Integrity(bytes) {
+  return `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
+}
+
+function requireArtifact(artifact) {
+  if (!artifact || typeof artifact !== "object") {
+    throw new FatalRegistryError("release artifact metadata is missing", { code: "invalid-artifact" });
+  }
+  if (!PACKAGE_NAME_PATTERN.test(artifact.name ?? "")) {
+    throw new FatalRegistryError(`release artifact has invalid package name: ${String(artifact.name)}`, {
+      code: "invalid-artifact",
+    });
+  }
+  if (!PACKAGE_VERSION_PATTERN.test(artifact.version ?? "")) {
+    throw new FatalRegistryError(
+      `${artifact.name} release artifact has invalid version: ${String(artifact.version)}`,
+      { code: "invalid-artifact" },
+    );
+  }
+  if (!SHA512_INTEGRITY_PATTERN.test(artifact.integrity ?? "")) {
+    throw new FatalRegistryError(
+      `${artifact.name}@${artifact.version} release artifact has invalid sha512 integrity`,
+      { code: "invalid-artifact" },
+    );
+  }
+  if (!Number.isSafeInteger(artifact.size) || artifact.size < 0 || artifact.size > REGISTRY_TARBALL_MAX_BYTES) {
+    throw new FatalRegistryError(
+      `${artifact.name}@${artifact.version} release artifact has invalid size`,
+      { code: "invalid-artifact" },
+    );
+  }
+}
+
+function registryRoot() {
+  return new URL(`${NPM_REGISTRY_ORIGIN}/`);
+}
+
+export function registryVersionUrl(packageName, version) {
+  return new URL(`${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`, registryRoot()).toString();
+}
+
+export function registryTarballUrl(packageName, version) {
+  const basename = packageName.includes("/") ? packageName.slice(packageName.lastIndexOf("/") + 1) : packageName;
+  return new URL(`${packageName}/-/${basename}-${version}.tgz`, registryRoot()).toString();
+}
+
+function registryKeysUrl() {
+  return new URL("-/npm/v1/keys", registryRoot()).toString();
+}
+
+function trustedRegistryUrl(value, { label, pathPrefix } = {}) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch (error) {
+    throw new FatalRegistryError(`${label} is not a valid URL`, {
+      code: "untrusted-registry-url",
+      cause: error,
+    });
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.origin !== NPM_REGISTRY_ORIGIN ||
+    (pathPrefix !== undefined && !parsed.pathname.startsWith(pathPrefix))
+  ) {
+    throw new FatalRegistryError(`${label} is outside the pinned npm registry origin`, {
+      code: "untrusted-registry-url",
+    });
+  }
+  return parsed;
+}
+
+function isRetryableStatus(status) {
+  return status === 404 || status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function looksLikeTransientNetworkError(error) {
+  const detail = `${error instanceof Error ? `${error.name}: ${error.message}` : String(error)} ${
+    error?.cause instanceof Error ? `${error.cause.name}: ${error.cause.message}` : ""
+  }`;
+  return /TUFError|aborted|ECONNRESET|EAI_AGAIN|ETIMEDOUT|fetch failed|network|socket|timed out/iu.test(
+    detail,
+  );
+}
+
+async function cancelResponse(response) {
+  await response.body?.cancel().catch(() => undefined);
+}
+
+async function fetchResponse(url, { accept, fetchImpl, label, timeoutMs }) {
+  trustedRegistryUrl(url, { label });
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      headers: accept ? { accept } : undefined,
+      redirect: "error",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    const detail = `${error instanceof Error ? error.message : String(error)} ${
+      error?.cause instanceof Error ? error.cause.message : ""
+    }`;
+    if (/redirect/iu.test(detail)) {
+      throw new FatalRegistryError(`${label} attempted a redirect`, {
+        code: "registry-redirect",
+        cause: error,
+      });
+    }
+    throw new RetryableRegistryError(`${label} request failed: ${detail.trim()}`, {
+      code: "registry-request",
+      cause: error,
+    });
+  }
+  if (isRetryableStatus(response.status)) {
+    await cancelResponse(response);
+    throw new RetryableRegistryError(`${label} returned HTTP ${response.status}`, {
+      code: response.status === 404 ? "not-found" : "registry-http",
+    });
+  }
+  if (!response.ok) {
+    await cancelResponse(response);
+    throw new FatalRegistryError(`${label} returned HTTP ${response.status}`, {
+      code: "registry-http",
+    });
+  }
+  return response;
+}
+
+async function readBoundedBytes(response, { label, maximumBytes }) {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const parsedLength = Number(contentLength);
+    if (Number.isFinite(parsedLength) && parsedLength > maximumBytes) {
+      await cancelResponse(response);
+      throw new FatalRegistryError(`${label} exceeds ${maximumBytes} bytes`, {
+        code: "registry-body-too-large",
+      });
+    }
+  }
+  if (!response.body) {
+    throw new RetryableRegistryError(`${label} returned no body`, { code: "registry-body" });
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > maximumBytes) {
+        await reader.cancel();
+        throw new FatalRegistryError(`${label} exceeds ${maximumBytes} bytes`, {
+          code: "registry-body-too-large",
+        });
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => undefined);
+    if (error instanceof RegistryVerificationError) throw error;
+    throw new RetryableRegistryError(`${label} body read failed`, {
+      code: "registry-body",
+      cause: error,
+    });
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), size);
+}
+
+async function fetchJson(url, options) {
+  const response = await fetchResponse(url, { ...options, accept: "application/json" });
+  const bytes = await readBoundedBytes(response, {
+    label: options.label,
+    maximumBytes: REGISTRY_JSON_MAX_BYTES,
+  });
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch (error) {
+    throw new RetryableRegistryError(`${options.label} returned invalid JSON`, {
+      code: "registry-json",
+      cause: error,
+    });
+  }
+}
+
+function expectedProvenanceSubject(packageName, version) {
+  if (!packageName.startsWith("@")) return `pkg:npm/${packageName}@${version}`;
+  const [scope, name] = packageName.split("/");
+  return `pkg:npm/${encodeURIComponent(scope)}/${name}@${version}`;
+}
+
+export function verifyNpmRegistrySignatures({ integrity, keys, packageName, signatures, version }) {
+  if (!Array.isArray(signatures) || signatures.length === 0) {
+    throw new RetryableRegistryError(`npm registry signatures are missing for ${packageName}@${version}`, {
+      code: "incomplete-signatures",
+    });
+  }
+  if (!Array.isArray(keys) || keys.length === 0) {
+    throw new RetryableRegistryError("npm registry signing keys are missing", {
+      code: "incomplete-signing-keys",
+    });
+  }
+  const payload = `${packageName}@${version}:${integrity}`;
+  for (const signature of signatures) {
+    const key = keys.find((candidate) => candidate?.keyid === signature?.keyid);
+    if (!key || typeof key.key !== "string" || typeof signature.sig !== "string") continue;
+    try {
+      const publicKey = createPublicKey({
+        key: Buffer.from(key.key, "base64"),
+        format: "der",
+        type: "spki",
+      });
+      if (
+        verifySignature(
+          "sha256",
+          Buffer.from(payload, "utf8"),
+          publicKey,
+          Buffer.from(signature.sig, "base64"),
+        )
+      ) {
+        return signature.keyid;
+      }
+    } catch {
+      // Try every advertised signature before returning the fatal verdict.
+    }
+  }
+  throw new FatalRegistryError(`npm registry signatures did not verify for ${packageName}@${version}`, {
+    code: "invalid-registry-signature",
+  });
+}
+
+function provenancePolicy(statement, version) {
+  const workflow = statement.predicate?.buildDefinition?.externalParameters?.workflow;
+  const expectedRef = `refs/tags/v${version}`;
+  if (
+    workflow?.repository !== NPM_PROVENANCE_REPOSITORY ||
+    workflow?.path !== NPM_PROVENANCE_WORKFLOW_PATH ||
+    workflow?.ref !== expectedRef ||
+    statement.predicate?.runDetails?.builder?.id !== NPM_PROVENANCE_BUILDER_ID
+  ) {
+    throw new FatalRegistryError(
+      `npm provenance does not bind ${version} to the trusted fs-safe release workflow`,
+      { code: "untrusted-provenance-policy" },
+    );
+  }
+  return {
+    certificateIssuer: NPM_PROVENANCE_CERTIFICATE_ISSUER,
+    certificateIdentityURI: `${NPM_PROVENANCE_REPOSITORY}/${NPM_PROVENANCE_WORKFLOW_PATH}@${expectedRef}`,
+  };
+}
+
+export async function verifyNpmProvenanceAttestation({
+  attestations,
+  integrity,
+  packageName,
+  verifyBundle = verifySigstoreBundle,
+  version,
+}) {
+  const expectedSubject = expectedProvenanceSubject(packageName, version);
+  const expectedSha512 = Buffer.from(integrity.slice("sha512-".length), "base64").toString("hex");
+  let matchingSubject = false;
+  for (const attestation of attestations) {
+    if (attestation?.predicateType !== NPM_PROVENANCE_PREDICATE_TYPE) continue;
+    const payload = attestation.bundle?.dsseEnvelope?.payload;
+    if (typeof payload !== "string") continue;
+    let statement;
+    try {
+      statement = JSON.parse(Buffer.from(payload, "base64").toString("utf8"));
+    } catch {
+      continue;
+    }
+    if (
+      !statement.subject?.some(
+        (subject) => subject?.name === expectedSubject && subject?.digest?.sha512 === expectedSha512,
+      )
+    ) {
+      continue;
+    }
+    matchingSubject = true;
+    const policy = provenancePolicy(statement, version);
+    try {
+      await verifyBundle(attestation.bundle, policy);
+      return { policy, subject: expectedSubject };
+    } catch (error) {
+      if (looksLikeTransientNetworkError(error)) {
+        throw new RetryableRegistryError(
+          `npm provenance verification was temporarily unavailable for ${packageName}@${version}`,
+          { code: "provenance-network", cause: error },
+        );
+      }
+      throw new FatalRegistryError(
+        `npm provenance attestation failed Sigstore verification for ${packageName}@${version}`,
+        { code: "invalid-sigstore-bundle", cause: error },
+      );
+    }
+  }
+  throw new RetryableRegistryError(
+    matchingSubject
+      ? `npm provenance verification is incomplete for ${packageName}@${version}`
+      : `npm provenance attestation does not match ${packageName}@${version} and its artifact digest`,
+    { code: "incomplete-provenance" },
+  );
+}
+
+async function verifyTarballBytes(artifact, { fetchImpl, timeoutMs }) {
+  const tarballUrl = registryTarballUrl(artifact.name, artifact.version);
+  const response = await fetchResponse(tarballUrl, {
+    fetchImpl,
+    label: `${artifact.name}@${artifact.version} canonical tarball`,
+    timeoutMs,
+  });
+  const bytes = await readBoundedBytes(response, {
+    label: `${artifact.name}@${artifact.version} canonical tarball`,
+    maximumBytes: REGISTRY_TARBALL_MAX_BYTES,
+  });
+  if (bytes.length !== artifact.size) {
+    throw new FatalRegistryError(
+      `${artifact.name}@${artifact.version} canonical tarball size mismatch: expected ${artifact.size}, found ${bytes.length}`,
+      { code: "tarball-size-mismatch" },
+    );
+  }
+  const integrity = sha512Integrity(bytes);
+  if (integrity !== artifact.integrity) {
+    throw new FatalRegistryError(
+      `${artifact.name}@${artifact.version} canonical tarball integrity mismatch: expected ${artifact.integrity}, found ${integrity}`,
+      { code: "tarball-integrity-mismatch" },
+    );
+  }
+  return tarballUrl;
+}
+
+export async function verifyPublishedPackageOnce(
+  artifact,
+  {
+    fetchImpl = fetch,
+    log = console.log,
+    timeoutMs = REGISTRY_REQUEST_TIMEOUT_MS,
+    verifyBundle = verifySigstoreBundle,
+  } = {},
+) {
+  requireArtifact(artifact);
+  const spec = `${artifact.name}@${artifact.version}`;
+  let packageDocument;
+  try {
+    packageDocument = await fetchJson(registryVersionUrl(artifact.name, artifact.version), {
+      fetchImpl,
+      label: `${spec} version metadata`,
+      timeoutMs,
+    });
+  } catch (error) {
+    if (error instanceof RetryableRegistryError && error.code === "not-found") {
+      error.code = "version-missing";
+    }
+    throw error;
+  }
+  if (packageDocument?.name !== artifact.name || packageDocument?.version !== artifact.version) {
+    throw new FatalRegistryError(`${spec} registry metadata has the wrong package identity`, {
+      code: "registry-identity-mismatch",
+    });
+  }
+  const dist = packageDocument.dist;
+  if (!dist || typeof dist !== "object") {
+    throw new RetryableRegistryError(`${spec} registry distribution metadata is incomplete`, {
+      code: "incomplete-dist",
+    });
+  }
+  const canonicalTarball = registryTarballUrl(artifact.name, artifact.version);
+  if (typeof dist.tarball !== "string" || dist.tarball.length === 0) {
+    throw new RetryableRegistryError(`${spec} registry tarball metadata is incomplete`, {
+      code: "incomplete-dist",
+    });
+  }
+  const advertisedTarball = trustedRegistryUrl(dist.tarball, { label: `${spec} tarball URL` }).toString();
+  if (advertisedTarball !== canonicalTarball) {
+    throw new FatalRegistryError(`${spec} registry advertised a non-canonical tarball URL`, {
+      code: "untrusted-registry-url",
+    });
+  }
+
+  let byteEvidence = "packument-integrity";
+  if (dist.integrity !== artifact.integrity) {
+    log(
+      `registry metadata integrity conflict for ${spec}: expected ${artifact.integrity}, observed ${String(
+        dist.integrity,
+      )}; verifying canonical tarball bytes`,
+    );
+    await verifyTarballBytes(artifact, { fetchImpl, timeoutMs });
+    byteEvidence = "canonical-tarball";
+  }
+
+  const signatures = dist.signatures;
+  const keysDocument = await fetchJson(registryKeysUrl(), {
+    fetchImpl,
+    label: "npm registry signing keys",
+    timeoutMs,
+  });
+  const signatureKeyId = verifyNpmRegistrySignatures({
+    integrity: artifact.integrity,
+    keys: keysDocument?.keys,
+    packageName: artifact.name,
+    signatures,
+    version: artifact.version,
+  });
+
+  const provenance = dist.attestations?.provenance;
+  const attestationUrl = dist.attestations?.url;
+  if (
+    provenance?.predicateType !== NPM_PROVENANCE_PREDICATE_TYPE ||
+    typeof attestationUrl !== "string" ||
+    attestationUrl.length === 0
+  ) {
+    throw new RetryableRegistryError(`npm provenance metadata is incomplete for ${spec}`, {
+      code: "incomplete-provenance",
+    });
+  }
+  const attestationPathPrefix = new URL("-/npm/v1/attestations/", registryRoot()).pathname;
+  const parsedAttestationUrl = trustedRegistryUrl(attestationUrl, {
+    label: `${spec} provenance attestation URL`,
+    pathPrefix: attestationPathPrefix,
+  });
+  const attestationDocument = await fetchJson(parsedAttestationUrl.toString(), {
+    fetchImpl,
+    label: `${spec} provenance attestation`,
+    timeoutMs,
+  });
+  const attestations = attestationDocument?.attestations;
+  if (!Array.isArray(attestations) || attestations.length === 0) {
+    throw new RetryableRegistryError(`npm provenance attestations are incomplete for ${spec}`, {
+      code: "incomplete-provenance",
+    });
+  }
+  const verifiedProvenance = await verifyNpmProvenanceAttestation({
+    attestations,
+    integrity: artifact.integrity,
+    packageName: artifact.name,
+    verifyBundle,
+    version: artifact.version,
+  });
+  return {
+    attestationUrl: parsedAttestationUrl.toString(),
+    byteEvidence,
+    integrity: artifact.integrity,
+    observedIntegrity: dist.integrity,
+    provenanceSubject: verifiedProvenance.subject,
+    signatureKeyId,
+    spec,
+    tarballUrl: canonicalTarball,
+  };
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+}
+
+export function isRetryableRegistryError(error) {
+  return error instanceof RegistryVerificationError && error.retryable === true;
+}
+
+export async function verifyPublishedPackage(
+  artifact,
+  {
+    fetchImpl = fetch,
+    log = console.log,
+    onVersionMissing,
+    retryDelaysMs = REGISTRY_RETRY_DELAYS_MS,
+    timeoutMs = REGISTRY_REQUEST_TIMEOUT_MS,
+    verifyBundle = verifySigstoreBundle,
+    wait = sleep,
+  } = {},
+) {
+  let missingHandled = false;
+  let lastError;
+  for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
+    try {
+      return await verifyPublishedPackageOnce(artifact, { fetchImpl, log, timeoutMs, verifyBundle });
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableRegistryError(error)) throw error;
+      if (error.code === "version-missing" && !missingHandled && onVersionMissing) {
+        missingHandled = true;
+        await onVersionMissing();
+      }
+      if (attempt === retryDelaysMs.length) break;
+      const delayMs = retryDelaysMs[attempt];
+      log(
+        `registry verification attempt ${attempt + 1}/${retryDelaysMs.length + 1} has not confirmed ${
+          artifact.name
+        }@${artifact.version} (${error.message}); retrying in ${delayMs / 1_000}s`,
+      );
+      await wait(delayMs);
+    }
+  }
+  throw new Error(
+    `registry verification exhausted ${retryDelaysMs.length + 1} attempts for ${artifact.name}@${
+      artifact.version
+    }: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+    { cause: lastError },
+  );
+}

--- a/scripts/publish-or-verify.mjs
+++ b/scripts/publish-or-verify.mjs
@@ -1,27 +1,14 @@
-import { execFileSync, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import {
+  REGISTRY_RETRY_DELAYS_MS,
+  sha512Integrity,
+  verifyPublishedPackage,
+} from "./npm-registry-verification.mjs";
 
-export const REGISTRY_RETRY_DELAYS_MS = [
-  5_000,
-  10_000,
-  20_000,
-  30_000,
-  45_000,
-  60_000,
-  60_000,
-  60_000,
-  60_000,
-  60_000,
-  60_000,
-  60_000,
-];
-
-function sha512Integrity(bytes) {
-  return `sha512-${createHash("sha512").update(bytes).digest("base64")}`;
-}
+export { REGISTRY_RETRY_DELAYS_MS };
 
 export function loadReleaseArtifact(packageName, artifactsDirectory) {
   const artifactsDir = resolve(artifactsDirectory);
@@ -30,16 +17,12 @@ export function loadReleaseArtifact(packageName, artifactsDirectory) {
 
   const artifact = manifest.find((entry) => entry?.name === packageName);
   if (!artifact) throw new Error(`release manifest has no entry for ${packageName}`);
-  if (
-    typeof artifact.version !== "string" ||
-    typeof artifact.filename !== "string" ||
-    basename(artifact.filename) !== artifact.filename
-  ) {
+  if (typeof artifact.version !== "string" || typeof artifact.filename !== "string") {
     throw new Error(`release manifest has invalid artifact metadata for ${packageName}`);
   }
 
   const artifactPath = resolve(artifactsDir, artifact.filename);
-  if (dirname(artifactPath) !== artifactsDir) {
+  if (basename(artifact.filename) !== artifact.filename || dirname(artifactPath) !== artifactsDir) {
     throw new Error(`release artifact escapes artifacts directory: ${artifact.filename}`);
   }
 
@@ -48,94 +31,81 @@ export function loadReleaseArtifact(packageName, artifactsDirectory) {
   if (integrity !== artifact.integrity) {
     throw new Error(`${packageName}@${artifact.version} artifact bytes do not match release manifest`);
   }
-  if (Number.isSafeInteger(artifact.size) && bytes.length !== artifact.size) {
+  if (!Number.isSafeInteger(artifact.size) || artifact.size < 0) {
+    throw new Error(`${packageName}@${artifact.version} release manifest has invalid artifact size`);
+  }
+  if (bytes.length !== artifact.size) {
     throw new Error(`${packageName}@${artifact.version} artifact size does not match release manifest`);
   }
 
   return { ...artifact, path: artifactPath, integrity };
 }
 
-function registryState(artifact, execNpm) {
-  const spec = `${artifact.name}@${artifact.version}`;
-  try {
-    const raw = execNpm("npm", ["view", spec, "dist", "--json", "--prefer-online"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const dist = JSON.parse(raw);
-    if (dist.integrity !== artifact.integrity) {
-      return { state: "pending", reason: "registry reports different package bytes" };
-    }
-    if (!dist.attestations?.url) {
-      return { state: "pending", reason: "registry has not exposed npm provenance" };
-    }
-    return { state: "verified" };
-  } catch (error) {
-    const stderr = String(error?.stderr ?? "");
-    if (stderr.includes("E404")) return { state: "missing", reason: "version is not visible" };
-    return { state: "pending", reason: error instanceof Error ? error.message : String(error) };
-  }
-}
-
-function sleep(milliseconds) {
-  return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
-}
-
 export async function publishOrVerify({
   packageName,
   artifactsDir,
-  execNpm = execFileSync,
+  fetchImpl = fetch,
   spawnNpm = spawnSync,
   retryDelaysMs = REGISTRY_RETRY_DELAYS_MS,
-  wait = sleep,
+  verifyBundle,
+  verifyPackage = verifyPublishedPackage,
+  wait,
   log = console.log,
 }) {
   if (!packageName) throw new Error("--package is required");
   const artifact = loadReleaseArtifact(packageName, artifactsDir);
   const spec = `${artifact.name}@${artifact.version}`;
   let publishResult;
-
-  for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
-    const registry = registryState(artifact, execNpm);
-    if (registry.state === "verified") {
-      log(`verified ${spec} byte identity and provenance`);
-      return;
-    }
-
-    if (registry.state === "missing" && publishResult === undefined) {
-      publishResult = spawnNpm(
-        "npm",
-        ["publish", artifact.path, "--access", "public", "--provenance"],
-        { stdio: "inherit" },
-      );
-      if (publishResult.error) {
-        log(`npm publish could not start: ${publishResult.error.message}`);
-      } else if (publishResult.status !== 0) {
-        log(`npm publish exited ${publishResult.status}; checking whether the registry committed it`);
-      }
-    }
-
-    if (attempt === retryDelaysMs.length) {
-      const publishSummary =
-        publishResult === undefined ? "npm publish was not attempted" : `npm publish exited ${publishResult.status}`;
-      throw new Error(`${publishSummary}; registry never confirmed ${spec}: ${registry.reason}`);
-    }
-
-    const delayMs = retryDelaysMs[attempt];
-    log(
-      `registry verification attempt ${attempt + 1}/${retryDelaysMs.length + 1} has not confirmed ${spec}` +
-        ` (${registry.reason}); retrying in ${delayMs / 1_000}s`,
-    );
-    await wait(delayMs);
+  try {
+    const proof = await verifyPackage(artifact, {
+      fetchImpl,
+      log,
+      retryDelaysMs,
+      verifyBundle,
+      wait,
+      onVersionMissing: async () => {
+        publishResult = spawnNpm(
+          "npm",
+          ["publish", artifact.path, "--access", "public", "--provenance"],
+          { stdio: "inherit" },
+        );
+        if (publishResult.error) {
+          log(`npm publish could not start: ${publishResult.error.message}`);
+        } else if (publishResult.status !== 0) {
+          log(`npm publish exited ${publishResult.status}; checking whether the registry committed it`);
+        }
+      },
+    });
+    log(`verified ${spec} byte identity, registry signature, and provenance (${proof.byteEvidence})`);
+    return proof;
+  } catch (error) {
+    const publishSummary =
+      publishResult === undefined
+        ? "npm publish was not attempted"
+        : publishResult.error
+          ? "npm publish could not start"
+          : `npm publish exited ${String(publishResult.status)}`;
+    throw new Error(`${publishSummary}; registry did not verify ${spec}: ${error.message}`, {
+      cause: error,
+    });
   }
 }
 
-function parseArguments(argv) {
-  const packageIndex = argv.indexOf("--package");
-  const artifactsIndex = argv.indexOf("--artifacts");
+export function parseArguments(argv) {
+  let packageName;
+  let artifacts = "release-artifacts";
+  for (let index = 0; index < argv.length; index += 2) {
+    const option = argv[index];
+    const value = argv[index + 1];
+    if ((option !== "--package" && option !== "--artifacts") || !value || value.startsWith("--")) {
+      throw new Error(`invalid argument: ${String(option)}`);
+    }
+    if (option === "--package") packageName = value;
+    if (option === "--artifacts") artifacts = value;
+  }
   return {
-    packageName: packageIndex >= 0 ? argv[packageIndex + 1] : undefined,
-    artifactsDir: resolve(artifactsIndex >= 0 ? argv[artifactsIndex + 1] : "release-artifacts"),
+    packageName,
+    artifactsDir: resolve(artifacts),
   };
 }
 

--- a/test/append-release-proof.test.ts
+++ b/test/append-release-proof.test.ts
@@ -1,0 +1,103 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { appendReleaseProof, parseArguments } from "../scripts/append-release-proof.mjs";
+
+const temporaryDirectories: string[] = [];
+
+async function releaseFiles() {
+  const directory = await mkdtemp(join(tmpdir(), "fs-safe-release-proof-test-"));
+  temporaryDirectories.push(directory);
+  const notesPath = join(directory, "notes.md");
+  const manifestPath = join(directory, "manifest.json");
+  await writeFile(notesPath, "# Release\n", "utf8");
+  await writeFile(
+    manifestPath,
+    `${JSON.stringify([
+      {
+        name: "@openclaw/fs-safe",
+        version: "9.9.9",
+        integrity: "sha512-test",
+        size: 42,
+      },
+    ])}\n`,
+    "utf8",
+  );
+  return { manifestPath, notesPath };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("append-release-proof", () => {
+  it("uses the shared verifier and appends verified registry evidence", async () => {
+    const files = await releaseFiles();
+    const proof = {
+      attestationUrl: "https://registry.npmjs.org/-/npm/v1/attestations/proof",
+      integrity: "sha512-verified",
+      spec: "@openclaw/fs-safe@9.9.9",
+      tarballUrl: "https://registry.npmjs.org/@openclaw/fs-safe/-/fs-safe-9.9.9.tgz",
+    };
+    const verifyPackage = vi.fn(async () => proof);
+    const wait = vi.fn();
+
+    await expect(
+      appendReleaseProof({
+        ...files,
+        repository: "openclaw/fs-safe",
+        retryDelaysMs: [5, 10],
+        runId: "12345",
+        verifyPackage,
+        wait,
+      }),
+    ).resolves.toEqual([proof]);
+
+    expect(verifyPackage).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "@openclaw/fs-safe", version: "9.9.9" }),
+      expect.objectContaining({ retryDelaysMs: [5, 10], wait }),
+    );
+    const notes = await readFile(files.notesPath, "utf8");
+    expect(notes).toContain("| Package | Registry tarball | Verified integrity | Provenance |");
+    expect(notes).toContain("[verified attestation](https://registry.npmjs.org/-/npm/v1/attestations/proof)");
+    expect(notes).toContain("https://github.com/openclaw/fs-safe/actions/runs/12345");
+  });
+
+  it("does not append incomplete proof when registry verification fails", async () => {
+    const files = await releaseFiles();
+
+    await expect(
+      appendReleaseProof({
+        ...files,
+        repository: "openclaw/fs-safe",
+        runId: "12345",
+        verifyPackage: vi.fn(async () => {
+          throw new Error("provenance did not verify");
+        }),
+      }),
+    ).rejects.toThrow("provenance did not verify");
+    await expect(readFile(files.notesPath, "utf8")).resolves.toBe("# Release\n");
+  });
+
+  it("rejects malformed manifests and parses exactly four CLI arguments", async () => {
+    const files = await releaseFiles();
+    await writeFile(files.manifestPath, "{}\n", "utf8");
+    await expect(
+      appendReleaseProof({ ...files, repository: "openclaw/fs-safe", runId: "12345" }),
+    ).rejects.toThrow("release manifest must be a non-empty array");
+
+    expect(parseArguments(["notes.md", "manifest.json", "openclaw/fs-safe", "12345"])).toEqual({
+      manifestPath: "manifest.json",
+      notesPath: "notes.md",
+      repository: "openclaw/fs-safe",
+      runId: "12345",
+    });
+    expect(() => parseArguments([])).toThrow("usage: append-release-proof");
+    expect(() => parseArguments(["a", "b", "c", "d", "e"])).toThrow(
+      "usage: append-release-proof",
+    );
+  });
+});

--- a/test/npm-registry-fixture.ts
+++ b/test/npm-registry-fixture.ts
@@ -1,0 +1,120 @@
+import { createHash, generateKeyPairSync, sign } from "node:crypto";
+import { vi } from "vitest";
+import {
+  NPM_PROVENANCE_PREDICATE_TYPE,
+  registryTarballUrl,
+  registryVersionUrl,
+} from "../scripts/npm-registry-verification.mjs";
+
+export type TestArtifact = {
+  integrity: string;
+  name: string;
+  size: number;
+  version: string;
+};
+
+export function testArtifact(bytes = Buffer.from("validated tarball bytes")): TestArtifact {
+  return {
+    integrity: `sha512-${createHash("sha512").update(bytes).digest("base64")}`,
+    name: "@openclaw/fs-safe",
+    size: bytes.length,
+    version: "9.9.9",
+  };
+}
+
+function provenanceSubject(packageName: string, version: string) {
+  const [scope, name] = packageName.split("/");
+  return `pkg:npm/${encodeURIComponent(scope)}/${name}@${version}`;
+}
+
+export function registryFixture(
+  artifact: TestArtifact,
+  {
+    attestationDocument,
+    distOverrides = {},
+    observedIntegrity = artifact.integrity,
+    tarballBytes = Buffer.from("validated tarball bytes"),
+  }: {
+    attestationDocument?: unknown;
+    distOverrides?: Record<string, unknown>;
+    observedIntegrity?: string;
+    tarballBytes?: Buffer;
+  } = {},
+) {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  const keyid = "SHA256:test-key";
+  const signature = sign(
+    "sha256",
+    Buffer.from(`${artifact.name}@${artifact.version}:${artifact.integrity}`, "utf8"),
+    privateKey,
+  ).toString("base64");
+  const attestationUrl =
+    "https://registry.npmjs.org/-/npm/v1/attestations/@openclaw%2ffs-safe@9.9.9";
+  const statement = {
+    subject: [
+      {
+        name: provenanceSubject(artifact.name, artifact.version),
+        digest: {
+          sha512: Buffer.from(artifact.integrity.slice("sha512-".length), "base64").toString("hex"),
+        },
+      },
+    ],
+    predicate: {
+      buildDefinition: {
+        externalParameters: {
+          workflow: {
+            repository: "https://github.com/openclaw/fs-safe",
+            path: ".github/workflows/release.yml",
+            ref: `refs/tags/v${artifact.version}`,
+          },
+        },
+      },
+      runDetails: { builder: { id: "https://github.com/actions/runner/github-hosted" } },
+    },
+  };
+  const bundle = {
+    dsseEnvelope: { payload: Buffer.from(JSON.stringify(statement)).toString("base64") },
+  };
+  const versionDocument = {
+    name: artifact.name,
+    version: artifact.version,
+    dist: {
+      integrity: observedIntegrity,
+      tarball: registryTarballUrl(artifact.name, artifact.version),
+      signatures: [{ keyid, sig: signature }],
+      attestations: {
+        url: attestationUrl,
+        provenance: { predicateType: NPM_PROVENANCE_PREDICATE_TYPE },
+      },
+      ...distOverrides,
+    },
+  };
+  const keysDocument = {
+    keys: [
+      {
+        keyid,
+        key: publicKey.export({ format: "der", type: "spki" }).toString("base64"),
+      },
+    ],
+  };
+  const resolvedAttestationDocument = attestationDocument ?? {
+    attestations: [{ predicateType: NPM_PROVENANCE_PREDICATE_TYPE, bundle }],
+  };
+  const bodies = new Map<string, BodyInit>([
+    [registryVersionUrl(artifact.name, artifact.version), JSON.stringify(versionDocument)],
+    ["https://registry.npmjs.org/-/npm/v1/keys", JSON.stringify(keysDocument)],
+    [attestationUrl, JSON.stringify(resolvedAttestationDocument)],
+    [registryTarballUrl(artifact.name, artifact.version), tarballBytes],
+  ]);
+  const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    const body = bodies.get(url);
+    if (body === undefined) return new Response("missing", { status: 404 });
+    const length = typeof body === "string" ? Buffer.byteLength(body) : (body as Buffer).byteLength;
+    return new Response(body, {
+      headers: { "content-length": String(length) },
+      status: 200,
+    });
+  });
+  return { attestationUrl, bundle, fetchImpl, verifyBundle: vi.fn(async () => undefined) };
+}

--- a/test/npm-registry-verification.test.ts
+++ b/test/npm-registry-verification.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  FatalRegistryError,
+  RetryableRegistryError,
+  isRetryableRegistryError,
+  registryTarballUrl,
+  registryVersionUrl,
+  verifyPublishedPackage,
+  verifyPublishedPackageOnce,
+} from "../scripts/npm-registry-verification.mjs";
+import { registryFixture, testArtifact } from "./npm-registry-fixture.js";
+
+describe("npm registry verification", () => {
+  it("verifies registry signatures and provenance against the validated artifact", async () => {
+    const artifact = testArtifact();
+    const fixture = registryFixture(artifact);
+
+    const proof = await verifyPublishedPackageOnce(artifact, {
+      fetchImpl: fixture.fetchImpl,
+      verifyBundle: fixture.verifyBundle,
+    });
+
+    expect(proof).toMatchObject({
+      byteEvidence: "packument-integrity",
+      integrity: artifact.integrity,
+      observedIntegrity: artifact.integrity,
+      provenanceSubject: "pkg:npm/%40openclaw/fs-safe@9.9.9",
+      tarballUrl: registryTarballUrl(artifact.name, artifact.version),
+    });
+    expect(fixture.verifyBundle).toHaveBeenCalledWith(
+      fixture.bundle,
+      {
+        certificateIdentityURI:
+          "https://github.com/openclaw/fs-safe/.github/workflows/release.yml@refs/tags/v9.9.9",
+        certificateIssuer: "https://token.actions.githubusercontent.com",
+      },
+    );
+    expect(fixture.fetchImpl).not.toHaveBeenCalledWith(
+      registryTarballUrl(artifact.name, artifact.version),
+      expect.anything(),
+    );
+  });
+
+  it("accepts canonical tarball bytes when packument integrity conflicts and logs both values", async () => {
+    const bytes = Buffer.from("validated tarball bytes");
+    const artifact = testArtifact(bytes);
+    const fixture = registryFixture(artifact, {
+      observedIntegrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+      tarballBytes: bytes,
+    });
+    const log = vi.fn();
+
+    const proof = await verifyPublishedPackageOnce(artifact, {
+      fetchImpl: fixture.fetchImpl,
+      log,
+      verifyBundle: fixture.verifyBundle,
+    });
+
+    expect(proof.byteEvidence).toBe("canonical-tarball");
+    expect(log).toHaveBeenCalledWith(expect.stringContaining(`expected ${artifact.integrity}, observed sha512-`));
+    expect(fixture.fetchImpl).toHaveBeenCalledWith(
+      registryTarballUrl(artifact.name, artifact.version),
+      expect.objectContaining({ redirect: "error" }),
+    );
+  });
+
+  it("fails fatally and without retry when canonical tarball bytes are corrupt", async () => {
+    const artifact = testArtifact();
+    const fixture = registryFixture(artifact, {
+      observedIntegrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+      tarballBytes: Buffer.from("corrupt tarball bytes"),
+    });
+    const wait = vi.fn(async () => undefined);
+
+    await expect(
+      verifyPublishedPackage(artifact, {
+        fetchImpl: fixture.fetchImpl,
+        retryDelaysMs: [1, 2, 3],
+        verifyBundle: fixture.verifyBundle,
+        wait,
+      }),
+    ).rejects.toMatchObject({ code: "tarball-size-mismatch", retryable: false });
+    expect(wait).not.toHaveBeenCalled();
+  });
+
+  it("fails fatally when same-size canonical tarball bytes have a different sha512", async () => {
+    const artifact = testArtifact();
+    const fixture = registryFixture(artifact, {
+      observedIntegrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+      tarballBytes: Buffer.from("invalidxx tarball bytes"),
+    });
+
+    await expect(
+      verifyPublishedPackageOnce(artifact, {
+        fetchImpl: fixture.fetchImpl,
+        verifyBundle: fixture.verifyBundle,
+      }),
+    ).rejects.toMatchObject({ code: "tarball-integrity-mismatch", retryable: false });
+  });
+
+  it("retries incomplete provenance and reports exhaustion after the configured attempts", async () => {
+    const artifact = testArtifact();
+    const fixture = registryFixture(artifact, { distOverrides: { attestations: {} } });
+    const wait = vi.fn(async () => undefined);
+
+    await expect(
+      verifyPublishedPackage(artifact, {
+        fetchImpl: fixture.fetchImpl,
+        retryDelaysMs: [5, 10],
+        verifyBundle: fixture.verifyBundle,
+        wait,
+      }),
+    ).rejects.toThrow("registry verification exhausted 3 attempts");
+    expect(wait.mock.calls.map(([delay]) => delay)).toEqual([5, 10]);
+    expect(
+      fixture.fetchImpl.mock.calls.filter(([url]) => String(url) === registryVersionUrl(artifact.name, artifact.version)),
+    ).toHaveLength(3);
+  });
+
+  it("retries transient Sigstore trust-root network failures", async () => {
+    const artifact = testArtifact();
+    const fixture = registryFixture(artifact);
+    const verifyBundle = vi.fn(async () => {
+      throw Object.assign(new Error("fetch failed"), { name: "TUFError" });
+    });
+    const wait = vi.fn(async () => undefined);
+
+    await expect(
+      verifyPublishedPackage(artifact, {
+        fetchImpl: fixture.fetchImpl,
+        retryDelaysMs: [5],
+        verifyBundle,
+        wait,
+      }),
+    ).rejects.toThrow("registry verification exhausted 2 attempts");
+    expect(verifyBundle).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledWith(5);
+  });
+
+  it("treats authentication errors, untrusted URLs, signatures, policy, and bytes as fatal", async () => {
+    const artifact = testArtifact();
+    const forbidden = vi.fn(async () => new Response("forbidden", { status: 403 }));
+    await expect(verifyPublishedPackageOnce(artifact, { fetchImpl: forbidden })).rejects.toMatchObject({
+      code: "registry-http",
+      retryable: false,
+    });
+
+    const untrusted = registryFixture(artifact, {
+      distOverrides: { tarball: "https://example.test/package.tgz" },
+    });
+    await expect(
+      verifyPublishedPackageOnce(artifact, {
+        fetchImpl: untrusted.fetchImpl,
+        verifyBundle: untrusted.verifyBundle,
+      }),
+    ).rejects.toMatchObject({ code: "untrusted-registry-url", retryable: false });
+
+    const badSignature = registryFixture(artifact, {
+      distOverrides: { signatures: [{ keyid: "unknown", sig: "invalid" }] },
+    });
+    await expect(
+      verifyPublishedPackageOnce(artifact, {
+        fetchImpl: badSignature.fetchImpl,
+        verifyBundle: badSignature.verifyBundle,
+      }),
+    ).rejects.toMatchObject({ code: "invalid-registry-signature", retryable: false });
+
+    const badPolicy = registryFixture(artifact);
+    const originalResponse = badPolicy.fetchImpl;
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const response = await originalResponse(input, init);
+      if (String(input) !== badPolicy.attestationUrl) return response;
+      const document = await response.json();
+      const statement = JSON.parse(
+        Buffer.from(document.attestations[0].bundle.dsseEnvelope.payload, "base64").toString("utf8"),
+      );
+      statement.predicate.buildDefinition.externalParameters.workflow.repository = "https://github.com/evil/repo";
+      document.attestations[0].bundle.dsseEnvelope.payload = Buffer.from(JSON.stringify(statement)).toString("base64");
+      return Response.json(document);
+    });
+    await expect(
+      verifyPublishedPackageOnce(artifact, { fetchImpl, verifyBundle: badPolicy.verifyBundle }),
+    ).rejects.toMatchObject({ code: "untrusted-provenance-policy", retryable: false });
+  });
+
+  it("exposes an explicit retryability taxonomy", () => {
+    expect(isRetryableRegistryError(new RetryableRegistryError("pending"))).toBe(true);
+    expect(isRetryableRegistryError(new FatalRegistryError("fatal"))).toBe(false);
+    expect(isRetryableRegistryError(new Error("unknown"))).toBe(false);
+  });
+});

--- a/test/publish-or-verify.test.ts
+++ b/test/publish-or-verify.test.ts
@@ -6,12 +6,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   REGISTRY_RETRY_DELAYS_MS,
   loadReleaseArtifact,
+  parseArguments,
   publishOrVerify,
 } from "../scripts/publish-or-verify.mjs";
 
 const temporaryDirectories: string[] = [];
 
-async function releaseArtifact(bytes = Buffer.from("validated tarball bytes")) {
+async function releaseArtifact(
+  bytes = Buffer.from("validated tarball bytes"),
+  overrides: Record<string, unknown> = {},
+) {
   const directory = await mkdtemp(join(tmpdir(), "fs-safe-publish-test-"));
   temporaryDirectories.push(directory);
   const filename = "openclaw-fs-safe-9.9.9.tgz";
@@ -26,10 +30,11 @@ async function releaseArtifact(bytes = Buffer.from("validated tarball bytes")) {
         filename,
         integrity,
         size: bytes.length,
+        ...overrides,
       },
     ])}\n`,
   );
-  return { directory, filename, integrity };
+  return { bytes, directory, filename, integrity };
 }
 
 afterEach(async () => {
@@ -48,66 +53,117 @@ describe("publish-or-verify", () => {
     );
   });
 
-  it("publishes the exact validated tarball path and verifies its registry identity", async () => {
+  it("rejects artifact size mismatches and paths escaping the artifact directory", async () => {
+    const wrongSize = await releaseArtifact(undefined, { size: 1 });
+    expect(() => loadReleaseArtifact("@openclaw/fs-safe", wrongSize.directory)).toThrow(
+      "artifact size does not match release manifest",
+    );
+
+    const escaped = await releaseArtifact(undefined, { filename: "../outside.tgz" });
+    expect(() => loadReleaseArtifact("@openclaw/fs-safe", escaped.directory)).toThrow(
+      "release artifact escapes artifacts directory",
+    );
+  });
+
+  it("publishes the exact validated tarball after a missing-version result", async () => {
     const artifact = await releaseArtifact();
-    const registryResponses = [
-      Object.assign(new Error("missing"), { stderr: "npm error code E404" }),
-      JSON.stringify({ integrity: "sha512-stale", attestations: { url: "https://example.test/stale" } }),
-      JSON.stringify({ integrity: artifact.integrity, attestations: { url: "https://example.test/provenance" } }),
-    ];
-    const execNpm = vi.fn(() => {
-      const response = registryResponses.shift();
-      if (response instanceof Error) throw response;
-      return response;
-    });
     const spawnNpm = vi.fn(() => ({ status: 0 }));
-    const wait = vi.fn(async () => undefined);
-
-    await publishOrVerify({
-      packageName: "@openclaw/fs-safe",
-      artifactsDir: artifact.directory,
-      execNpm,
-      spawnNpm,
-      retryDelaysMs: [5_000, 10_000],
-      wait,
-      log: vi.fn(),
+    const proof = { byteEvidence: "packument-integrity" };
+    const verifyPackage = vi.fn(async (_entry, options) => {
+      await options.onVersionMissing();
+      return proof;
     });
+    const log = vi.fn();
 
-    expect(spawnNpm).toHaveBeenCalledOnce();
+    await expect(
+      publishOrVerify({
+        packageName: "@openclaw/fs-safe",
+        artifactsDir: artifact.directory,
+        log,
+        spawnNpm,
+        verifyPackage,
+      }),
+    ).resolves.toBe(proof);
+
     expect(spawnNpm).toHaveBeenCalledWith(
       "npm",
       ["publish", resolve(artifact.directory, artifact.filename), "--access", "public", "--provenance"],
       { stdio: "inherit" },
     );
-    expect(wait.mock.calls.map(([delay]) => delay)).toEqual([5_000, 10_000]);
+    expect(log).toHaveBeenCalledWith(
+      "verified @openclaw/fs-safe@9.9.9 byte identity, registry signature, and provenance (packument-integrity)",
+    );
   });
 
-  it("backs off through transient mismatches without republishing an existing version", async () => {
+  it("does not republish an existing verified version", async () => {
     const artifact = await releaseArtifact();
-    const execNpm = vi
-      .fn()
-      .mockReturnValueOnce(JSON.stringify({ integrity: "sha512-stale", attestations: {} }))
-      .mockReturnValueOnce(JSON.stringify({ integrity: "sha512-stale", attestations: {} }))
-      .mockReturnValueOnce(
-        JSON.stringify({ integrity: artifact.integrity, attestations: { url: "https://example.test/provenance" } }),
-      );
     const spawnNpm = vi.fn(() => ({ status: 0 }));
-    const wait = vi.fn(async () => undefined);
+    const verifyPackage = vi.fn(async () => ({ byteEvidence: "canonical-tarball" }));
 
     await publishOrVerify({
       packageName: "@openclaw/fs-safe",
       artifactsDir: artifact.directory,
-      execNpm,
       spawnNpm,
-      retryDelaysMs: [5_000, 10_000],
-      wait,
-      log: vi.fn(),
+      verifyPackage,
     });
 
     expect(spawnNpm).not.toHaveBeenCalled();
-    expect(wait.mock.calls.map(([delay]) => delay)).toEqual([5_000, 10_000]);
-    expect(REGISTRY_RETRY_DELAYS_MS.reduce((total, delay) => total + delay, 0)).toBeGreaterThanOrEqual(
-      8 * 60_000,
+  });
+
+  it.each([
+    [{ error: new Error("spawn failed"), status: null }, "npm publish could not start"],
+    [{ status: 17 }, "npm publish exited 17"],
+  ])("reports publish failure while continuing registry verification", async (publishResult, summary) => {
+    const artifact = await releaseArtifact();
+    const verifyPackage = vi.fn(async (_entry, options) => {
+      await options.onVersionMissing();
+      throw new Error("registry verification exhausted 2 attempts");
+    });
+
+    await expect(
+      publishOrVerify({
+        packageName: "@openclaw/fs-safe",
+        artifactsDir: artifact.directory,
+        spawnNpm: vi.fn(() => publishResult),
+        verifyPackage,
+      }),
+    ).rejects.toThrow(`${summary}; registry did not verify @openclaw/fs-safe@9.9.9`);
+  });
+
+  it("exhausts the configured attempts, publishes once, and preserves the final reason", async () => {
+    const artifact = await releaseArtifact();
+    const fetchImpl = vi.fn(async () => new Response("missing", { status: 404 }));
+    const spawnNpm = vi.fn(() => ({ status: 0 }));
+    const wait = vi.fn(async () => undefined);
+
+    await expect(
+      publishOrVerify({
+        packageName: "@openclaw/fs-safe",
+        artifactsDir: artifact.directory,
+        fetchImpl,
+        retryDelaysMs: [5, 10],
+        spawnNpm,
+        wait,
+      }),
+    ).rejects.toThrow(
+      "npm publish exited 0; registry did not verify @openclaw/fs-safe@9.9.9: registry verification exhausted 3 attempts",
     );
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(spawnNpm).toHaveBeenCalledOnce();
+    expect(wait.mock.calls.map(([delay]) => delay)).toEqual([5, 10]);
+  });
+
+  it("parses CLI arguments and retains the production retry budget", () => {
+    expect(parseArguments(["--package", "@openclaw/fs-safe", "--artifacts", "proof"])).toEqual({
+      artifactsDir: resolve("proof"),
+      packageName: "@openclaw/fs-safe",
+    });
+    expect(parseArguments([])).toEqual({
+      artifactsDir: resolve("release-artifacts"),
+      packageName: undefined,
+    });
+    expect(() => parseArguments(["--package"])).toThrow("invalid argument: --package");
+    expect(() => parseArguments(["--unknown", "value"])).toThrow("invalid argument: --unknown");
+    expect(REGISTRY_RETRY_DELAYS_MS.reduce((total, delay) => total + delay, 0)).toBe(530_000);
   });
 });


### PR DESCRIPTION
## Summary

- create an idempotent draft GitHub Release before npm publication, then attach proof and promote it only after verification succeeds
- share one pinned-origin npm verifier across publication and release-proof generation, with canonical tarball fallback for conflicting packument integrity
- verify npm registry signatures and Sigstore provenance against the validated digest, package identity, repository, release workflow, tag ref, builder, and certificate identity
- classify transient registry/provenance propagation separately from fatal identity, URL, signature, policy, and downloaded-byte failures
- cover retry exhaustion, fallback success/failure, provenance, argument and manifest validation, publish failure paths, and release-proof generation

## Live proof

- verified the real `@openclaw/fs-safe@0.5.1` registry signature and Sigstore bundle
- downloaded 5,609,950 bytes with SHA-1 `f4dabf3ed706bf08ea7a282750baa4ebf1707b60` and integrity `sha512-WcaG3NUMd4q+puq/I55zxwc0+OjNVhqxSprKzpS17c2cDd9bYc8c2DrYrs6Io3mmNXNa90re/UWSwVkX4I6PkA==`
- reproduced persistent divergent metadata: current main exhausted 13 attempts; this branch logged the conflict, verified the real tarball bytes, registry signature, and provenance, and passed
- flipped one downloaded byte and observed immediate fatal `tarball-integrity-mismatch` without retry

## Verification

- `pnpm check`
- `pnpm test:security`
- `pnpm pack:check`
- focused verifier/proof tests: 19 passed
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings

No package, tag, or GitHub Release was published or created during verification.

Closes #81
