### PR TITLE
test(api): guard public export surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "native:build": "pnpm --filter @openclaw/fs-safe-native-build build",
     "native:test": "cargo test --manifest-path native/Cargo.toml",
     "pack:check": "pnpm build && node scripts/check-pack.mjs",
+    "public-api:update": "pnpm build && node scripts/check-pack.mjs --update-public-api",
     "package:smoke": "node scripts/check-release-packages.mjs --allow-host-only --output release-artifacts",
     "check:changed": "pnpm run check",
     "release:notes": "node scripts/release-notes.mjs",

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -9,6 +9,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
+import {
+  assertPublicApi,
+  inspectPublicApi,
+  writePublicApiManifest,
+} from "./public-api-surface.mjs";
 
 const workdir = mkdtempSync(join(tmpdir(), "fs-safe-pack-"));
 const npmCommand = resolveNpmCli();
@@ -117,6 +122,16 @@ try {
     ],
     { cwd: workdir, stdio: "pipe" },
   );
+  const publicApi = inspectPublicApi({
+    packageName: pkg.name,
+    packageSubpaths: Object.keys(pkg.exports),
+    workdir,
+  });
+  if (process.argv.includes("--update-public-api")) {
+    writePublicApiManifest(publicApi);
+  } else {
+    assertPublicApi(publicApi);
+  }
 } finally {
   rmSync(workdir, { force: true, recursive: true });
 }

