### PR TITLE
fix: harden archive extraction validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Keep the POSIX parent-directory no-follow identity check active for synchronous atomic-replacement adapters that omit `fchmodSync`, preventing the documented default adapter path from writing through a symlinked parent.
 - Synchronize the actual destination after descriptor-bound mode application when atomic rename uses copy fallback, and include both bytes and mode in bounded fallback restoration.
 - Continue accepting legacy atomic-replacement adapter literals that expose pathname `chmod` or `chmodSync` methods while keeping those methods unused.
+- Reject archive NUL names, drive-relative path segments, duplicate output names (including collisions introduced by `stripComponents`), and ZIP CRC or declared-size mismatches before publishing output. Explicit zero archive limits now remain zero, and stripped TAR entries count toward `maxEntries`, keeping the native and JavaScript policies aligned.
 
 - Reject non-file sidecars without spinning, and read contended async and synchronous sidecar locks through bounded, no-follow, identity-checked descriptors; keep valid `createdAt` timestamps authoritative under filesystem clock skew; fail closed when fallback Windows ACL inspection returns no verifiable access entries; preserve synchronous stale-reclaim guards owned by another acquirer; and share one process-exit cleanup listener across file-lock manager domains.
 

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -122,7 +122,7 @@ type ArchiveExtractLimits = {
 };
 ```
 
-Defaults exist for each (`DEFAULT_MAX_ARCHIVE_BYTES_ZIP`, `DEFAULT_MAX_ENTRIES`, `DEFAULT_MAX_EXTRACTED_BYTES`, `DEFAULT_MAX_ENTRY_BYTES`, `DEFAULT_MAX_META_ENTRY_BYTES`, `DEFAULT_MAX_ENTRY_PATH_COMPONENTS`). The path-component default is 256. It is evaluated after `stripComponents` and before TypeScript accepts an entry for either JavaScript or native extraction, so rejected entries cannot cause implicit parent-directory creation. The 1 MiB metadata default matches node-tar's `maxMetaEntrySize`; fs-safe passes the same resolved value to node-tar and the native TAR meter.
+Defaults exist for each (`DEFAULT_MAX_ARCHIVE_BYTES_ZIP`, `DEFAULT_MAX_ENTRIES`, `DEFAULT_MAX_EXTRACTED_BYTES`, `DEFAULT_MAX_ENTRY_BYTES`, `DEFAULT_MAX_META_ENTRY_BYTES`, `DEFAULT_MAX_ENTRY_PATH_COMPONENTS`). An explicit zero remains zero rather than selecting the default. `maxEntries` counts every archive entry, including entries removed by `stripComponents` or an explicit filter. The path-component default is 256. It is evaluated after `stripComponents` and before TypeScript accepts an entry for either JavaScript or native extraction, so rejected entries cannot cause implicit parent-directory creation. The 1 MiB metadata default matches node-tar's `maxMetaEntrySize`; fs-safe passes the same resolved value to node-tar and the native TAR meter.
 
 A limit violation throws `ArchiveLimitError`. Its constant and string code are:
 
@@ -148,10 +148,12 @@ codes remain `"destination-not-directory"`, `"destination-symlink"`, and
 
 ## What it defends against
 
-- **Path traversal:** entries with `..`, absolute paths, or Windows drive prefixes are rejected (`ArchiveSecurityError`).
+- **Path traversal:** entries with `..`, absolute paths, NUL bytes, or Windows drive-relative segments such as `C:secret` and `nested/C:secret` are rejected (`ArchiveSecurityError`).
 - **Symlink/hardlink entries:** rejected by default. Some archives ship symlink/hardlink entries that point outside the destination once resolved; `extractArchive` does not follow them.
+- **Ambiguous output names:** duplicate names and distinct names that collide after `stripComponents` are rejected instead of relying on backend-specific overwrite order.
 - **TOCTOU during merge:** extraction first writes to a private temp dir, then merges into `destDir` using the same boundary checks as `root().write()`. Destination symlink swaps are checked with the selected platform mechanism; non-Linux routes retain the best-effort race window documented in the [security model](security-model.md#containment-guarantees-by-platform).
 - **Zip bombs:** `maxExtractedBytes` and `maxEntryBytes` apply to *post-decompression* bytes, so highly-compressed payloads hit the cap before they exhaust disk.
+- **Corrupt ZIP payloads:** streamed output must match both the central-directory CRC and declared uncompressed size before it can leave private staging.
 - **Slow-loris archives:** `timeoutMs` is a hard wall-clock budget. Extraction is aborted on overrun.
 - **Metadata bombs:** a fixed-header pass-through reader rejects oversized PAX, GNU long-name, and GNU long-link bodies before either TAR implementation buffers them. It understands octal and base-256 size fields without interpreting metadata content.
 
@@ -208,7 +210,8 @@ await extractArchive({
 
 `readArchiveEntry(archivePath, entryPath, { maxBytes, kind? })` reads one
 regular-file entry into a bounded `Buffer` without extracting a tree. It pins
-and privately stages the archive input, rejects link and directory entries,
+and privately stages the archive input, rejects link, directory, and duplicate
+entries, verifies ZIP CRC and declared size,
 and throws `ArchiveLimitError` if decompressed bytes exceed `maxBytes`. ZIP
 inputs retain the archive subpath's 256 MiB compressed-input ceiling.
 With a native binding it uses the same Rust decoders as extraction, including
@@ -252,11 +255,11 @@ import {
 } from "@openclaw/fs-safe/archive";
 ```
 
