### PR TITLE
fix(root): contain native overwrite writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         run: node scripts/native-mode-smoke.mjs off
 
       - name: Test native security and path equivalence
-        run: pnpm test test/native-integration.test.ts test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts test/private-directory.test.ts
+        run: pnpm test test/native-integration.test.ts test/native-write-containment.test.ts test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts test/private-directory.test.ts
 
   native-musl:
     name: Native check (linux-x64-musl)
@@ -133,7 +133,7 @@ jobs:
             node scripts/native-mode-smoke.mjs auto
             node scripts/native-mode-smoke.mjs require
             node scripts/native-mode-smoke.mjs off
-            pnpm test test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts
+            pnpm test test/native-write-containment.test.ts test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts
           '
 
   cargo-quality:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Security and Correctness
 
+- Route `Root.copyIn()` and overwrite-capable `Root.write()` commits through a new descriptor-relative native replace rename, closing a parent-symlink swap that could create a missing destination directory outside the root before the JavaScript fallback detected the escape. Native `auto` and `require` mode now protect both create-only and replacing pinned writes; the explicitly best-effort JavaScript fallback remains available in `off` mode or when `auto` cannot load a binding.
+
 - Apply `movePathWithCopyFallback()` file and POSIX directory modes through staging descriptors before publication, so a replaceable staging pathname cannot redirect `chmod` to an unrelated symlink target. Windows no longer uses a pathname fallback for directory modes because Node cannot portably open a directory descriptor there and does not enforce POSIX modes.
 
 - Reject drive-relative segments such as `C:secret.txt` and `a/C:b` in portable relative-path parsing and every `FileStore` key, and reject leading drive-relative spellings on `Root` destinations and `resolve()` with `invalid-path`. Existing-object Root operations, including reads, inspection, removal, and the source of `move()`, continue to accept legal POSIX filenames such as `c:notes.txt`; thanks @Yigtwxx for the fix.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ configureFsSafeNative({ mode: "off" });     // guarded JavaScript only
 configureFsSafeNative({ mode: "require" }); // fail closed if the binding is unavailable
 ```
 
+Native mode performs `write()`, `create()`, and `copyIn()` parent creation and
+publication relative to pinned directory descriptors, including atomic
+replacement. The JavaScript path selected by `off`, or by `auto` when no
+binding can load, is explicitly best-effort: a same-privilege peer that can
+replace a writable parent between its identity check and Node's pathname
+mutation can redirect that mutation outside the root before the post-check
+reports the escape. Use `require` when hostile concurrent mutation is in scope.
+
 Equivalent env var: `FS_SAFE_NATIVE_MODE=auto|off|require`. All seven binaries
 ship inside `@openclaw/fs-safe`; there are no platform packages, postinstall
 steps, downloads, or consumer Rust builds. This makes the tarball larger than

--- a/docs/native-helper.md
+++ b/docs/native-helper.md
@@ -30,20 +30,26 @@ Configure the mode once during startup. Loading is lazy and cached; changing fro
 ## Native boundary
 
 The bundled native layer exposes policy-free filesystem mechanisms: beneath-root
-open/mkdir/link, no-replace rename, identity reads, archive decode/execution,
+open/mkdir/link, replace and no-replace rename, identity reads, archive decode/execution,
 clone/copy/hash workers, and Windows security descriptor calls. The TypeScript
 layer owns policy, retries, filters, budgets, modes, cleanup, error
 normalization, and the decision to fall back.
 
-- Linux uses `openat2` with `RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS` and `renameat2(RENAME_NOREPLACE)`.
-- macOS 15.4 and newer prefer `O_RESOLVE_BENEATH`; older kernels resolve components with `O_NOFOLLOW` and restart in-root symlinks from the pinned root descriptor. Both routes use an `F_GETPATH` post-open escape detector and report `best-effort` because directory rename races are not atomic with that check. No-replace publication uses `renameatx_np(RENAME_EXCL)`.
-- Windows uses handle-relative `NtCreateFile`, rejects reparse points, and uses `FileRenameInfoEx` with replacement disabled.
+- Linux uses `openat2` with `RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS`, `renameat`, and `renameat2(RENAME_NOREPLACE)`.
+- macOS 15.4 and newer prefer `O_RESOLVE_BENEATH`; older kernels resolve components with `O_NOFOLLOW` and restart in-root symlinks from the pinned root descriptor. Both routes use an `F_GETPATH` post-open escape detector and report `best-effort` because directory rename races are not atomic with that check. Publication uses `renameat` for replacement and `renameatx_np(RENAME_EXCL)` for no-replace.
+- Windows uses handle-relative `NtCreateFile`, rejects reparse points, and uses `FileRenameInfoEx` with replacement selected explicitly by the TypeScript policy layer.
 
-Native primitives back create-only pinned writes, async sidecar creation,
+Native primitives back create-only and replacing pinned writes, async sidecar creation,
 guarded publication, archive acceleration, and direct Windows ACL operations.
 Equivalent JavaScript paths remain available for documented fallback-capable
 features. See [Native architecture](native.md#javascript-fallback-guarantees-and-delta)
 for the exact difference.
+
+The guarded JavaScript mutation path is detection-based, not containment-atomic.
+If a same-privilege peer can replace a writable parent after its identity guard
+but before Node resolves a pathname mutation, the mutation can land outside the
+intended root before the post-operation guard throws. Select `require` rather
+than `auto` or `off` when that concurrent attacker is part of the threat model.
 
 `openBeneath()` returns `{ fd, containment }`. `containment` is
 `"kernel-atomic"` for Linux `openat2` and `"best-effort"` for macOS and

--- a/docs/native.md
+++ b/docs/native.md
@@ -41,7 +41,7 @@ The TypeScript layer validates and decides. The native layer never decides
 whether a path, archive entry, mode, owner, or cleanup policy is acceptable.
 
 - Linux uses `openat2(RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS)`, fd-relative
-  `mkdirat`/`linkat`/`renameat2`, `FICLONE`, and `copy_file_range`.
+  `mkdirat`/`linkat`/`renameat`/`renameat2`, `FICLONE`, and `copy_file_range`.
 - macOS 15.4 and newer first use `openat(O_RESOLVE_BENEATH)`; older kernels walk
   components with `openat(O_NOFOLLOW)` and restart in-root symlinks from the
   pinned root. Both routes apply an `F_GETPATH` post-open containment detector,
@@ -99,7 +99,7 @@ remain TypeScript-owned. What changes is the syscall strength or availability:
 
 | Capability | Native path | Guarded JavaScript path |
 |---|---|---|
-| Root-relative opens/mutations | Descriptor-relative beneath operations. Linux reports `kernel-atomic`; macOS and Windows report `best-effort`. macOS uses `O_RESOLVE_BENEATH` when available plus an `F_GETPATH` detector, while Windows rejects reparse traversal in the object-manager call. | Reports `best-effort`: component-wise alias checks, no-follow opens where Node exposes them, private temp/rename, and post-operation identity verification. A hostile same-UID peer has a wider pathname race window. |
+| Root-relative opens/mutations | Descriptor-relative beneath operations. Pinned writes create parents and publish both replacement and no-replace targets relative to open directory descriptors. Linux reports `kernel-atomic`; macOS and Windows report `best-effort`. macOS uses `O_RESOLVE_BENEATH` when available plus an `F_GETPATH` detector, while Windows rejects reparse traversal in the object-manager call. | Reports `best-effort`: component-wise alias checks, no-follow opens where Node exposes them, private temp/rename, and post-operation identity verification. A same-privilege peer can replace a writable parent after a guard assertion but before Node resolves the pathname mutation; the mutation may land outside the intended root before the post-check detects it. |
 | ZIP/TAR/gzip | Rust streaming decode and fd-relative output creation. | JSZip/node-tar into a private stage, then the same guarded merge policy. |
 | Zstd/bzip2 TAR | Supported. | Unsupported; typed `helper-unavailable`. |
 | Publication copy | Clone, Linux `copy_file_range`, async native SHA-256. | Exclusive `wx` byte loop and Node SHA-256 with the same content/identity fences. |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -54,7 +54,20 @@ Per-call `symlinks: "follow-within-root"` allows symlinks whose final target is 
 
 ### Symlinks (write side)
 
-Writes use a sibling-temp + rename helper that opens the parent directory by fd, then performs the rename `at` the parent fd. Replacing the parent directory with a symlink between the parent-fd open and the rename does not divert the write.
+With the native binding loaded, `write()`, `create()`, and `copyIn()` use a
+sibling temp file and create parents and publish the target relative to pinned
+directory descriptors. Replacement uses descriptor-relative rename just like
+no-replace publication, so replacing the parent pathname does not divert the
+mutation.
+
+The JavaScript fallback used by `off`, by `auto` when no binding loads, and by
+the explicit `renameIdentity: "verify-content-with-lock"` compatibility policy
+cannot provide that guarantee because Node exposes no `mkdirat` or `renameat`.
+It asserts directory identity around a pathname mutation and detects many
+swaps, but detection occurs after the kernel may already have followed a new
+parent symlink. A same-privilege peer with write access to the parent can
+therefore cause an out-of-root side effect before the operation throws. Use
+native `require` mode when concurrent hostile mutation is in scope.
 
 ### Hardlink aliasing
 
@@ -120,6 +133,7 @@ The public `OpenResult`, `ReadResult`, and `WritableOpenResult` expose `containm
 | Absolute paths are escape hatches | APIs that accept or return absolute paths exist for audit, ingest, and advanced composition. Prefer root-relative names in normal application flow. |
 | Not a mount boundary | `root()` keeps path traversal inside the directory tree and blocks known unsafe read device paths, but it does not make bind mounts or virtual filesystems safe to expose wholesale. |
 | Per-call, not per-session | Another process with the same privileges can still mutate the tree between calls, and best-effort mechanisms retain documented same-call race windows. Use one verb method to minimize the window and inspect its reported containment class. |
