### PR TITLE
fix(store): consolidate mutation guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Pin synchronous file-store roots across every parent-walk segment, so private and non-private writes reject a store root replaced during directory creation, and route deny-mutation ancestor canonicalization through the shared root resolver on Windows and POSIX.
 - Keep the POSIX parent-directory no-follow identity check active for synchronous atomic-replacement adapters that omit `fchmodSync`, preventing the documented default adapter path from writing through a symlinked parent.
 - Synchronize the actual destination after descriptor-bound mode application when atomic rename uses copy fallback, and include both bytes and mode in bounded fallback restoration.
 - Continue accepting legacy atomic-replacement adapter literals that expose pathname `chmod` or `chmodSync` methods while keeping those methods unused.

--- a/src/deny-mutations.ts
+++ b/src/deny-mutations.ts
@@ -1,45 +1,9 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
-import { assertNoNulPathInput, isNotFoundPathError, isPathInside } from "./path.js";
+import { assertNoNulPathInput, isPathInside } from "./path.js";
+import { resolvePathViaExistingAncestor } from "./root-path-existing.js";
 
-async function pathExists(filePath: string): Promise<boolean> {
-  try {
-    await fs.lstat(filePath);
-    return true;
-  } catch (err) {
-    if (!isNotFoundPathError(err)) {
-      throw err;
-    }
-    return false;
-  }
-}
-
-async function resolvePathViaExistingAncestor(targetPath: string): Promise<string> {
-  const normalized = path.resolve(targetPath);
-  let cursor = normalized;
-  const missingSuffix: string[] = [];
-
-  while (path.dirname(cursor) !== cursor && !(await pathExists(cursor))) {
-    missingSuffix.unshift(path.basename(cursor));
-    cursor = path.dirname(cursor);
-  }
-
-  if (!(await pathExists(cursor))) {
-    return normalized;
-  }
-
-  try {
-    const resolvedAncestor = path.resolve(await fs.realpath(cursor));
-    return missingSuffix.length === 0
-      ? resolvedAncestor
-      : path.resolve(resolvedAncestor, ...missingSuffix);
-  } catch {
-    return normalized;
-  }
-}
-
-async function comparablePaths(rawPath: string): Promise<Set<string>> {
+export async function resolveMutationComparablePaths(rawPath: string): Promise<Set<string>> {
   assertNoNulPathInput(rawPath, "path contains a NUL byte");
   const resolved = path.resolve(rawPath);
   return new Set([resolved, await resolvePathViaExistingAncestor(resolved)]);
@@ -86,9 +50,9 @@ export async function assertMutationNotDenied(
     return;
   }
 
-  const targetPaths = await comparablePaths(filePath);
+  const targetPaths = await resolveMutationComparablePaths(filePath);
   for (const deniedPath of policyPathEntries(policy.paths)) {
-    const deniedPaths = await comparablePaths(deniedPath);
+    const deniedPaths = await resolveMutationComparablePaths(deniedPath);
     for (const target of targetPaths) {
       for (const denied of deniedPaths) {
         if (
@@ -102,7 +66,7 @@ export async function assertMutationNotDenied(
   }
 
   for (const deniedPrefix of policyPathEntries(policy.prefixes)) {
-    const deniedPaths = await comparablePaths(deniedPrefix);
+    const deniedPaths = await resolveMutationComparablePaths(deniedPrefix);
     for (const target of targetPaths) {
       for (const denied of deniedPaths) {
         if (

--- a/src/file-store-boundary.ts
+++ b/src/file-store-boundary.ts
@@ -9,6 +9,7 @@ import {
   type SyncDirectoryGuard,
 } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
+import { sameFileIdentity } from "./file-identity.js";
 import { isPathInside, isPathRelativeEscape } from "./path.js";
 import { resolveOpenedFileRealPathForHandle, root, type Root } from "./root.js";
 import { resolveSecureTempRoot } from "./secure-temp-dir.js";
@@ -159,8 +160,22 @@ export function ensureParentSync(params: {
   filePath: string;
   mode: number;
 }): SyncParentGuard {
+  return ensureStoreDirectorySync({
+    rootDir: params.rootDir,
+    targetDir: path.dirname(path.resolve(params.filePath)),
+    mode: params.mode,
+    messagePrefix: "store",
+  });
+}
+
+export function ensureStoreDirectorySync(params: {
+  rootDir: string;
+  targetDir: string;
+  mode: number;
+  messagePrefix: "private store" | "store";
+}): SyncParentGuard {
   const rootDir = path.resolve(params.rootDir);
-  const dir = path.dirname(path.resolve(params.filePath));
+  const dir = path.resolve(params.targetDir);
   const relative = path.relative(rootDir, dir);
   if (isPathRelativeEscape(relative)) {
     throw new FsSafeError("outside-workspace", "file path escapes store root");
@@ -169,7 +184,10 @@ export function ensureParentSync(params: {
   syncFs.mkdirSync(rootDir, { recursive: true, mode: params.mode });
   const rootStat = syncFs.lstatSync(rootDir);
   if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
-    throw new FsSafeError("not-file", `store root must be a directory: ${rootDir}`);
+    throw new FsSafeError(
+      "not-file",
+      `${params.messagePrefix} root must be a directory: ${rootDir}`,
+    );
   }
   const rootReal = syncFs.realpathSync(rootDir);
   chmodDirectorySyncBestEffort(rootDir, params.mode);
@@ -180,7 +198,10 @@ export function ensureParentSync(params: {
     try {
       const stat = syncFs.lstatSync(current);
       if (stat.isSymbolicLink() || !stat.isDirectory()) {
-        throw new FsSafeError("not-file", `store directory component must be a directory: ${current}`);
+        throw new FsSafeError(
+          "not-file",
+          `${params.messagePrefix} directory component must be a directory: ${current}`,
+        );
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -188,9 +209,20 @@ export function ensureParentSync(params: {
       }
       syncFs.mkdirSync(current, { mode: params.mode });
     }
+    const currentRootStat = syncFs.lstatSync(rootDir);
+    const currentRootReal = syncFs.realpathSync(rootDir);
     const currentReal = syncFs.realpathSync(current);
-    if (!isPathInside(rootReal, currentReal)) {
-      throw new FsSafeError("outside-workspace", "store directory escapes root");
+    if (
+      currentRootStat.isSymbolicLink() ||
+      !currentRootStat.isDirectory() ||
+      !sameFileIdentity(rootStat, currentRootStat) ||
+      currentRootReal !== rootReal ||
+      !isPathInside(rootReal, currentReal)
+    ) {
+      throw new FsSafeError(
+        "outside-workspace",
+        `${params.messagePrefix} directory escapes root`,
+      );
     }
     chmodDirectorySyncBestEffort(current, params.mode);
   }

--- a/src/file-store.ts
+++ b/src/file-store.ts
@@ -4,7 +4,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { Readable } from "node:stream";
 import { readFileDescriptorBoundedSync } from "./bounded-read.js";
-import { createSyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { pruneExpiredStoreEntries, type FileStorePruneOptions } from "./file-store-prune.js";
 export type { FileStorePruneOptions } from "./file-store-prune.js";
@@ -12,6 +11,7 @@ import {
   assertSyncDirectoryGuard,
   ensureParentInRoot,
   ensureParentSync,
+  ensureStoreDirectorySync,
   openWritableStoreRoot,
   type SyncParentGuard,
   writeStreamToTempSource,
@@ -394,50 +394,12 @@ export function fileStore(options: FileStoreOptions): FileStore {
 }
 
 function ensurePrivateDirectorySync(rootDir: string, targetDir: string, mode: number): SyncParentGuard {
-  const root = path.resolve(rootDir);
-  const target = path.resolve(targetDir);
-  assertStoreFilePath(root, target);
-  let current = root;
-  syncFs.mkdirSync(current, { recursive: true, mode });
-  const rootStat = syncFs.lstatSync(current);
-  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
-    throw new FsSafeError("not-file", `private store root must be a directory: ${current}`);
-  }
-  try {
-    syncFs.chmodSync(current, mode);
-  } catch {
-    // Best-effort on platforms that do not enforce POSIX modes.
-  }
-  for (const segment of path.relative(root, target).split(path.sep).filter(Boolean)) {
-    current = path.join(current, segment);
-    try {
-      const stat = syncFs.lstatSync(current);
-      if (stat.isSymbolicLink() || !stat.isDirectory()) {
-        throw new FsSafeError(
-          "not-file",
-          `private store directory component must be a directory: ${current}`,
-        );
-      }
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
-      }
-      syncFs.mkdirSync(current, { mode });
-    }
-    const rootReal = syncFs.realpathSync(root);
-    const currentReal = syncFs.realpathSync(current);
-    if (!isPathInside(rootReal, currentReal)) {
-      throw new FsSafeError("outside-workspace", "private store directory escapes root");
-    }
-    try {
-      syncFs.chmodSync(current, mode);
-    } catch {
-      // Best-effort on platforms that do not enforce POSIX modes.
-    }
-  }
-  const guard = createSyncDirectoryGuard(target);
-  assertSyncDirectoryGuard(guard);
-  return guard;
+  return ensureStoreDirectorySync({
+    rootDir,
+    targetDir,
+    mode,
+    messagePrefix: "private store",
+  });
 }
 
 function writeFileSyncAtomic(params: {

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -809,6 +809,43 @@ async function verifyAtomicWriteResult(params: {
   }
 }
 
+type GuardedWritePath = Awaited<ReturnType<typeof resolvePathInRoot>>;
+
+async function resolveGuardedWritePathInRoot(
+  root: RootContext,
+  params: {
+    relativePath: string;
+    denyMutations?: DenyMutationPolicy;
+    allowFinalSymlink?: boolean;
+    protectDeniedAncestors?: boolean;
+    shouldAssertNoPathAlias?: (resolved: GuardedWritePath) => Promise<boolean> | boolean;
+  },
+): Promise<GuardedWritePath> {
+  const resolvedPath = await resolvePathInRoot(root, params.relativePath, {
+    aliasErrorCode: "path-alias",
+    allowFinalSymlink: params.allowFinalSymlink,
+  });
+  await assertMutationNotDenied(
+    resolvedPath.resolved,
+    params.denyMutations,
+    params.protectDeniedAncestors ? { protectAncestors: true } : undefined,
+  );
+  if (await (params.shouldAssertNoPathAlias?.(resolvedPath) ?? true)) {
+    try {
+      await assertNoPathAliasEscape({
+        absolutePath: resolvedPath.resolved,
+        rootPath: resolvedPath.rootReal,
+        boundaryLabel: "root",
+      });
+    } catch (error) {
+      throw new FsSafeError("path-alias", "path alias escape blocked", {
+        cause: error instanceof Error ? error : undefined,
+      });
+    }
+  }
+  return resolvedPath;
+}
+
 async function openWritableFileInRoot(
   root: RootContext,
   params: {
@@ -820,21 +857,10 @@ async function openWritableFileInRoot(
     append?: boolean;
   },
 ): Promise<WritableOpenResult> {
-  const { rootReal, rootWithSep, resolved } = await resolvePathInRoot(
-    root,
-    params.relativePath,
-    { aliasErrorCode: "path-alias" },
-  );
-  await assertMutationNotDenied(resolved, params.denyMutations);
-  try {
-    await assertNoPathAliasEscape({
-      absolutePath: resolved,
-      rootPath: rootReal,
-      boundaryLabel: "root",
-    });
-  } catch (err) {
-    throw new FsSafeError("path-alias", "path alias escape blocked", { cause: err });
-  }
+  const { rootReal, rootWithSep, resolved } = await resolveGuardedWritePathInRoot(root, {
+    relativePath: params.relativePath,
+    denyMutations: params.denyMutations,
+  });
   let ioPath = params.mkdir === false
     ? resolved
     : await prepareRootWriteTarget(rootReal, resolved);
@@ -1199,19 +1225,10 @@ async function resolvePinnedWriteTargetInRoot(
   requestedMode?: number,
   denyMutations?: DenyMutationPolicy,
 ): Promise<PinnedWriteTarget> {
-  const { rootReal, rootWithSep, resolved } = await resolvePathInRoot(root, relativePath, {
-    aliasErrorCode: "path-alias",
+  const { rootReal, rootWithSep, resolved } = await resolveGuardedWritePathInRoot(root, {
+    relativePath,
+    denyMutations,
   });
-  await assertMutationNotDenied(resolved, denyMutations);
-  try {
-    await assertNoPathAliasEscape({
-      absolutePath: resolved,
-      rootPath: rootReal,
-      boundaryLabel: "root",
-    });
-  } catch (err) {
-    throw new FsSafeError("path-alias", "path alias escape blocked", { cause: err });
-  }
 
   // resolvePathInRoot already enforces isPathInside, so any actual escape
   // is rejected upstream.
@@ -1468,31 +1485,24 @@ async function movePathFallback(
     relativePath: params.fromRelative,
     policy: PATH_ALIAS_POLICIES.strict,
   });
-  const target = await resolvePathInRoot(root, params.toRelative, {
-    aliasErrorCode: "path-alias",
-    allowFinalSymlink: true,
-  });
-  await assertMutationNotDenied(target.resolved, params.denyMutations, { protectAncestors: true });
-  await resolvePinnedRootPathInRoot(root, {
+  const target = await resolveGuardedWritePathInRoot(root, {
     relativePath: params.toRelative,
-    policy: PATH_ALIAS_POLICIES.unlinkTarget,
+    denyMutations: params.denyMutations,
+    allowFinalSymlink: true,
+    protectDeniedAncestors: true,
+    shouldAssertNoPathAlias: async (resolvedTarget) => {
+      await resolvePinnedRootPathInRoot(root, {
+        relativePath: params.toRelative,
+        policy: PATH_ALIAS_POLICIES.unlinkTarget,
+      });
+      const targetStat = await fs.lstat(resolvedTarget.resolved).catch(() => undefined);
+      return !(
+        process.platform !== "win32" &&
+        params.overwrite &&
+        targetStat?.isSymbolicLink() === true
+      );
+    },
   });
-  const targetStat = await fs.lstat(target.resolved).catch(() => undefined);
-  const replacesFinalSymlink =
-    process.platform !== "win32" && params.overwrite && targetStat?.isSymbolicLink() === true;
-  if (!replacesFinalSymlink) {
-    try {
-      await assertNoPathAliasEscape({
-        absolutePath: target.resolved,
-        rootPath: target.rootReal,
-        boundaryLabel: "root",
-      });
-    } catch (error) {
-      throw new FsSafeError("path-alias", "path alias escape blocked", {
-        cause: error instanceof Error ? error : undefined,
-      });
-    }
-  }
 
   let sourceStat: Stats;
   try {
@@ -1627,19 +1637,10 @@ async function writeMissingFileFallback(
     denyMutations?: DenyMutationPolicy;
   },
 ): Promise<void> {
-  const { rootReal, resolved } = await resolvePathInRoot(root, params.relativePath, {
-    aliasErrorCode: "path-alias",
+  const { rootReal, resolved } = await resolveGuardedWritePathInRoot(root, {
+    relativePath: params.relativePath,
+    denyMutations: params.denyMutations,
   });
-  await assertMutationNotDenied(resolved, params.denyMutations);
-  try {
-    await assertNoPathAliasEscape({
-      absolutePath: resolved,
-      rootPath: rootReal,
-      boundaryLabel: "root",
-    });
-  } catch (err) {
-    throw new FsSafeError("path-alias", "path alias escape blocked", { cause: err });
-  }
   const targetPath = params.mkdir === false
     ? resolved
     : await prepareRootWriteTarget(rootReal, resolved);

--- a/test/deny-mutations.test.ts
+++ b/test/deny-mutations.test.ts
@@ -1,8 +1,10 @@
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import fs, { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveMutationComparablePaths } from "../src/deny-mutations.js";
 import { root as openRoot } from "../src/index.js";
+import { resolvePathViaExistingAncestor } from "../src/root-path-existing.js";
 
 const skipOnWindows = process.platform === "win32";
 const tempDirs: string[] = [];
@@ -14,10 +16,27 @@ async function tempRoot(prefix: string): Promise<string> {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
 });
 
 describe("root denyMutations policies", () => {
+  it.runIf(process.platform === "win32")(
+    "uses the root ancestor canonicalizer for drive-relative and UNC roots",
+    async () => {
+      vi.spyOn(fs, "lstat").mockRejectedValue(Object.assign(new Error("missing"), { code: "ENOENT" }));
+
+      for (const input of ["C:foo", "\\\\?\\C:\\", "\\\\server\\share"]) {
+        const normalized = path.resolve(input);
+        const rootCanonical = await resolvePathViaExistingAncestor(input);
+        const denyCanonical = await resolveMutationComparablePaths(input);
+
+        expect(rootCanonical, input).toBe(normalized);
+        expect(denyCanonical, input).toEqual(new Set([normalized]));
+      }
+    },
+  );
+
   it("denies root mutations by exact denied path", async () => {
     const rootPath = await tempRoot("fs-safe-deny-exact-");
     const sourceRoot = await tempRoot("fs-safe-deny-exact-source-");

--- a/test/guard-consolidation.test.ts
+++ b/test/guard-consolidation.test.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { fileStoreSync } from "../src/file-store.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
+});
+
+it.runIf(process.platform !== "win32")(
+  "rejects store-root swaps during private and non-private parent walks",
+  async () => {
+    for (const privateMode of [false, true]) {
+      const container = await fsp.mkdtemp(
+        path.join(os.tmpdir(), `fs-safe-sync-root-swap-${privateMode}-`),
+      );
+      tempDirs.push(container);
+      const storeRoot = path.join(container, "store");
+      const originalRoot = path.join(container, "store-original");
+      const outside = path.join(container, "outside");
+      const firstDir = path.join(storeRoot, "first");
+      await fsp.mkdir(storeRoot);
+      await fsp.mkdir(path.join(outside, "first"), { recursive: true });
+
+      const originalRealpathSync = fs.realpathSync.bind(fs);
+      let swapped = false;
+      const realpathSpy = vi.spyOn(fs, "realpathSync").mockImplementation((...args) => {
+        const realPath = originalRealpathSync(...args);
+        if (!swapped && String(args[0]) === firstDir) {
+          swapped = true;
+          fs.renameSync(storeRoot, originalRoot);
+          fs.symlinkSync(outside, storeRoot, "dir");
+        }
+        return realPath;
+      });
+
+      try {
+        const store = fileStoreSync({ rootDir: storeRoot, private: privateMode });
+        expect(() => store.writeText("first/second/value.txt", "secret")).toThrow(
+          expect.objectContaining({ code: "outside-workspace" }),
+        );
+        expect(fs.existsSync(path.join(outside, "first", "second", "value.txt"))).toBe(false);
+      } finally {
+        realpathSpy.mockRestore();
+      }
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- consolidate both synchronous file-store directory walkers behind one guarded helper
- pin the initial store-root canonical path and filesystem identity, then revalidate both for every walked segment
- reuse the shared existing-ancestor resolver for deny-mutation comparisons
- centralize the root write resolve/deny/path-alias prologue while preserving the move fallback's final-symlink overwrite exception

## Investigation corrections

The divergent store walker was a live root-swap bug, but the vulnerable side was the private walker: recomputing the root realpath after a redirect followed the replacement and accepted it. The non-private walker's hoisted canonical root already rejected that redirect. The shared implementation is stricter than both because it pins the original canonical path and inode and revalidates them per segment.

The two ancestor-loop predicates were behaviorally equivalent for the reported Windows spellings after their common path resolution step. This PR still removes the duplicate implementation and adds a native-Windows table for drive-relative, device-root, and UNC spellings so future drift is impossible, but does not claim a Windows behavior change.

## Proof

- new root-swap regression fails against origin/main (the private write succeeds) and passes on this branch for both private and non-private entry points
- native Windows deny-mutation table passes for C:foo, the extended-length C drive root, and a UNC share root
- pnpm check
- pnpm test:security
- git diff --check
- Codex autoreview: clean, no actionable findings

Production source is reduced by 41 lines; including focused regressions and the changelog, the net change is +32 lines.