-- `validateArchiveEntryPath(raw, opts)` — throws `ArchiveSecurityError` for `..`, absolute, drive-prefixed, or otherwise unsafe entry paths.
-- `normalizeArchiveEntryPath(raw)` — POSIX-normalizes the entry path (forward slashes, no `.` segments).
+- `validateArchiveEntryPath(raw, opts)` — throws `ArchiveSecurityError` for `..`, absolute, NUL-containing, drive-relative, or otherwise unsafe entry paths.
+- `normalizeArchiveEntryPath(raw)` — converts backslashes in the entry path to forward slashes.
 - `stripArchivePath(entryPath, n)` — strip the leading N path components, returning `null` if not enough remain.
 - `resolveArchiveOutputPath({ destDir, entryPath })` — combines the entry path with the destination, after validation.
-- `isWindowsDrivePath(value)` — detects `C:\…` style entries that should be rejected.
+- `isWindowsDrivePath(value)` — detects drive-relative segments such as `C:secret` or `nested/C:secret` that should be rejected.
 
 ## Common patterns
 

--- a/docs/secret-file.md
+++ b/docs/secret-file.md
@@ -79,6 +79,12 @@ itself must not be an alias. Hardlinks are rejected by default so another
 in-tree name cannot alias the credential; pass `rejectHardlinks: false` only
 when you explicitly trust that layout.
 
+These readers do not enforce ownership or mode bits on an existing file. Their
+read contract covers pinned identity, file type, link policy, and byte bounds;
+the `0o600` guarantee belongs to the write helpers below. Use
+[`readSecureFile`](secure-file.md) when reading an externally managed
+credential must also fail on broad permissions or unexpected ownership.
+
 `readSecretFile()` and `tryReadSecretFile()` are asynchronous counterparts with
 the same pinned-handle validation, byte cap, trimming, error codes, and strict
 versus missing-is-undefined naming semantics.

--- a/src/archive-entry.ts
+++ b/src/archive-entry.ts
@@ -3,7 +3,9 @@ import { ArchiveSecurityError } from "./archive-errors.js";
 import { resolveSafeBaseDir } from "./path.js";
 
 export function isWindowsDrivePath(value: string): boolean {
-  return /^[a-zA-Z]:[\\/]/.test(value);
+  return normalizeArchiveEntryPath(value)
+    .split("/")
+    .some((segment) => /^[a-zA-Z]:/.test(segment));
 }
 
 export function normalizeArchiveEntryPath(raw: string): string {
@@ -19,6 +21,12 @@ export function validateArchiveEntryPath(
   }
   if (isWindowsDrivePath(entryPath)) {
     throw new ArchiveSecurityError("entry-path", `archive entry uses a drive path: ${entryPath}`);
+  }
+  if (entryPath.includes("\0")) {
+    throw new ArchiveSecurityError(
+      "entry-path",
+      `archive entry contains a NUL byte: ${entryPath}`,
+    );
   }
   const normalized = path.posix.normalize(normalizeArchiveEntryPath(entryPath));
   const escapeLabel = params?.escapeLabel ?? "destination";
@@ -47,6 +55,20 @@ export function stripArchivePath(entryPath: string, stripComponents: number): st
     return null;
   }
   return result;