+| JavaScript mutations are detection-based | Without the native binding, Node pathname mutations retain a check-to-syscall race. A writable parent can be swapped so a create, rename, or removal affects an out-of-root path before the fallback detects identity drift. |
 | Hardlink rejection is best-effort | Link-count checks depend on platform metadata. Treat `hardlinks: "reject"` as a tripwire, not an authorization primitive. |
 | Mode bits are not a full policy engine | `replaceFileAtomic` and secret-file helpers set requested modes, but you should still set umask and inspect modes when policy requires it. |
 | Archive extraction is path safety, not content safety | Unsafe entry paths and links are rejected; malicious payload contents remain your application layer's problem. |

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -16,8 +16,8 @@ await fs.mkdir("snapshots/2026/05");
 ## What every write does
 
 1. Resolve the relative target against the canonical root and reject anything that escapes (`outside-workspace`).
-2. If `mkdir: true`, create missing parent directories with the parent fd pinned.
-3. Pin or guard the parent directory for the selected mechanism. Native operations use a parent fd; guarded JavaScript verifies directory identity before and after mutation. Linux beneath opens are kernel-atomic, while macOS, Windows, and JavaScript routes retain the best-effort race boundaries in the [security model](security-model.md#containment-guarantees-by-platform).
+2. If `mkdir: true`, create missing parent directories relative to a pinned parent fd in the native path, or with per-component identity guards in the JavaScript fallback.
+3. Pin or guard the parent directory for the selected mechanism. Native operations use a parent fd; guarded JavaScript verifies directory identity before and after mutation. The JavaScript check cannot make the intervening pathname syscall atomic, so a same-privilege peer that can replace the parent may cause an out-of-root side effect before detection. Use native `require` mode for that threat model; see the [security model](security-model.md#symlinks-write-side).
 4. Write data to a sibling temp file in the same directory.
 5. Atomically rename the temp file over the destination.
 6. Stat the resulting fd and verify identity.

--- a/native/src/archive.rs
+++ b/native/src/archive.rs
@@ -11,7 +11,7 @@ use napi::{Env, Error, Result, Status};
 use napi_derive::napi;
 
 use crate::tar_meter::TarMetadataMeter;
-use crate::{NativeResult, native_error, platform, validate_relative_path};
+use crate::{NativeResult, native_error, platform, validate_portable_relative_path};
 
 #[napi(object)]
 pub struct NativeArchiveEntry {
@@ -477,7 +477,7 @@ fn checked_limit(value: f64, label: &str) -> Result<u64> {
 fn plan_map(plan: Vec<NativeArchivePlanEntry>) -> Result<HashMap<usize, NativeArchivePlanEntry>> {
     let mut entries = HashMap::with_capacity(plan.len());
     for entry in plan {
-        validate_relative_path(&entry.path, false)
+        validate_portable_relative_path(&entry.path, false)
             .map_err(|error| Error::new(Status::InvalidArg, error.reason))?;
         if entry.kind != "file" && entry.kind != "directory" {
             return Err(Error::new(

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -40,7 +40,11 @@ fn invalid_path(message: impl Into<String>) -> Error<String> {
     native_error("EINVAL", message)
 }
 
-fn validate_relative_path(path: &str, allow_root: bool) -> NativeResult<()> {
+fn validate_relative_path_with_separators(
+    path: &str,
+    allow_root: bool,
+    backslash_is_separator: bool,
+) -> NativeResult<()> {
     if path.as_bytes().contains(&0) {
         return Err(invalid_path("relative path contains a NUL byte"));
     }
@@ -51,15 +55,28 @@ fn validate_relative_path(path: &str, allow_root: bool) -> NativeResult<()> {
             Err(invalid_path("operation requires a non-root path"))
         };
     }
-    if path.starts_with('/') || path.starts_with('\\') {
+    if path.starts_with('/') || (backslash_is_separator && path.starts_with('\\')) {
         return Err(invalid_path(
             "path must be relative to the supplied root descriptor",
         ));
     }
-    if path.split(['/', '\\']).any(|segment| segment == "..") {
+    let escapes = if backslash_is_separator {
+        path.split(['/', '\\']).any(|segment| segment == "..")
+    } else {
+        path.split('/').any(|segment| segment == "..")
+    };
+    if escapes {
         return Err(invalid_path("relative path must not contain '..'"));
     }
     Ok(())
+}
+
+fn validate_relative_path(path: &str, allow_root: bool) -> NativeResult<()> {
+    validate_relative_path_with_separators(path, allow_root, cfg!(windows))
+}
+
+pub(crate) fn validate_portable_relative_path(path: &str, allow_root: bool) -> NativeResult<()> {
+    validate_relative_path_with_separators(path, allow_root, true)
 }
 
 fn into_napi<T>(env: Env, result: NativeResult<T>) -> Result<T> {
@@ -148,6 +165,29 @@ pub fn rename_no_replace(
     )
 }
 
+#[napi(js_name = "renameReplace")]
+pub fn rename_replace(
+    env: Env,
+    source_root_fd: i32,
+    source_rel_path: String,
+    target_root_fd: i32,
+    target_rel_path: String,
+) -> Result<()> {
+    into_napi(
+        env,
+        validate_relative_path(&source_rel_path, false)
+            .and_then(|()| validate_relative_path(&target_rel_path, false))
+            .and_then(|()| {
+                platform::rename_replace(
+                    source_root_fd,
+                    &source_rel_path,
+                    target_root_fd,
+                    &target_rel_path,
+                )
+            }),
+    )
+}
+
 #[napi(js_name = "fstatIdentity")]
 pub fn fstat_identity(env: Env, fd: i32) -> Result<FileIdentity> {
     into_napi(env, platform::fstat_identity(fd))
@@ -164,6 +204,22 @@ pub use windows_security::{
     WindowsAccessControlEntry, WindowsAceFlags, WindowsSecurityFacts, create_private_directory,
     read_owner_and_dacl,
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filesystem_paths_follow_host_separator_rules() {
+        assert!(validate_relative_path("../escape", false).is_err());
+        if cfg!(windows) {
+            assert!(validate_relative_path("..\\escape", false).is_err());
+        } else {
+            assert!(validate_relative_path("..\\literal", false).is_ok());
+        }
+        assert!(validate_portable_relative_path("..\\escape", false).is_err());
+    }
+}
 
 #[cfg(unix)]
 use unix as platform;

--- a/native/src/unix.rs
+++ b/native/src/unix.rs
@@ -172,6 +172,23 @@ pub fn rename_no_replace(
     }
 }
 
+pub fn rename_replace(
+    source_root_fd: i32,
+    source_rel_path: &str,
+    target_root_fd: i32,
+    target_rel_path: &str,
+) -> NativeResult<()> {
+    let (source_parent, source_name) = open_parent(source_root_fd, source_rel_path)?;
+    let (target_parent, target_name) = open_parent(target_root_fd, target_rel_path)?;
+    rustix::fs::renameat(
+        source_parent.as_fd(),
+        source_name,
+        target_parent.as_fd(),
+        target_name,
+    )
+    .map_err(|error| os_error(error, "rename with replacement"))
+}
+
 pub fn fstat_identity(fd: i32) -> NativeResult<FileIdentity> {
     let stat = rustix::fs::fstat(borrowed(fd)).map_err(|error| os_error(error, "fstat"))?;
     let file_type = FileType::from_raw_mode(stat.st_mode);
@@ -909,6 +926,24 @@ mod tests {
         .unwrap_err();
         assert_eq!(error.status, "EEXIST");
         assert_eq!(fs::read(root.join("target")).unwrap(), b"target");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rename_replace_replaces_existing_target() {
+        let root = temp_root("rename-replace");
+        fs::write(root.join("source"), b"source").unwrap();
+        fs::write(root.join("target"), b"target").unwrap();
+        let root_handle = OpenOptions::new().read(true).open(&root).unwrap();
+        rename_replace(
+            root_handle.as_raw_fd(),
+            "source",
+            root_handle.as_raw_fd(),
+            "target",
+        )
+        .unwrap();
+        assert!(!root.join("source").exists());
+        assert_eq!(fs::read(root.join("target")).unwrap(), b"source");
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/native/src/windows.rs
+++ b/native/src/windows.rs
@@ -44,6 +44,7 @@ const FILE_NON_DIRECTORY_FILE: u32 = 0x0000_0040;
 const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
 const OBJ_CASE_INSENSITIVE: u32 = 0x0000_0040;
 const OBJ_DONT_REPARSE: u32 = 0x0000_1000;
+const FILE_RENAME_FLAG_REPLACE_IF_EXISTS: u32 = 0x0000_0001;
 const FILE_RENAME_FLAG_POSIX_SEMANTICS: u32 = 0x0000_0002;
 const FILE_LINK_INFORMATION_CLASS: i32 = 11;
 const FILE_RENAME_INFORMATION_EX_CLASS: i32 = 65;
@@ -397,6 +398,7 @@ fn set_rename_information(
     source: HANDLE,
     target_root: HANDLE,
     target_path: &str,
+    replace: bool,
     operation: &str,
 ) -> NativeResult<()> {
     let name = wide_relative(target_path)?;
@@ -408,7 +410,12 @@ fn set_rename_information(
     // large enough for the trailing UTF-16 filename.
     unsafe {
         let header = buffer.as_mut_ptr().cast::<FileNameInfoHeader>();
-        (*header).flags = FILE_RENAME_FLAG_POSIX_SEMANTICS;
+        (*header).flags = FILE_RENAME_FLAG_POSIX_SEMANTICS
+            | if replace {
+                FILE_RENAME_FLAG_REPLACE_IF_EXISTS
+            } else {
+                0
+            };
         (*header).root_directory = target_root;
         (*header).file_name_length = name_bytes as u32;
         std::ptr::copy_nonoverlapping(
@@ -430,7 +437,10 @@ fn set_rename_information(
         )
     };
     if status < 0 {
-        if nt_open_relative(target_root, target_path, FILE_READ_ATTRIBUTES, FILE_OPEN, 0).is_ok() {
+        if !replace
+            && nt_open_relative(target_root, target_path, FILE_READ_ATTRIBUTES, FILE_OPEN, 0)
+                .is_ok()
+        {
             return Err(native_error("EEXIST", "rename destination already exists"));
         }
         return Err(nt_error(status, operation));
@@ -512,7 +522,24 @@ pub fn rename_no_replace(
         source.0,
         root_handle(target_root_fd)?,
         target_rel_path,
+        false,
         "rename without replacement",
+    )
+}
+
+pub fn rename_replace(
+    source_root_fd: i32,
+    source_rel_path: &str,
+    target_root_fd: i32,
+    target_rel_path: &str,
+) -> NativeResult<()> {
+    let source = open_source_for_metadata(source_root_fd, source_rel_path, DELETE_ACCESS)?;
+    set_rename_information(
+        source.0,
+        root_handle(target_root_fd)?,
+        target_rel_path,
+        true,
+        "rename with replacement",
     )
 }
 
@@ -702,11 +729,33 @@ mod tests {
             source.0,
             root_handle.as_raw_handle() as HANDLE,
             "target",
+            false,
             "rename without replacement",
         )
         .unwrap_err();
         assert_eq!(error.status, "EEXIST");
         assert_eq!(fs::read(root.join("target")).unwrap(), b"target");
+        drop(source);
+
+        fs::write(root.join("replacement"), b"replacement").unwrap();
+        let replacement = nt_open_relative(
+            root_handle.as_raw_handle() as HANDLE,
+            "replacement",
+            FILE_READ_ATTRIBUTES | DELETE_ACCESS,
+            FILE_OPEN,
+            FILE_NON_DIRECTORY_FILE,
+        )
+        .unwrap();
+        set_rename_information(
+            replacement.0,
+            root_handle.as_raw_handle() as HANDLE,
+            "target",
+            true,
+            "rename with replacement",
+        )
+        .unwrap();
+        assert_eq!(fs::read(root.join("target")).unwrap(), b"replacement");
+        drop(replacement);
         fs::remove_dir_all(root).unwrap();
     }
 }

--- a/native/src/windows.rs
+++ b/native/src/windows.rs
@@ -6,9 +6,9 @@ use std::os::windows::io::FromRawHandle;
 use std::ptr::{null, null_mut};
 
 use windows_sys::Win32::Foundation::{
-    CloseHandle, ERROR_ACCESS_DENIED, ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS,
-    ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, GENERIC_READ, GetLastError, HANDLE,
-    INVALID_HANDLE_VALUE,
+    CloseHandle, DUPLICATE_SAME_ACCESS, DuplicateHandle, ERROR_ACCESS_DENIED, ERROR_ALREADY_EXISTS,
+    ERROR_FILE_EXISTS, ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, GENERIC_READ, GetLastError,
+    HANDLE, INVALID_HANDLE_VALUE,
 };
 use windows_sys::Win32::Storage::FileSystem::{
     BY_HANDLE_FILE_INFORMATION, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
@@ -18,6 +18,7 @@ use windows_sys::Win32::Storage::FileSystem::{
 };
 use windows_sys::Win32::System::IO::IO_STATUS_BLOCK;
 use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
 use crate::{FileIdentity, NativeResult, native_error};
 
@@ -340,9 +341,33 @@ fn disposition_from_flags(flags: i32) -> u32 {
 }
 
 pub fn open_beneath(root_fd: i32, rel_path: &str, flags: i32) -> NativeResult<i32> {
+    if rel_path.is_empty() || rel_path == "." {
+        let process = unsafe { GetCurrentProcess() };
+        let mut duplicate = null_mut();
+        if unsafe {
+            DuplicateHandle(
+                process,
+                root_handle(root_fd)?,
+                process,
+                &mut duplicate,
+                0,
+                0,
+                DUPLICATE_SAME_ACCESS,
+            )
+        } == 0
+        {
+            return Err(win_error(
+                unsafe { GetLastError() },
+                "duplicate root handle",
+            ));
+        }
+        let duplicate = OwnedHandle(duplicate);
+        assert_not_reparse(duplicate.0)?;
+        return node_fd_from_handle(duplicate, flags);
+    }
     let handle = nt_open_relative(
         root_handle(root_fd)?,
-        if rel_path.is_empty() { "." } else { rel_path },
+        rel_path,
         access_from_flags(flags),
         disposition_from_flags(flags),
         0,

--- a/src/guarded-mkdir.ts
+++ b/src/guarded-mkdir.ts
@@ -46,8 +46,8 @@ export async function mkdirPathComponentsWithGuards(params: {
   for (const part of relative.split(path.sep).filter(Boolean)) {
     const next = path.join(current, part);
     const parentGuard = await createAsyncDirectoryGuard(current);
-    await params.beforeComponent?.(next);
     await assertAsyncDirectoryGuard(parentGuard);
+    await params.beforeComponent?.(next);
     try {
       await fs.mkdir(next);
     } catch (error) {

--- a/src/native-binding.ts
+++ b/src/native-binding.ts
@@ -117,5 +117,11 @@ export interface NativeBinding {
     targetRootFd: number,
     targetRelPath: string,
   ): void;
+  renameReplace(
+    sourceRootFd: number,
+    sourceRelPath: string,
+    targetRootFd: number,
+    targetRelPath: string,
+  ): void;
   sha256File(fd: number): Promise<NativeFileHash>;
 }

--- a/src/native-pinned-write.ts
+++ b/src/native-pinned-write.ts
@@ -101,14 +101,6 @@ export async function runPinnedWriteNative(
     ) {
       throw new FsSafeError("path-mismatch", "native write parent changed during resolution");
     }
-    try {
-      await fs.lstat(path.join(parentPath, params.basename));
-      throw Object.assign(new Error("destination already exists"), { code: "EEXIST" });
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
-      }
-    }
     tempFd = binding.openBeneath(
       parentFd,
       tempName,
@@ -120,7 +112,11 @@ export async function runPinnedWriteNative(
     writeNativeFd(tempFd, data);
     syncNativeFileBestEffort(tempFd);
     tempIdentity = fsSync.fstatSync(tempFd);
-    binding.renameNoReplace(parentFd, tempName, parentFd, params.basename);
+    if (params.overwrite === false) {
+      binding.renameNoReplace(parentFd, tempName, parentFd, params.basename);
+    } else {
+      binding.renameReplace(parentFd, tempName, parentFd, params.basename);
+    }
     renamed = true;
     targetFd = binding.openBeneath(
       parentFd,

--- a/src/native-pinned-write.ts
+++ b/src/native-pinned-write.ts
@@ -101,6 +101,16 @@ export async function runPinnedWriteNative(
     ) {
       throw new FsSafeError("path-mismatch", "native write parent changed during resolution");
     }
+    if (params.overwrite === false) {
+      try {
+        await fs.lstat(path.join(parentPath, params.basename));
+        throw Object.assign(new Error("destination already exists"), { code: "EEXIST" });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      }
+    }
     tempFd = binding.openBeneath(
       parentFd,
       tempName,

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -111,7 +111,7 @@ export async function runPinnedWriteHelper(params: PinnedWriteParams): Promise<F
     return await runPinnedWriteFallback(params);
   }
   const native = getNativeBinding();
-  if (native && params.overwrite === false) {
+  if (native) {
     return await runPinnedWriteNative(native, params);
   }
   return await runPinnedWriteFallback(params);
@@ -173,6 +173,8 @@ async function runPinnedWriteFallback(params: {
     parentPath = await mkdirPathComponentsWithGuards({
       rootReal: params.rootPath,
       targetPath: parentPath,
+      beforeComponent: async (componentPath) =>
+        await getFsSafeTestHooks()?.beforeRootFallbackMutation?.("mkdir", componentPath),
     });
   }
   const parentGuard = params.mkdir

--- a/src/root-context.ts
+++ b/src/root-context.ts
@@ -9,6 +9,7 @@ import { isDriveRelativePath } from "./safe-path-segment.js";
 
 export type RootContext = {
   rootDir: string;
+  rootIdentity: { dev: number; ino: number };
   rootReal: string;
   rootWithSep: string;
 };
@@ -46,12 +47,14 @@ export async function expandRelativePathWithHome(relativePath: string): Promise<
 export async function resolveRootContext(rootDir: string): Promise<RootContext> {
   assertNoNulPathInput(rootDir, "root dir contains a NUL byte");
   let rootReal: string;
+  let rootIdentity: { dev: number; ino: number };
   try {
     rootReal = await fs.realpath(rootDir);
     const rootStat = await fs.stat(rootReal);
     if (!rootStat.isDirectory()) {
       throw new FsSafeError("invalid-path", "root dir is not a directory");
     }
+    rootIdentity = { dev: rootStat.dev, ino: rootStat.ino };
   } catch (err) {
     if (err instanceof FsSafeError) {
       throw err;
@@ -63,6 +66,7 @@ export async function resolveRootContext(rootDir: string): Promise<RootContext> 
   }
   return {
     rootDir: path.resolve(rootDir),
+    rootIdentity,
     rootReal,
     rootWithSep: ensureTrailingSep(rootReal),
   };

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -22,6 +22,7 @@ import {
   runPinnedWriteHelper,
   runPinnedWriteWithRenamePolicy,
 } from "./pinned-write.js";
+import { getNativeBinding } from "./native.js";
 import { validatePinnedOperationPayload } from "./pinned-operation.js";
 import { assertNoPathAliasEscape, PATH_ALIAS_POLICIES } from "./path-policy.js";
 import {
@@ -344,12 +345,14 @@ export interface Root {
 }
 
 class RootHandle implements Root {
+  private readonly rootIdentity: RootContext["rootIdentity"];
   readonly rootDir: string;
   readonly rootReal: string;
   readonly rootWithSep: string;
   readonly defaults: RootDefaults;
 
   constructor(context: RootContext, defaults: RootDefaults = {}) {
+    this.rootIdentity = context.rootIdentity;
     this.rootDir = context.rootDir;
     this.rootReal = context.rootReal;
     this.rootWithSep = context.rootWithSep;
@@ -359,6 +362,7 @@ class RootHandle implements Root {
   private get context(): RootContext {
     return {
       rootDir: this.rootDir,
+      rootIdentity: this.rootIdentity,
       rootReal: this.rootReal,
       rootWithSep: this.rootWithSep,
     };
@@ -1021,7 +1025,10 @@ async function writeFileInRoot(
   root: RootContext,
   params: RootWriteOptions & { relativePath: string; data: string | Buffer },
 ): Promise<void> {
-  if (process.platform === "win32") {
+  if (
+    process.platform === "win32" &&
+    (params.renameIdentity === "verify-content-with-lock" || !getNativeBinding())
+  ) {
     await serializePathWrite(rootWriteQueueKey(root, params.relativePath), async () => {
       await writeFileFallback(root, params);
     });
@@ -1057,6 +1064,7 @@ async function commitPinnedWriteInRoot(
       mode: params.mode ?? pinned.mode,
       overwrite: params.overwrite,
       input: { kind: "buffer", data: params.data, encoding: params.encoding },
+      rootIdentity: root.rootIdentity,
     });
   } catch (error) {
     const errorCode = (error as { code?: unknown })?.code;
@@ -1126,6 +1134,7 @@ async function copyFileInRoot(
         overwrite: true,
         maxBytes: params.maxBytes,
         input: { kind: "stream", stream: source.handle.createReadStream() },
+        rootIdentity: root.rootIdentity,
       });
       try {
         await assertCopySourcePathCurrent(source);

--- a/test/native-integration.test.ts
+++ b/test/native-integration.test.ts
@@ -126,6 +126,25 @@ describe.runIf(native)("native filesystem primitives", () => {
     await expect(fs.readFile(path.join(directory, "nested/value"), "utf8")).resolves.toBe("native");
   });
 
+  it("uses the native transaction for root-level pinned writes", async () => {
+    __setNativeLoaderForTest(() => native!);
+    configureFsSafeNative({ mode: "require" });
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-root-write-"));
+    roots.push(directory);
+    await runPinnedWriteHelper({
+      rootPath: directory,
+      relativeParentPath: "",
+      basename: "value",
+      mkdir: true,
+      mode: 0o600,
+      overwrite: false,
+      input: { kind: "buffer", data: "native-root" },
+    });
+    await expect(fs.readFile(path.join(directory, "value"), "utf8")).resolves.toBe(
+      "native-root",
+    );
+  });
+
   it("uses native replace commits for overwrite pinned writes", async () => {
     let replaceCalls = 0;
     __setNativeLoaderForTest(() => ({

--- a/test/native-integration.test.ts
+++ b/test/native-integration.test.ts
@@ -124,6 +124,17 @@ describe.runIf(native)("native filesystem primitives", () => {
     });
     expect(renameCalls).toBe(1);
     await expect(fs.readFile(path.join(directory, "nested/value"), "utf8")).resolves.toBe("native");
+    await expect(
+      runPinnedWriteHelper({
+        rootPath: directory,
+        relativeParentPath: "nested",
+        basename: "value",
+        mkdir: true,
+        mode: 0o600,
+        overwrite: false,
+        input: { kind: "buffer", data: "second" },
+      }),
+    ).rejects.toMatchObject({ code: "EEXIST" });
   });
 
   it("uses the native transaction for root-level pinned writes", async () => {

--- a/test/native-integration.test.ts
+++ b/test/native-integration.test.ts
@@ -70,6 +70,21 @@ describe.runIf(native)("native filesystem primitives", () => {
     await expect(fs.readFile(path.join(root, "target"), "utf8")).resolves.toBe("target");
   });
 
+  it("replaces an existing target by descriptor-relative native rename", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-rename-replace-"));
+    roots.push(root);
+    await fs.writeFile(path.join(root, "source"), "source");
+    await fs.writeFile(path.join(root, "target"), "target");
+    const rootFd = fsSync.openSync(root, fsSync.constants.O_RDONLY);
+    try {
+      native!.renameReplace(rootFd, "source", rootFd, "target");
+    } finally {
+      fsSync.closeSync(rootFd);
+    }
+    await expect(fs.lstat(path.join(root, "source"))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(path.join(root, "target"), "utf8")).resolves.toBe("source");
+  });
+
   it.runIf(process.platform === "win32")("rejects reparse-point directory components", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-reparse-"));
     roots.push(root);
@@ -109,6 +124,33 @@ describe.runIf(native)("native filesystem primitives", () => {
     });
     expect(renameCalls).toBe(1);
     await expect(fs.readFile(path.join(directory, "nested/value"), "utf8")).resolves.toBe("native");
+  });
+
+  it("uses native replace commits for overwrite pinned writes", async () => {
+    let replaceCalls = 0;
+    __setNativeLoaderForTest(() => ({
+      ...native!,
+      renameReplace(...args) {
+        replaceCalls += 1;
+        return native!.renameReplace(...args);
+      },
+    }));
+    configureFsSafeNative({ mode: "require" });
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-overwrite-"));
+    roots.push(directory);
+    await fs.mkdir(path.join(directory, "nested"));
+    await fs.writeFile(path.join(directory, "nested/value"), "old");
+    await runPinnedWriteHelper({
+      rootPath: directory,
+      relativeParentPath: "nested",
+      basename: "value",
+      mkdir: true,
+      mode: 0o600,
+      overwrite: true,
+      input: { kind: "buffer", data: "new" },
+    });
+    expect(replaceCalls).toBe(1);
+    await expect(fs.readFile(path.join(directory, "nested/value"), "utf8")).resolves.toBe("new");
   });
 
   it("rejects native writes when the expected root identity does not match", async () => {

--- a/test/native-write-containment.test.ts
+++ b/test/native-write-containment.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { configureFsSafeNative } from "../src/native-config.js";
+import {
+  __loadBundledNativeForTest,
+  __resetNativeLoaderForTest,
+} from "../src/native.js";
+import { root, type Root } from "../src/root.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+
+let bundledNativeAvailable = false;
+try {
+  __loadBundledNativeForTest();
+  bundledNativeAvailable = true;
+} catch {
+  // Ordinary JavaScript-only CI legs intentionally have no host binding.
+}
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  __setFsSafeTestHooksForTest();
+  configureFsSafeNative({ mode: "auto" });
+  __resetNativeLoaderForTest();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+type WriteOperation = {
+  label: string;
+  run(safeRoot: Root, source: string): Promise<void>;
+};
+
+const overwriteOperations: WriteOperation[] = [
+  {
+    label: "copyIn",
+    run: async (safeRoot, source) => await safeRoot.copyIn("data/nested/value.txt", source),
+  },
+  {
+    label: "write default overwrite",
+    run: async (safeRoot) => await safeRoot.write("data/nested/value.txt", "payload"),
+  },
+  {
+    label: "write explicit overwrite",
+    run: async (safeRoot) =>
+      await safeRoot.write("data/nested/value.txt", "payload", { overwrite: true }),
+  },
+];
+
+describe.runIf(bundledNativeAvailable)("native overwrite containment", () => {
+  it.each(overwriteOperations)(
+    "keeps $label parent creation descriptor-relative in default mode",
+    async ({ run }) => {
+      const base = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-write-containment-")),
+      );
+      tempDirs.push(base);
+      const rootDir = path.join(base, "root");
+      const outside = path.join(base, "outside");
+      const parent = path.join(rootDir, "data");
+      const movedParent = path.join(rootDir, "data-original");
+      const source = path.join(base, "source.txt");
+      await fs.mkdir(parent, { recursive: true });
+      await fs.mkdir(outside);
+      await fs.writeFile(source, "payload");
+
+      let fallbackMutationReached = false;
+      __setFsSafeTestHooksForTest({
+        async beforeRootFallbackMutation(operation, targetPath) {
+          if (operation !== "mkdir" || targetPath !== path.join(parent, "nested")) {
+            return;
+          }
+          fallbackMutationReached = true;
+          await fs.rename(parent, movedParent);
+          await fs.symlink(outside, parent, process.platform === "win32" ? "junction" : "dir");
+        },
+      });
+
+      const safeRoot = await root(rootDir);
+      await expect(run(safeRoot, source)).resolves.toBeUndefined();
+
+      expect(fallbackMutationReached).toBe(false);
+      await expect(fs.readFile(path.join(parent, "nested/value.txt"), "utf8")).resolves.toBe(
+        "payload",
+      );
+      await expect(fs.lstat(path.join(outside, "nested"))).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+});
+
+it("documents the bounded mode-off parent-mutation limitation", async () => {
+  configureFsSafeNative({ mode: "off" });
+  const base = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-fallback-write-containment-")),
+  );
+  tempDirs.push(base);
+  const rootDir = path.join(base, "root");
+  const outside = path.join(base, "outside");
+  const parent = path.join(rootDir, "data");
+  const source = path.join(base, "source.txt");
+  await fs.mkdir(parent, { recursive: true });
+  await fs.mkdir(outside);
+  await fs.writeFile(source, "payload");
+
+  let fallbackMutationReached = false;
+  __setFsSafeTestHooksForTest({
+    async beforeRootFallbackMutation(operation, targetPath) {
+      if (operation !== "mkdir" || targetPath !== path.join(parent, "nested")) {
+        return;
+      }
+      fallbackMutationReached = true;
+      await fs.rename(parent, `${parent}-original`);
+      await fs.symlink(outside, parent, process.platform === "win32" ? "junction" : "dir");
+    },
+  });
+
+  const safeRoot = await root(rootDir);
+  await expect(safeRoot.copyIn("data/nested/value.txt", source)).rejects.toBeTruthy();
+
+  expect(fallbackMutationReached).toBe(true);
+  await expect(fs.lstat(path.join(outside, "nested"))).resolves.toSatisfy((stat) =>
+    stat.isDirectory()
+  );
+  await expect(fs.lstat(path.join(outside, "nested/value.txt"))).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+});


### PR DESCRIPTION
## Summary

`runPinnedWriteHelper()` only selected the native transaction for `overwrite === false`. That gate was introduced during the 0.5 Python-to-native migration because the first native binding exposed only `renameNoReplace`; it was a historical capability restriction, not a platform limit. Consequently `Root.copyIn()`, default `Root.write()`, and explicit overwrite writes all used the guarded JavaScript fallback even when the bundled binding was loaded.

This adds a policy-free descriptor-relative `renameReplace` primitive (`renameat` on Linux/macOS and `FileRenameInfoEx` with `FILE_RENAME_FLAG_REPLACE_IF_EXISTS` on Windows), selects it for overwrite commits, and routes Windows Root writes through the native transaction when available. The transaction also verifies the Root identity captured when the handle was created before mutating. POSIX filesystem validation now follows POSIX separator rules while archive plans retain portable slash/backslash traversal validation.

The JavaScript fallback remains available to preserve the existing non-breaking `auto` / `off` contract. Its check-to-pathname-syscall limitation is now documented precisely, with `require` recommended when a same-privilege concurrent mutator is in scope.

## Containment proof

The regression drives a real parent rename + outside-pointing symlink through a deterministic hook placed after the fallback parent assertion and immediately before `mkdir`.

- On `origin/main` (`209fbd1`), default `auto` mode loaded the real bundled native binding but `copyIn()` still entered the fallback. The proof reported `{"nativeLoaded":true,"swapped":true,"escaped":true}`; the operation threw `outside-workspace` only after `lstat()` confirmed the out-of-root directory existed.
- On this branch in default mode, `copyIn()`, default `write()`, and `{ overwrite: true }` all succeed through the native transaction. The fallback hook remains false, the requested bytes appear inside the root, and the outside path is `ENOENT`.
- In `mode: "off"`, the same deterministic proof still reports `{"mode":"off","swapped":true,"escaped":true}`. The operation throws `outside-workspace`; the directory has already been created outside, although the payload file is not published there. This is retained and documented rather than hidden or mislabeled as containment.

## Remaining pathname-race surfaces

This PR intentionally does not claim to fix the broader guarded-mutation class:

- `pinned-write.ts` remains detection-based when native mode is `off`, `auto` cannot load a binding, or `renameIdentity: "verify-content-with-lock"` explicitly selects the compatibility fallback. Its guarded create/temp/rename operations and parent mkdir are pathname syscalls.
- `Root.mkdir()`, `remove()`, and `move()` remain guarded pathname mutations. `append()` and `openWritable()` still use guarded parent creation and pathname opens. Windows Root writes also retain their prior fallback when no binding is available or the rename-identity compatibility policy is selected.
- Non-private async `FileStore` nested writes call `Root.mkdir()` before the now-native file commit. Synchronous store parent creation and temp publication remain by-path; private store helpers have their own guarded/helper boundaries.
- `guardedRename()` / `guardedRm()` remain check-then-path primitives. Their consumers include `movePathWithCopyFallback()`, `replaceDirectoryAtomic()`, sibling/output staging, and trash operations. `movePathWithCopyFallback()` also performs staging-tree creation and source cleanup by path.
- `removeCopyTargetIfUnchanged()` and native failure cleanup retain guarded best-effort pathname cleanup behavior.

Fixing those surfaces requires separate operation-specific descriptor-relative transactions. Failing all JavaScript mutations closed here would be a breaking public policy change, so it is outside this narrow fix.

## Verification

- `pnpm check` — 68 test files passed; 691 tests passed, 37 skipped
- `pnpm test:security` with the host native binding built and loaded — 64 passed
- focused native containment/integration suite — 12 passed, 3 platform-specific skipped on macOS
- `pnpm native:test` — 16 passed
- `actionlint .github/workflows/ci.yml`
- `cargo fmt --check`
- `git diff --check`
- source-blind built-API behavior contract — all default/native, overwrite, mode-off, and traversal clauses passed
- Codex autoreview (`gpt-5.6-sol`, high reasoning) — clean, no accepted/actionable findings
