### PR TITLE
fix(atomic): close descriptor mode gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Security and Correctness
 
+- Keep the POSIX parent-directory no-follow identity check active for synchronous atomic-replacement adapters that omit `fchmodSync`, preventing the documented default adapter path from writing through a symlinked parent.
+- Synchronize the actual destination after descriptor-bound mode application when atomic rename uses copy fallback, and include both bytes and mode in bounded fallback restoration.
+- Continue accepting legacy atomic-replacement adapter literals that expose pathname `chmod` or `chmodSync` methods while keeping those methods unused.
+
 - Reject non-file sidecars without spinning, and read contended async and synchronous sidecar locks through bounded, no-follow, identity-checked descriptors; keep valid `createdAt` timestamps authoritative under filesystem clock skew; fail closed when fallback Windows ACL inspection returns no verifiable access entries; preserve synchronous stale-reclaim guards owned by another acquirer; and share one process-exit cleanup listener across file-lock manager domains.
 
 - Route `Root.copyIn()` and overwrite-capable `Root.write()` commits through a new descriptor-relative native replace rename, closing a parent-symlink swap that could create a missing destination directory outside the root before the JavaScript fallback detected the escape. Native `auto` and `require` mode now protect both create-only and replacing pinned writes; the explicitly best-effort JavaScript fallback remains available in `off` mode or when `auto` cannot load a binding.

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -48,8 +48,8 @@ type ReplaceFileAtomicOptions = {
   copyFallbackRestore?: "restore-original" | "none"; // default: "none"
   maxRestoreBytes?: number;          // required with "restore-original"
   destinationHardlinks?: "reject"; // default unset (no destination nlink policy)
-  syncTempFile?: boolean;           // fsync(temp) before rename; default false
-  syncParentDir?: boolean;          // fsync(parent) after rename; default false
+  syncTempFile?: boolean;           // fsync(temp) before rename, or the final file after copy fallback; default false
+  syncParentDir?: boolean;          // fsync(parent) after rename, POSIX only; default false
   throwOnCleanupError?: boolean;    // report temp cleanup failure; default false
   beforeRename?: (params: { filePath: string; tempPath: string }) => Promise<void>;
   fileSystem?: ReplaceFileAtomicFileSystem; // injectable fs for tests
@@ -90,9 +90,10 @@ The default `copyFallbackRestore: "none"` preserves the existing fallback
 contract: a failed copy can leave a partial destination. For state files where
 preserving the old bytes is more important, choose `"restore-original"` and set
 an explicit `maxRestoreBytes` memory budget. If the destination exists, fs-safe
-snapshots it through a pinned descriptor, overwrites through that same
-descriptor, and synchronizes the result. Any write or sync failure triggers a
-restore and another sync through the same descriptor.
+snapshots it through a pinned descriptor, overwrites and mode-adjusts through
+that same descriptor, and synchronizes the result. Any write, mode, or sync
+failure triggers a byte-and-mode restore and another sync through the same
+descriptor.
 
 Restore failures are `FsSafeError("helper-failed")` values with typed
 `details.cleanup` set to `"restored"` or `"restore-failed"`. An original larger
@@ -163,7 +164,11 @@ Rename a path. If the rename fails with `EXDEV` (cross-device), fall back to
 copying into a staged sibling path, renaming that staged path into place, and
 then removing only the source entries that were copied. The fallback avoids
 buffering regular files into memory and does not tighten the destination parent
-directory mode.
+directory mode. Staged file modes are applied through their still-open handles.
+On POSIX, staged directory modes are applied through no-follow directory
+descriptors; on Windows, Node cannot portably open those descriptors and no
+pathname `chmod` fallback is attempted, so directory modes remain subject to
+Windows' `mkdir(mode)` behavior.
 
 ```ts
 import { movePathWithCopyFallback } from "@openclaw/fs-safe/atomic";
@@ -227,7 +232,7 @@ type ReplaceFileAtomicSyncFileSystem = {
 };
 ```
 
-The async interface already requires `open()`, whose `FileHandle` supplies `chmod()`, so injecting `node:fs` or another conforming adapter needs no new async member. On POSIX, that `open()` must support no-follow directory descriptors as Node does. A custom synchronous filesystem that passes `mode`, `dirMode`, or `preserveExistingMode` must supply `fchmodSync`; omission fails before any file or directory is created and never falls back to a pathname `chmod`. Existing synchronous adapters that request none of those options may omit it. Injecting plain `node:fs` supports explicit file and directory modes. Copy fallback applies the file mode through its pinned destination descriptor as well, preserving exact modes despite the process umask.
+The async interface already requires `open()`, whose `FileHandle` supplies `chmod()`, so injecting `node:fs` or another conforming adapter needs no new async member. On POSIX, that `open()` must support no-follow directory descriptors as Node does. A custom synchronous filesystem that passes `mode`, `dirMode`, or `preserveExistingMode` must supply `fchmodSync`; omission fails before any file or directory is created and never falls back to a pathname `chmod`. Existing synchronous adapters that request none of those options may omit it; their parent is still opened and identity-checked through a no-follow directory descriptor. Injecting plain `node:fs` supports explicit file and directory modes. Older adapter literals may continue to include `chmod` or `chmodSync` for source compatibility, but those operations are ignored. Copy fallback applies the file mode through its pinned destination descriptor as well, preserving exact modes despite the process umask.
 
 ## See also
 

--- a/src/replace-file-copy-fallback.ts
+++ b/src/replace-file-copy-fallback.ts
@@ -250,14 +250,18 @@ async function replacePinnedWithRestore(
   handle: FileHandle,
   replacement: Buffer,
   maxRestoreBytes: number,
+  replacementMode: number,
 ): Promise<void> {
+  const originalMode = (await handle.stat()).mode;
   const original = await readBounded(handle, maxRestoreBytes);
   try {
     await writeAll(handle, replacement);
+    await handle.chmod(replacementMode);
     await handle.sync();
   } catch (writeError) {
     try {
       await writeAll(handle, original);
+      await handle.chmod(originalMode);
       await handle.sync();
       throw restoreFailure(writeError, "restored");
     } catch (restoreError) {
@@ -274,14 +278,19 @@ function replacePinnedWithRestoreSync(
   fd: number,
   replacement: Buffer,
   maxRestoreBytes: number,
+  replacementMode: number,
+  fchmodSync?: (fd: number, mode: number) => void,
 ): void {
+  const originalMode = fsModule.fstatSync(fd).mode;
   const original = readBoundedSync(fsModule, fd, maxRestoreBytes);
   try {
     writeAllSync(fsModule, fd, replacement);
+    fchmodSync?.(fd, replacementMode);
     fsModule.fsyncSync(fd);
   } catch (writeError) {
     try {
       writeAllSync(fsModule, fd, original);
+      fchmodSync?.(fd, originalMode);
       fsModule.fsyncSync(fd);
       throw restoreFailure(writeError, "restored");
     } catch (restoreError) {
@@ -300,6 +309,7 @@ export async function copyFallbackReplace(params: {
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
   restore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
+  sync: boolean;
 }): Promise<void> {
   const sourcePreview = await params.fsModule.lstat(params.src);
   if (sourcePreview.isSymbolicLink() || !sourcePreview.isFile()) {
@@ -323,7 +333,12 @@ export async function copyFallbackReplace(params: {
       );
       if (pinned) {
         destHandle = pinned.handle;
-        await replacePinnedWithRestore(destHandle, replacement, params.maxRestoreBytes!);
+        await replacePinnedWithRestore(
+          destHandle,
+          replacement,
+          params.maxRestoreBytes!,
+          sourceStat.mode,
+        );
       }
     }
 
@@ -349,8 +364,11 @@ export async function copyFallbackReplace(params: {
         sourceStat.mode & 0o777,
       );
       await destHandle.writeFile(replacement);
+      await destHandle.chmod(sourceStat.mode);
+      if (params.sync) {
+        await destHandle.sync();
+      }
     }
-    await destHandle.chmod(sourceStat.mode);
   } finally {
     await destHandle?.close().catch(() => undefined);
     await sourceHandle.close().catch(() => undefined);
@@ -366,6 +384,7 @@ export function copyFallbackReplaceSync(params: {
   restore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
   fchmodSync?: (fd: number, mode: number) => void;
+  sync: boolean;
 }): void {
   const sourcePreview = params.fsModule.lstatSync(params.src);
   if (sourcePreview.isSymbolicLink() || !sourcePreview.isFile()) {
@@ -394,6 +413,8 @@ export function copyFallbackReplaceSync(params: {
           destFd,
           replacement,
           params.maxRestoreBytes!,
+          sourceStat.mode,
+          params.fchmodSync,
         );
       }
     }
@@ -422,8 +443,11 @@ export function copyFallbackReplaceSync(params: {
         sourceStat.mode & 0o777,
       );
       writeAllSync(params.fsModule, destFd, replacement);
+      params.fchmodSync?.(destFd, sourceStat.mode);
+      if (params.sync) {
+        params.fsModule.fsyncSync(destFd);
+      }
     }
-    params.fchmodSync?.(destFd, sourceStat.mode);
   } finally {
     if (destFd !== undefined) {
       try {

--- a/src/replace-file-descriptor.ts
+++ b/src/replace-file-descriptor.ts
@@ -65,7 +65,7 @@ export function applyDirectoryModeSync(params: {
   mode: number;
   fchmodSync?: SyncFchmod;
 }): void {
-  if (process.platform === "win32" || !params.fchmodSync) {
+  if (process.platform === "win32") {
     return;
   }
 
@@ -74,7 +74,7 @@ export function applyDirectoryModeSync(params: {
   const fd = params.fsModule.openSync(params.dirPath, directoryOpenFlags());
   try {
     assertSameDirectory(expected, params.fsModule.fstatSync(fd), params.dirPath);
-    params.fchmodSync(fd, params.mode);
+    params.fchmodSync?.(fd, params.mode);
   } finally {
     params.fsModule.closeSync(fd);
   }

--- a/src/replace-file.ts
+++ b/src/replace-file.ts
@@ -36,7 +36,10 @@ export type ReplaceFileAtomicFileSystem = {
     | "open"
     | "stat"
     | "lstat"
-  >;
+  > & {
+    /** @deprecated Accepted for adapter compatibility but never called. */
+    chmod?: typeof fs.chmod;
+  };
 };
 
 export type ReplaceFileAtomicSyncFileSystem = Pick<
@@ -58,6 +61,8 @@ export type ReplaceFileAtomicSyncFileSystem = Pick<
   | "readSync"
   | "writeSync"
 > & {
+  /** @deprecated Accepted for adapter compatibility but never called. */
+  chmodSync?: typeof syncFs.chmodSync;
   fchmodSync?: typeof syncFs.fchmodSync;
 };
 
@@ -123,6 +128,7 @@ async function renameWithRetry(params: {
   copyFallbackRestore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
+  syncFallback: boolean;
 }): Promise<ReplaceFileAtomicResult> {
   for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
     try {
@@ -141,6 +147,7 @@ async function renameWithRetry(params: {
           destinationHardlinks: params.destinationHardlinks,
           restore: params.copyFallbackRestore,
           maxRestoreBytes: params.maxRestoreBytes,
+          sync: params.syncFallback,
         });
         return { method: "copy-fallback" };
       }
@@ -168,6 +175,7 @@ function renameWithRetrySync(params: {
   maxRestoreBytes?: number;
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
   fchmodSync?: SyncFchmod;
+  syncFallback: boolean;
 }): ReplaceFileAtomicResult {
   for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
     try {
@@ -187,6 +195,7 @@ function renameWithRetrySync(params: {
           restore: params.copyFallbackRestore,
           maxRestoreBytes: params.maxRestoreBytes,
           fchmodSync: params.fchmodSync,
+          sync: params.syncFallback,
         });
         return { method: "copy-fallback" };
       }
@@ -331,9 +340,9 @@ async function replaceFileAtomicUnserialized(
   const unregisterTempPath = registerTempPathForExit(tempPath);
   let tempExists = false;
   let originalError: unknown;
-  await fsModule.mkdir(dir, { recursive: true, mode: dirMode });
-  await applyDirectoryMode({ fsModule, dirPath: dir, mode: dirMode });
   try {
+    await fsModule.mkdir(dir, { recursive: true, mode: dirMode });
+    await applyDirectoryMode({ fsModule, dirPath: dir, mode: dirMode });
     tempExists = true;
     unregisterTempPath.setIdentity(await writeTempFile({
       fsModule,
@@ -356,6 +365,7 @@ async function replaceFileAtomicUnserialized(
       copyFallbackRestore: options.copyFallbackRestore ?? "none",
       maxRestoreBytes: options.maxRestoreBytes,
       destinationHardlinks: options.destinationHardlinks,
+      syncFallback: options.syncTempFile === true,
     });
     tempExists = false;
     unregisterTempPath();
@@ -404,9 +414,9 @@ export function replaceFileAtomicSync(
   const unregisterTempPath = registerTempPathForExit(tempPath);
   let tempExists = false;
   let originalError: unknown;
-  fsModule.mkdirSync(dir, { recursive: true, mode: dirMode });
-  applyDirectoryModeSync({ fsModule, dirPath: dir, mode: dirMode, fchmodSync });
   try {
+    fsModule.mkdirSync(dir, { recursive: true, mode: dirMode });
+    applyDirectoryModeSync({ fsModule, dirPath: dir, mode: dirMode, fchmodSync });
     tempExists = true;
     unregisterTempPath.setIdentity(writeTempFileSync({
       fsModule,
@@ -431,6 +441,7 @@ export function replaceFileAtomicSync(
       maxRestoreBytes: options.maxRestoreBytes,
       destinationHardlinks: options.destinationHardlinks,
       fchmodSync,
+      syncFallback: options.syncTempFile === true,
     });
     tempExists = false;
     unregisterTempPath();

--- a/test/atomic-dirmode-regression.test.ts
+++ b/test/atomic-dirmode-regression.test.ts
@@ -206,4 +206,26 @@ describe("atomic parent-directory descriptor modes", () => {
       await expect(fs.access(path.dirname(filePath))).rejects.toMatchObject({ code: "ENOENT" });
     },
   );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked parent with a sync adapter that omits fchmodSync",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-dirmode-symlink-");
+      const outside = await tempRoot("fs-safe-atomic-dirmode-outside-");
+      const linkedDir = path.join(root, "linked");
+      const filePath = path.join(linkedDir, "state.txt");
+      const { fchmodSync: _fchmodSync, ...syncWithoutFchmod } = fsSync;
+      await fs.symlink(outside, linkedDir, "dir");
+
+      expect(() => replaceFileAtomicSync({
+        filePath,
+        content: "must not escape",
+        fileSystem: syncWithoutFchmod,
+      })).toThrow("Atomic replace parent must be a real directory");
+
+      await expect(fs.access(path.join(outside, "state.txt"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
 });

--- a/test/atomic-fchmod-regression.test.ts
+++ b/test/atomic-fchmod-regression.test.ts
@@ -17,6 +17,88 @@ afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
 });
 
+async function runAsyncFallbackOrderProbe(root: string): Promise<{
+  filePath: string;
+  operations: string[];
+}> {
+  const filePath = path.join(root, "state.txt");
+  const operations: string[] = [];
+  const renameDenied = () => Object.assign(new Error("rename denied"), { code: "EPERM" });
+
+  await replaceFileAtomic({
+    filePath,
+    content: "replacement",
+    mode: 0o640,
+    copyFallbackOnPermissionError: true,
+    syncTempFile: true,
+    fileSystem: {
+      promises: {
+        ...fs,
+        rename: async () => { throw renameDenied(); },
+        open: (async (...args: Parameters<typeof fs.open>) => {
+          const handle = await fs.open(...args);
+          if (String(args[0]) === filePath) {
+            const chmod = handle.chmod.bind(handle);
+            const sync = handle.sync.bind(handle);
+            handle.chmod = async (mode) => {
+              operations.push("chmod");
+              await chmod(mode);
+            };
+            handle.sync = async () => {
+              operations.push("sync");
+              await sync();
+            };
+          }
+          return handle;
+        }) as typeof fs.open,
+      },
+    },
+  });
+  return { filePath, operations };
+}
+
+function runSyncFallbackOrderProbe(root: string): {
+  destinationFds: Set<number>;
+  filePath: string;
+  operations: string[];
+} {
+  const filePath = path.join(root, "state.txt");
+  const destinationFds = new Set<number>();
+  const operations: string[] = [];
+  const renameDenied = () => Object.assign(new Error("rename denied"), { code: "EPERM" });
+  const fileSystem = {
+    ...fsSync,
+    renameSync: () => { throw renameDenied(); },
+    openSync: ((candidate, flags, mode) => {
+      const fd = fsSync.openSync(candidate, flags, mode);
+      if (String(candidate) === filePath) destinationFds.add(fd);
+      return fd;
+    }) as typeof fsSync.openSync,
+    fchmodSync: ((fd, mode) => {
+      if (destinationFds.has(fd)) operations.push("chmod");
+      fsSync.fchmodSync(fd, mode);
+    }) as typeof fsSync.fchmodSync,
+    fsyncSync: ((fd) => {
+      if (destinationFds.has(fd)) operations.push("sync");
+      fsSync.fsyncSync(fd);
+    }) as typeof fsSync.fsyncSync,
+    closeSync: ((fd) => {
+      fsSync.closeSync(fd);
+      destinationFds.delete(fd);
+    }) as typeof fsSync.closeSync,
+  };
+
+  replaceFileAtomicSync({
+    filePath,
+    content: "replacement",
+    mode: 0o640,
+    copyFallbackOnPermissionError: true,
+    syncTempFile: true,
+    fileSystem,
+  });
+  return { destinationFds, filePath, operations };
+}
+
 describe("atomic descriptor modes", () => {
   it.runIf(process.platform !== "win32")(
     "does not chmod an async destination swapped for a symlink after rename",
@@ -123,6 +205,68 @@ describe("atomic descriptor modes", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "keeps explicit and preserved modes exact across restrictive umasks",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-fchmod-umasks-");
+      const previousUmask = process.umask();
+      try {
+        for (const mask of [0o000, 0o022, 0o077, 0o777]) {
+          process.umask(mask);
+          const suffix = mask.toString(8);
+          const asyncPath = path.join(root, `async-${suffix}.txt`);
+          const syncPath = path.join(root, `sync-${suffix}.txt`);
+          const preservedPath = path.join(root, `preserved-${suffix}.txt`);
+          const preservedSyncPath = path.join(root, `preserved-sync-${suffix}.txt`);
+          const missingPath = path.join(root, `missing-${suffix}.txt`);
+          const missingSyncPath = path.join(root, `missing-sync-${suffix}.txt`);
+          await Promise.all([
+            fs.writeFile(preservedPath, "old"),
+            fs.writeFile(preservedSyncPath, "old"),
+          ]);
+          await Promise.all([
+            fs.chmod(preservedPath, 0o651),
+            fs.chmod(preservedSyncPath, 0o651),
+          ]);
+
+          await replaceFileAtomic({ filePath: asyncPath, content: "async", mode: 0o670 });
+          replaceFileAtomicSync({ filePath: syncPath, content: "sync", mode: 0o670 });
+          await replaceFileAtomic({
+            filePath: preservedPath,
+            content: "preserved",
+            preserveExistingMode: true,
+          });
+          await replaceFileAtomic({
+            filePath: missingPath,
+            content: "missing",
+            mode: 0o642,
+            preserveExistingMode: true,
+          });
+          replaceFileAtomicSync({
+            filePath: preservedSyncPath,
+            content: "preserved",
+            preserveExistingMode: true,
+          });
+          replaceFileAtomicSync({
+            filePath: missingSyncPath,
+            content: "missing",
+            mode: 0o642,
+            preserveExistingMode: true,
+          });
+
+          expect((await fs.stat(asyncPath)).mode & 0o777).toBe(0o670);
+          expect(fsSync.statSync(syncPath).mode & 0o777).toBe(0o670);
+          expect((await fs.stat(preservedPath)).mode & 0o777).toBe(0o651);
+          expect((await fs.stat(missingPath)).mode & 0o777).toBe(0o642);
+          expect(fsSync.statSync(preservedSyncPath).mode & 0o777).toBe(0o651);
+          expect(fsSync.statSync(missingSyncPath).mode & 0o777).toBe(0o642);
+        }
+      } finally {
+        process.umask(previousUmask);
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "preserves exact descriptor modes through async and sync copy fallback",
     async () => {
       const root = await tempRoot("fs-safe-atomic-fchmod-fallback-");
@@ -164,6 +308,107 @@ describe("atomic descriptor modes", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "applies and syncs the final copy-fallback mode before closing the destination",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-");
+      const { filePath, operations } = await runAsyncFallbackOrderProbe(root);
+
+      expect(operations).toEqual(["chmod", "sync"]);
+      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o640);
+      expect(await fs.readFile(filePath, "utf8")).toBe("replacement");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps synchronous copy-fallback chmod before the final destination sync",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-sync-");
+      const { destinationFds, filePath, operations } = runSyncFallbackOrderProbe(root);
+
+      expect(operations).toEqual(["chmod", "sync"]);
+      expect(fsSync.statSync(filePath).mode & 0o777).toBe(0o640);
+      expect(fsSync.readFileSync(filePath, "utf8")).toBe("replacement");
+      expect(destinationFds.size).toBe(0);
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "publishes and syncs async copy fallback without claiming POSIX mode enforcement",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-win32-");
+      const { filePath, operations } = await runAsyncFallbackOrderProbe(root);
+
+      expect(operations).toEqual(["chmod", "sync"]);
+      expect(await fs.readFile(filePath, "utf8")).toBe("replacement");
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "publishes and syncs synchronous copy fallback without claiming POSIX mode enforcement",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-sync-win32-");
+      const { destinationFds, filePath, operations } = runSyncFallbackOrderProbe(root);
+
+      expect(operations).toEqual(["chmod", "sync"]);
+      expect(fsSync.readFileSync(filePath, "utf8")).toBe("replacement");
+      expect(destinationFds.size).toBe(0);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "restores bytes and mode and closes descriptors when fallback chmod fails",
+    async () => {
+      const root = await tempRoot("fs-safe-atomic-fchmod-restore-");
+      const filePath = path.join(root, "state.txt");
+      const descriptorDirectory = process.platform === "linux" ? "/proc/self/fd" : "/dev/fd";
+      await fs.writeFile(filePath, "original");
+      await fs.chmod(filePath, 0o644);
+      const descriptorsBefore = (await fs.readdir(descriptorDirectory)).length;
+      let failMode = true;
+
+      await expect(replaceFileAtomic({
+        filePath,
+        content: "replacement",
+        mode: 0o600,
+        copyFallbackOnPermissionError: true,
+        copyFallbackRestore: "restore-original",
+        maxRestoreBytes: 1024,
+        fileSystem: {
+          promises: {
+            ...fs,
+            rename: async () => {
+              throw Object.assign(new Error("rename denied"), { code: "EPERM" });
+            },
+            open: (async (...args: Parameters<typeof fs.open>) => {
+              const handle = await fs.open(...args);
+              if (String(args[0]) === filePath) {
+                const chmod = handle.chmod.bind(handle);
+                handle.chmod = async (mode) => {
+                  if (failMode) {
+                    failMode = false;
+                    throw Object.assign(new Error("mode denied"), { code: "EPERM" });
+                  }
+                  await chmod(mode);
+                };
+              }
+              return handle;
+            }) as typeof fs.open,
+          },
+        },
+      })).rejects.toMatchObject({
+        code: "helper-failed",
+        details: { cleanup: "restored" },
+      });
+
+      expect(await fs.readFile(filePath, "utf8")).toBe("original");
+      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o644);
+      expect((await fs.readdir(root)).filter((entry) => entry.startsWith(".fs-safe-replace")))
+        .toEqual([]);
+      expect((await fs.readdir(descriptorDirectory)).length).toBe(descriptorsBefore);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "accepts node:fs injection with an explicit async mode",
     async () => {
       const root = await tempRoot("fs-safe-atomic-node-fs-");
@@ -189,6 +434,7 @@ describe("atomic descriptor modes", () => {
     const root = await tempRoot("fs-safe-atomic-fchmod-missing-");
     const syncPath = path.join(root, "sync.txt");
     const syncDefaultPath = path.join(root, "sync-default.txt");
+    const syncPreservePath = path.join(root, "sync-preserve.txt");
     const { fchmodSync: _fchmodSync, ...syncWithoutFchmod } = fsSync;
 
     expect(() => replaceFileAtomicSync({
@@ -199,6 +445,15 @@ describe("atomic descriptor modes", () => {
     })).toThrow("fileSystem.fchmodSync is required");
 
     await expect(fs.access(syncPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+    expect(() => replaceFileAtomicSync({
+      filePath: syncPreservePath,
+      content: "sync",
+      preserveExistingMode: true,
+      fileSystem: syncWithoutFchmod,
+    })).toThrow("fileSystem.fchmodSync is required");
+
+    await expect(fs.access(syncPreservePath)).rejects.toMatchObject({ code: "ENOENT" });
 
     replaceFileAtomicSync({
       filePath: syncDefaultPath,

--- a/test/move-path-fchmod-regression.test.ts
+++ b/test/move-path-fchmod-regression.test.ts
@@ -74,6 +74,45 @@ afterEach(async () => {
 });
 
 describe.runIf(process.platform !== "win32")("move staging descriptor modes", () => {
+  it("preserves exact file modes across all umasks and directory modes while reopenable", async () => {
+    const root = await tempRoot("fs-safe-move-mode-umasks-");
+    const previousUmask = process.umask();
+    try {
+      for (const mask of [0o000, 0o022, 0o077, 0o777]) {
+        process.umask(mask);
+        const suffix = mask.toString(8);
+        const sourceFile = path.join(root, `source-${suffix}.txt`);
+        const targetFile = path.join(root, `target-${suffix}.txt`);
+        const sourceDir = path.join(root, `source-${suffix}`);
+        const targetDir = path.join(root, `target-${suffix}`);
+        await fs.writeFile(sourceFile, "source");
+        await fs.chmod(sourceFile, 0o666);
+        await fs.mkdir(sourceDir);
+        await fs.chmod(sourceDir, 0o751);
+
+        await movePathWithCopyFallback({
+          from: sourceFile,
+          sourceHardlinks: "reject",
+          to: targetFile,
+        });
+        if (mask !== 0o777) {
+          await movePathWithCopyFallback({
+            from: sourceDir,
+            sourceHardlinks: "reject",
+            to: targetDir,
+          });
+        }
+
+        expect((await fs.stat(targetFile)).mode & 0o777).toBe(0o666);
+        if (mask !== 0o777) {
+          expect((await fs.stat(targetDir)).mode & 0o777).toBe(0o751);
+        }
+      }
+    } finally {
+      process.umask(previousUmask);
+    }
+  });
+
   it("does not redirect a staged file mode through a swapped symlink", async () => {
     const sourceDir = await tempRoot("fs-safe-move-file-source-");
     const targetDir = await tempRoot("fs-safe-move-file-target-");


### PR DESCRIPTION
## Summary

- keep the POSIX parent no-follow identity check active for synchronous adapters that omit `fchmodSync`
- apply fallback replacement modes before synchronizing the actual destination, and restore both bytes and mode when bounded restoration fails
- retain source compatibility for legacy adapter literals that still expose unused `chmod` or `chmodSync` methods

The audit also expands exact-mode coverage across umasks `000`, `022`, `077`, and `777`, verifies present and missing `preserveExistingMode` destinations for async and sync calls, counts descriptors after a forced fallback-mode failure, and documents the Windows staged-directory mode caveat.

## Verification

- `pnpm check`
- `pnpm test:security`
- `git diff --check`
- strict TypeScript compile of the atomic adapter regression file
- packaged, source-blind behavior validation of mode, adapter, fallback durability, restoration, cleanup, and descriptor outcomes
- Codex autoreview: clean, no accepted/actionable findings

## Escalated limitation

With a POSIX process umask of `0777`, a newly created directory lands as mode `000` and cannot be reopened for descriptor-bound mode application. This affects new atomic parent directories and staged directory move fallback. This PR does not reintroduce pathname `chmod` or mutate the process-wide umask; resolving that case safely needs an explicit design decision or a descriptor-relative creation primitive.