+}
+
+export function createArchiveOutputPathTracker(): (entryPath: string, originalPath: string) => void {
+  const seen = new Set<string>();
+  return (entryPath, originalPath) => {
+    const normalized = path.posix.normalize(normalizeArchiveEntryPath(entryPath));
+    if (seen.has(normalized)) {
+      throw new ArchiveSecurityError(
+        "entry-path",
+        `archive entries collide at output path ${normalized}: ${originalPath}`,
+      );
+    }
+    seen.add(normalized);
+  };
 }
 
 export function resolveArchiveOutputPath(params: {

--- a/src/archive-limits.ts
+++ b/src/archive-limits.ts
@@ -68,7 +68,7 @@ function clampLimit(value: number | undefined): number | undefined {
     return undefined;
   }
   const v = Math.floor(value);
-  return v > 0 ? v : undefined;
+  return v >= 0 ? v : undefined;
 }
 
 export function resolveExtractLimits(

--- a/src/archive-native.ts
+++ b/src/archive-native.ts
@@ -1,7 +1,12 @@
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import { ArchiveFormatError, ArchiveSecurityError } from "./archive-errors.js";
-import { resolveArchiveOutputPath, stripArchivePath, validateArchiveEntryPath } from "./archive-entry.js";
+import {
+  createArchiveOutputPathTracker,
+  resolveArchiveOutputPath,
+  stripArchivePath,
+  validateArchiveEntryPath,
+} from "./archive-entry.js";
 import type { ExtractionDeadline } from "./archive-deadline.js";
 import { stageArchiveFileForExtraction } from "./archive-input.js";
 import type { ArchiveKind } from "./archive-kind.js";
@@ -79,6 +84,7 @@ export async function extractNativeArchive(params: {
         assertArchiveEntryCountWithinLimit(manifest.length, limits);
         const strip = Math.max(0, Math.floor(params.stripComponents ?? 0));
         const budget = createByteBudgetTracker(limits);
+        const trackOutputPath = createArchiveOutputPathTracker();
         const plan: Array<{
           index: number;
           path: string;
@@ -94,6 +100,7 @@ export async function extractNativeArchive(params: {
           if (!relPath) continue;
           validateArchiveEntryPath(relPath);
           assertArchiveEntryPathComponentsWithinLimit(relPath, limits);
+          trackOutputPath(relPath, entry.path);
           resolveArchiveOutputPath({ rootDir: stagingDir, relPath, originalPath: entry.path });
           const kind = policyKind(entry.kind);
           if (

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -2,7 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { Readable } from "node:stream";
 import { readFileHandleBounded } from "./bounded-read.js";
-import { ArchiveFormatError } from "./archive-errors.js";
+import { ArchiveFormatError, ArchiveSecurityError } from "./archive-errors.js";
 import {
   normalizeArchiveEntryPath,
   validateArchiveEntryPath,
@@ -19,18 +19,12 @@ import { readTarEntryInfo } from "./archive-tar.js";
 import { preflightTarMetadata } from "./archive-tar-meta.js";
 import { importOptionalTar } from "./archive-tar-runtime.js";
 import { loadZipArchiveWithPreflight } from "./archive-zip-preflight.js";
+import { createZipIntegrityTransform } from "./archive-zip-integrity.js";
+import type { ZipEntry } from "./archive-zip-entry.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { getNativeBinding } from "./native.js";
 import { tempFile } from "./temp-target.js";
-
-type ZipEntry = {
-  name: string;
-  dir: boolean;
-  unixPermissions?: number;
-  nodeStream?: () => NodeJS.ReadableStream;
-  async(type: "nodebuffer"): Promise<Buffer>;
-};
 
 const ZIP_UNIX_FILE_TYPE_MASK = 0o170000;
 const ZIP_UNIX_SYMLINK_TYPE = 0o120000;
@@ -142,7 +136,7 @@ async function readZipEntry(buffer: Buffer, entryPath: string, maxBytes: number)
     typeof entry.nodeStream === "function"
       ? entry.nodeStream()
       : Readable.from(await entry.async("nodebuffer"));
-  return await readStreamBounded(stream, maxBytes);
+  return await readStreamBounded(stream.pipe(createZipIntegrityTransform(entry)), maxBytes);
 }
 
 async function readTarEntry(archivePath: string, entryPath: string, maxBytes: number): Promise<Buffer> {
@@ -152,6 +146,8 @@ async function readTarEntry(archivePath: string, entryPath: string, maxBytes: nu
     maxMetaEntryBytes: DEFAULT_MAX_META_ENTRY_BYTES,
   });
   let matched: Promise<Buffer> | undefined;
+  let entryError: Error | undefined;
+  const seenPaths = new Set<string>();
   await tar.t({
     file: archivePath,
     strict: true,
@@ -160,18 +156,27 @@ async function readTarEntry(archivePath: string, entryPath: string, maxBytes: nu
       const info = readTarEntryInfo(entry);
       validateArchiveEntryPath(info.path, { escapeLabel: "archive root" });
       const normalized = normalizeArchiveEntryPath(info.path).replace(/^\.\//, "");
+      if (seenPaths.has(normalized)) {
+        entryError ??= new ArchiveSecurityError(
+          "entry-path",
+          `archive contains duplicate entry path: ${normalized}`,
+        );
+        entry.resume();
+        return;
+      }
+      seenPaths.add(normalized);
       if (normalized !== entryPath) {
         entry.resume();
         return;
       }
       if (info.type !== "File" && info.type !== "OldFile" && info.type !== "ContiguousFile") {
-        matched = Promise.reject(new Error(`archive entry is not a file: ${entryPath}`));
+        entryError ??= new Error(`archive entry is not a file: ${entryPath}`);
         entry.resume();
         return;
       }
       if (info.size > maxBytes) {
-        matched = Promise.reject(
-          new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT),
+        entryError ??= new ArchiveLimitError(
+          ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT,
         );
         entry.resume();
         return;
@@ -179,6 +184,9 @@ async function readTarEntry(archivePath: string, entryPath: string, maxBytes: nu
       matched = readStreamBounded(entry, maxBytes);
     },
   });
+  if (entryError) {
+    throw entryError;
+  }
   if (!matched) {
     throw new Error(`archive entry not found: ${entryPath}`);
   }
@@ -213,15 +221,22 @@ export async function readArchiveEntry(
           signal,
         );
         let rawEntryPath: string | undefined;
+        const seenPaths = new Set<string>();
         for (const entry of manifest) {
           validateArchiveEntryPath(entry.path, { escapeLabel: "archive root" });
           const normalized = normalizeArchiveEntryPath(entry.path).replace(/^\.\//, "");
+          if (seenPaths.has(normalized)) {
+            throw new ArchiveSecurityError(
+              "entry-path",
+              `archive contains duplicate entry path: ${normalized}`,
+            );
+          }
+          seenPaths.add(normalized);
           if (normalized === requestedEntry) {
             if (entry.kind !== "file") {
               throw new Error(`archive entry is not a file: ${entryPath}`);
             }
             rawEntryPath = entry.path;
-            break;
           }
         }
         if (!rawEntryPath) throw new Error(`archive entry not found: ${entryPath}`);

--- a/src/archive-tar.ts
+++ b/src/archive-tar.ts
@@ -1,4 +1,5 @@
 import {
+  createArchiveOutputPathTracker,
   resolveArchiveOutputPath,
   stripArchivePath,
   validateArchiveEntryPath,
@@ -68,8 +69,11 @@ export function createTarEntryPreflightChecker(params: {
   const limits = resolveExtractLimits(params.limits);
   let entryCount = 0;
   const budget = createByteBudgetTracker(limits);
+  const trackOutputPath = createArchiveOutputPathTracker();
 
   return (entry: TarEntryInfo) => {
+    entryCount += 1;
+    assertArchiveEntryCountWithinLimit(entryCount, limits);
     validateArchiveEntryPath(entry.path, { escapeLabel: params.escapeLabel });
 
     const relPath = stripArchivePath(entry.path, strip);
@@ -78,15 +82,13 @@ export function createTarEntryPreflightChecker(params: {
     }
     validateArchiveEntryPath(relPath, { escapeLabel: params.escapeLabel });
     assertArchiveEntryPathComponentsWithinLimit(relPath, limits);
+    trackOutputPath(relPath, entry.path);
     resolveArchiveOutputPath({
       rootDir: params.rootDir,
       relPath,
       originalPath: entry.path,
       escapeLabel: params.escapeLabel,
     });
-
-    entryCount += 1;
-    assertArchiveEntryCountWithinLimit(entryCount, limits);
 
     const kind = archiveEntryKindFromTarType(entry.type);
     if (

--- a/src/archive-zip-entry.ts
+++ b/src/archive-zip-entry.ts
@@ -7,7 +7,7 @@ export type ZipEntry = {
   name: string;
   dir: boolean;
   unixPermissions?: number;
-  _data?: { uncompressedSize?: number };
+  _data?: { crc32?: number; uncompressedSize?: number };
   nodeStream?: () => NodeJS.ReadableStream;
   async: (type: "nodebuffer") => Promise<Buffer>;
 };

--- a/src/archive-zip-integrity.ts
+++ b/src/archive-zip-integrity.ts
@@ -1,0 +1,51 @@
+import { Transform } from "node:stream";
+import { ArchiveFormatError } from "./archive-errors.js";
+import type { ZipEntry } from "./archive-zip-entry.js";
+
+const CRC32_TABLE = Array.from({ length: 256 }, (_, index) => {
+  let value = index;
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = (value & 1) !== 0 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+  }
+  return value >>> 0;
+});
+
+function updateCrc32(previous: number, buffer: Buffer): number {
+  let crc = previous ^ -1;
+  for (const byte of buffer) {
+    crc = (crc >>> 8) ^ (CRC32_TABLE[(crc ^ byte) & 0xff] ?? 0);
+  }
+  return (crc ^ -1) >>> 0;
+}
+
+export function createZipIntegrityTransform(entry: ZipEntry): Transform {
+  const expectedCrc32 = entry._data?.crc32;
+  const expectedSize = entry._data?.uncompressedSize;
+  if (
+    typeof expectedCrc32 !== "number" ||
+    !Number.isInteger(expectedCrc32) ||
+    typeof expectedSize !== "number" ||
+    !Number.isSafeInteger(expectedSize) ||
+    expectedSize < 0
+  ) {
+    throw new ArchiveFormatError(`zip entry has invalid integrity metadata: ${entry.name}`);
+  }
+
+  let actualCrc32 = 0;
+  let actualSize = 0;
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      const buffer = chunk instanceof Buffer ? chunk : Buffer.from(chunk as Uint8Array);
+      actualCrc32 = updateCrc32(actualCrc32, buffer);
+      actualSize += buffer.byteLength;
+      callback(null, buffer);
+    },
+    flush(callback) {
+      if (actualSize !== expectedSize || actualCrc32 !== (expectedCrc32 >>> 0)) {
+        callback(new ArchiveFormatError(`zip entry integrity check failed: ${entry.name}`));
+        return;
+      }
+      callback();
+    },
+  });
+}

--- a/src/archive-zip-preflight.ts
+++ b/src/archive-zip-preflight.ts
@@ -5,6 +5,7 @@ import {
   resolveExtractLimits,
   type ArchiveExtractLimits,
 } from "./archive-limits.js";
+import { ArchiveSecurityError } from "./archive-errors.js";
 
 export type ZipArchiveWithFiles = {
   files: Record<string, unknown>;
@@ -210,7 +211,14 @@ export async function loadZipArchiveWithPreflight(
     assertArchiveEntryCountWithinLimit(entryCount, resolvedLimits);
   }
   const JSZip = await importOptionalJsZip();
-  return await JSZip.loadAsync(buffer);
+  const archive = await JSZip.loadAsync(buffer);
+  if (entryCount !== null && Object.keys(archive.files).length !== entryCount) {
+    throw new ArchiveSecurityError(
+      "entry-path",
+      "zip archive contains duplicate or colliding entry names",
+    );
+  }
+  return archive;
 }
 
 async function importOptionalJsZip(): Promise<JsZipConstructor> {

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import {
+  createArchiveOutputPathTracker,
   resolveArchiveOutputPath,
   stripArchivePath,
   validateArchiveEntryPath,
@@ -42,6 +43,7 @@ import {
   zipEntryMode,
   type ZipEntry,
 } from "./archive-zip-entry.js";
+import { createZipIntegrityTransform } from "./archive-zip-integrity.js";
 import { FsSafeError } from "./errors.js";
 import { ArchiveSecurityError } from "./archive-errors.js";
 import { extractNativeArchive } from "./archive-native.js";
@@ -179,6 +181,7 @@ async function writeZipFileEntry(params: {
           await pipeline(
             readable,
             createExtractBudgetTransform({ onChunkBytes: params.budget.addBytes }),
+            createZipIntegrityTransform(params.entry),
             writable,
             { signal: params.deadline.signal },
           );
@@ -236,6 +239,7 @@ async function extractZip(params: {
     assertArchiveEntryCountWithinLimit(entries.length, limits);
 
     const budget = createByteBudgetTracker(limits);
+    const trackOutputPath = createArchiveOutputPathTracker();
 
     await withStagedArchiveDestination({
       destinationRealDir,
@@ -252,6 +256,7 @@ async function extractZip(params: {
             continue;
           }
           assertArchiveEntryPathComponentsWithinLimit(output.relPath, limits);
+          trackOutputPath(output.relPath, entry.name);
 
           const isSymlink = isZipSymlinkEntry(entry);
           const entryKind = isSymlink ? "symlink" : entry.dir ? "directory" : "file";

--- a/src/bounded-read-stream.ts
+++ b/src/bounded-read-stream.ts
@@ -2,6 +2,12 @@ import { Transform } from "node:stream";
 import { FsSafeError } from "./errors.js";
 
 export function createMaxBytesTransform(maxBytes: number): Transform {
+  if (
+    maxBytes !== Number.POSITIVE_INFINITY &&
+    (!Number.isSafeInteger(maxBytes) || maxBytes < 0)
+  ) {
+    throw new RangeError("maxBytes must be a non-negative safe integer or Infinity");
+  }
   let bytes = 0;
   return new Transform({
     transform(chunk, _encoding, callback) {

--- a/test/archive-stress-regression.test.ts
+++ b/test/archive-stress-regression.test.ts
@@ -1,0 +1,134 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import JSZip from "jszip";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ARCHIVE_LIMIT_ERROR_CODE,
+  ArchiveFormatError,
+  extractArchive,
+  readArchiveEntry,
+} from "../src/archive.js";
+import {
+  __resetFsSafeNativeConfigForTest,
+  configureFsSafeNative,
+} from "../src/native-config.js";
+
+const tempDirs: string[] = [];
+
+beforeEach(() => configureFsSafeNative({ mode: "off" }));
+
+afterEach(async () => {
+  __resetFsSafeNativeConfigForTest();
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })),
+  );
+});
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function duplicateOnlyZipEntry(bytes: Buffer): Buffer {
+  const eocd = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x05, 0x06]));
+  if (eocd < 0) throw new Error("ZIP fixture has no end-of-central-directory record");
+  const centralOffset = bytes.readUInt32LE(eocd + 16);
+  const centralSize = bytes.readUInt32LE(eocd + 12);
+  const local = bytes.subarray(0, centralOffset);
+  const central = bytes.subarray(centralOffset, centralOffset + centralSize);
+  const secondCentral = Buffer.from(central);
+  secondCentral.writeUInt32LE(local.byteLength, 42);
+  const nextEocd = Buffer.from(bytes.subarray(eocd));
+  nextEocd.writeUInt16LE(2, 8);
+  nextEocd.writeUInt16LE(2, 10);
+  nextEocd.writeUInt32LE(centralSize * 2, 12);
+  nextEocd.writeUInt32LE(local.byteLength * 2, 16);
+  return Buffer.concat([local, local, central, secondCentral, nextEocd]);
+}
+
+describe("archive stress regressions", () => {
+  it.each(["C:secret.txt", "nested/C:secret.txt"])(
+    "rejects drive-relative zip entry %s without destination debris",
+    async (entryName) => {
+      const root = await tempRoot("fs-safe-archive-drive-relative-");
+      const archivePath = path.join(root, "payload.zip");
+      const destDir = path.join(root, "dest");
+      await fs.mkdir(destDir);
+      const zip = new JSZip();
+      zip.file(entryName, "secret");
+      await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+
+      await expect(
+        extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 }),
+      ).rejects.toMatchObject({ name: "ArchiveSecurityError", code: "entry-path" });
+      await expect(fs.readdir(destDir)).resolves.toEqual([]);
+    },
+  );
+
+  it("honors an explicit zero entry budget", async () => {
+    const root = await tempRoot("fs-safe-archive-zero-limit-");
+    const archivePath = path.join(root, "payload.zip");
+    const destDir = path.join(root, "dest");
+    await fs.mkdir(destDir);
+    const zip = new JSZip();
+    zip.file("payload.txt", "payload");
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+
+    await expect(
+      extractArchive({
+        archivePath,
+        destDir,
+        kind: "zip",
+        timeoutMs: 15_000,
+        limits: { maxEntries: 0 },
+      }),
+    ).rejects.toMatchObject({ code: ARCHIVE_LIMIT_ERROR_CODE.ENTRY_COUNT_EXCEEDS_LIMIT });
+    await expect(fs.readdir(destDir)).resolves.toEqual([]);
+  });
+
+  it("rejects a zip entry whose payload does not match its CRC", async () => {
+    const root = await tempRoot("fs-safe-archive-crc-");
+    const archivePath = path.join(root, "payload.zip");
+    const destDir = path.join(root, "dest");
+    await fs.mkdir(destDir);
+    const zip = new JSZip();
+    zip.file("payload.txt", "payload");
+    const bytes = await zip.generateAsync({ type: "nodebuffer" });
+    const localHeader = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    const centralHeader = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+    expect(localHeader).toBeGreaterThanOrEqual(0);
+    expect(centralHeader).toBeGreaterThanOrEqual(0);
+    bytes.writeUInt32LE(0, localHeader + 14);
+    bytes.writeUInt32LE(0, centralHeader + 16);
+    await fs.writeFile(archivePath, bytes);
+
+    await expect(
+      extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 }),
+    ).rejects.toBeInstanceOf(ArchiveFormatError);
+    await expect(readArchiveEntry(archivePath, "payload.txt", { maxBytes: 16, kind: "zip" }))
+      .rejects.toBeInstanceOf(ArchiveFormatError);
+    await expect(fs.readdir(destDir)).resolves.toEqual([]);
+  });
+
+  it("rejects duplicate zip entry names for extraction and bounded reads", async () => {
+    const root = await tempRoot("fs-safe-archive-duplicate-");
+    const archivePath = path.join(root, "duplicate.zip");
+    const destDir = path.join(root, "dest");
+    await fs.mkdir(destDir);
+    const zip = new JSZip();
+    zip.file("payload.txt", "payload");
+    const duplicate = duplicateOnlyZipEntry(
+      await zip.generateAsync({ type: "nodebuffer", compression: "STORE" }),
+    );
+    await fs.writeFile(archivePath, duplicate);
+
+    await expect(
+      extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 }),
+    ).rejects.toMatchObject({ name: "ArchiveSecurityError", code: "entry-path" });
+    await expect(readArchiveEntry(archivePath, "payload.txt", { maxBytes: 16, kind: "zip" }))
+      .rejects.toMatchObject({ name: "ArchiveSecurityError", code: "entry-path" });
+    await expect(fs.readdir(destDir)).resolves.toEqual([]);
+  });
+});

--- a/test/bounded-read.test.ts
+++ b/test/bounded-read.test.ts
@@ -9,6 +9,7 @@ import {
   readFileDescriptorBoundedSync,
   readFileHandleBounded,
 } from "../src/bounded-read.js";
+import { createMaxBytesTransform } from "../src/bounded-read-stream.js";
 import { FsSafeError } from "../src/errors.js";
 import { readJson, readJsonSync } from "../src/json.js";
 import { root } from "../src/root.js";
@@ -33,6 +34,10 @@ afterEach(async () => {
 });
 
 describe("bounded descriptor reads", () => {
+  it("rejects a non-finite stream byte cap instead of disabling the bound", () => {
+    expect(() => createMaxBytesTransform(Number.NaN)).toThrow(RangeError);
+    expect(() => createMaxBytesTransform(Number.NEGATIVE_INFINITY)).toThrow(RangeError);
+  });
   it("exports the descriptor and handle primitives from the advanced surface", () => {
     expect(advanced.readFileDescriptorBounded).toBe(readFileDescriptorBounded);
     expect(advanced.readFileDescriptorBoundedSync).toBe(readFileDescriptorBoundedSync);

--- a/test/coverage-gaps.test.ts
+++ b/test/coverage-gaps.test.ts
@@ -169,7 +169,7 @@ describe("archive kind and tar preflight helpers", () => {
     const check = createTarEntryPreflightChecker({
       rootDir: "/tmp/extract",
       stripComponents: 1,
-      limits: { maxEntries: 2, maxEntryBytes: 10, maxExtractedBytes: 20 },
+      limits: { maxEntries: 4, maxEntryBytes: 10, maxExtractedBytes: 20 },
     });
     expect(() => check({ path: "package/", type: "Directory", size: 0 })).not.toThrow();
     expect(() => check({ path: "package/file.txt", type: "File", size: 4 })).not.toThrow();

--- a/test/extracted-helpers.test.ts
+++ b/test/extracted-helpers.test.ts
@@ -117,6 +117,8 @@ describe("json helpers", () => {
 describe("archive entry helpers", () => {
   it("validates and strips archive paths", () => {
     expect(isWindowsDrivePath("C:\\temp\\file.txt")).toBe(true);
+    expect(isWindowsDrivePath("C:secret.txt")).toBe(true);
+    expect(isWindowsDrivePath("nested/C:secret.txt")).toBe(true);
     expect(normalizeArchiveEntryPath("dir\\file.txt")).toBe("dir/file.txt");
     expect(stripArchivePath("a//b/file.txt", 1)).toBe("b/file.txt");
     expect(stripArchivePath("./", 0)).toBeNull();
@@ -125,6 +127,15 @@ describe("archive entry helpers", () => {
     );
     expect(() => validateArchiveEntryPath("C:\\temp\\file.txt")).toThrow(
       "archive entry uses a drive path",
+    );
+    expect(() => validateArchiveEntryPath("C:secret.txt")).toThrow(
+      "archive entry uses a drive path",
+    );
+    expect(() => validateArchiveEntryPath("nested/C:secret.txt")).toThrow(
+      "archive entry uses a drive path",
+    );
+    expect(() => validateArchiveEntryPath("nested/secret\0.txt")).toThrow(
+      "archive entry contains a NUL byte",
     );
   });
 

--- a/test/native-archive-equivalence.test.ts
+++ b/test/native-archive-equivalence.test.ts
@@ -248,6 +248,73 @@ describe.each(archiveBackends)("%s archive path", (backend) => {
     }
   });
 
+  it("counts entries removed by stripComponents against maxEntries", async () => {
+    useBackend(backend);
+    const root = await tempRoot();
+    const archivePath = path.join(root, "stripped-entry-limit.tar");
+    const destination = path.join(root, "destination");
+    await fs.writeFile(
+      archivePath,
+      tarFixture([
+        { path: "one", body: "1" },
+        { path: "two", body: "2" },
+      ]),
+    );
+    await fs.mkdir(destination);
+
+    await expect(
+      extractArchive({
+        archivePath,
+        destDir: destination,
+        timeoutMs: 10_000,
+        stripComponents: 1,
+        limits: { maxEntries: 1 },
+      }),
+    ).rejects.toMatchObject({ code: ARCHIVE_LIMIT_ERROR_CODE.ENTRY_COUNT_EXCEEDS_LIMIT });
+    await expect(fs.readdir(destination)).resolves.toEqual([]);
+  });
+
+  it("rejects entries that collide after stripComponents", async () => {
+    useBackend(backend);
+    const root = await tempRoot();
+    const archivePath = path.join(root, "stripped-collision.tar");
+    const destination = path.join(root, "destination");
+    await fs.writeFile(
+      archivePath,
+      tarFixture([
+        { path: "one/value.txt", body: "first" },
+        { path: "two/value.txt", body: "second" },
+      ]),
+    );
+    await fs.mkdir(destination);
+
+    await expect(
+      extractArchive({
+        archivePath,
+        destDir: destination,
+        timeoutMs: 10_000,
+        stripComponents: 1,
+      }),
+    ).rejects.toMatchObject({ name: "ArchiveSecurityError", code: "entry-path" });
+    await expect(fs.readdir(destination)).resolves.toEqual([]);
+  });
+
+  it("rejects duplicate TAR names during bounded reads", async () => {
+    useBackend(backend);
+    const root = await tempRoot();
+    const archivePath = path.join(root, "duplicate-read.tar");
+    await fs.writeFile(
+      archivePath,
+      tarFixture([
+        { path: "value.txt", body: "first" },
+        { path: "value.txt", body: "second" },
+      ]),
+    );
+
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 16 }))
+      .rejects.toMatchObject({ name: "ArchiveSecurityError", code: "entry-path" });
+  });
+
   it("rejects deep entry paths before creating implicit directories", async () => {
     useBackend(backend);
     const root = await tempRoot();


### PR DESCRIPTION
## Summary

- reject NUL and drive-relative archive names, duplicate names, and output collisions introduced by stripping
- keep explicit zero limits effective and count stripped TAR entries toward the archive-wide entry budget
- verify streamed JavaScript ZIP payload CRC and declared size for extraction and bounded reads
- align native and JavaScript duplicate/collision behavior and reject invalid non-finite stream bounds
- clarify that secret read helpers pin identity and enforce link/size policy, while permission validation belongs to `readSecureFile`

## Proof

- `pnpm check` (699 passed, 32 skipped)
- `pnpm test:security` (64 passed)
- `pnpm native:test` (14 passed)
- native + JavaScript archive equivalence (39 passed)
- Codex autoreview clean; no accepted/actionable findings
