### PR TITLE
fix(atomic): bind directory modes to descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Apply atomic-replacement parent-directory modes through verified no-follow descriptors on POSIX, so a directory-entry swap cannot redirect `chmod` through a symlink to an unrelated directory. Windows keeps its explicit `mkdir(mode)`-only behavior because Node does not enforce POSIX directory modes there.
 - Retry a contended file-lock acquisition when Windows denies access to a lock file whose directory entry is still being torn down, including when the native binding performs the exclusive create. Both the exclusive create and the holder's snapshot read reported that transient `EPERM` as a hard failure, so concurrent `acquireFileLock()` calls failed intermittently on Windows even though the very next attempt would have succeeded. Retries stay bounded, so a genuine permission denial still surfaces as `EPERM` rather than a lock timeout; thanks @Yigtwxx for the fix.
 - Apply `replaceFileAtomic()` and `replaceFileAtomicSync()` modes through pinned temp-file descriptors before rename, and through pinned copy-fallback descriptors, so a post-rename symlink swap cannot redirect `chmod` to an unrelated file while exact modes remain independent of umask; thanks @yetval for reporting this (#86).
 - Bound fallback Windows owner and ACL command execution to 10 seconds per process and report owner-query failures as unverified instead of returning a partial permission classification; thanks @Yigtwxx for the diagnosis.
@@ -13,7 +14,7 @@
 ### Compatibility
 
 - Report access-denied failures from native Windows operations as `EPERM` rather than `EACCES`, matching Node/libuv and the JavaScript fallback. Consumers that matched the previous native-only `EACCES` code should accept `EPERM` as well when supporting older package versions.
-- Add an optional `fchmodSync` operation to the injectable synchronous atomic-replacement filesystem type. Async adapters need no new member because their required `open()` returns a mode-capable `FileHandle`; custom sync adapters that pass `mode` or `preserveExistingMode` now fail before mutation when `fchmodSync` is absent, while adapters that request neither option remain compatible.
+- Add an optional `fchmodSync` operation to the injectable synchronous atomic-replacement filesystem type. Async adapters need no new member because their required `open()` returns a mode-capable `FileHandle`; custom sync adapters that pass `mode`, `dirMode`, or `preserveExistingMode` now fail before mutation when `fchmodSync` is absent, while plain `node:fs` injection and adapters that request none of those options remain compatible.
 - Classify `not-found`, `not-empty` and `not-removable` as operational rather than policy errors, so `FsSafeError.category` no longer reports routine filesystem outcomes as safety-policy rejections.
 
 ### Features

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -14,7 +14,9 @@ import {
 
 ## `replaceFileAtomic` / `replaceFileAtomicSync`
 
-Write `content` to a sibling temp file in the destination directory, apply the final mode through its still-open descriptor, optionally `fsync` that descriptor, optionally `fsync` the parent directory after rename, then atomically rename over the destination. No permission change follows the caller-supplied destination path after publication.
+Write `content` to a sibling temp file in the destination directory, apply the parent-directory and final file modes through verified descriptors, optionally `fsync` the file descriptor, optionally `fsync` the parent directory after rename, then atomically rename over the destination. No permission change follows a caller-supplied pathname.
+
+On POSIX, the parent is opened with no-follow and directory-only flags, checked against its pre-open identity, and mode-adjusted through that descriptor. A replacement symlink is rejected rather than followed. If the directory cannot be opened for descriptor access, the operation fails closed instead of retrying by pathname. Windows does not enforce POSIX directory modes and Node cannot consistently open directory descriptors there, so `dirMode` is passed only to `mkdir`; no pathname `chmod` fallback is attempted.
 
 Async replacements to the same destination are serialized inside the current process, so two overlapping `replaceFileAtomic()` calls do not interleave their temp-write/rename phases. Use a sidecar lock when multiple processes may write the same target.
 
@@ -36,7 +38,7 @@ await replaceFileAtomic({
 type ReplaceFileAtomicOptions = {
   filePath: string;                 // destination
   content: string | Uint8Array;
-  dirMode?: number;                 // mode for parent dirs created by the helper
+  dirMode?: number;                 // parent-directory mode (POSIX; default 0o700)
   mode?: number;                    // explicit mode for the new file (e.g. 0o600)
   preserveExistingMode?: boolean;   // copy mode from existing destination, when present
   tempPrefix?: string;
@@ -212,7 +214,7 @@ await replaceFileAtomic({
 });
 ```
 
-The synchronous injectable interface adds one optional descriptor-mode operation:
+The synchronous injectable interface has one optional descriptor-mode operation:
 
 ```ts
 type ReplaceFileAtomicSyncFileSystem = {
@@ -221,7 +223,7 @@ type ReplaceFileAtomicSyncFileSystem = {
 };
 ```
 
-The async interface already requires `open()`, whose `FileHandle` supplies `chmod()`, so injecting `node:fs` or another conforming adapter needs no new async member. A custom synchronous filesystem that passes `mode` or `preserveExistingMode` must supply `fchmodSync`; omission fails before any file is created and never falls back to `chmod(destination)`. Existing synchronous adapters that request neither option may omit it. Copy fallback applies the mode through its pinned destination descriptor as well, preserving exact modes despite the process umask.
+The async interface already requires `open()`, whose `FileHandle` supplies `chmod()`, so injecting `node:fs` or another conforming adapter needs no new async member. On POSIX, that `open()` must support no-follow directory descriptors as Node does. A custom synchronous filesystem that passes `mode`, `dirMode`, or `preserveExistingMode` must supply `fchmodSync`; omission fails before any file or directory is created and never falls back to a pathname `chmod`. Existing synchronous adapters that request none of those options may omit it. Injecting plain `node:fs` supports explicit file and directory modes. Copy fallback applies the file mode through its pinned destination descriptor as well, preserving exact modes despite the process umask.
 
 ## See also
 

--- a/src/replace-file-descriptor.ts
+++ b/src/replace-file-descriptor.ts
@@ -1,13 +1,84 @@
 import syncFs, { type Stats } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
+import { FsSafeError } from "./errors.js";
+import { sameFileIdentity } from "./file-identity.js";
 
-type AsyncTempFileSystem = Pick<typeof fs, "open" | "writeFile">;
+type AsyncTempFileSystem = Pick<typeof fs, "lstat" | "open" | "writeFile">;
 type SyncTempFileSystem = Pick<
   typeof syncFs,
-  "closeSync" | "fstatSync" | "fsyncSync" | "openSync" | "writeFileSync"
+  "closeSync" | "fstatSync" | "fsyncSync" | "lstatSync" | "openSync" | "writeFileSync"
 >;
 
 export type SyncFchmod = (fd: number, mode: number) => void;
+
+function directoryOpenFlags(): number {
+  return (
+    syncFs.constants.O_RDONLY |
+    syncFs.constants.O_DIRECTORY |
+    syncFs.constants.O_NOFOLLOW |
+    syncFs.constants.O_NONBLOCK
+  );
+}
+
+function assertDirectory(identity: Stats, dirPath: string): void {
+  if (identity.isSymbolicLink() || !identity.isDirectory()) {
+    throw new FsSafeError("not-file", `Atomic replace parent must be a real directory: ${dirPath}`);
+  }
+}
+
+function assertSameDirectory(expected: Stats, opened: Stats, dirPath: string): void {
+  assertDirectory(opened, dirPath);
+  if (!sameFileIdentity(expected, opened)) {
+    throw new FsSafeError(
+      "path-mismatch",
+      `Atomic replace parent changed before its mode could be applied: ${dirPath}`,
+    );
+  }
+}
+
+export async function applyDirectoryMode(params: {
+  fsModule: AsyncTempFileSystem;
+  dirPath: string;
+  mode: number;
+}): Promise<void> {
+  // Node does not enforce POSIX directory modes on Windows, and its directory
+  // descriptors are not consistently openable. mkdir(mode) remains the only
+  // bounded behavior there; never fall back to a pathname chmod.
+  if (process.platform === "win32") {
+    return;
+  }
+
+  const expected = await params.fsModule.lstat(params.dirPath);
+  assertDirectory(expected, params.dirPath);
+  const handle = await params.fsModule.open(params.dirPath, directoryOpenFlags());
+  try {
+    assertSameDirectory(expected, await handle.stat(), params.dirPath);
+    await handle.chmod(params.mode);
+  } finally {
+    await handle.close();
+  }
+}
+
+export function applyDirectoryModeSync(params: {
+  fsModule: SyncTempFileSystem;
+  dirPath: string;
+  mode: number;
+  fchmodSync?: SyncFchmod;
+}): void {
+  if (process.platform === "win32" || !params.fchmodSync) {
+    return;
+  }
+
+  const expected = params.fsModule.lstatSync(params.dirPath);
+  assertDirectory(expected, params.dirPath);
+  const fd = params.fsModule.openSync(params.dirPath, directoryOpenFlags());
+  try {
+    assertSameDirectory(expected, params.fsModule.fstatSync(fd), params.dirPath);
+    params.fchmodSync(fd, params.mode);
+  } finally {
+    params.fsModule.closeSync(fd);
+  }
+}
 
 export async function writeTempFile(params: {
   fsModule: AsyncTempFileSystem;

--- a/src/replace-file.ts
+++ b/src/replace-file.ts
@@ -14,6 +14,8 @@ import {
   type ReplaceFileDestinationHardlinkPolicy,
 } from "./replace-file-copy-fallback.js";
 import {
+  applyDirectoryMode,
+  applyDirectoryModeSync,
   type SyncFchmod,
   writeTempFile,
   writeTempFileSync,
@@ -26,7 +28,6 @@ export type ReplaceFileAtomicFileSystem = {
   promises: Pick<
     typeof fs,
     | "mkdir"
-    | "chmod"
     | "writeFile"
     | "rename"
     | "copyFile"
@@ -41,7 +42,6 @@ export type ReplaceFileAtomicFileSystem = {
 export type ReplaceFileAtomicSyncFileSystem = Pick<
   typeof syncFs,
   | "mkdirSync"
-  | "chmodSync"
   | "readFileSync"
   | "writeFileSync"
   | "renameSync"
@@ -251,7 +251,7 @@ function resolveModeSync(options: ReplaceFileAtomicSyncOptions): number {
 
 function missingFchmodSyncError(): TypeError {
   return new TypeError(
-    "fileSystem.fchmodSync is required when mode or preserveExistingMode is specified",
+    "fileSystem.fchmodSync is required when mode, dirMode, or preserveExistingMode is specified",
   );
 }
 
@@ -332,7 +332,7 @@ async function replaceFileAtomicUnserialized(
   let tempExists = false;
   let originalError: unknown;
   await fsModule.mkdir(dir, { recursive: true, mode: dirMode });
-  await fsModule.chmod(dir, dirMode).catch(() => undefined);
+  await applyDirectoryMode({ fsModule, dirPath: dir, mode: dirMode });
   try {
     tempExists = true;
     unregisterTempPath.setIdentity(await writeTempFile({
@@ -392,7 +392,12 @@ export function replaceFileAtomicSync(
   const fchmodSync = options.fileSystem?.fchmodSync ?? (
     options.fileSystem === undefined ? syncFs.fchmodSync : undefined
   );
-  if (!fchmodSync && (options.mode !== undefined || options.preserveExistingMode === true)) {
+  if (
+    !fchmodSync &&
+    (options.mode !== undefined ||
+      options.preserveExistingMode === true ||
+      (process.platform !== "win32" && options.dirMode !== undefined))
+  ) {
     throw missingFchmodSyncError();
   }
   const tempPath = buildReplaceTempPath(filePath, options.tempPrefix);
@@ -400,11 +405,7 @@ export function replaceFileAtomicSync(
   let tempExists = false;
   let originalError: unknown;
   fsModule.mkdirSync(dir, { recursive: true, mode: dirMode });
-  try {
-    fsModule.chmodSync(dir, dirMode);
-  } catch {
-    // Best-effort on platforms that do not enforce POSIX modes.
-  }
+  applyDirectoryModeSync({ fsModule, dirPath: dir, mode: dirMode, fchmodSync });
   try {
     tempExists = true;
     unregisterTempPath.setIdentity(writeTempFileSync({

--- a/test/atomic-dirmode-regression.test.ts
+++ b/test/atomic-dirmode-regression.test.ts
@@ -1,0 +1,209 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { replaceFileAtomic, replaceFileAtomicSync } from "../src/atomic.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function isDirectoryOpen(flags: string | number): boolean {
+  return typeof flags === "number" && (flags & fsSync.constants.O_DIRECTORY) !== 0;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
+});
+
+describe("atomic parent-directory descriptor modes", () => {
+  it.runIf(process.platform !== "win32")(
+    "keeps an async directory mode bound to the opened directory across a pathname swap",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-dirmode-race-");
+      const targetDir = path.join(root, "target");
+      const displacedDir = path.join(root, "displaced");
+      const victimDir = path.join(root, "victim");
+      const filePath = path.join(targetDir, "state.txt");
+      await Promise.all([fs.mkdir(targetDir), fs.mkdir(victimDir)]);
+      await Promise.all([fs.chmod(targetDir, 0o755), fs.chmod(victimDir, 0o755)]);
+      let swapped = false;
+
+      const swap = async () => {
+        await fs.rename(targetDir, displacedDir);
+        await fs.symlink(victimDir, targetDir, "dir");
+        swapped = true;
+      };
+      const restore = async () => {
+        await fs.unlink(targetDir);
+        await fs.rename(displacedDir, targetDir);
+        swapped = false;
+      };
+      const injectedPromises = {
+        ...fs,
+        chmod: async (candidate: fsSync.PathLike, mode: fsSync.Mode) => {
+          if (!swapped && path.resolve(String(candidate)) === targetDir) {
+            await swap();
+          }
+          await fs.chmod(candidate, mode);
+        },
+        open: (async (...args: Parameters<typeof fs.open>) => {
+          const [candidate, flags] = args;
+          if (swapped && flags === "wx") {
+            await restore();
+          }
+          const handle = await fs.open(...args);
+          if (
+            !swapped &&
+            path.resolve(String(candidate)) === targetDir &&
+            isDirectoryOpen(flags)
+          ) {
+            await swap();
+          }
+          return handle;
+        }) as typeof fs.open,
+      };
+
+      const previousUmask = process.umask(0o077);
+      try {
+        await replaceFileAtomic({
+          filePath,
+          content: "async",
+          dirMode: 0o751,
+          fileSystem: { promises: injectedPromises },
+        });
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      expect({
+        targetMode: (await fs.stat(targetDir)).mode & 0o777,
+        victimMode: (await fs.stat(victimDir)).mode & 0o777,
+        content: await fs.readFile(filePath, "utf8"),
+      }).toEqual({ targetMode: 0o751, victimMode: 0o755, content: "async" });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps a sync directory mode bound to the opened directory across a pathname swap",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-dirmode-race-sync-");
+      const targetDir = path.join(root, "target");
+      const displacedDir = path.join(root, "displaced");
+      const victimDir = path.join(root, "victim");
+      const filePath = path.join(targetDir, "state.txt");
+      fsSync.mkdirSync(targetDir);
+      fsSync.mkdirSync(victimDir);
+      fsSync.chmodSync(targetDir, 0o755);
+      fsSync.chmodSync(victimDir, 0o755);
+      let swapped = false;
+
+      const swap = () => {
+        fsSync.renameSync(targetDir, displacedDir);
+        fsSync.symlinkSync(victimDir, targetDir, "dir");
+        swapped = true;
+      };
+      const restore = () => {
+        fsSync.unlinkSync(targetDir);
+        fsSync.renameSync(displacedDir, targetDir);
+        swapped = false;
+      };
+      const injectedFileSystem = {
+        ...fsSync,
+        chmodSync: ((candidate: fsSync.PathLike, mode: fsSync.Mode) => {
+          if (!swapped && path.resolve(String(candidate)) === targetDir) {
+            swap();
+          }
+          fsSync.chmodSync(candidate, mode);
+        }) as typeof fsSync.chmodSync,
+        openSync: ((candidate, flags, mode) => {
+          if (swapped && flags === "wx") {
+            restore();
+          }
+          const fd = fsSync.openSync(candidate, flags, mode);
+          if (
+            !swapped &&
+            path.resolve(String(candidate)) === targetDir &&
+            isDirectoryOpen(flags)
+          ) {
+            swap();
+          }
+          return fd;
+        }) as typeof fsSync.openSync,
+      };
+
+      const previousUmask = process.umask(0o077);
+      try {
+        replaceFileAtomicSync({
+          filePath,
+          content: "sync",
+          dirMode: 0o751,
+          fileSystem: injectedFileSystem,
+        });
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      expect({
+        targetMode: fsSync.statSync(targetDir).mode & 0o777,
+        victimMode: fsSync.statSync(victimDir).mode & 0o777,
+        content: fsSync.readFileSync(filePath, "utf8"),
+      }).toEqual({ targetMode: 0o751, victimMode: 0o755, content: "sync" });
+    },
+  );
+
+  it("accepts plain node:fs injection with explicit async and sync dirMode", async () => {
+    const root = await tempRoot("fs-safe-atomic-dirmode-node-fs-");
+    const asyncDir = path.join(root, "async");
+    const syncDir = path.join(root, "sync");
+    const asyncPath = path.join(asyncDir, "state.txt");
+    const syncPath = path.join(syncDir, "state.txt");
+
+    const previousUmask = process.umask(0o077);
+    try {
+      await replaceFileAtomic({
+        filePath: asyncPath,
+        content: "async",
+        dirMode: 0o751,
+        fileSystem: fsSync,
+      });
+      replaceFileAtomicSync({
+        filePath: syncPath,
+        content: "sync",
+        dirMode: 0o751,
+        fileSystem: fsSync,
+      });
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    await expect(fs.readFile(asyncPath, "utf8")).resolves.toBe("async");
+    expect(fsSync.readFileSync(syncPath, "utf8")).toBe("sync");
+    if (process.platform !== "win32") {
+      expect((await fs.stat(asyncDir)).mode & 0o777).toBe(0o751);
+      expect(fsSync.statSync(syncDir).mode & 0o777).toBe(0o751);
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "fails before mutation when an injected sync filesystem cannot honor dirMode",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-dirmode-fchmod-missing-");
+      const filePath = path.join(root, "missing", "state.txt");
+      const { fchmodSync: _fchmodSync, ...syncWithoutFchmod } = fsSync;
+
+      expect(() => replaceFileAtomicSync({
+        filePath,
+        content: "sync",
+        dirMode: 0o751,
+        fileSystem: syncWithoutFchmod,
+      })).toThrow("fileSystem.fchmodSync is required");
+      await expect(fs.access(path.dirname(filePath))).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+});

--- a/test/atomic-fchmod-regression.test.ts
+++ b/test/atomic-fchmod-regression.test.ts
@@ -59,7 +59,7 @@ describe("atomic descriptor modes", () => {
         chmodPaths,
         publishedMode,
         victimMode: (await fs.stat(victimPath)).mode & 0o777,
-      }).toEqual({ chmodPaths: [root], publishedMode: 0o600, victimMode: 0o644 });
+      }).toEqual({ chmodPaths: [], publishedMode: 0o600, victimMode: 0o644 });
     },
   );
 
@@ -98,7 +98,7 @@ describe("atomic descriptor modes", () => {
         chmodPaths,
         publishedMode,
         victimMode: fsSync.statSync(victimPath).mode & 0o777,
-      }).toEqual({ chmodPaths: [root], publishedMode: 0o600, victimMode: 0o644 });
+      }).toEqual({ chmodPaths: [], publishedMode: 0o600, victimMode: 0o644 });
     },
   );
 


### PR DESCRIPTION
## Summary

- apply `dirMode` through verified, no-follow directory descriptors on POSIX
- remove the remaining pathname `chmod` / `chmodSync` calls from atomic replacement
- preserve plain `node:fs` injection and reuse the existing optional `fchmodSync` sync capability
- document the fail-closed POSIX open behavior and bounded Windows `mkdir(mode)` behavior

## Security impact

The previous pathname chmod could be redirected through a symlink when an attacker could rename entries in the destination directory's parent. That prerequisite is stronger than write access inside the destination directory and, on sticky directories, also depends on ownership or equivalent privilege. The caller must additionally have chmod authority over the unrelated symlink target.

The regression swaps the directory entry at the mode-application boundary with real syscalls under umask `0077`. On `origin/main`, both async and sync paths leave the requested directory at `0755` and change the unrelated directory to `0751`. This branch leaves the unrelated directory at `0755` and applies `0751` to the opened real target.

Windows does not enforce POSIX directory modes and Node cannot consistently open directory descriptors there. The implementation therefore keeps mode passing on `mkdir` but does not make a vulnerable pathname fallback.

## Verification

- `pnpm check` (679 passed, 32 skipped)
- `pnpm test:security` (64 passed)
- focused descriptor-mode regressions (10 passed)
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings
