### PR TITLE
fix(move): bind staging modes to descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Security and Correctness
 
+- Apply `movePathWithCopyFallback()` file and POSIX directory modes through staging descriptors before publication, so a replaceable staging pathname cannot redirect `chmod` to an unrelated symlink target. Windows no longer uses a pathname fallback for directory modes because Node cannot portably open a directory descriptor there and does not enforce POSIX modes.
+
 - Reject drive-relative segments such as `C:secret.txt` and `a/C:b` in portable relative-path parsing and every `FileStore` key, and reject leading drive-relative spellings on `Root` destinations and `resolve()` with `invalid-path`. Existing-object Root operations, including reads, inspection, removal, and the source of `move()`, continue to accept legal POSIX filenames such as `c:notes.txt`; thanks @Yigtwxx for the fix.
 
 - Apply atomic-replacement parent-directory modes through verified no-follow descriptors on POSIX, so a directory-entry swap cannot redirect `chmod` through a symlink to an unrelated directory. Windows keeps its explicit `mkdir(mode)`-only behavior because Node does not enforce POSIX directory modes there.

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -169,6 +169,24 @@ function regularReadFlags(): number {
   );
 }
 
+async function chmodDirectoryPinned(directoryPath: string, mode: number): Promise<void> {
+  if (process.platform === "win32") {
+    // Node cannot portably open a Windows directory for descriptor-bound
+    // chmod. POSIX modes are not enforced there, so do not fall back to a
+    // pathname operation that could follow a replacement symlink.
+    return;
+  }
+  const handle = await fs.open(
+    directoryPath,
+    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+  );
+  try {
+    await handle.chmod(mode);
+  } finally {
+    await handle.close();
+  }
+}
+
 async function writeAll(handle: FileHandle, buffer: Buffer, bytesRead: number): Promise<void> {
   let offset = 0;
   while (offset < bytesRead) {
@@ -219,20 +237,19 @@ async function copyRegularFilePinned(params: {
         }
         await writeAll(destinationHandle, scratch, bytesRead);
       }
+      // Re-check the opened source before the staged tree can be committed. If
+      // it changed while we copied, the caller should retry the move.
+      const finalSourceStat = await sourceHandle.stat();
+      if (params.rejectHardlinks && finalSourceStat.nlink > 1) {
+        throw hardlinkedSourceError(params.from);
+      }
+      if (!sameIdentity(params.identity, entryIdentity(finalSourceStat))) {
+        throw sourceChangedError(params.from);
+      }
+      await destinationHandle.chmod(modeBits(params.mode)).catch(() => undefined);
     } finally {
       await destinationHandle.close();
     }
-
-    // Re-check the opened handle before the staged tree can be committed. If
-    // the source changed while we copied, the caller should retry the move.
-    const finalSourceStat = await sourceHandle.stat();
-    if (params.rejectHardlinks && finalSourceStat.nlink > 1) {
-      throw hardlinkedSourceError(params.from);
-    }
-    if (!sameIdentity(params.identity, entryIdentity(finalSourceStat))) {
-      throw sourceChangedError(params.from);
-    }
-    await fs.chmod(params.to, modeBits(params.mode)).catch(() => undefined);
   } catch (error) {
     if (destinationCreated) {
       await fs.rm(params.to, { force: true }).catch(() => undefined);
@@ -284,7 +301,7 @@ async function copyEntryWithManifest(
     await assertSourceStillMatches(from, identity);
     // mkdir() honors process umask. Restore the source mode before commit so
     // EXDEV fallback preserves directory permissions like fs.cp did.
-    await fs.chmod(to, modeBits(sourceStat.mode));
+    await chmodDirectoryPinned(to, modeBits(sourceStat.mode));
     return { ...identity, children, kind: "directory" };
   }
 

--- a/test/move-path-fchmod-regression.test.ts
+++ b/test/move-path-fchmod-regression.test.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { movePathWithCopyFallback } from "../src/move-path.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function installStagingModeSwap(params: {
+  targetDir: string;
+  victimPath: string;
+  symlinkType: "dir" | "file";
+}): Promise<() => number> {
+  const probePath = path.join(params.targetDir, "handle-probe");
+  const probe = await fs.open(probePath, "w");
+  const handlePrototype = Object.getPrototypeOf(probe) as {
+    chmod(mode: number): Promise<void>;
+  };
+  const realHandleChmod = handlePrototype.chmod;
+  await probe.close();
+  await fs.unlink(probePath);
+
+  const realPathChmod = fs.chmod;
+  let swaps = 0;
+
+  const findStagingPath = async (): Promise<string> => {
+    const name = (await fs.readdir(params.targetDir)).find(
+      (entry) => entry.startsWith(".fs-safe-move-") && entry.endsWith(".tmp"),
+    );
+    if (!name) {
+      throw new Error("move staging entry not found");
+    }
+    return path.join(params.targetDir, name);
+  };
+
+  const swapAround = async (stagingPath: string, applyMode: () => Promise<void>) => {
+    swaps += 1;
+    const parkedPath = `${stagingPath}.parked`;
+    await fs.rename(stagingPath, parkedPath);
+    await fs.symlink(params.victimPath, stagingPath, params.symlinkType);
+    try {
+      await applyMode();
+    } finally {
+      await fs.unlink(stagingPath);
+      await fs.rename(parkedPath, stagingPath);
+    }
+  };
+
+  vi.spyOn(fs, "chmod").mockImplementation(async (candidate, mode) => {
+    const candidatePath = String(candidate);
+    if (!path.basename(candidatePath).startsWith(".fs-safe-move-")) {
+      await realPathChmod(candidate, mode);
+      return;
+    }
+    await swapAround(candidatePath, async () => await realPathChmod(candidate, mode));
+  });
+  vi.spyOn(handlePrototype, "chmod").mockImplementation(async function (mode) {
+    const stagingPath = await findStagingPath();
+    await swapAround(stagingPath, async () => await realHandleChmod.call(this, mode));
+  });
+
+  return () => swaps;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
+});
+
+describe.runIf(process.platform !== "win32")("move staging descriptor modes", () => {
+  it("does not redirect a staged file mode through a swapped symlink", async () => {
+    const sourceDir = await tempRoot("fs-safe-move-file-source-");
+    const targetDir = await tempRoot("fs-safe-move-file-target-");
+    const victimDir = await tempRoot("fs-safe-move-file-victim-");
+    const sourcePath = path.join(sourceDir, "source.txt");
+    const targetPath = path.join(targetDir, "target.txt");
+    const victimPath = path.join(victimDir, "victim.txt");
+    await fs.writeFile(sourcePath, "source");
+    await fs.chmod(sourcePath, 0o666);
+    await fs.writeFile(victimPath, "victim");
+    await fs.chmod(victimPath, 0o644);
+    const swaps = await installStagingModeSwap({
+      targetDir,
+      victimPath,
+      symlinkType: "file",
+    });
+
+    const previousUmask = process.umask(0o077);
+    try {
+      await movePathWithCopyFallback({
+        from: sourcePath,
+        sourceHardlinks: "reject",
+        to: targetPath,
+      });
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    expect({
+      publishedMode: (await fs.stat(targetPath)).mode & 0o777,
+      swaps: swaps(),
+      victimMode: (await fs.stat(victimPath)).mode & 0o777,
+    }).toEqual({ publishedMode: 0o666, swaps: 1, victimMode: 0o644 });
+  });
+
+  it("does not redirect a staged directory mode through a swapped symlink", async () => {
+    const sourceParent = await tempRoot("fs-safe-move-dir-source-");
+    const targetDir = await tempRoot("fs-safe-move-dir-target-");
+    const victimParent = await tempRoot("fs-safe-move-dir-victim-");
+    const sourcePath = path.join(sourceParent, "source");
+    const targetPath = path.join(targetDir, "target");
+    const victimPath = path.join(victimParent, "victim");
+    await fs.mkdir(sourcePath, { mode: 0o777 });
+    await fs.chmod(sourcePath, 0o777);
+    await fs.mkdir(victimPath, { mode: 0o755 });
+    await fs.chmod(victimPath, 0o755);
+    const swaps = await installStagingModeSwap({
+      targetDir,
+      victimPath,
+      symlinkType: "dir",
+    });
+
+    const previousUmask = process.umask(0o077);
+    try {
+      await movePathWithCopyFallback({
+        from: sourcePath,
+        sourceHardlinks: "reject",
+        to: targetPath,
+      });
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    expect({
+      publishedMode: (await fs.stat(targetPath)).mode & 0o777,
+      swaps: swaps(),
+      victimMode: (await fs.stat(victimPath)).mode & 0o777,
+    }).toEqual({ publishedMode: 0o777, swaps: 1, victimMode: 0o755 });
+  });
+});


### PR DESCRIPTION
## Summary

- apply copied-file modes through the still-open staging descriptor
- apply POSIX directory modes through a no-follow directory descriptor and avoid a pathname fallback on Windows
- add deterministic real-filesystem regressions that swap each staging entry at the mode boundary under a restrictive umask

## Proof

- `pnpm check`
- `pnpm test:security`
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings

The regression demonstrates the old behavior redirecting the requested mode to an unrelated symlink target while leaving the published entry umask-clamped. With this patch, the same swap occurs once, the unrelated target remains unchanged, and the requested mode lands on the real published file or directory.
