### PR TITLE
fix: harden lock contention and permission verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Security and Correctness
 
+- Reject non-file sidecars without spinning, and read contended async and synchronous sidecar locks through bounded, no-follow, identity-checked descriptors; keep valid `createdAt` timestamps authoritative under filesystem clock skew; fail closed when fallback Windows ACL inspection returns no verifiable access entries; preserve synchronous stale-reclaim guards owned by another acquirer; and share one process-exit cleanup listener across file-lock manager domains.
+
 - Route `Root.copyIn()` and overwrite-capable `Root.write()` commits through a new descriptor-relative native replace rename, closing a parent-symlink swap that could create a missing destination directory outside the root before the JavaScript fallback detected the escape. Native `auto` and `require` mode now protect both create-only and replacing pinned writes; the explicitly best-effort JavaScript fallback remains available in `off` mode or when `auto` cannot load a binding.
 
 - Apply `movePathWithCopyFallback()` file and POSIX directory modes through staging descriptors before publication, so a replaceable staging pathname cannot redirect `chmod` to an unrelated symlink target. Windows no longer uses a pathname fallback for directory modes because Node cannot portably open a directory descriptor there and does not enforce POSIX modes.

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -96,6 +96,12 @@ type FileLockRetryOptions = {
 result is passed to `shouldReclaim` and `shouldRemoveStaleLock`, allowing PID,
 process-start, argv, or role schemas to remain application-owned.
 
+On Windows, a pathed `EPERM` from creating or opening the lock file can be a
+short teardown race after another holder unlinks it. The async lock retries that
+specific denial at most eight times. A parent-directory denial, a denial from a
+callback, or a ninth consecutive lock-file denial surfaces as the original
+`EPERM`; it is not converted to `file_lock_timeout`.
+
 ## Owner-scoped reentrancy
 
 Version 0.5 removes the unsound process-scoped `allowReentrant` boolean and
@@ -167,10 +173,10 @@ progress.
 ## Synchronous locks
 
 `acquireFileLockSync()` and `withFileLockSync()` mirror filesystem arbitration,
-retry, payload parsing, stale policy, guarded identity-conditioned reclaim,
-verification, and compromise monitoring. They do not use the async manager
-queue, support async callbacks, or provide same-process reentrancy. Retry waits
-block the calling thread; use the async API in request-serving code.
+retry, payload parsing, stale policy, owner-scoped reentrancy, guarded
+identity-conditioned reclaim, verification, and compromise monitoring. They do
+not use the async manager queue or support async callbacks. Retry waits block
+the calling thread; use the async API in request-serving code.
 
 Always release in a `finally`:
 
@@ -236,7 +242,11 @@ await locks.drain();
 
 ## Stale policy: `shouldReclaim`
 
-The default policy treats locks whose `createdAt` is older than `staleMs` as stale. Pass a custom callback when you want a richer notion of "is the holder still alive":
+The default policy treats locks whose valid `createdAt` is older than `staleMs`
+as stale. A valid current or future timestamp remains authoritative under
+filesystem clock skew; only absent or malformed timestamps fall back to the
+sidecar `mtime`. Pass a custom callback when you want a richer notion of "is the
+holder still alive":
 
 ```ts
 import { kill } from "node:process";

--- a/docs/test-hooks.md
+++ b/docs/test-hooks.md
@@ -37,6 +37,7 @@ type FsSafeTestHooks = {
   beforeRootFallbackMutation?: (operation: "mkdir" | "move" | "remove", targetPath: string) => Promise<void> | void;
   afterPinnedWriteFallbackRename?: (targetPath: string) => Promise<void> | void;
   beforeSiblingTempWrite?: (tempPath: string) => Promise<void> | void;
+  beforeSidecarLockSnapshotOpen?: (lockPath: string) => Promise<void> | void;
   beforeTrashMove?: (targetPath: string, destPath: string) => void;
   afterPublishTargetCreated?: (method, targetPath, identity) => Promise<void> | void;
   beforePublishDirectorySync?: (method, targetPath, identity) => Promise<void> | void;
@@ -54,6 +55,7 @@ type FsSafeTestHooks = {
 | `beforeRootFallbackMutation` | A guarded JS root fallback is about to mkdir, move, or remove. |
 | `afterPinnedWriteFallbackRename` | A fallback rename committed and post-commit identity checks have not run yet. |
 | `beforeSiblingTempWrite` | A sibling temp file exists and its writer is about to run. |
+| `beforeSidecarLockSnapshotOpen` | A sidecar lock was inspected and is about to be opened for a bounded snapshot read. |
 | `beforeTrashMove` | Trash handling is about to move the target. |
 | `afterPublishTargetCreated` | Exclusive publication created its target and final fences have not run yet. |
 | `beforePublishDirectorySync` | Publication verified the target and is about to sync its parent directory. |

--- a/src/file-lock-sync.ts
+++ b/src/file-lock-sync.ts
@@ -13,7 +13,7 @@ import {
 } from "./sidecar-lock-reclaim.js";
 import {
   computeSidecarLockDelayMs,
-  sidecarLockPayloadIsStale,
+  sidecarLockPayloadCreatedAtMs,
 } from "./sidecar-lock-policy.js";
 import type {
   SidecarLockCompromisedInfo,
@@ -135,7 +135,8 @@ function boundedLockPath(lockPath: string, lockRoot?: Root): string {
 }
 
 function defaultShouldReclaim(payload: unknown, lockPath: string, staleMs: number, nowMs: number): boolean {
-  if (sidecarLockPayloadIsStale(payload, staleMs, nowMs)) return true;
+  const createdAtMs = sidecarLockPayloadCreatedAtMs(payload);
+  if (createdAtMs !== null) return nowMs - createdAtMs > staleMs;
   try {
     return nowMs - fs.statSync(lockPath).mtimeMs > staleMs;
   } catch {
@@ -145,6 +146,16 @@ function defaultShouldReclaim(payload: unknown, lockPath: string, staleMs: numbe
 
 function sleep(milliseconds: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function reclaimGuardExists(reclaimGuardPath: string): boolean {
+  try {
+    fs.lstatSync(reclaimGuardPath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
 }
 
 export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
@@ -168,8 +179,26 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
   const retry = options.retry ?? {};
   const startedAt = Date.now();
   let attempt = 0;
+  const reclaimGuardPath = `${lockPath}.reclaim`;
+  const waitForRetry = (): void => {
+    const elapsed = Date.now() - startedAt;
+    const timedOut = options.timeoutMs !== undefined && elapsed >= options.timeoutMs;
+    if (timedOut || (retry.retries !== undefined && attempt >= retry.retries)) {
+      throw Object.assign(new Error(`file lock timeout for ${normalizedTargetPath}`), {
+        code: "file_lock_timeout",
+        lockPath,
+        normalizedTargetPath,
+      });
+    }
+    sleep(computeSidecarLockDelayMs(retry, attempt));
+    attempt += 1;
+  };
 
   while (true) {
+    if (reclaimGuardExists(reclaimGuardPath)) {
+      waitForRetry();
+      continue;
+    }
     let fd: number | undefined;
     try {
       const payload = options.payload();
@@ -223,20 +252,12 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
       }
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       if (heldLocks.has(normalizedTargetPath)) {
-        const elapsed = Date.now() - startedAt;
-        const timedOut = options.timeoutMs !== undefined && elapsed >= options.timeoutMs;
-        if (timedOut || (retry.retries !== undefined && attempt >= retry.retries)) {
-          throw Object.assign(new Error(`file lock timeout for ${normalizedTargetPath}`), {
-            code: "file_lock_timeout",
-            lockPath,
-            normalizedTargetPath,
-          });
-        }
-        sleep(computeSidecarLockDelayMs(retry, attempt));
-        attempt += 1;
+        waitForRetry();
         continue;
       }
-      const snapshot = readSidecarLockSnapshotSync(lockPath, options.parsePayload);
+      const snapshot = readSidecarLockSnapshotSync(lockPath, options.parsePayload, {
+        rejectNonFile: true,
+      });
       if (!snapshot) continue;
       const nowMs = Date.now();
       const reclaim = options.shouldReclaim
@@ -260,15 +281,24 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
             payload: snapshot.payload,
           })
         ) {
-          const reclaimGuard = `${lockPath}.reclaim`;
+          let ownsReclaimGuard = false;
           try {
-            fs.mkdirSync(reclaimGuard);
+            fs.mkdirSync(reclaimGuardPath);
+            ownsReclaimGuard = true;
             if (removeSidecarLockIfUnchangedSync(lockPath, snapshot)) continue;
+          } catch (reclaimError) {
+            if ((reclaimError as NodeJS.ErrnoException).code !== "EEXIST") {
+              throw reclaimError;
+            }
+            waitForRetry();
+            continue;
           } finally {
-            try {
-              fs.rmdirSync(reclaimGuard);
-            } catch {
-              // A surviving reclaim guard fails closed.
+            if (ownsReclaimGuard) {
+              try {
+                fs.rmdirSync(reclaimGuardPath);
+              } catch {
+                // A surviving reclaim guard fails closed.
+              }
             }
           }
         }
@@ -278,17 +308,7 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
           normalizedTargetPath,
         });
       }
-      const elapsed = Date.now() - startedAt;
-      const timedOut = options.timeoutMs !== undefined && elapsed >= options.timeoutMs;
-      if (timedOut || (retry.retries !== undefined && attempt >= retry.retries)) {
-        throw Object.assign(new Error(`file lock timeout for ${normalizedTargetPath}`), {
-          code: "file_lock_timeout",
-          lockPath,
-          normalizedTargetPath,
-        });
-      }
-      sleep(computeSidecarLockDelayMs(retry, attempt));
-      attempt += 1;
+      waitForRetry();
     }
   }
 }

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -471,6 +471,7 @@ export async function inspectWindowsAcl(
       targetPath,
     ]);
     let entries = parseIcaclsOutput(`${stdout}\n${stderr}`.trim(), targetPath);
+    if (!entries.length) throw new Error("Windows ACL output could not be verified");
     const unresolvedPrincipals = entries
       .filter((entry) => !entry.sid)
       .map((entry) => entry.principal);

--- a/src/sidecar-lock-acquire.ts
+++ b/src/sidecar-lock-acquire.ts
@@ -236,6 +236,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
           snapshot = await readSidecarLockSnapshot(lockPath, {
             lockRoot: options.lockRoot,
             parsePayload: options.parsePayload,
+            rejectNonFile: true,
           });
         } catch (readErr) {
           if (!isTransientLockFileDenial(readErr, lockPath) || !withinDenialBudget()) throw readErr;

--- a/src/sidecar-lock-policy.ts
+++ b/src/sidecar-lock-policy.ts
@@ -29,6 +29,11 @@ export function sidecarLockPayloadIsStale(
   staleMs: number,
   nowMs: number,
 ): boolean {
+  const createdAtMs = sidecarLockPayloadCreatedAtMs(payload);
+  return createdAtMs !== null && nowMs - createdAtMs > staleMs;
+}
+
+export function sidecarLockPayloadCreatedAtMs(payload: unknown): number | null {
   const createdAt =
     payload &&
     typeof payload === "object" &&
@@ -37,7 +42,7 @@ export function sidecarLockPayloadIsStale(
       ? payload.createdAt
       : "";
   const createdAtMs = Date.parse(createdAt);
-  return Number.isFinite(createdAtMs) && nowMs - createdAtMs > staleMs;
+  return Number.isFinite(createdAtMs) ? createdAtMs : null;
 }
 
 export async function defaultSidecarLockShouldReclaim(params: {
@@ -46,7 +51,8 @@ export async function defaultSidecarLockShouldReclaim(params: {
   staleMs: number;
   nowMs: number;
 }): Promise<boolean> {
-  if (sidecarLockPayloadIsStale(params.payload, params.staleMs, params.nowMs)) return true;
+  const createdAtMs = sidecarLockPayloadCreatedAtMs(params.payload);
+  if (createdAtMs !== null) return params.nowMs - createdAtMs > params.staleMs;
   try {
     return params.nowMs - (await fs.stat(params.lockPath)).mtimeMs > params.staleMs;
   } catch {

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -2,10 +2,11 @@ import { randomBytes } from "node:crypto";
 import fsSync, { type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { readFileHandleBounded } from "./bounded-read.js";
+import { readFileDescriptorBoundedSync, readFileHandleBounded } from "./bounded-read.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import type { Root } from "./root-impl.js";
+import { getFsSafeTestHooks } from "./test-hooks.js";
 
 const MAX_LOCK_PAYLOAD_BYTES = 1024 * 1024;
 
@@ -87,8 +88,14 @@ export function parseSidecarLockPayload(
 
 export async function readSidecarLockSnapshot(
   lockPath: string,
-  options: { lockRoot?: Root; parsePayload?: (raw: string) => unknown } = {},
+  options: {
+    lockRoot?: Root;
+    parsePayload?: (raw: string) => unknown;
+    rejectNonFile?: boolean;
+    allowDescriptorIdentityDrift?: boolean;
+  } = {},
 ): Promise<SidecarLockSnapshot | null> {
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
     if (options.lockRoot) {
       const opened = await options.lockRoot.open(relativeSidecarLockPath(options.lockRoot, lockPath));
@@ -103,9 +110,45 @@ export async function readSidecarLockSnapshot(
         await opened.handle.close().catch(() => undefined);
       }
     }
-    const stat = await fs.lstat(lockPath);
-    const raw = await fs.readFile(lockPath, "utf8");
-    return { raw, payload: parseSidecarLockPayload(raw, options.parsePayload), stat };
+    const before = await fs.lstat(lockPath);
+    if (!before.isFile() || before.isSymbolicLink()) {
+      if (options.rejectNonFile) {
+        throw new FsSafeError("not-file", `sidecar lock is not a regular file: ${lockPath}`);
+      }
+      return null;
+    }
+    await getFsSafeTestHooks()?.beforeSidecarLockSnapshotOpen?.(lockPath);
+    const noFollow =
+      process.platform !== "win32" && typeof fsSync.constants.O_NOFOLLOW === "number"
+        ? fsSync.constants.O_NOFOLLOW
+        : 0;
+    try {
+      handle = await fs.open(
+        lockPath,
+        fsSync.constants.O_RDONLY |
+          noFollow |
+          (typeof fsSync.constants.O_NONBLOCK === "number" ? fsSync.constants.O_NONBLOCK : 0),
+      );
+    } catch (error) {
+      if (options.rejectNonFile && (error as NodeJS.ErrnoException).code === "ELOOP") {
+        throw new FsSafeError("not-file", `sidecar lock is not a regular file: ${lockPath}`, {
+          cause: error,
+        });
+      }
+      throw error;
+    }
+    const opened = await handle.stat();
+    if (!opened.isFile()) {
+      if (options.rejectNonFile) {
+        throw new FsSafeError("not-file", `sidecar lock is not a regular file: ${lockPath}`);
+      }
+      return null;
+    }
+    if (!options.allowDescriptorIdentityDrift && !sameFileIdentity(before, opened)) return null;
+    const raw = (await readFileHandleBounded(handle, MAX_LOCK_PAYLOAD_BYTES)).toString("utf8");
+    const after = await fs.lstat(lockPath);
+    if (!after.isFile() || !sameFileIdentity(before, after)) return null;
+    return { raw, payload: parseSidecarLockPayload(raw, options.parsePayload), stat: after };
   } catch (err) {
     if (
       (err as NodeJS.ErrnoException).code === "ENOENT" ||
@@ -114,24 +157,32 @@ export async function readSidecarLockSnapshot(
       return null;
     }
     throw err;
+  } finally {
+    await handle?.close().catch(() => undefined);
   }
 }
 
 export function readSidecarLockSnapshotSync(
   lockPath: string,
   parsePayload?: (raw: string) => unknown,
+  options: { rejectNonFile?: boolean } = {},
 ): SidecarLockSnapshot | null {
   let fd: number | undefined;
   try {
     const before = fsSync.lstatSync(lockPath);
-    if (!before.isFile() || before.isSymbolicLink()) return null;
+    if (!before.isFile() || before.isSymbolicLink()) {
+      if (options.rejectNonFile) {
+        throw new FsSafeError("not-file", `sidecar lock is not a regular file: ${lockPath}`);
+      }
+      return null;
+    }
     const noFollow =
       process.platform !== "win32" && typeof fsSync.constants.O_NOFOLLOW === "number"
         ? fsSync.constants.O_NOFOLLOW
         : 0;
     fd = fsSync.openSync(lockPath, fsSync.constants.O_RDONLY | noFollow);
     const opened = fsSync.fstatSync(fd);
-    const raw = fsSync.readFileSync(fd, "utf8");
+    const raw = readFileDescriptorBoundedSync(fd, MAX_LOCK_PAYLOAD_BYTES).toString("utf8");
     const after = fsSync.lstatSync(lockPath);
     if (!sameFileIdentity(before, opened) || !sameFileIdentity(opened, after)) return null;
     return {
@@ -186,7 +237,10 @@ export async function removeSidecarLockIfUnchanged(
   observed: SidecarLockSnapshot | null,
   options: { lockRoot?: Root; parsePayload?: (raw: string) => unknown } = {},
 ): Promise<boolean> {
-  const current = await readSidecarLockSnapshot(lockPath, options);
+  const current = await readSidecarLockSnapshot(lockPath, {
+    ...options,
+    allowDescriptorIdentityDrift: observed?.ownershipToken !== undefined,
+  });
   if (!current || !observed || !sidecarLockSnapshotMatches(current, observed)) {
     return false;
   }
@@ -203,7 +257,10 @@ export async function sidecarLockSnapshotStillPresent(
   observed: SidecarLockSnapshot | null,
   options: { lockRoot?: Root; parsePayload?: (raw: string) => unknown } = {},
 ): Promise<boolean> {
-  const current = await readSidecarLockSnapshot(lockPath, options);
+  const current = await readSidecarLockSnapshot(lockPath, {
+    ...options,
+    allowDescriptorIdentityDrift: observed?.ownershipToken !== undefined,
+  });
   return !!current && !!observed && sidecarLockSnapshotMatches(current, observed);
 }
 

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -30,6 +30,8 @@ type SidecarLockManagerState = {
   reclaimGuards: Set<string>;
 };
 const GLOBAL_STATE_KEY = Symbol.for("fsSafe.sidecarLockManagers");
+const GLOBAL_CLEANUP_KEY = Symbol.for("fsSafe.sidecarLockCleanupRegistered");
+const GLOBAL_CLEANUP_HANDLER_KEY = Symbol.for("fsSafe.sidecarLockCleanupHandler");
 function getGlobalManagers(): Map<string, SidecarLockManagerState> {
   const globalWithState = globalThis as typeof globalThis & {
     [GLOBAL_STATE_KEY]?: Map<string, SidecarLockManagerState>;
@@ -129,6 +131,22 @@ function releaseAllLocksSync(state: SidecarLockManagerState): void {
   releaseAllReclaimGuardsSync(state);
 }
 
+function ensureGlobalExitCleanupRegistered(): void {
+  const globalWithCleanup = globalThis as typeof globalThis & {
+    [GLOBAL_CLEANUP_KEY]?: boolean;
+    [GLOBAL_CLEANUP_HANDLER_KEY]?: () => void;
+  };
+  if (globalWithCleanup[GLOBAL_CLEANUP_KEY]) return;
+  globalWithCleanup[GLOBAL_CLEANUP_KEY] = true;
+  const cleanup = () => {
+    for (const state of getGlobalManagers().values()) {
+      releaseAllLocksSync(state);
+    }
+  };
+  globalWithCleanup[GLOBAL_CLEANUP_HANDLER_KEY] = cleanup;
+  process.on("exit", cleanup);
+}
+
 async function releaseHeldLock(
   state: SidecarLockManagerState,
   normalizedTargetPath: string,
@@ -187,16 +205,9 @@ export function createSidecarLockManager(key: string) {
   const state = resolveManagerState(key);
 
   function ensureExitCleanupRegistered(): void {
-    if (!state.cleanupRegistered) {
-      state.cleanupRegistered = true;
-      state.reclaimCleanupRegistered = true;
-      process.on("exit", () => releaseAllLocksSync(state));
-      return;
-    }
-    if (!state.reclaimCleanupRegistered) {
-      state.reclaimCleanupRegistered = true;
-      process.on("exit", () => releaseAllReclaimGuardsSync(state));
-    }
+    state.cleanupRegistered = true;
+    state.reclaimCleanupRegistered = true;
+    ensureGlobalExitCleanupRegistered();
   }
 
   async function acquire<TPayload extends Record<string, unknown>>(

--- a/src/test-hooks.ts
+++ b/src/test-hooks.ts
@@ -17,6 +17,7 @@ export type FsSafeTestHooks = {
   ) => Promise<void> | void;
   afterPinnedWriteFallbackRename?: (targetPath: string) => Promise<void> | void;
   beforeSiblingTempWrite?: (tempPath: string) => Promise<void> | void;
+  beforeSidecarLockSnapshotOpen?: (lockPath: string) => Promise<void> | void;
   beforeTrashMove?: (targetPath: string, destPath: string) => void;
   afterPublishTargetCreated?: (
     method: "hardlink" | "exclusive-copy" | "rename-noreplace",

--- a/test/file-lock-concurrency-stress.test.ts
+++ b/test/file-lock-concurrency-stress.test.ts
@@ -1,0 +1,191 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { acquireFileLock, acquireFileLockSync, withFileLock } from "../src/file-lock.js";
+import { createSidecarLockManager } from "../src/sidecar-lock.js";
+
+const childTarget = process.env.FS_SAFE_STRESS_LOCK_TARGET;
+const childLog = process.env.FS_SAFE_STRESS_LOCK_LOG;
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function tempRoot(prefix: string): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(directory);
+  return directory;
+}
+
+describe("file-lock concurrency stress", () => {
+  it.runIf(!childTarget)("bounds attacker-controlled sidecar payload reads", async () => {
+    const base = await tempRoot("fs-safe-sidecar-payload-limit-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    await fs.writeFile(lockPath, Buffer.alloc(1024 * 1024 + 1, 0x20));
+    const manager = createSidecarLockManager(`fs-safe-payload-limit-${Date.now()}`);
+
+    await expect(
+      manager.acquire({
+        targetPath,
+        lockPath,
+        staleMs: 1,
+        timeoutMs: 0,
+        retry: { retries: 0 },
+        payload: async () => ({ createdAt: new Date().toISOString() }),
+      }),
+    ).rejects.toMatchObject({ code: "too-large" });
+    expect(() =>
+      acquireFileLockSync(targetPath, {
+        staleMs: 1,
+        timeoutMs: 0,
+        retry: { retries: 0 },
+        payload: () => ({ createdAt: new Date().toISOString() }),
+      }),
+    ).toThrow(expect.objectContaining({ code: "too-large" }));
+  });
+
+  it.runIf(!childTarget && process.platform !== "win32")(
+    "rejects a dangling symlink sidecar without ignoring the deadline",
+    async () => {
+      const base = await tempRoot("fs-safe-sidecar-dangling-symlink-");
+      const targetPath = path.join(base, "state.json");
+      await fs.symlink(path.join(base, "missing"), `${targetPath}.lock`);
+
+      await expect(
+        acquireFileLock(targetPath, {
+          staleMs: 1,
+          timeoutMs: 0,
+          retry: { retries: 0 },
+          payload: async () => ({ createdAt: new Date().toISOString() }),
+        }),
+      ).rejects.toMatchObject({ code: "not-file" });
+      expect(() =>
+        acquireFileLockSync(targetPath, {
+          staleMs: 1,
+          timeoutMs: 0,
+          retry: { retries: 0 },
+          payload: () => ({ createdAt: new Date().toISOString() }),
+        }),
+      ).toThrow(expect.objectContaining({ code: "not-file" }));
+    },
+  );
+
+  it.runIf(!childTarget)("never overlaps many in-process holders and releases after throws", async () => {
+    const root = await tempRoot("fs-safe-lock-in-process-");
+    const targetPath = path.join(root, "state.json");
+    let active = 0;
+    let peak = 0;
+
+    const results = await Promise.allSettled(
+      Array.from({ length: 40 }, async (_, index) => {
+        return await withFileLock(
+          targetPath,
+          {
+            staleMs: 60_000,
+            timeoutMs: 10_000,
+            retry: { minTimeout: 1, maxTimeout: 2 },
+            payload: async () => ({ index, createdAt: new Date().toISOString() }),
+          },
+          async () => {
+            active += 1;
+            peak = Math.max(peak, active);
+            try {
+              await delay(index % 3);
+              if (index % 11 === 0) throw new Error(`holder ${index} failed`);
+              return index;
+            } finally {
+              active -= 1;
+            }
+          },
+        );
+      }),
+    );
+
+    expect(peak).toBe(1);
+    expect(active).toBe(0);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(4);
+    await expect(fs.stat(`${targetPath}.lock`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(!childTarget)(
+    "never overlaps holders across real child processes",
+    async () => {
+      const root = await tempRoot("fs-safe-lock-child-process-");
+      const targetPath = path.join(root, "state.json");
+      const logPath = path.join(root, "critical-sections.log");
+      const vitestPath = path.resolve("node_modules/vitest/vitest.mjs");
+      const testPath = path.relative(process.cwd(), import.meta.filename);
+
+      const children = Array.from({ length: 8 }, (_, index) =>
+        new Promise<void>((resolve, reject) => {
+          const child = spawn(
+            process.execPath,
+            [vitestPath, "run", testPath, "--maxWorkers=1", "--silent"],
+            {
+              env: {
+                ...process.env,
+                FS_SAFE_STRESS_LOCK_TARGET: targetPath,
+                FS_SAFE_STRESS_LOCK_LOG: logPath,
+                FS_SAFE_STRESS_LOCK_INDEX: String(index),
+              },
+              stdio: ["ignore", "ignore", "pipe"],
+            },
+          );
+          let stderr = "";
+          child.stderr.on("data", (chunk) => {
+            stderr += String(chunk);
+          });
+          child.once("error", reject);
+          child.once("exit", (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(`lock child ${index} exited ${code}: ${stderr}`));
+          });
+        }),
+      );
+      await Promise.all(children);
+
+      const events = (await fs.readFile(logPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => line.split(" "));
+      const active = new Set<string>();
+      let peak = 0;
+      for (const [event, owner] of events) {
+        if (event === "enter") {
+          active.add(owner!);
+          peak = Math.max(peak, active.size);
+        } else {
+          active.delete(owner!);
+        }
+      }
+      expect(events).toHaveLength(16);
+      expect(peak).toBe(1);
+      expect(active.size).toBe(0);
+      await expect(fs.stat(`${targetPath}.lock`)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+    20_000,
+  );
+
+  it.runIf(!!childTarget)("holds one cross-process critical section", async () => {
+    const owner = `${process.pid}:${process.env.FS_SAFE_STRESS_LOCK_INDEX ?? "unknown"}`;
+    const lock = await acquireFileLock(childTarget!, {
+      staleMs: 60_000,
+      timeoutMs: 10_000,
+      retry: { minTimeout: 1, maxTimeout: 5 },
+      payload: async () => ({ owner, createdAt: new Date().toISOString() }),
+    });
+    try {
+      await fs.appendFile(childLog!, `enter ${owner}\n`);
+      await delay(20);
+      await fs.appendFile(childLog!, `exit ${owner}\n`);
+    } finally {
+      await lock.release();
+    }
+    expect(await fs.readFile(childLog!, "utf8")).toContain(owner);
+  });
+});

--- a/test/permissions-exec.test.ts
+++ b/test/permissions-exec.test.ts
@@ -64,6 +64,51 @@ describe("Windows permission command execution", () => {
     expect(exec).toHaveBeenCalledTimes(1);
   });
 
+  it("fails closed when a successful ACL command yields no verifiable entries", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-permission-empty-acl-"));
+    tempDirs.push(dir);
+    const target = path.join(dir, "secret.json");
+    await fs.writeFile(target, "{}", { mode: 0o600 });
+    const exec = vi.fn(async (command: string) => {
+      if (command.toLowerCase().endsWith("powershell.exe")) {
+        return {
+          stdout: JSON.stringify({
+            ownerSid: "S-1-5-21-42",
+            currentUserSid: "S-1-5-21-42",
+            principalSids: [],
+            principalTranslationFailed: false,
+            remote: false,
+          }),
+          stderr: "",
+        };
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    await expect(
+      inspectPathPermissions(target, {
+        platform: "win32",
+        env: { SystemRoot: "C:\\Windows" },
+        exec,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      source: "unknown",
+      error: expect.stringContaining("could not be verified"),
+    });
+
+    await expect(
+      readSecureFile({
+        filePath: target,
+        inject: {
+          platform: "win32",
+          env: { SystemRoot: "C:\\Windows" },
+          exec,
+        },
+      }),
+    ).rejects.toMatchObject({ code: "permission-unverified" });
+  });
+
   it("inspects permissions once for one secure read", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-permission-count-"));
     tempDirs.push(dir);

--- a/test/sidecar-lock-ownership-token.test.ts
+++ b/test/sidecar-lock-ownership-token.test.ts
@@ -77,7 +77,6 @@ describe("sidecar lock ownership tokens", () => {
     const targetPath = path.join(base, "state.json");
     const lockPath = `${targetPath}.lock`;
     const manager = createSidecarLockManager(`fs-safe-sync-identity-drift-${Date.now()}`);
-    const listenersBefore = new Set(process.listeners("exit"));
     let exitListener: (() => void) | undefined;
 
     try {
@@ -98,17 +97,15 @@ describe("sidecar lock ownership tokens", () => {
         });
       });
 
-      exitListener = process
-        .listeners("exit")
-        .find((listener) => !listenersBefore.has(listener)) as (() => void) | undefined;
+      exitListener = Reflect.get(
+        globalThis,
+        Symbol.for("fsSafe.sidecarLockCleanupHandler"),
+      ) as (() => void) | undefined;
       expect(exitListener).toBeDefined();
       exitListener?.();
 
       expect(fsSync.existsSync(lockPath)).toBe(false);
     } finally {
-      if (exitListener) {
-        process.removeListener("exit", exitListener);
-      }
       manager.reset();
     }
   });
@@ -121,7 +118,6 @@ describe("sidecar lock ownership tokens", () => {
       const lockPath = `${targetPath}.lock`;
       const replacementPath = path.join(base, "replacement.lock");
       const manager = createSidecarLockManager(`fs-safe-sync-non-regular-${Date.now()}`);
-      const listenersBefore = new Set(process.listeners("exit"));
       let exitListener: (() => void) | undefined;
 
       try {
@@ -137,18 +133,16 @@ describe("sidecar lock ownership tokens", () => {
         await fsp.symlink(replacementPath, lockPath);
         const readFileSync = vi.spyOn(fsSync, "readFileSync");
 
-        exitListener = process
-          .listeners("exit")
-          .find((listener) => !listenersBefore.has(listener)) as (() => void) | undefined;
+        exitListener = Reflect.get(
+          globalThis,
+          Symbol.for("fsSafe.sidecarLockCleanupHandler"),
+        ) as (() => void) | undefined;
         expect(exitListener).toBeDefined();
         exitListener?.();
 
         expect(readFileSync).not.toHaveBeenCalledWith(lockPath, "utf8");
         expect((await fsp.lstat(lockPath)).isSymbolicLink()).toBe(true);
       } finally {
-        if (exitListener) {
-          process.removeListener("exit", exitListener);
-        }
         manager.reset();
       }
     },

--- a/test/sidecar-lock-regression.test.ts
+++ b/test/sidecar-lock-regression.test.ts
@@ -3,9 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fileStore } from "../src/file-store.js";
-import { acquireFileLock } from "../src/file-lock.js";
+import { acquireFileLock, acquireFileLockSync } from "../src/file-lock.js";
 import { configureFsSafeLocks, getFsSafeLockConfig } from "../src/lock-config.js";
 import { createSidecarLockManager } from "../src/sidecar-lock.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 
 const tempDirs: string[] = [];
 
@@ -16,6 +17,7 @@ async function tempRoot(prefix: string): Promise<string> {
 }
 
 afterEach(async () => {
+  __setFsSafeTestHooksForTest();
   vi.restoreAllMocks();
   configureFsSafeLocks({
     retry: undefined,
@@ -265,6 +267,43 @@ describe("sidecar lock regressions", () => {
     await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("does not remove a reclaim guard owned by another synchronous acquirer", async () => {
+    const base = await tempRoot("fs-safe-sidecar-sync-reclaim-guard-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const reclaimGuardPath = `${lockPath}.reclaim`;
+    await fsp.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
+    await fsp.mkdir(reclaimGuardPath);
+
+    expect(() =>
+      acquireFileLockSync(targetPath, {
+        staleMs: 1,
+        timeoutMs: 0,
+        retry: { retries: 0 },
+        staleRecovery: "remove-if-unchanged",
+        payload: () => ({ createdAt: new Date().toISOString() }),
+        shouldReclaim: () => true,
+        shouldRemoveStaleLock: () => true,
+      }),
+    ).toThrow(expect.objectContaining({ code: "file_lock_timeout" }));
+    expect((await fsp.stat(reclaimGuardPath)).isDirectory()).toBe(true);
+    await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("2000");
+  });
+
+  it("registers one process-exit cleanup for many lock manager domains", async () => {
+    const base = await tempRoot("fs-safe-sidecar-exit-listener-");
+    const before = process.listenerCount("exit");
+
+    for (let index = 0; index < 12; index += 1) {
+      const lock = await acquireFileLock(path.join(base, `state-${index}.json`), {
+        payload: async () => ({ index }),
+      });
+      await lock.release();
+    }
+
+    expect(process.listenerCount("exit")).toBeLessThanOrEqual(before + 1);
+  });
+
   it("backfills reclaim state created by an older package copy", async () => {
     const base = await tempRoot("fs-safe-sidecar-legacy-manager-state-");
     const targetPath = path.join(base, "state.json");
@@ -326,18 +365,51 @@ describe("sidecar lock regressions", () => {
     await expect(fsp.readFile(lockPath, "utf8")).resolves.toBe("{");
   });
 
+  it("does not override a valid future createdAt with a skewed old mtime", async () => {
+    const base = await tempRoot("fs-safe-sidecar-clock-skew-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    await fsp.writeFile(
+      lockPath,
+      JSON.stringify({ createdAt: "2999-01-01T00:00:00.000Z", owner: "future-clock" }),
+    );
+    await fsp.utimes(lockPath, new Date(0), new Date(0));
+
+    const manager = createSidecarLockManager(`fs-safe-clock-skew-${Date.now()}`);
+    await expect(
+      manager.acquire({
+        targetPath,
+        lockPath,
+        staleMs: 1,
+        timeoutMs: 0,
+        retry: { retries: 0 },
+        payload: async () => ({ createdAt: new Date().toISOString() }),
+      }),
+    ).rejects.toMatchObject({ code: "file_lock_timeout" });
+
+    expect(() =>
+      acquireFileLockSync(targetPath, {
+        staleMs: 1,
+        timeoutMs: 0,
+        retry: { retries: 0 },
+        payload: () => ({ createdAt: new Date().toISOString() }),
+      }),
+    ).toThrow(expect.objectContaining({ code: "file_lock_timeout" }));
+    await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("future-clock");
+  });
+
   it("fails closed when an existing sidecar cannot be read", async () => {
     const base = await tempRoot("fs-safe-sidecar-unreadable-");
     const targetPath = path.join(base, "state.json");
     const lockPath = `${targetPath}.lock`;
     const manager = createSidecarLockManager(`fs-safe-unreadable-test-${Date.now()}`);
     await fsp.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
-    const realReadFile = fsp.readFile.bind(fsp);
-    vi.spyOn(fsp, "readFile").mockImplementation(async (...args) => {
-      if (String(args[0]) === lockPath) {
+    const realOpen = fsp.open.bind(fsp);
+    vi.spyOn(fsp, "open").mockImplementation(async (...args) => {
+      if (String(args[0]) === lockPath && typeof args[1] === "number") {
         throw Object.assign(new Error("permission denied"), { code: "EACCES" });
       }
-      return await realReadFile(...args);
+      return await realOpen(...args);
     });
 
     await expect(
@@ -351,6 +423,53 @@ describe("sidecar lock regressions", () => {
       }),
     ).rejects.toMatchObject({ code: "EACCES" });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "does not follow a sidecar replaced with a symlink during inspection",
+    async () => {
+      const base = await tempRoot("fs-safe-sidecar-snapshot-symlink-");
+      const targetPath = path.join(base, "state.json");
+      const lockPath = `${targetPath}.lock`;
+      const oldLockPath = `${lockPath}.old`;
+      const secretPath = path.join(base, "secret.json");
+      await fsp.writeFile(
+        lockPath,
+        JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z", owner: "original" }),
+      );
+      await fsp.writeFile(
+        secretPath,
+        JSON.stringify({ createdAt: "2999-01-01T00:00:00.000Z", secret: "do-not-read" }),
+      );
+
+      let swapped = false;
+      __setFsSafeTestHooksForTest({
+        beforeSidecarLockSnapshotOpen: async (inspectedPath) => {
+          if (swapped || inspectedPath !== lockPath) return;
+          swapped = true;
+          await fsp.rename(lockPath, oldLockPath);
+          await fsp.symlink(secretPath, lockPath);
+        },
+      });
+      const observedPayloads: unknown[] = [];
+      const manager = createSidecarLockManager(`fs-safe-snapshot-symlink-${Date.now()}`);
+
+      await expect(
+        manager.acquire({
+          targetPath,
+          lockPath,
+          staleMs: 1,
+          timeoutMs: 1,
+          retry: { retries: 0 },
+          payload: async () => ({ createdAt: new Date().toISOString() }),
+          shouldReclaim: async ({ payload }) => {
+            observedPayloads.push(payload);
+            return false;
+          },
+        }),
+      ).rejects.toMatchObject({ code: "not-file" });
+      expect(observedPayloads).toEqual([]);
+    },
+  );
 
   it("keeps lock config as explicit defaults, not global auto-locking", async () => {
     const base = await tempRoot("fs-safe-lock-config-");

--- a/test/sidecar-lock-windows-denial.test.ts
+++ b/test/sidecar-lock-windows-denial.test.ts
@@ -137,6 +137,38 @@ describe.runIf(process.platform === "win32")("Windows sidecar lock denials", () 
     await expect(fsp.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("retries exactly eight pathed lock-file denials before surfacing EPERM", async () => {
+    const base = await fsp.realpath(await tempRoot("fs-safe-sidecar-eperm-budget-"));
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    configureFsSafeNative({ mode: "off" });
+    const realOpen = fsp.open.bind(fsp) as typeof fsp.open;
+    let deniedCreates = 0;
+    let payloadCalls = 0;
+    vi.spyOn(fsp, "open").mockImplementation((async (...args: Parameters<typeof fsp.open>) => {
+      if (args[0] === lockPath && args[1] === "wx") {
+        deniedCreates += 1;
+        throw denial(lockPath);
+      }
+      return await realOpen(...args);
+    }) as typeof fsp.open);
+
+    await expect(
+      acquireFileLock(targetPath, {
+        managerKey: `eperm-budget-${Date.now()}-${Math.random()}`,
+        staleMs: 60_000,
+        timeoutMs: 1_000,
+        retry: { minTimeout: 1, maxTimeout: 1 },
+        payload: async () => {
+          payloadCalls += 1;
+          return { pid: process.pid };
+        },
+      }),
+    ).rejects.toMatchObject({ code: "EPERM", path: lockPath });
+    expect(deniedCreates).toBe(9);
+    expect(payloadCalls).toBe(9);
+  });
+
   it("retries a contended snapshot read denied mid-teardown", async () => {
     const base = await fsp.realpath(await tempRoot("fs-safe-sidecar-eperm-read-"));
     const targetPath = path.join(base, "state.json");
@@ -146,17 +178,17 @@ describe.runIf(process.platform === "win32")("Windows sidecar lock denials", () 
       lockPath,
       JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }),
     );
-    const realReadFile = fsp.readFile.bind(fsp) as typeof fsp.readFile;
+    const realOpen = fsp.open.bind(fsp) as typeof fsp.open;
     let injected = 0;
-    vi.spyOn(fsp, "readFile").mockImplementation((async (...args: Parameters<typeof fsp.readFile>) => {
-      if (args[0] === lockPath && injected === 0) {
+    vi.spyOn(fsp, "open").mockImplementation((async (...args: Parameters<typeof fsp.open>) => {
+      if (args[0] === lockPath && typeof args[1] === "number" && injected === 0) {
         injected += 1;
         // The holder's unlink lands while the reader is being denied.
         await fsp.rm(lockPath, { force: true });
         throw denial(lockPath);
       }
-      return await realReadFile(...args);
-    }) as typeof fsp.readFile);
+      return await realOpen(...args);
+    }) as typeof fsp.open);
 
     const lock = await acquireFileLock(targetPath, {
       managerKey: `eperm-read-${Date.now()}-${Math.random()}`,


### PR DESCRIPTION
## Summary

- read contended sidecars through bounded, no-follow, identity-checked descriptors and reject non-file sidecars without spinning
- make valid payload timestamps authoritative under filesystem clock skew and preserve reclaim guards owned by other synchronous acquirers
- fail closed on empty/unverifiable fallback Windows ACL output and keep the eight-retry pathed-`EPERM` budget covered
- consolidate process-exit cleanup to one listener and add real in-process and cross-process mutual-exclusion stress coverage

## Findings fixed

- synchronous stale recovery removed a foreign `.reclaim` directory after `mkdir` returned `EEXIST`
- empty `icacls` output was classified as verified `windows-acl` with permissive facts
- async sidecar inspection could follow a swapped symlink, and async/sync snapshot reads were unbounded
- an old `mtime` overrode a valid future `createdAt`, falsely marking a lock stale
- synchronous acquisition spun forever on a dangling-symlink sidecar, ignoring a zero deadline
- every distinct lock-manager domain registered another permanent process exit listener

## Verification

- `pnpm check` (699 passed, 34 skipped)
- `pnpm test:security` (64 passed)
- `git diff --check`
- autoreview Codex (`--mode local`): clean, no accepted/actionable findings
- real stress: 40 concurrent in-process holders with throwing callbacks and eight independent child processes; peak critical-section occupancy remained one

Host verification ran on macOS/APFS. Windows-only denial cases remain explicitly gated and now cover the exact eight-retry budget and descriptor-based snapshot read.