--- a/scripts/public-api-surface.mjs
+++ b/scripts/public-api-surface.mjs
@@ -1,0 +1,200 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { isImportDeclaration } from "typescript/unstable/ast";
+import {
+  API,
+  SymbolFlags,
+  isStringLiteralType,
+  isUnionType,
+} from "typescript/unstable/sync";
+
+const MANIFEST_PATH = "test/public-api.json";
+
+/**
+ * @param {{ packageName: string; packageSubpaths: string[]; workdir: string }} options
+ */
+export function inspectPublicApi(options) {
+  const importableSubpaths = options.packageSubpaths.filter(
+    (subpath) => subpath !== "./package.json",
+  );
+  const specifiers = importableSubpaths.map((subpath) =>
+    subpath === "." ? options.packageName : `${options.packageName}/${subpath.slice(2)}`,
+  );
+  const runtime = inspectRuntimeExports(options.workdir, importableSubpaths, specifiers);
+  const declarations = inspectDeclarationExports(options.workdir, importableSubpaths, specifiers);
+  const packageSubpaths = Object.fromEntries(
+    options.packageSubpaths.map((subpath) => {
+      if (subpath === "./package.json") return [subpath, { kind: "json" }];
+      return [
+        subpath,
+        {
+          runtime: runtime[subpath],
+          types: declarations[subpath].types,
+          errorCodes: declarations[subpath].errorCodes,
+        },
+      ];
+    }),
+  );
+  return { packageSubpaths };
+}
+
+/**
+ * @param {string} workdir
+ * @param {string[]} subpaths
+ * @param {string[]} specifiers
+ */
+function inspectRuntimeExports(workdir, subpaths, specifiers) {
+  const script = `
+    const subpaths = ${JSON.stringify(subpaths)};
+    const specifiers = ${JSON.stringify(specifiers)};
+    const surface = {};
+    for (let index = 0; index < specifiers.length; index += 1) {
+      surface[subpaths[index]] = Object.keys(await import(specifiers[index])).sort();
+    }
+    process.stdout.write(JSON.stringify(surface));
+  `;
+  return JSON.parse(
+    execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
+      cwd: workdir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  );
+}
+
+/**
+ * @param {string} workdir
+ * @param {string[]} subpaths
+ * @param {string[]} specifiers
+ */
+function inspectDeclarationExports(workdir, subpaths, specifiers) {
+  const probePath = join(workdir, "public-api-surface.ts");
+  writeFileSync(
+    probePath,
+    specifiers
+      .map((specifier, index) => `import type * as surface${index} from ${JSON.stringify(specifier)};`)
+      .join("\n"),
+  );
+  const api = new API({ cwd: workdir });
+  const snapshot = api.updateSnapshot({ openFiles: [probePath] });
+  try {
+    const project = snapshot.getDefaultProjectForFile(probePath);
+    const source = project?.program.getSourceFile(probePath);
+    if (!project || !source) throw new Error("could not create the public API declaration probe");
+    const imports = source.statements.filter(isImportDeclaration);
+    const checker = project.checker;
+
+    return Object.fromEntries(imports.map((declaration, index) => {
+      const moduleSymbol = checker.getSymbolAtLocation(declaration.moduleSpecifier);
+      if (!moduleSymbol) {
+        throw new Error(`could not resolve declarations for ${specifiers[index]}`);
+      }
+      const types = [];
+      const errorCodes = {};
+      for (const exportedSymbol of checker.getExportsOfModule(moduleSymbol)) {
+        const symbol =
+          exportedSymbol.flags & SymbolFlags.Alias
+            ? checker.getAliasedSymbol(exportedSymbol)
+            : exportedSymbol;
+        if (!(symbol.flags & SymbolFlags.Type)) continue;
+        const name = exportedSymbol.name;
+        types.push(name);
+        if (!name.endsWith("ErrorCode")) continue;
+        const declaredType = checker.getDeclaredTypeOfSymbol(symbol);
+        const members = isUnionType(declaredType) ? declaredType.getTypes() : [declaredType];
+        if (members.every(isStringLiteralType)) {
+          errorCodes[name] = members.map((member) => member.value).sort();
+        }
+      }
+      return [
+        subpaths[index],
+        {
+          types: types.sort(),
+          errorCodes: Object.fromEntries(
+            Object.entries(errorCodes).sort(([left], [right]) =>
+              left < right ? -1 : left > right ? 1 : 0,
+            ),
+          ),
+        },
+      ];
+    }));
+  } finally {
+    snapshot.dispose();
+    api.close();
+  }
+}
+
+/**
+ * @param {ReturnType<typeof inspectPublicApi>} actual
+ */
+export function assertPublicApi(actual) {
+  const expected = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+  const failures = [];
+  compareNames(
+    failures,
+    "package subpath",
+    "package.json exports",
+    Object.keys(expected.packageSubpaths),
+    Object.keys(actual.packageSubpaths),
+  );
+
+  for (const subpath of Object.keys(actual.packageSubpaths)) {
+    const expectedEntry = expected.packageSubpaths[subpath];
+    const actualEntry = actual.packageSubpaths[subpath];
+    if (!expectedEntry || expectedEntry.kind === "json" || actualEntry.kind === "json") continue;
+    compareNames(failures, "runtime export", subpath, expectedEntry.runtime, actualEntry.runtime);
+    compareNames(failures, "type export", subpath, expectedEntry.types, actualEntry.types);
+    const sharedErrorCodeTypes = Object.keys(expectedEntry.errorCodes).filter((typeName) =>
+      Object.hasOwn(actualEntry.errorCodes, typeName),
+    );
+    for (const typeName of sharedErrorCodeTypes) {
+      compareNames(
+        failures,
+        `error code in ${typeName}`,
+        subpath,
+        expectedEntry.errorCodes[typeName] ?? [],
+        actualEntry.errorCodes[typeName] ?? [],
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      [
+        "Public API surface changed:",
+        ...failures.map((failure) => `- ${failure}`),
+        "Remove accidental changes. If every change is deliberate, run `pnpm public-api:update` and review test/public-api.json before committing it.",
+      ].join("\n"),
+    );
+  }
+}
+
+/**
+ * @param {string[]} failures
+ * @param {string} kind
+ * @param {string} location
+ * @param {string[]} expected
+ * @param {string[]} actual
+ */
+function compareNames(failures, kind, location, expected, actual) {
+  const expectedNames = new Set(expected);
+  const actualNames = new Set(actual);
+  for (const name of actualNames) {
+    if (!expectedNames.has(name)) {
+      failures.push(`${kind} appeared at ${location}: ${name} (the public API widened)`);
+    }
+  }
+  for (const name of expectedNames) {
+    if (!actualNames.has(name)) {
+      failures.push(`${kind} vanished from ${location}: ${name} (existing consumers may break)`);
+    }
+  }
+}
+
+/**
+ * @param {ReturnType<typeof inspectPublicApi>} surface
+ */
+export function writePublicApiManifest(surface) {
+  writeFileSync(MANIFEST_PATH, `${JSON.stringify(surface, null, 2)}\n`);
+}

--- a/test/public-api.json
+++ b/test/public-api.json
@@ -1,0 +1,669 @@
+{
+  "packageSubpaths": {
+    ".": {
+      "runtime": [
+        "DEFAULT_ROOT_MAX_BYTES",
+        "FsSafeError",
+        "categorizeFsSafeError",
+        "configureFsSafeLocks",
+        "configureFsSafeNative",
+        "configureFsSafePython",
+        "getFsSafeLockConfig",
+        "getFsSafeNativeConfig",
+        "root",
+        "writeExternalFileWithinRoot"
+      ],
+      "types": [
+        "ContainmentGuarantee",
+        "DenyMutationPolicy",
+        "ExternalFileWriteOptions",
+        "ExternalFileWriteResult",
+        "FsSafeError",
+        "FsSafeErrorCategory",
+        "FsSafeErrorCode",
+        "FsSafeErrorDetails",
+        "FsSafeLockConfig",
+        "FsSafeNativeConfig",
+        "FsSafeNativeMode",
+        "FsSafePythonConfig",
+        "HardlinkPolicy",
+        "OpenResult",
+        "ReadResult",
+        "RenameIdentityPolicy",
+        "Root",
+        "RootAppendOptions",
+        "RootCopyOptions",
+        "RootCreateJsonOptions",
+        "RootCreateOptions",
+        "RootDefaults",
+        "RootMkdirOptions",
+        "RootMoveOptions",
+        "RootOpenOptions",
+        "RootOpenWritableOptions",
+        "RootOptions",
+        "RootReadOptions",
+        "RootRemoveOptions",
+        "RootWalkDataEntry",
+        "RootWalkDataEntryKind",
+        "RootWalkDirectoryErrorBehavior",
+        "RootWalkEntry",
+        "RootWalkEntryFilter",
+        "RootWalkEntryFilterResult",
+        "RootWalkEntryKind",
+        "RootWalkLimitBehavior",
+        "RootWalkOptions",
+        "RootWalkSymlinkPolicy",
+        "RootWriteJsonOptions",
+        "RootWriteOptions",
+        "SymlinkPolicy",
+        "WritableOpenMode",
+        "WritableOpenResult"
+      ],
+      "errorCodes": {
+        "FsSafeErrorCode": [
+          "already-exists",
+          "denied-path",
+          "device-path",
+          "hardlink",
+          "helper-failed",
+          "helper-unavailable",
+          "insecure-permissions",
+          "invalid-path",
+          "not-empty",
+          "not-file",
+          "not-found",
+          "not-owned",
+          "not-removable",
+          "outside-workspace",
+          "path-alias",
+          "path-mismatch",
+          "permission-unverified",
+          "secret-exists",
+          "store-reentrant-update",
+          "symlink",
+          "timeout",
+          "too-large",
+          "unsupported-platform"
+        ]
+      }
+    },
+    "./root": {
+      "runtime": [
+        "DEFAULT_ROOT_MAX_BYTES",
+        "openLocalFileSafely",
+        "readLocalFileSafely",
+        "resolveOpenedFileRealPathForHandle",
+        "root"
+      ],
+      "types": [
+        "ContainmentGuarantee",
+        "DenyMutationPolicy",
+        "HardlinkPolicy",
+        "OpenResult",
+        "ReadResult",
+        "RenameIdentityPolicy",
+        "Root",
+        "RootAppendOptions",
+        "RootCopyOptions",
+        "RootCreateJsonOptions",
+        "RootCreateOptions",
+        "RootDefaults",
+        "RootMkdirOptions",
+        "RootMoveOptions",
+        "RootOpenOptions",
+        "RootOpenWritableOptions",
+        "RootOptions",
+        "RootReadOptions",
+        "RootRemoveOptions",
+        "RootWalkDataEntry",
+        "RootWalkDataEntryKind",
+        "RootWalkDirectoryErrorBehavior",
+        "RootWalkEntry",
+        "RootWalkEntryFilter",
+        "RootWalkEntryFilterResult",
+        "RootWalkEntryKind",
+        "RootWalkLimitBehavior",
+        "RootWalkOptions",
+        "RootWalkSymlinkPolicy",
+        "RootWriteJsonOptions",
+        "RootWriteOptions",
+        "SymlinkPolicy",
+        "WritableOpenMode",
+        "WritableOpenResult"
+      ],
+      "errorCodes": {}
+    },
+    "./config": {
+      "runtime": [
+        "configureFsSafeLocks",
+        "configureFsSafeNative",
+        "configureFsSafePython",
+        "getFsSafeLockConfig",
+        "getFsSafeNativeConfig"
+      ],
+      "types": [
+        "FsSafeLockConfig",
+        "FsSafeNativeConfig",
+        "FsSafeNativeMode",
+        "FsSafePythonConfig"
+      ],
+      "errorCodes": {}
+    },
+    "./path": {
+      "runtime": [
+        "assertNoNulPathInput",
+        "assertNoUnsafeDeviceReadPath",
+        "hasNodeErrorCode",
+        "isNodeError",
+        "isNotFoundPathError",
+        "isPathInside",
+        "isPathInsideWithRealpath",
+        "isPathRelativeEscape",
+        "isSymlinkOpenError",
+        "isUnsafeDeviceReadPath",
+        "isWithinDir",
+        "matchUnsafeDeviceReadPath",
+        "normalizeWindowsPathForComparison",
+        "resolveSafeBaseDir",
+        "resolveSafeRelativePath",
+        "safeRealpathSync",
+        "safeStatSync",
+        "splitSafeRelativePath"
+      ],
+      "types": [
+        "UnsafeDeviceReadPathMatch",
+        "UnsafeDeviceReadPathOptions",
+        "UnsafeDeviceReadPathReason"
+      ],
+      "errorCodes": {}
+    },
+    "./output": {
+      "runtime": [
+        "writeExternalFileWithinRoot"
+      ],
+      "types": [
+        "ExternalFileWriteOptions",
+        "ExternalFileWriteResult"
+      ],
+      "errorCodes": {}
+    },
+    "./advanced": {
+      "runtime": [
+        "PATH_ALIAS_POLICIES",
+        "ROOT_PATH_ALIAS_POLICIES",
+        "appendRegularFile",
+        "appendRegularFileSync",
+        "assertAbsolutePathInput",
+        "assertCanonicalPathWithinBase",
+        "assertNoHardlinkedFinalPath",
+        "assertNoPathAliasEscape",
+        "assertNoSymlinkParents",
+        "assertNoSymlinkParentsSync",
+        "assertNoUnsafeDeviceReadPath",
+        "assertNoWindowsNetworkPath",
+        "basenameFromMediaSource",
+        "buildRandomTempFilePath",
+        "canUseRootFileOpen",
+        "canonicalPathFromExistingAncestor",
+        "configureFsSafeLocks",
+        "createAsyncLock",
+        "createIcaclsResetCommand",
+        "ensureAbsoluteDirectory",
+        "ensureDirectoryWithinRoot",
+        "findExistingAncestor",
+        "formatIcaclsResetCommand",
+        "formatPosixMode",
+        "formatWindowsAclSummary",
+        "getFsSafeLockConfig",
+        "hasEncodedFileUrlSeparator",
+        "inspectWindowsAcl",
+        "isUnsafeDeviceReadPath",
+        "isWindowsDriveLetterPath",
+        "isWindowsNetworkPath",
+        "matchRootFileOpenFailure",
+        "matchUnsafeDeviceReadPath",
+        "movePathToTrash",
+        "openRootFile",
+        "openRootFileSync",
+        "parseIcaclsOutput",
+        "pathExists",
+        "pathExistsSync",
+        "pathScope",
+        "readFileDescriptorBounded",
+        "readFileDescriptorBoundedSync",
+        "readFileHandleBounded",
+        "readLocalFileFromRoots",
+        "readRegularFile",
+        "readRegularFileSync",
+        "resolveAbsolutePathForRead",
+        "resolveAbsolutePathForWrite",
+        "resolveExistingPathsWithinRoot",
+        "resolveHomeRelativePath",
+        "resolveLocalPathFromRootsSync",
+        "resolvePathViaExistingAncestorSync",
+        "resolvePathWithinRoot",
+        "resolvePathsWithinRoot",
+        "resolveRegularFileAppendFlags",
+        "resolveRootPath",
+        "resolveRootPathSync",
+        "resolveSafeInstallDir",
+        "resolveStrictExistingPathsWithinRoot",
+        "resolveWindowsUserPrincipal",
+        "resolveWritablePathWithinRoot",
+        "safeDirName",
+        "safeFileURLToPath",
+        "safePathSegmentHashed",
+        "sameFileIdentity",
+        "sanitizeTempFileName",
+        "sanitizeUntrustedFileName",
+        "statRegularFile",
+        "statRegularFileSync",
+        "summarizeWindowsAcl",
+        "tempFile",
+        "trySafeFileURLToPath",
+        "withTempFile",
+        "withTimeout",
+        "writeSiblingTempFile",
+        "writeViaSiblingTempPath"
+      ],
+      "types": [
+        "AbsolutePathSymlinkPolicy",
+        "AppendRegularFileOptions",
+        "AssertNoSymlinkParentsOptions",
+        "EnsureAbsoluteDirectoryOptions",
+        "EnsureAbsoluteDirectoryResult",
+        "FileIdentityStat",
+        "FsSafeLockConfig",
+        "IcaclsResetCommandOptions",
+        "LocalRootsInputOptions",
+        "LocalRootsPathResult",
+        "LocalRootsReadResult",
+        "MovePathToTrashOptions",
+        "OpenRootFileParams",
+        "OpenRootFileSyncParams",
+        "PathAliasPolicy",
+        "PathScope",
+        "PathScopeOptions",
+        "PathScopeResolveOptions",
+        "PermissionExec",
+        "ReadLocalFileFromRootsOptions",
+        "RegularFileStatResult",
+        "ResolveLocalPathFromRootsSyncOptions",
+        "ResolvedAbsolutePath",
+        "ResolvedRootPath",
+        "ResolvedWritableAbsolutePath",
+        "RootFileOpenFailure",
+        "RootFileOpenFailureReason",
+        "RootFileOpenResult",
+        "RootPathAliasPolicy",
+        "TempFile",
+        "UnsafeDeviceReadPathMatch",
+        "UnsafeDeviceReadPathOptions",
+        "UnsafeDeviceReadPathReason",
+        "WindowsAclEntry",
+        "WindowsAclSummary",
+        "WriteSiblingTempFileOptions",
+        "WriteSiblingTempFileResult"
+      ],
+      "errorCodes": {}
+    },
+    "./json": {
+      "runtime": [
+        "JsonFileReadError",
+        "readJson",
+        "readJsonIfExists",
+        "readJsonSync",
+        "readRootJsonObjectSync",
+        "readRootJsonSync",
+        "readRootStructuredFileSync",
+        "tryReadJson",
+        "tryReadJsonSync",
+        "writeJson",
+        "writeJsonSync"
+      ],
+      "types": [
+        "JsonFileReadError",
+        "ReadJsonOptions",
+        "ReadRootJsonSyncOptions",
+        "ReadRootStructuredFileSyncOptions",
+        "RootStructuredFileReadResult",
+        "WriteJsonOptions"
+      ],
+      "errorCodes": {}
+    },
+    "./store": {
+      "runtime": [
+        "ackJsonDurableQueueEntry",
+        "ensureJsonDurableQueueDirs",
+        "fileStore",
+        "fileStoreSync",
+        "jsonDurableQueueEntryExists",
+        "jsonStore",
+        "loadJsonDurableQueueEntry",
+        "loadPendingJsonDurableQueueEntries",
+        "moveJsonDurableQueueEntryToFailed",
+        "readJsonDurableQueueEntry",
+        "resolveJsonDurableQueueEntryPaths",
+        "unlinkBestEffort",
+        "writeJsonDurableQueueEntry"
+      ],
+      "types": [
+        "FileStore",
+        "FileStoreOptions",
+        "FileStorePruneOptions",
+        "FileStoreReadOptions",
+        "FileStoreSync",
+        "FileStoreWriteOptions",
+        "JsonDurableQueueEntryPaths",
+        "JsonDurableQueueLoadOptions",
+        "JsonDurableQueueReadResult",
+        "JsonFileStoreOptions",
+        "JsonStore",
+        "JsonStoreLockOptions",
+        "JsonStoreOptions"
+      ],
+      "errorCodes": {}
+    },
+    "./secret": {
+      "runtime": [
+        "DEFAULT_SECRET_FILE_MAX_BYTES",
+        "PRIVATE_SECRET_DIR_MODE",
+        "PRIVATE_SECRET_FILE_MODE",
+        "createSecretFileAtomic",
+        "readSecretFile",
+        "readSecretFileSync",
+        "tryReadSecretFile",
+        "tryReadSecretFileSync",
+        "writeSecretFileAtomic"
+      ],
+      "types": [
+        "SecretFileReadOptions"
+      ],
+      "errorCodes": {}
+    },
+    "./permissions": {
+      "runtime": [
+        "createPrivateDirectory",
+        "formatOctal",
+        "formatPermissionDetail",
+        "formatPermissionRemediation",
+        "inspectPathPermissions",
+        "isGroupReadable",
+        "isGroupWritable",
+        "isWorldReadable",
+        "isWorldWritable",
+        "modeBits",
+        "readOwnerAndDacl",
+        "safeStat"
+      ],
+      "types": [
+        "CreatePrivateDirectoryOptions",
+        "OwnerAndDaclResult",
+        "PermissionCheck",
+        "PermissionCheckOptions",
+        "SafeStatResult",
+        "WindowsAccessControlEntry",
+        "WindowsAceFlags"
+      ],
+      "errorCodes": {}
+    },
+    "./secure-file": {
+      "runtime": [
+        "readSecureFile"
+      ],
+      "types": [
+        "SecureFileInjectOptions",
+        "SecureFileIoOptions",
+        "SecureFilePermissionOptions",
+        "SecureFileReadOptions",
+        "SecureFileReadResult",
+        "SecureFileTrustOptions"
+      ],
+      "errorCodes": {}
+    },
+    "./file-lock": {
+      "runtime": [
+        "acquireFileLock",
+        "acquireFileLockSync",
+        "createFileLockManager",
+        "drainFileLockManagerForTest",
+        "resetFileLockManagerForTest",
+        "withFileLock",
+        "withFileLockSync"
+      ],
+      "types": [
+        "FileLockAcquireOptions",
+        "FileLockHandle",
+        "FileLockHeldEntry",
+        "FileLockManager",
+        "FileLockRetryOptions",
+        "FileLockStaleRecovery",
+        "FileLockSyncAcquireOptions",
+        "FileLockSyncHandle",
+        "SidecarLockCompromisedInfo"
+      ],
+      "errorCodes": {}
+    },
+    "./walk": {
+      "runtime": [
+        "walkDirectory",
+        "walkDirectorySync"
+      ],
+      "types": [
+        "WalkDirectoryEntry",
+        "WalkDirectoryFailure",
+        "WalkDirectoryOptions",
+        "WalkDirectoryResult",
+        "WalkEntryKind",
+        "WalkSymlinkPolicy"
+      ],
+      "errorCodes": {}
+    },
+    "./temp": {
+      "runtime": [
+        "resolveSecureTempRoot",
+        "tempWorkspace",
+        "tempWorkspaceSync",
+        "withTempWorkspace",
+        "withTempWorkspaceSync"
+      ],
+      "types": [
+        "ResolveSecureTempRootOptions",
+        "TempPathIdentityReceipt",
+        "TempWorkspace",
+        "TempWorkspaceCleanupResult",
+        "TempWorkspaceOptions",
+        "TempWorkspaceSync"
+      ],
+      "errorCodes": {}
+    },
+    "./atomic": {
+      "runtime": [
+        "movePathWithCopyFallback",
+        "replaceDirectoryAtomic",
+        "replaceFileAtomic",
+        "replaceFileAtomicSync",
+        "writeTextAtomic"
+      ],
+      "types": [
+        "MovePathWithCopyFallbackOptions",
+        "ReplaceDirectoryAtomicOptions",
+        "ReplaceFileAtomicFileSystem",
+        "ReplaceFileAtomicOptions",
+        "ReplaceFileAtomicRestoreCleanup",
+        "ReplaceFileAtomicRestoreFailureDetails",
+        "ReplaceFileAtomicResult",
+        "ReplaceFileAtomicSyncFileSystem",
+        "ReplaceFileAtomicSyncOptions",
+        "ReplaceFileCopyFallbackRestorePolicy",
+        "ReplaceFileDestinationHardlinkPolicy",
+        "WriteTextAtomicOptions"
+      ],
+      "errorCodes": {}
+    },
+    "./durability": {
+      "runtime": [
+        "ensureDurableDirectory",
+        "isHardlinkFallbackError",
+        "pinDirectory",
+        "publishFileExclusive",
+        "sha256File",
+        "syncDirectory",
+        "syncDirectoryBestEffort",
+        "syncDirectoryBestEffortSync",
+        "syncDirectorySync"
+      ],
+      "types": [
+        "DirectoryReceipt",
+        "DirectorySyncOutcome",
+        "DurableDirectoryReceipt",
+        "EnsureDurableDirectoryOptions",
+        "PinnedDirectory",
+        "PublishFileExclusiveCleanup",
+        "PublishFileExclusiveDirectorySyncFailure",
+        "PublishFileExclusiveFailureDetails",
+        "PublishFileExclusiveFailurePhase",
+        "PublishFileExclusiveResult",
+        "PublishFileExclusiveStrategy",
+        "PublishFileExclusiveSyncFailurePolicy",
+        "Sha256FileInput",
+        "Sha256FileResult"
+      ],
+      "errorCodes": {}
+    },
+    "./archive": {
+      "runtime": [
+        "ARCHIVE_LIMIT_ERROR_CODE",
+        "ArchiveFormatError",
+        "ArchiveLimitError",
+        "ArchiveSecurityError",
+        "DEFAULT_MAX_ARCHIVE_BYTES_ZIP",
+        "DEFAULT_MAX_ENTRIES",
+        "DEFAULT_MAX_ENTRY_BYTES",
+        "DEFAULT_MAX_ENTRY_PATH_COMPONENTS",
+        "DEFAULT_MAX_EXTRACTED_BYTES",
+        "DEFAULT_MAX_META_ENTRY_BYTES",
+        "createArchiveSymlinkTraversalError",
+        "createTarEntryPreflightChecker",
+        "extractArchive",
+        "isWindowsDrivePath",
+        "loadZipArchiveWithPreflight",
+        "mergeExtractedTreeIntoDestination",
+        "normalizeArchiveEntryPath",
+        "prepareArchiveDestinationDir",
+        "prepareArchiveOutputPath",
+        "readArchiveEntry",
+        "readZipCentralDirectoryEntryCount",
+        "resolveArchiveKind",
+        "resolveArchiveOutputPath",
+        "resolvePackedRootDir",
+        "stripArchivePath",
+        "validateArchiveEntryPath",
+        "withStagedArchiveDestination"
+      ],
+      "types": [
+        "ArchiveEntryFilter",
+        "ArchiveEntryKind",
+        "ArchiveEntryModePolicy",
+        "ArchiveExtractLimits",
+        "ArchiveFilteredEntryPolicy",
+        "ArchiveFormatError",
+        "ArchiveFormatErrorCode",
+        "ArchiveKind",
+        "ArchiveLimitError",
+        "ArchiveLimitErrorCode",
+        "ArchiveLogger",
+        "ArchiveSecurityError",
+        "ArchiveSecurityErrorCode",
+        "ExtractArchiveOptions",
+        "TarEntryInfo",
+        "ZipArchiveWithFiles"
+      ],
+      "errorCodes": {
+        "ArchiveFormatErrorCode": [
+          "archive-header-invalid"
+        ],
+        "ArchiveLimitErrorCode": [
+          "archive-entry-count-exceeds-limit",
+          "archive-entry-extracted-size-exceeds-limit",
+          "archive-entry-path-components-exceeds-limit",
+          "archive-extracted-size-exceeds-limit",
+          "archive-manifest-size-exceeds-limit",
+          "archive-meta-entry-size-exceeds-limit",
+          "archive-size-exceeds-limit"
+        ],
+        "ArchiveSecurityErrorCode": [
+          "destination-not-directory",
+          "destination-symlink",
+          "destination-symlink-traversal",
+          "entry-filtered",
+          "entry-link",
+          "entry-path"
+        ]
+      }
+    },
+    "./errors": {
+      "runtime": [
+        "FsSafeError",
+        "categorizeFsSafeError"
+      ],
+      "types": [
+        "FsSafeError",
+        "FsSafeErrorCategory",
+        "FsSafeErrorCode",
+        "FsSafeErrorDetails"
+      ],
+      "errorCodes": {
+        "FsSafeErrorCode": [
+          "already-exists",
+          "denied-path",
+          "device-path",
+          "hardlink",
+          "helper-failed",
+          "helper-unavailable",
+          "insecure-permissions",
+          "invalid-path",
+          "not-empty",
+          "not-file",
+          "not-found",
+          "not-owned",
+          "not-removable",
+          "outside-workspace",
+          "path-alias",
+          "path-mismatch",
+          "permission-unverified",
+          "secret-exists",
+          "store-reentrant-update",
+          "symlink",
+          "timeout",
+          "too-large",
+          "unsupported-platform"
+        ]
+      }
+    },
+    "./types": {
+      "runtime": [],
+      "types": [
+        "BasePathOptions",
+        "DirEntry",
+        "FastPathMode",
+        "PathStat",
+        "SafeEncoding"
+      ],
+      "errorCodes": {}
+    },
+    "./test-hooks": {
+      "runtime": [
+        "__setFsSafeTestHooksForTest",
+        "getFsSafeTestHooks"
+      ],
+      "types": [
+        "FsSafeTestHooks"
+      ],
+      "errorCodes": {}
+    },
+    "./package.json": {
+      "kind": "json"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- inspect every `package.json` export through the packed tarball installed in a clean temporary project
- pin runtime exports, exported type names, published subpaths, and exported `*ErrorCode` string unions in a reviewed manifest
- provide `pnpm public-api:update` as the explicit blessing path for deliberate compatibility changes

The guard reports each appeared or vanished symbol with its subpath and explains whether the API widened or existing consumers may break. It runs inside the existing pack verification, after the archive has been installed and imported exactly as a consumer would use it.

## Proof

- `pnpm check` (675 passed, 32 skipped)
- `pnpm test:security` (64 passed)
- `pnpm pack:check`
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings

A temporary `export const __publicApiGuardProbe = true` in the published `./path` module failed with:

```text
Public API surface changed:
- runtime export appeared at ./path: __publicApiGuardProbe (the public API widened)
Remove accidental changes. If every change is deliberate, run `pnpm public-api:update` and review test/public-api.json before committing it.
```

The probe was removed before commit. A temporary expected-only symbol also verified the inverse diagnostic for a vanished export.

No changelog entry: this changes repository tests and release verification only, not package behavior.
