### PR TITLE
fix(atomic): bind replacement modes to descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Suffix Windows reserved basenames with `_` in `sanitizeUntrustedFileName()` while preserving case and extensions on every platform, including dollar names and superscript COM/LPT variants; thanks @SebTardif (#67).
 
+### Security and Correctness
+
+- Apply `replaceFileAtomic()` and `replaceFileAtomicSync()` modes through pinned temp-file descriptors before rename, and through pinned copy-fallback descriptors, so a post-rename symlink swap cannot redirect `chmod` to an unrelated file while exact modes remain independent of umask; thanks @yetval for reporting this (#86).
+
+### Compatibility
+
+- Add optional `promises.fchmod` and `fchmodSync` operations to the injectable atomic-replacement filesystem types. Custom adapters that pass `mode` or `preserveExistingMode` must implement the matching descriptor operation and now fail before mutation when it is absent; adapters that request neither option remain compatible.
+
 ## 0.5.1 - 2026-08-01
 
 ### Security and Correctness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Compatibility
 
-- Add optional `promises.fchmod` and `fchmodSync` operations to the injectable atomic-replacement filesystem types. Custom adapters that pass `mode` or `preserveExistingMode` must implement the matching descriptor operation and now fail before mutation when it is absent; adapters that request neither option remain compatible.
+- Add an optional `fchmodSync` operation to the injectable synchronous atomic-replacement filesystem type. Async adapters need no new member because their required `open()` returns a mode-capable `FileHandle`; custom sync adapters that pass `mode` or `preserveExistingMode` now fail before mutation when `fchmodSync` is absent, while adapters that request neither option remain compatible.
 
 ## 0.5.1 - 2026-08-01
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ publication policy, creation callback, and platform contract.
 
 ## Atomic writes
 
-`replaceFileAtomic()` writes a sibling temp file, optionally fsyncs it, and renames it over the destination. Mode preservation, pinned-destination hardlink rejection, rename retry / copy fallback on `EPERM`, bounded original-content restoration after a torn fallback, parent-directory fsync, and a `beforeRename` hook for backup or observer flows are all opt-in. `movePathWithCopyFallback()` stages cross-device moves before commit and removes only the copied source entries, so concurrent source additions or replacements are preserved.
+`replaceFileAtomic()` writes a sibling temp file, applies its exact mode through the still-open descriptor, optionally fsyncs it, and renames it over the destination. It never follows the published destination path to set file permissions. Mode preservation, pinned-destination hardlink rejection, rename retry / copy fallback on `EPERM`, bounded original-content restoration after a torn fallback, parent-directory fsync, and a `beforeRename` hook for backup or observer flows are all opt-in. `movePathWithCopyFallback()` stages cross-device moves before commit and removes only the copied source entries, so concurrent source additions or replacements are preserved.
 
 ```ts
 import { replaceFileAtomic } from "@openclaw/fs-safe/atomic";
@@ -290,7 +290,7 @@ await replaceFileAtomic({
 });
 ```
 
-`replaceFileAtomicSync()` covers the synchronous case with the same options shape. Both accept an injectable `fileSystem` for tests.
+`replaceFileAtomicSync()` covers the synchronous case with the same options shape. Both accept an injectable `fileSystem` for tests; custom adapters using `mode` or `preserveExistingMode` provide the optional descriptor-bound `promises.fchmod` or `fchmodSync` operation.
 
 ## External outputs
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ await replaceFileAtomic({
 });
 ```
 
-`replaceFileAtomicSync()` covers the synchronous case with the same options shape. Both accept an injectable `fileSystem` for tests; custom adapters using `mode` or `preserveExistingMode` provide the optional descriptor-bound `promises.fchmod` or `fchmodSync` operation.
+`replaceFileAtomicSync()` covers the synchronous case with the same options shape. Both accept an injectable `fileSystem` for tests. Async adapters use `chmod()` on the `FileHandle` returned by their required `open()` operation; custom sync adapters using `mode` or `preserveExistingMode` provide the optional descriptor-bound `fchmodSync` operation.
 
 ## External outputs
 

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -205,7 +205,6 @@ await replaceFileAtomic({
   fileSystem: {
     promises: {
       ...realFs,
-      fchmod: async (handle, mode) => handle.chmod(mode),
       writeFile: async (...args) => { ops.push("write"); return realFs.writeFile(...args); },
       rename: async (...args) => { ops.push("rename"); return realFs.rename(...args); },
     },
@@ -213,23 +212,16 @@ await replaceFileAtomic({
 });
 ```
 
-The injectable interfaces add optional descriptor-mode operations:
+The synchronous injectable interface adds one optional descriptor-mode operation:
 
 ```ts
-type ReplaceFileAtomicFileSystem = {
-  promises: {
-    // other required operations omitted
-    fchmod?: (handle: import("node:fs/promises").FileHandle, mode: number) => Promise<void>;
-  };
-};
-
 type ReplaceFileAtomicSyncFileSystem = {
   // other required operations omitted
   fchmodSync?: typeof import("node:fs").fchmodSync;
 };
 ```
 
-The built-in filesystem always applies the resolved mode through the temporary file descriptor. A custom filesystem that passes `mode` or `preserveExistingMode` must supply the matching descriptor operation; omission fails before any file is created and never falls back to `chmod(destination)`. Existing custom filesystems that request neither option may omit the new member. Copy fallback applies the mode through its pinned destination descriptor as well, preserving exact modes despite the process umask.
+The async interface already requires `open()`, whose `FileHandle` supplies `chmod()`, so injecting `node:fs` or another conforming adapter needs no new async member. A custom synchronous filesystem that passes `mode` or `preserveExistingMode` must supply `fchmodSync`; omission fails before any file is created and never falls back to `chmod(destination)`. Existing synchronous adapters that request neither option may omit it. Copy fallback applies the mode through its pinned destination descriptor as well, preserving exact modes despite the process umask.
 
 ## See also
 

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -14,7 +14,7 @@ import {
 
 ## `replaceFileAtomic` / `replaceFileAtomicSync`
 
-Write `content` to a sibling temp file in the destination directory, optionally `fsync` the temp file, optionally `fsync` the parent directory after rename, then atomically rename over the destination.
+Write `content` to a sibling temp file in the destination directory, apply the final mode through its still-open descriptor, optionally `fsync` that descriptor, optionally `fsync` the parent directory after rename, then atomically rename over the destination. No permission change follows the caller-supplied destination path after publication.
 
 Async replacements to the same destination are serialized inside the current process, so two overlapping `replaceFileAtomic()` calls do not interleave their temp-write/rename phases. Use a sidecar lock when multiple processes may write the same target.
 
@@ -121,7 +121,7 @@ Use it when callers must see a whole staged tree at the target path. For single-
 ## `writeTextAtomic`
 
 Atomic UTF-8 text write with the same secure defaults as `writeJson`: sibling
-temp file, temp fsync, rename, parent fsync, and final chmod best-effort.
+temp file, descriptor-bound mode setting and fsync, rename, and parent fsync.
 It delegates to `replaceFileAtomic()` with a smaller call shape. Use it when
 you do not need replacement hooks such as `beforeRename`, `preserveExistingMode`,
 or custom copy-fallback policy.
@@ -205,12 +205,31 @@ await replaceFileAtomic({
   fileSystem: {
     promises: {
       ...realFs,
+      fchmod: async (handle, mode) => handle.chmod(mode),
       writeFile: async (...args) => { ops.push("write"); return realFs.writeFile(...args); },
       rename: async (...args) => { ops.push("rename"); return realFs.rename(...args); },
     },
   },
 });
 ```
+
+The injectable interfaces add optional descriptor-mode operations:
+
+```ts
+type ReplaceFileAtomicFileSystem = {
+  promises: {
+    // other required operations omitted
+    fchmod?: (handle: import("node:fs/promises").FileHandle, mode: number) => Promise<void>;
+  };
+};
+
+type ReplaceFileAtomicSyncFileSystem = {
+  // other required operations omitted
+  fchmodSync?: typeof import("node:fs").fchmodSync;
+};
+```
+
+The built-in filesystem always applies the resolved mode through the temporary file descriptor. A custom filesystem that passes `mode` or `preserveExistingMode` must supply the matching descriptor operation; omission fails before any file is created and never falls back to `chmod(destination)`. Existing custom filesystems that request neither option may omit the new member. Copy fallback applies the mode through its pinned destination descriptor as well, preserving exact modes despite the process umask.
 
 ## See also
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -2,6 +2,8 @@
 
 The types most callers reach for. Shared data shapes are exported from `@openclaw/fs-safe/types`; method-specific option/result types live next to their subpath.
 
+For atomic replacement, `ReplaceFileAtomicFileSystem` and `ReplaceFileAtomicSyncFileSystem` are exported from `@openclaw/fs-safe/atomic`. Their optional `promises.fchmod(handle, mode)` and `fchmodSync(fd, mode)` members let injected filesystems apply exact modes through pinned descriptors. Custom adapters that explicitly request `mode` or `preserveExistingMode` must implement the corresponding member; see [Atomic writes](atomic.md#test-injection).
+
 ```ts
 import type {
   BasePathOptions,

--- a/docs/types.md
+++ b/docs/types.md
@@ -2,7 +2,7 @@
 
 The types most callers reach for. Shared data shapes are exported from `@openclaw/fs-safe/types`; method-specific option/result types live next to their subpath.
 
-For atomic replacement, `ReplaceFileAtomicFileSystem` and `ReplaceFileAtomicSyncFileSystem` are exported from `@openclaw/fs-safe/atomic`. Their optional `promises.fchmod(handle, mode)` and `fchmodSync(fd, mode)` members let injected filesystems apply exact modes through pinned descriptors. Custom adapters that explicitly request `mode` or `preserveExistingMode` must implement the corresponding member; see [Atomic writes](atomic.md#test-injection).
+For atomic replacement, `ReplaceFileAtomicFileSystem` and `ReplaceFileAtomicSyncFileSystem` are exported from `@openclaw/fs-safe/atomic`. Async adapters use `chmod()` on the `FileHandle` returned by their required `open()` operation. The synchronous type adds optional `fchmodSync(fd, mode)`; custom sync adapters that explicitly request `mode` or `preserveExistingMode` must implement it. See [Atomic writes](atomic.md#test-injection).
 
 ```ts
 import type {

--- a/src/replace-file-copy-fallback.ts
+++ b/src/replace-file-copy-fallback.ts
@@ -300,7 +300,6 @@ export async function copyFallbackReplace(params: {
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
   restore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
-  fchmod?: (handle: FileHandle, mode: number) => Promise<void>;
 }): Promise<void> {
   const sourcePreview = await params.fsModule.lstat(params.src);
   if (sourcePreview.isSymbolicLink() || !sourcePreview.isFile()) {
@@ -351,9 +350,7 @@ export async function copyFallbackReplace(params: {
       );
       await destHandle.writeFile(replacement);
     }
-    if (params.fchmod) {
-      await params.fchmod(destHandle, sourceStat.mode);
-    }
+    await destHandle.chmod(sourceStat.mode);
   } finally {
     await destHandle?.close().catch(() => undefined);
     await sourceHandle.close().catch(() => undefined);

--- a/src/replace-file-copy-fallback.ts
+++ b/src/replace-file-copy-fallback.ts
@@ -300,6 +300,7 @@ export async function copyFallbackReplace(params: {
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
   restore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
+  fchmod?: (handle: FileHandle, mode: number) => Promise<void>;
 }): Promise<void> {
   const sourcePreview = await params.fsModule.lstat(params.src);
   if (sourcePreview.isSymbolicLink() || !sourcePreview.isFile()) {
@@ -350,6 +351,9 @@ export async function copyFallbackReplace(params: {
       );
       await destHandle.writeFile(replacement);
     }
+    if (params.fchmod) {
+      await params.fchmod(destHandle, sourceStat.mode);
+    }
   } finally {
     await destHandle?.close().catch(() => undefined);
     await sourceHandle.close().catch(() => undefined);
@@ -364,6 +368,7 @@ export function copyFallbackReplaceSync(params: {
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
   restore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
+  fchmodSync?: (fd: number, mode: number) => void;
 }): void {
   const sourcePreview = params.fsModule.lstatSync(params.src);
   if (sourcePreview.isSymbolicLink() || !sourcePreview.isFile()) {
@@ -421,6 +426,7 @@ export function copyFallbackReplaceSync(params: {
       );
       writeAllSync(params.fsModule, destFd, replacement);
     }
+    params.fchmodSync?.(destFd, sourceStat.mode);
   } finally {
     if (destFd !== undefined) {
       try {

--- a/src/replace-file-descriptor.ts
+++ b/src/replace-file-descriptor.ts
@@ -7,7 +7,6 @@ type SyncTempFileSystem = Pick<
   "closeSync" | "fstatSync" | "fsyncSync" | "openSync" | "writeFileSync"
 >;
 
-export type AsyncFchmod = (handle: FileHandle, mode: number) => Promise<void>;
 export type SyncFchmod = (fd: number, mode: number) => void;
 
 export async function writeTempFile(params: {
@@ -15,15 +14,12 @@ export async function writeTempFile(params: {
   tempPath: string;
   content: string | Uint8Array;
   mode: number;
-  fchmod?: AsyncFchmod;
   sync: boolean;
 }): Promise<Stats> {
   const handle = await params.fsModule.open(params.tempPath, "wx", params.mode);
   try {
     await params.fsModule.writeFile(handle, params.content);
-    if (params.fchmod) {
-      await params.fchmod(handle, params.mode);
-    }
+    await handle.chmod(params.mode);
     if (params.sync) {
       try {
         await handle.sync();

--- a/src/replace-file-descriptor.ts
+++ b/src/replace-file-descriptor.ts
@@ -1,0 +1,67 @@
+import syncFs, { type Stats } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+
+type AsyncTempFileSystem = Pick<typeof fs, "open" | "writeFile">;
+type SyncTempFileSystem = Pick<
+  typeof syncFs,
+  "closeSync" | "fstatSync" | "fsyncSync" | "openSync" | "writeFileSync"
+>;
+
+export type AsyncFchmod = (handle: FileHandle, mode: number) => Promise<void>;
+export type SyncFchmod = (fd: number, mode: number) => void;
+
+export async function writeTempFile(params: {
+  fsModule: AsyncTempFileSystem;
+  tempPath: string;
+  content: string | Uint8Array;
+  mode: number;
+  fchmod?: AsyncFchmod;
+  sync: boolean;
+}): Promise<Stats> {
+  const handle = await params.fsModule.open(params.tempPath, "wx", params.mode);
+  try {
+    await params.fsModule.writeFile(handle, params.content);
+    if (params.fchmod) {
+      await params.fchmod(handle, params.mode);
+    }
+    if (params.sync) {
+      try {
+        await handle.sync();
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EPERM") {
+          throw error;
+        }
+      }
+    }
+    return await handle.stat();
+  } finally {
+    await handle.close();
+  }
+}
+
+export function writeTempFileSync(params: {
+  fsModule: SyncTempFileSystem;
+  tempPath: string;
+  content: string | Uint8Array;
+  mode: number;
+  fchmodSync?: SyncFchmod;
+  sync: boolean;
+}): Stats {
+  const fd = params.fsModule.openSync(params.tempPath, "wx", params.mode);
+  try {
+    params.fsModule.writeFileSync(fd, params.content);
+    params.fchmodSync?.(fd, params.mode);
+    if (params.sync) {
+      try {
+        params.fsModule.fsyncSync(fd);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EPERM") {
+          throw error;
+        }
+      }
+    }
+    return params.fsModule.fstatSync(fd);
+  } finally {
+    params.fsModule.closeSync(fd);
+  }
+}

--- a/src/replace-file.ts
+++ b/src/replace-file.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import syncFs from "node:fs";
 import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import {
   assertDestinationHardlinkPolicy,
@@ -13,6 +14,12 @@ import {
   type ReplaceFileCopyFallbackRestorePolicy,
   type ReplaceFileDestinationHardlinkPolicy,
 } from "./replace-file-copy-fallback.js";
+import {
+  type AsyncFchmod,
+  type SyncFchmod,
+  writeTempFile,
+  writeTempFileSync,
+} from "./replace-file-descriptor.js";
 import { assertSafePathPrefix } from "./safe-path-segment.js";
 import { registerTempPathForExit } from "./temp-cleanup.js";
 import { serializePathWrite } from "./write-queue.js";
@@ -30,7 +37,9 @@ export type ReplaceFileAtomicFileSystem = {
     | "open"
     | "stat"
     | "lstat"
-  >;
+  > & {
+    fchmod?: (handle: FileHandle, mode: number) => Promise<void>;
+  };
 };
 
 export type ReplaceFileAtomicSyncFileSystem = Pick<
@@ -52,7 +61,9 @@ export type ReplaceFileAtomicSyncFileSystem = Pick<
   | "ftruncateSync"
   | "readSync"
   | "writeSync"
->;
+> & {
+  fchmodSync?: typeof syncFs.fchmodSync;
+};
 
 export type {
   ReplaceFileAtomicRestoreCleanup,
@@ -116,6 +127,7 @@ async function renameWithRetry(params: {
   copyFallbackRestore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
+  fchmod?: AsyncFchmod;
 }): Promise<ReplaceFileAtomicResult> {
   for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
     try {
@@ -134,6 +146,7 @@ async function renameWithRetry(params: {
           destinationHardlinks: params.destinationHardlinks,
           restore: params.copyFallbackRestore,
           maxRestoreBytes: params.maxRestoreBytes,
+          fchmod: params.fchmod,
         });
         return { method: "copy-fallback" };
       }
@@ -160,6 +173,7 @@ function renameWithRetrySync(params: {
   copyFallbackRestore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
+  fchmodSync?: SyncFchmod;
 }): ReplaceFileAtomicResult {
   for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
     try {
@@ -178,6 +192,7 @@ function renameWithRetrySync(params: {
           destinationHardlinks: params.destinationHardlinks,
           restore: params.copyFallbackRestore,
           maxRestoreBytes: params.maxRestoreBytes,
+          fchmodSync: params.fchmodSync,
         });
         return { method: "copy-fallback" };
       }
@@ -240,30 +255,10 @@ function resolveModeSync(options: ReplaceFileAtomicSyncOptions): number {
   return stat ? stat.mode : defaultMode;
 }
 
-async function syncTempFile(fsModule: ReplaceFileAtomicFileSystem["promises"], tempPath: string) {
-  const handle = await fsModule.open(tempPath, "r+");
-  try {
-    await handle.sync();
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EPERM") {
-      throw error;
-    }
-  } finally {
-    await handle.close();
-  }
-}
-
-function syncTempFileSync(fsModule: ReplaceFileAtomicSyncFileSystem, tempPath: string): void {
-  const fd = fsModule.openSync(tempPath, "r+");
-  try {
-    fsModule.fsyncSync(fd);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EPERM") {
-      throw error;
-    }
-  } finally {
-    fsModule.closeSync(fd);
-  }
+function missingFchmodError(member: "promises.fchmod" | "fchmodSync"): TypeError {
+  return new TypeError(
+    `fileSystem.${member} is required when mode or preserveExistingMode is specified`,
+  );
 }
 
 async function syncDirectoryBestEffort(
@@ -338,6 +333,14 @@ async function replaceFileAtomicUnserialized(
   const dir = path.dirname(filePath);
   const dirMode = options.dirMode ?? 0o700;
   const mode = await resolveMode(options);
+  const fchmod = options.fileSystem?.promises.fchmod ?? (
+    options.fileSystem === undefined
+      ? async (handle: FileHandle, requestedMode: number) => await handle.chmod(requestedMode)
+      : undefined
+  );
+  if (!fchmod && (options.mode !== undefined || options.preserveExistingMode === true)) {
+    throw missingFchmodError("promises.fchmod");
+  }
   const tempPath = buildReplaceTempPath(filePath, options.tempPrefix);
   const unregisterTempPath = registerTempPathForExit(tempPath);
   let tempExists = false;
@@ -346,11 +349,14 @@ async function replaceFileAtomicUnserialized(
   await fsModule.chmod(dir, dirMode).catch(() => undefined);
   try {
     tempExists = true;
-    await fsModule.writeFile(tempPath, options.content, { mode, flag: "wx" });
-    unregisterTempPath.setIdentity(await fsModule.lstat(tempPath));
-    if (options.syncTempFile) {
-      await syncTempFile(fsModule, tempPath);
-    }
+    unregisterTempPath.setIdentity(await writeTempFile({
+      fsModule,
+      tempPath,
+      content: options.content,
+      mode,
+      fchmod,
+      sync: options.syncTempFile === true,
+    }));
     if (options.beforeRename) {
       await options.beforeRename({ filePath, tempPath });
     }
@@ -365,10 +371,10 @@ async function replaceFileAtomicUnserialized(
       copyFallbackRestore: options.copyFallbackRestore ?? "none",
       maxRestoreBytes: options.maxRestoreBytes,
       destinationHardlinks: options.destinationHardlinks,
+      fchmod,
     });
     tempExists = false;
     unregisterTempPath();
-    await fsModule.chmod(filePath, mode).catch(() => undefined);
     if (options.syncParentDir) {
       await syncDirectoryBestEffort(fsModule, dir);
     }
@@ -399,6 +405,12 @@ export function replaceFileAtomicSync(
   const dir = path.dirname(filePath);
   const dirMode = options.dirMode ?? 0o700;
   const mode = resolveModeSync(options);
+  const fchmodSync = options.fileSystem?.fchmodSync ?? (
+    options.fileSystem === undefined ? syncFs.fchmodSync : undefined
+  );
+  if (!fchmodSync && (options.mode !== undefined || options.preserveExistingMode === true)) {
+    throw missingFchmodError("fchmodSync");
+  }
   const tempPath = buildReplaceTempPath(filePath, options.tempPrefix);
   const unregisterTempPath = registerTempPathForExit(tempPath);
   let tempExists = false;
@@ -411,11 +423,14 @@ export function replaceFileAtomicSync(
   }
   try {
     tempExists = true;
-    fsModule.writeFileSync(tempPath, options.content, { mode, flag: "wx" });
-    unregisterTempPath.setIdentity(fsModule.lstatSync(tempPath));
-    if (options.syncTempFile) {
-      syncTempFileSync(fsModule, tempPath);
-    }
+    unregisterTempPath.setIdentity(writeTempFileSync({
+      fsModule,
+      tempPath,
+      content: options.content,
+      mode,
+      fchmodSync,
+      sync: options.syncTempFile === true,
+    }));
     if (options.beforeRename) {
       options.beforeRename({ filePath, tempPath });
     }
@@ -430,14 +445,10 @@ export function replaceFileAtomicSync(
       copyFallbackRestore: options.copyFallbackRestore ?? "none",
       maxRestoreBytes: options.maxRestoreBytes,
       destinationHardlinks: options.destinationHardlinks,
+      fchmodSync,
     });
     tempExists = false;
     unregisterTempPath();
-    try {
-      fsModule.chmodSync(filePath, mode);
-    } catch {
-      // Best-effort on platforms that do not enforce POSIX modes.
-    }
     if (options.syncParentDir) {
       syncDirectoryBestEffortSync(fsModule, dir);
     }

--- a/src/replace-file.ts
+++ b/src/replace-file.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import syncFs from "node:fs";
 import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
-import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import {
   assertDestinationHardlinkPolicy,
@@ -15,7 +14,6 @@ import {
   type ReplaceFileDestinationHardlinkPolicy,
 } from "./replace-file-copy-fallback.js";
 import {
-  type AsyncFchmod,
   type SyncFchmod,
   writeTempFile,
   writeTempFileSync,
@@ -37,9 +35,7 @@ export type ReplaceFileAtomicFileSystem = {
     | "open"
     | "stat"
     | "lstat"
-  > & {
-    fchmod?: (handle: FileHandle, mode: number) => Promise<void>;
-  };
+  >;
 };
 
 export type ReplaceFileAtomicSyncFileSystem = Pick<
@@ -127,7 +123,6 @@ async function renameWithRetry(params: {
   copyFallbackRestore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
-  fchmod?: AsyncFchmod;
 }): Promise<ReplaceFileAtomicResult> {
   for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
     try {
@@ -146,7 +141,6 @@ async function renameWithRetry(params: {
           destinationHardlinks: params.destinationHardlinks,
           restore: params.copyFallbackRestore,
           maxRestoreBytes: params.maxRestoreBytes,
-          fchmod: params.fchmod,
         });
         return { method: "copy-fallback" };
       }
@@ -255,9 +249,9 @@ function resolveModeSync(options: ReplaceFileAtomicSyncOptions): number {
   return stat ? stat.mode : defaultMode;
 }
 
-function missingFchmodError(member: "promises.fchmod" | "fchmodSync"): TypeError {
+function missingFchmodSyncError(): TypeError {
   return new TypeError(
-    `fileSystem.${member} is required when mode or preserveExistingMode is specified`,
+    "fileSystem.fchmodSync is required when mode or preserveExistingMode is specified",
   );
 }
 
@@ -333,14 +327,6 @@ async function replaceFileAtomicUnserialized(
   const dir = path.dirname(filePath);
   const dirMode = options.dirMode ?? 0o700;
   const mode = await resolveMode(options);
-  const fchmod = options.fileSystem?.promises.fchmod ?? (
-    options.fileSystem === undefined
-      ? async (handle: FileHandle, requestedMode: number) => await handle.chmod(requestedMode)
-      : undefined
-  );
-  if (!fchmod && (options.mode !== undefined || options.preserveExistingMode === true)) {
-    throw missingFchmodError("promises.fchmod");
-  }
   const tempPath = buildReplaceTempPath(filePath, options.tempPrefix);
   const unregisterTempPath = registerTempPathForExit(tempPath);
   let tempExists = false;
@@ -354,7 +340,6 @@ async function replaceFileAtomicUnserialized(
       tempPath,
       content: options.content,
       mode,
-      fchmod,
       sync: options.syncTempFile === true,
     }));
     if (options.beforeRename) {
@@ -371,7 +356,6 @@ async function replaceFileAtomicUnserialized(
       copyFallbackRestore: options.copyFallbackRestore ?? "none",
       maxRestoreBytes: options.maxRestoreBytes,
       destinationHardlinks: options.destinationHardlinks,
-      fchmod,
     });
     tempExists = false;
     unregisterTempPath();
@@ -409,7 +393,7 @@ export function replaceFileAtomicSync(
     options.fileSystem === undefined ? syncFs.fchmodSync : undefined
   );
   if (!fchmodSync && (options.mode !== undefined || options.preserveExistingMode === true)) {
-    throw missingFchmodError("fchmodSync");
+    throw missingFchmodSyncError();
   }
   const tempPath = buildReplaceTempPath(filePath, options.tempPrefix);
   const unregisterTempPath = registerTempPathForExit(tempPath);

--- a/test/atomic-fchmod-regression.test.ts
+++ b/test/atomic-fchmod-regression.test.ts
@@ -1,0 +1,205 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { replaceFileAtomic, replaceFileAtomicSync } from "../src/atomic.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
+});
+
+describe("atomic descriptor modes", () => {
+  it.runIf(process.platform !== "win32")(
+    "does not chmod an async destination swapped for a symlink after rename",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-chmod-race-");
+      const filePath = path.join(root, "state.txt");
+      const victimPath = path.join(root, "victim.txt");
+      const chmodPaths: string[] = [];
+      let publishedMode: number | undefined;
+      await fs.writeFile(victimPath, "victim", { mode: 0o644 });
+      await fs.chmod(victimPath, 0o644);
+
+      const previousUmask = process.umask(0o077);
+      try {
+        await replaceFileAtomic({
+          filePath,
+          content: "new",
+          mode: 0o600,
+          fileSystem: {
+            promises: {
+              ...fs,
+              fchmod: async (handle, mode) => await handle.chmod(mode),
+              chmod: async (candidate, mode) => {
+                chmodPaths.push(String(candidate));
+                await fs.chmod(candidate, mode);
+              },
+              rename: async (source, destination) => {
+                await fs.rename(source, destination);
+                publishedMode = (await fs.stat(destination)).mode & 0o777;
+                await fs.unlink(destination);
+                await fs.symlink(victimPath, destination);
+              },
+            },
+          },
+        });
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      expect({
+        chmodPaths,
+        publishedMode,
+        victimMode: (await fs.stat(victimPath)).mode & 0o777,
+      }).toEqual({ chmodPaths: [root], publishedMode: 0o600, victimMode: 0o644 });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not chmod a sync destination swapped for a symlink after rename",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-chmod-race-sync-");
+      const filePath = path.join(root, "state.txt");
+      const victimPath = path.join(root, "victim.txt");
+      const chmodPaths: string[] = [];
+      let publishedMode: number | undefined;
+      await fs.writeFile(victimPath, "victim", { mode: 0o644 });
+      await fs.chmod(victimPath, 0o644);
+      const fileSystem = {
+        ...fsSync,
+        chmodSync: ((candidate: fsSync.PathLike, mode: fsSync.Mode) => {
+          chmodPaths.push(String(candidate));
+          fsSync.chmodSync(candidate, mode);
+        }) as typeof fsSync.chmodSync,
+        renameSync: ((source: fsSync.PathLike, destination: fsSync.PathLike) => {
+          fsSync.renameSync(source, destination);
+          publishedMode = fsSync.statSync(destination).mode & 0o777;
+          fsSync.unlinkSync(destination);
+          fsSync.symlinkSync(victimPath, destination);
+        }) as typeof fsSync.renameSync,
+      };
+
+      const previousUmask = process.umask(0o077);
+      try {
+        replaceFileAtomicSync({ filePath, content: "new", mode: 0o600, fileSystem });
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      expect({
+        chmodPaths,
+        publishedMode,
+        victimMode: fsSync.statSync(victimPath).mode & 0o777,
+      }).toEqual({ chmodPaths: [root], publishedMode: 0o600, victimMode: 0o644 });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "applies exact async and sync modes through temp descriptors despite umask",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-fchmod-mode-");
+      const asyncPath = path.join(root, "async.txt");
+      const syncPath = path.join(root, "sync.txt");
+
+      const previousUmask = process.umask(0o077);
+      try {
+        await replaceFileAtomic({ filePath: asyncPath, content: "async", mode: 0o666 });
+        replaceFileAtomicSync({ filePath: syncPath, content: "sync", mode: 0o666 });
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      expect((await fs.stat(asyncPath)).mode & 0o777).toBe(0o666);
+      expect(fsSync.statSync(syncPath).mode & 0o777).toBe(0o666);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves exact descriptor modes through async and sync copy fallback",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-fchmod-fallback-");
+      const asyncPath = path.join(root, "async.txt");
+      const syncPath = path.join(root, "sync.txt");
+      const renameDenied = () => Object.assign(new Error("rename denied"), { code: "EPERM" });
+
+      const previousUmask = process.umask(0o077);
+      try {
+        await replaceFileAtomic({
+          filePath: asyncPath,
+          content: "async",
+          mode: 0o666,
+          copyFallbackOnPermissionError: true,
+          fileSystem: {
+            promises: {
+              ...fs,
+              fchmod: async (handle, mode) => await handle.chmod(mode),
+              rename: async () => { throw renameDenied(); },
+            },
+          },
+        });
+        replaceFileAtomicSync({
+          filePath: syncPath,
+          content: "sync",
+          mode: 0o666,
+          copyFallbackOnPermissionError: true,
+          fileSystem: {
+            ...fsSync,
+            renameSync: () => { throw renameDenied(); },
+          },
+        });
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      expect((await fs.stat(asyncPath)).mode & 0o777).toBe(0o666);
+      expect(fsSync.statSync(syncPath).mode & 0o777).toBe(0o666);
+    },
+  );
+
+  it("fails closed before mutation when an injected filesystem cannot set an explicit mode", async () => {
+    const root = await tempRoot("fs-safe-atomic-fchmod-missing-");
+    const asyncPath = path.join(root, "async.txt");
+    const syncPath = path.join(root, "sync.txt");
+    const asyncDefaultPath = path.join(root, "async-default.txt");
+    const syncDefaultPath = path.join(root, "sync-default.txt");
+    const { fchmodSync: _fchmodSync, ...syncWithoutFchmod } = fsSync;
+
+    await expect(replaceFileAtomic({
+      filePath: asyncPath,
+      content: "async",
+      mode: 0o600,
+      fileSystem: { promises: { ...fs } },
+    })).rejects.toThrow("fileSystem.promises.fchmod is required");
+    expect(() => replaceFileAtomicSync({
+      filePath: syncPath,
+      content: "sync",
+      mode: 0o600,
+      fileSystem: syncWithoutFchmod,
+    })).toThrow("fileSystem.fchmodSync is required");
+
+    await expect(fs.access(asyncPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(syncPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+    await replaceFileAtomic({
+      filePath: asyncDefaultPath,
+      content: "async default",
+      fileSystem: { promises: { ...fs } },
+    });
+    replaceFileAtomicSync({
+      filePath: syncDefaultPath,
+      content: "sync default",
+      fileSystem: syncWithoutFchmod,
+    });
+    await expect(fs.readFile(asyncDefaultPath, "utf8")).resolves.toBe("async default");
+    expect(fsSync.readFileSync(syncDefaultPath, "utf8")).toBe("sync default");
+  });
+});

--- a/test/atomic-fchmod-regression.test.ts
+++ b/test/atomic-fchmod-regression.test.ts
@@ -38,7 +38,6 @@ describe("atomic descriptor modes", () => {
           fileSystem: {
             promises: {
               ...fs,
-              fchmod: async (handle, mode) => await handle.chmod(mode),
               chmod: async (candidate, mode) => {
                 chmodPaths.push(String(candidate));
                 await fs.chmod(candidate, mode);
@@ -141,7 +140,6 @@ describe("atomic descriptor modes", () => {
           fileSystem: {
             promises: {
               ...fs,
-              fchmod: async (handle, mode) => await handle.chmod(mode),
               rename: async () => { throw renameDenied(); },
             },
           },
@@ -165,20 +163,34 @@ describe("atomic descriptor modes", () => {
     },
   );
 
-  it("fails closed before mutation when an injected filesystem cannot set an explicit mode", async () => {
+  it.runIf(process.platform !== "win32")(
+    "accepts node:fs injection with an explicit async mode",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-node-fs-");
+      const filePath = path.join(root, "state.txt");
+      const previousUmask = process.umask(0o077);
+      try {
+        await replaceFileAtomic({
+          filePath,
+          content: "injected",
+          mode: 0o666,
+          fileSystem: fsSync,
+        });
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("injected");
+      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o666);
+    },
+  );
+
+  it("fails closed before mutation when an injected sync filesystem cannot set an explicit mode", async () => {
     const root = await tempRoot("fs-safe-atomic-fchmod-missing-");
-    const asyncPath = path.join(root, "async.txt");
     const syncPath = path.join(root, "sync.txt");
-    const asyncDefaultPath = path.join(root, "async-default.txt");
     const syncDefaultPath = path.join(root, "sync-default.txt");
     const { fchmodSync: _fchmodSync, ...syncWithoutFchmod } = fsSync;
 
-    await expect(replaceFileAtomic({
-      filePath: asyncPath,
-      content: "async",
-      mode: 0o600,
-      fileSystem: { promises: { ...fs } },
-    })).rejects.toThrow("fileSystem.promises.fchmod is required");
     expect(() => replaceFileAtomicSync({
       filePath: syncPath,
       content: "sync",
@@ -186,20 +198,13 @@ describe("atomic descriptor modes", () => {
       fileSystem: syncWithoutFchmod,
     })).toThrow("fileSystem.fchmodSync is required");
 
-    await expect(fs.access(asyncPath)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(fs.access(syncPath)).rejects.toMatchObject({ code: "ENOENT" });
 
-    await replaceFileAtomic({
-      filePath: asyncDefaultPath,
-      content: "async default",
-      fileSystem: { promises: { ...fs } },
-    });
     replaceFileAtomicSync({
       filePath: syncDefaultPath,
       content: "sync default",
       fileSystem: syncWithoutFchmod,
     });
-    await expect(fs.readFile(asyncDefaultPath, "utf8")).resolves.toBe("async default");
     expect(fsSync.readFileSync(syncDefaultPath, "utf8")).toBe("sync default");
   });
 });

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -30,13 +30,20 @@ afterEach(async () => {
 
 function mockOpenForSyncCounting(): { readonly syncCalls: number; restore: () => void } {
   let syncCalls = 0;
-  const openSpy = vi.spyOn(fs, "open").mockImplementation(async () => {
-    return {
-      sync: async () => {
-        syncCalls += 1;
+  const realOpen = fs.open.bind(fs);
+  const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await realOpen(...args);
+    return new Proxy(handle, {
+      get(target, property) {
+        if (property === "sync") {
+          return async () => {
+            syncCalls += 1;
+          };
+        }
+        const value = Reflect.get(target, property);
+        return typeof value === "function" ? value.bind(target) : value;
       },
-      close: async () => undefined,
-    } as Awaited<ReturnType<typeof fs.open>>;
+    });
   });
   return {
     get syncCalls() {

--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -1304,12 +1304,10 @@ describe("atomic file replacement", () => {
         ...fs,
         open: async (...args: Parameters<typeof fs.open>) => {
           const handle = await fs.open(...args);
-          return {
-            sync: async () => {
-              syncCalls += 1;
-            },
-            close: async () => await handle.close(),
-          } as Awaited<ReturnType<typeof fs.open>>;
+          handle.sync = async () => {
+            syncCalls += 1;
+          };
+          return handle;
         },
       },
     };
@@ -1357,10 +1355,8 @@ describe("atomic file replacement", () => {
         open: async (...args: Parameters<typeof fs.open>) => {
           openedDir = String(args[0]);
           const handle = await fs.open(...args);
-          return {
-            sync: async () => undefined,
-            close: async () => await handle.close(),
-          } as Awaited<ReturnType<typeof fs.open>>;
+          handle.sync = async () => undefined;
+          return handle;
         },
       },
     };


### PR DESCRIPTION
Fixes #86.

## What was wrong

`replaceFileAtomic()` and `replaceFileAtomicSync()` reached the caller-requested `mode` by calling `chmod` on the destination **path**, after the rename had already completed. A local user able to write the parent directory could unlink the destination in that window and drop a symlink in its place; `chmod` followed it and the mode change landed on an unrelated file.

The temp file could not carry the mode on its own, because it was created with `writeFile(tempPath, content, { mode, flag: "wx" })` and so had its mode reduced by the process umask. The post-rename `chmod` was the only thing that reached the exact requested mode, and no option disabled it.

Reported with a complete reproduction by @yetval.

## What changed

The exclusive temp descriptor is now held open across write, mode application, optional `fsync`, and close, before the rename. The copy fallback applies modes through its pinned destination descriptor. No post-publication destination `chmod` remains anywhere in the replacement path.

The async interface needs no new member: it applies the mode through the `FileHandle` returned by the already-required `open`. The synchronous path does add an optional `fchmodSync`, because `openSync` returns a bare descriptor with no equivalent method; `typeof fs` satisfies it, and adapters that pass neither `mode` nor `preserveExistingMode` are unaffected. A sync adapter that requests a mode without providing `fchmodSync` fails before any mutation rather than silently falling back.

## Proof

Real syscalls, real on-disk directories, umask `077`, with the destination swap staged at the rename boundary. Before, on both entry points, the recorded `chmod` path list contained the destination and an unrelated `644` file silently became `600`. After:

```
async victim before: 644
async chmod paths: <parent>
async published mode before swap: 600
async victim after: 644
sync victim before: 644
sync chmod paths: <parent>
sync published mode before swap: 600
sync victim after: 644
node:fs injected async mode under umask 077: 666
```

The unrelated file keeps `644`, only the parent directory is chmodded, and the requested mode is still reached exactly despite the umask. The final line covers the compatibility shape that matters most in practice — a plain `node:fs` injected as `fileSystem` together with an explicit `mode` — which is now pinned by a regression test.

`pnpm check` 651 passed / 25 skipped, `pnpm test:security` 62 passed, `git diff --check` clean, Codex autoreview clean. Regressions fail on `main` and pass here.

## Follow-ups, deliberately not in this PR

Two adjacent by-path `chmod` calls deserve their own review and are untouched here. `dirMode` is applied via `chmod(dir, dirMode)` after a recursive `mkdir` that may return a pre-existing directory, so an attacker controlling the destination's **parent** could redirect it — a stronger prerequisite than this issue. And `movePathWithCopyFallback` chmods randomized staging paths before publication; the names are unpredictable but visible to anyone who can list the writable target directory.
