### PR TITLE
refactor(test): remove repeated suite boilerplate

### DIFF
--- a/scripts/check-file-size.mjs
+++ b/scripts/check-file-size.mjs
@@ -7,7 +7,7 @@ const LINE_BUDGETS = new Map([
   ["src/permissions.ts", 566],
   ["src/root-impl.ts", 1750],
   ["src/root-path.ts", 862],
-  ["test/api-coverage.test.ts", 983],
+  ["test/api-coverage.test.ts", 915],
   ["test/new-primitives.test.ts", 1500],
 ]);
 

--- a/test/absolute-directory.test.ts
+++ b/test/absolute-directory.test.ts
@@ -1,20 +1,14 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { ensureAbsoluteDirectory } from "../src/absolute-path.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
 });
 
 describe("ensureAbsoluteDirectory", () => {
@@ -46,43 +40,37 @@ describe("ensureAbsoluteDirectory", () => {
     ).resolves.toMatchObject({ ok: false, code: "not-file" });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects absolute directory creation through symlinked existing segments",
-    async () => {
-      const root = await fs.realpath(await tempRoot("fs-safe-absolute-dir-link-"));
-      const outside = await fs.realpath(await tempRoot("fs-safe-absolute-dir-outside-"));
-      const linkDir = path.join(root, "link");
-      await fs.symlink(outside, linkDir);
+  itPosix("rejects absolute directory creation through symlinked existing segments", async () => {
+    const root = await fs.realpath(await tempRoot("fs-safe-absolute-dir-link-"));
+    const outside = await fs.realpath(await tempRoot("fs-safe-absolute-dir-outside-"));
+    const linkDir = path.join(root, "link");
+    await fs.symlink(outside, linkDir);
 
-      await expect(
-        ensureAbsoluteDirectory(path.join(linkDir, "nested"), {
-          scopeLabel: "output directory",
-        }),
-      ).resolves.toMatchObject({ ok: false, code: "symlink" });
-      await expect(fs.readdir(outside)).resolves.toEqual([]);
-    },
-  );
+    await expect(
+      ensureAbsoluteDirectory(path.join(linkDir, "nested"), {
+        scopeLabel: "output directory",
+      }),
+    ).resolves.toMatchObject({ ok: false, code: "symlink" });
+    await expect(fs.readdir(outside)).resolves.toEqual([]);
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects symlinked parents even when the requested suffix already exists",
-    async () => {
-      const root = await fs.realpath(await tempRoot("fs-safe-absolute-dir-link-existing-"));
-      const outside = await fs.realpath(
-        await tempRoot("fs-safe-absolute-dir-link-existing-outside-"),
-      );
-      const existing = path.join(outside, "existing");
-      const linkDir = path.join(root, "link");
-      await fs.mkdir(existing);
-      await fs.symlink(outside, linkDir);
+  itPosix("rejects symlinked parents even when the requested suffix already exists", async () => {
+    const root = await fs.realpath(await tempRoot("fs-safe-absolute-dir-link-existing-"));
+    const outside = await fs.realpath(
+      await tempRoot("fs-safe-absolute-dir-link-existing-outside-"),
+    );
+    const existing = path.join(outside, "existing");
+    const linkDir = path.join(root, "link");
+    await fs.mkdir(existing);
+    await fs.symlink(outside, linkDir);
 
-      await expect(
-        ensureAbsoluteDirectory(path.join(linkDir, "existing", "new"), {
-          scopeLabel: "output directory",
-        }),
-      ).resolves.toMatchObject({ ok: false, code: "symlink" });
-      await expect(fs.stat(path.join(existing, "new"))).rejects.toMatchObject({ code: "ENOENT" });
-    },
-  );
+    await expect(
+      ensureAbsoluteDirectory(path.join(linkDir, "existing", "new"), {
+        scopeLabel: "output directory",
+      }),
+    ).resolves.toMatchObject({ ok: false, code: "symlink" });
+    await expect(fs.stat(path.join(existing, "new"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
 
   it("returns a policy failure when an intermediate component is a file", async () => {
     const root = await fs.realpath(await tempRoot("fs-safe-absolute-dir-file-component-"));
@@ -96,72 +84,66 @@ describe("ensureAbsoluteDirectory", () => {
     ).resolves.toMatchObject({ ok: false, code: "not-file" });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects absolute directory creation when an existing parent is swapped before mkdir",
-    async () => {
-      const root = await fs.realpath(await tempRoot("fs-safe-absolute-dir-race-"));
-      const outside = await fs.realpath(await tempRoot("fs-safe-absolute-dir-race-outside-"));
-      const parentDir = path.join(root, "parent");
-      const targetDir = path.join(parentDir, "child");
-      await fs.mkdir(parentDir);
+  itPosix("rejects absolute directory creation when an existing parent is swapped before mkdir", async () => {
+    const root = await fs.realpath(await tempRoot("fs-safe-absolute-dir-race-"));
+    const outside = await fs.realpath(await tempRoot("fs-safe-absolute-dir-race-outside-"));
+    const parentDir = path.join(root, "parent");
+    const targetDir = path.join(parentDir, "child");
+    await fs.mkdir(parentDir);
 
-      const realLstat = fs.lstat.bind(fs);
-      let swapped = false;
-      const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-        const candidate = String(args[0]);
-        if (!swapped && candidate === targetDir) {
-          swapped = true;
-          await fs.rename(parentDir, `${parentDir}-real`);
-          await fs.symlink(outside, parentDir, "dir");
-        }
-        return await realLstat(...args);
-      });
-
-      try {
-        await expect(
-          ensureAbsoluteDirectory(targetDir, { scopeLabel: "output directory" }),
-        ).resolves.toMatchObject({ ok: false, code: "symlink" });
-      } finally {
-        lstatSpy.mockRestore();
+    const realLstat = fs.lstat.bind(fs);
+    let swapped = false;
+    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      const candidate = String(args[0]);
+      if (!swapped && candidate === targetDir) {
+        swapped = true;
+        await fs.rename(parentDir, `${parentDir}-real`);
+        await fs.symlink(outside, parentDir, "dir");
       }
+      return await realLstat(...args);
+    });
 
-      await expect(fs.stat(path.join(outside, "child"))).rejects.toMatchObject({ code: "ENOENT" });
-    },
-  );
+    try {
+      await expect(
+        ensureAbsoluteDirectory(targetDir, { scopeLabel: "output directory" }),
+      ).resolves.toMatchObject({ ok: false, code: "symlink" });
+    } finally {
+      lstatSpy.mockRestore();
+    }
 
-  it.runIf(process.platform !== "win32")(
-    "rejects absolute directory creation when the existing target changes before return",
-    async () => {
-      const root = await fs.realpath(await tempRoot("fs-safe-absolute-dir-target-race-"));
-      const outside = await fs.realpath(
-        await tempRoot("fs-safe-absolute-dir-target-race-outside-"),
-      );
-      const targetDir = path.join(root, "target");
-      await fs.mkdir(targetDir);
+    await expect(fs.stat(path.join(outside, "child"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
 
-      const realRealpath = fs.realpath.bind(fs);
-      let swapped = false;
-      const realpathSpy = vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
-        const candidate = String(args[0]);
-        if (!swapped && candidate === targetDir) {
-          swapped = true;
-          const resolved = await realRealpath(...args);
-          await fs.rename(targetDir, `${targetDir}-real`);
-          await fs.symlink(outside, targetDir, "dir");
-          return resolved;
-        }
-        return await realRealpath(...args);
-      });
+  itPosix("rejects absolute directory creation when the existing target changes before return", async () => {
+    const root = await fs.realpath(await tempRoot("fs-safe-absolute-dir-target-race-"));
+    const outside = await fs.realpath(
+      await tempRoot("fs-safe-absolute-dir-target-race-outside-"),
+    );
+    const targetDir = path.join(root, "target");
+    await fs.mkdir(targetDir);
 
-      try {
-        await expect(
-          ensureAbsoluteDirectory(targetDir, { scopeLabel: "output directory" }),
-        ).resolves.toMatchObject({ ok: false, code: "symlink" });
-      } finally {
-        realpathSpy.mockRestore();
+    const realRealpath = fs.realpath.bind(fs);
+    let swapped = false;
+    const realpathSpy = vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+      const candidate = String(args[0]);
+      if (!swapped && candidate === targetDir) {
+        swapped = true;
+        const resolved = await realRealpath(...args);
+        await fs.rename(targetDir, `${targetDir}-real`);
+        await fs.symlink(outside, targetDir, "dir");
+        return resolved;
       }
-    },
-  );
+      return await realRealpath(...args);
+    });
+
+    try {
+      await expect(
+        ensureAbsoluteDirectory(targetDir, { scopeLabel: "output directory" }),
+      ).resolves.toMatchObject({ ok: false, code: "symlink" });
+    } finally {
+      realpathSpy.mockRestore();
+    }
+  });
 
   it("rethrows operational absolute directory creation failures", async () => {
     const root = await fs.realpath(await tempRoot("fs-safe-absolute-dir-io-"));

--- a/test/additional-boundary-bypass.test.ts
+++ b/test/additional-boundary-bypass.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectNoOutsideWrite, makeTempLayout } from "./helpers/security.js";
+import { useTempDirs } from "./helpers/vitest.js";
 import { safeFileURLToPath } from "../src/local-file-access.js";
 import { assertCanonicalPathWithinBase, resolveSafeInstallDir } from "../src/install-path.js";
 import { createJsonStore } from "../src/json-document-store.js";
@@ -13,13 +15,7 @@ import { prepareArchiveOutputPath } from "../src/archive-staging.js";
 import { sanitizeTempFileName, tempFile } from "../src/temp-target.js";
 import { walkDirectory, walkDirectorySync } from "../src/walk.js";
 
-type TempLayout = {
-  base: string;
-  outside: string;
-  outsideFile: string;
-};
-
-const tempDirs: string[] = [];
+const { tempDirs } = useTempDirs();
 
 const ARCHIVE_ESCAPE_PAYLOADS = [
   "../evil.txt",
@@ -33,45 +29,35 @@ const ARCHIVE_ESCAPE_PAYLOADS = [
   "nested\\..\\..\\evil.txt",
 ] as const;
 
-async function makeTempLayout(prefix: string): Promise<TempLayout> {
-  const base = await fsp.mkdtemp(path.join(os.tmpdir(), `${prefix}-base-`));
-  const outside = await fsp.mkdtemp(path.join(os.tmpdir(), `${prefix}-outside-`));
-  tempDirs.push(base, outside);
-  const outsideFile = path.join(outside, "secret.txt");
-  await fsp.writeFile(outsideFile, "outside secret");
-  return { base, outside, outsideFile };
-}
-
 afterEach(async () => {
   vi.restoreAllMocks();
-  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
 });
 
 describe("additional helper boundary bypass attempts", () => {
   it("rejects archive traversal payloads before resolving output paths", async () => {
-    const layout = await makeTempLayout("fs-safe-archive-payloads");
+    const layout = await makeTempLayout("fs-safe-archive-payloads", tempDirs);
 
     for (const payload of ARCHIVE_ESCAPE_PAYLOADS) {
       expect(() => validateArchiveEntryPath(payload), `validate ${payload}`).toThrow();
       await expect(
-        prepareArchiveOutputPath({ destDir: layout.base, relativePath: payload, originalPath: payload }),
+        prepareArchiveOutputPath({ destDir: layout.root, relativePath: payload, originalPath: payload }),
       ).rejects.toThrow();
     }
   });
 
   it("keeps archive output resolution inside the destination for benign weird names", async () => {
-    const layout = await makeTempLayout("fs-safe-archive-literals");
+    const layout = await makeTempLayout("fs-safe-archive-literals", tempDirs);
     const payloads = ["%2e%2e%2fevil.txt", "..%2fevil.txt", "safe/..hidden/file.txt"];
 
     for (const payload of payloads) {
       validateArchiveEntryPath(payload);
-      const output = resolveArchiveOutputPath({ rootDir: layout.base, relPath: payload, originalPath: payload });
-      expect(output.startsWith(`${layout.base}${path.sep}`)).toBe(true);
+      const output = resolveArchiveOutputPath({ rootDir: layout.root, relPath: payload, originalPath: payload });
+      expect(output.startsWith(`${layout.root}${path.sep}`)).toBe(true);
     }
   });
 
   it("sanitizes temp file names and keeps temp file helpers inside their created directory", async () => {
-    const layout = await makeTempLayout("fs-safe-temp");
+    const layout = await makeTempLayout("fs-safe-temp", tempDirs);
     expect(sanitizeTempFileName("../../evil.txt")).toBe("evil.txt");
     if (process.platform !== "win32") {
       // On windows "\" is a reserved path separator and cannot appear in a
@@ -81,9 +67,9 @@ describe("additional helper boundary bypass attempts", () => {
     }
     expect(sanitizeTempFileName("\u0000../evil.txt")).toBe("evil.txt");
 
-    const target = await tempFile({ rootDir: layout.base, prefix: "../../prefix", fileName: "../../evil.txt" });
+    const target = await tempFile({ rootDir: layout.root, prefix: "../../prefix", fileName: "../../evil.txt" });
     tempDirs.push(target.dir);
-    expect(target.dir.startsWith(`${layout.base}${path.sep}`)).toBe(true);
+    expect(target.dir.startsWith(`${layout.root}${path.sep}`)).toBe(true);
     expect(target.path).toBe(path.join(target.dir, "evil.txt"));
     expect(target.file("../../other.txt")).toBe(path.join(target.dir, "other.txt"));
     await target.cleanup();
@@ -100,20 +86,20 @@ describe("additional helper boundary bypass attempts", () => {
   });
 
   it("keeps install directories and canonical base checks inside their base", async () => {
-    const layout = await makeTempLayout("fs-safe-install");
-    const safe = resolveSafeInstallDir({ baseDir: layout.base, id: "../../evil/pkg", invalidNameMessage: "bad package" });
+    const layout = await makeTempLayout("fs-safe-install", tempDirs);
+    const safe = resolveSafeInstallDir({ baseDir: layout.root, id: "../../evil/pkg", invalidNameMessage: "bad package" });
     expect(safe).toMatchObject({ ok: true });
     if (!safe.ok) throw new Error("expected safe install dir");
-    expect(safe.path.startsWith(`${layout.base}${path.sep}`)).toBe(true);
+    expect(safe.path.startsWith(`${layout.root}${path.sep}`)).toBe(true);
 
     await expect(
-      assertCanonicalPathWithinBase({ baseDir: layout.base, candidatePath: layout.outsideFile, boundaryLabel: "install base" }),
+      assertCanonicalPathWithinBase({ baseDir: layout.root, candidatePath: layout.outsideFile, boundaryLabel: "install base" }),
     ).rejects.toThrow();
-    const insideDir = path.join(layout.base, "inside");
+    const insideDir = path.join(layout.root, "inside");
     await fsp.mkdir(insideDir);
     await expect(
       assertCanonicalPathWithinBase({
-        baseDir: layout.base,
+        baseDir: layout.root,
         boundaryLabel: "install base",
         candidatePath: path.join(insideDir, "future-file.txt"),
       }),
@@ -121,33 +107,33 @@ describe("additional helper boundary bypass attempts", () => {
   });
 
   it("walks do not follow symlinks by default and do not loop when following cycles", async () => {
-    const layout = await makeTempLayout("fs-safe-walk");
-    await fsp.mkdir(path.join(layout.base, "dir"));
-    await fsp.writeFile(path.join(layout.base, "dir", "inside.txt"), "inside");
-    await fsp.symlink(layout.outside, path.join(layout.base, "outside-link"), "dir");
-    await fsp.symlink(layout.base, path.join(layout.base, "dir", "cycle"), "dir");
+    const layout = await makeTempLayout("fs-safe-walk", tempDirs);
+    await fsp.mkdir(path.join(layout.root, "dir"));
+    await fsp.writeFile(path.join(layout.root, "dir", "inside.txt"), "inside");
+    await fsp.symlink(layout.outside, path.join(layout.root, "outside-link"), "dir");
+    await fsp.symlink(layout.root, path.join(layout.root, "dir", "cycle"), "dir");
 
-    const skipped = await walkDirectory(layout.base);
+    const skipped = await walkDirectory(layout.root);
     expect(skipped.entries.some((entry) => entry.path.startsWith(layout.outside))).toBe(false);
     expect(skipped.entries.some((entry) => entry.relativePath.includes("outside-link"))).toBe(false);
 
-    const followed = await walkDirectory(layout.base, { symlinks: "follow", maxEntries: 20 });
+    const followed = await walkDirectory(layout.root, { symlinks: "follow", maxEntries: 20 });
     expect(followed.entries.length).toBeLessThanOrEqual(20);
     expect(followed.entries.some((entry) => entry.path.startsWith(layout.outside))).toBe(false);
 
-    const syncFollowed = walkDirectorySync(layout.base, { symlinks: "follow", maxEntries: 20 });
+    const syncFollowed = walkDirectorySync(layout.root, { symlinks: "follow", maxEntries: 20 });
     expect(syncFollowed.entries.length).toBeLessThanOrEqual(20);
   });
 
   it("refuses to trash targets outside explicit allowed roots and does not move them", async () => {
-    const layout = await makeTempLayout("fs-safe-trash");
-    await expect(movePathToTrash(layout.outsideFile, { allowedRoots: [layout.base] })).rejects.toThrow();
-    await expect(fsp.readFile(layout.outsideFile, "utf8")).resolves.toBe("outside secret");
+    const layout = await makeTempLayout("fs-safe-trash", tempDirs);
+    await expect(movePathToTrash(layout.outsideFile, { allowedRoots: [layout.root] })).rejects.toThrow();
+    await expectNoOutsideWrite(layout);
   });
 
   it("json stores cannot bypass adapter-enforced root checks through lock/update flow", async () => {
-    const layout = await makeTempLayout("fs-safe-json-store");
-    const filePath = path.join(layout.base, "state.json");
+    const layout = await makeTempLayout("fs-safe-json-store", tempDirs);
+    const filePath = path.join(layout.root, "state.json");
     const adapter = {
       filePath,
       async readIfExists(): Promise<{ ok: boolean } | undefined> {
@@ -163,7 +149,7 @@ describe("additional helper boundary bypass attempts", () => {
       },
       async write(value: { ok: boolean }): Promise<void> {
         const resolved = path.resolve(filePath);
-        if (!resolved.startsWith(`${layout.base}${path.sep}`)) {
+        if (!resolved.startsWith(`${layout.root}${path.sep}`)) {
           throw new Error("adapter escaped root");
         }
         await fsp.writeFile(filePath, JSON.stringify(value));
@@ -172,6 +158,6 @@ describe("additional helper boundary bypass attempts", () => {
     const store = createJsonStore(adapter, { lock: true });
     await expect(store.updateOr({ ok: false }, () => ({ ok: true }))).resolves.toEqual({ ok: true });
     await expect(fsp.readFile(filePath, "utf8")).resolves.toBe('{"ok":true}');
-    await expect(fsp.readFile(layout.outsideFile, "utf8")).resolves.toBe("outside secret");
+    await expectNoOutsideWrite(layout);
   });
 });

--- a/test/adversarial-boundary-payloads.test.ts
+++ b/test/adversarial-boundary-payloads.test.ts
@@ -1,16 +1,11 @@
 import fsp from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { expectNoOutsideWrite, makeTempLayout } from "./helpers/security.js";
+import { useTempDirs } from "./helpers/vitest.js";
 import { root as openRoot } from "../src/index.js";
 
-type TempLayout = {
-  outside: string;
-  outsideFile: string;
-  root: string;
-};
-
-const tempDirs: string[] = [];
+const { tempDirs } = useTempDirs();
 
 const DOT_SEGMENTS = ["..", "...", ". .", ".. ", " ..", "%2e%2e", "%252e%252e"] as const;
 const SEPARATORS = ["/", "//", "\\", "\\\\", "%2f", "%5c"] as const;
@@ -23,15 +18,6 @@ const CONTROL_PAYLOADS = [
   "safe\u202ename.txt",
   "safe\ufeffname.txt",
 ] as const;
-
-async function makeTempLayout(prefix: string): Promise<TempLayout> {
-  const root = await fsp.mkdtemp(path.join(os.tmpdir(), `${prefix}-root-`));
-  const outside = await fsp.mkdtemp(path.join(os.tmpdir(), `${prefix}-outside-`));
-  tempDirs.push(root, outside);
-  const outsideFile = path.join(outside, "secret.txt");
-  await fsp.writeFile(outsideFile, "outside secret");
-  return { outside, outsideFile, root };
-}
 
 function buildPayloadCorpus(): string[] {
   const payloads = new Set<string>();
@@ -51,10 +37,6 @@ function buildPayloadCorpus(): string[] {
     payloads.add(payload);
   }
   return [...payloads];
-}
-
-async function expectOutsideUntouched(layout: TempLayout): Promise<void> {
-  await expect(fsp.readFile(layout.outsideFile, "utf8")).resolves.toBe("outside secret");
 }
 
 async function closeIfOpened(value: unknown): Promise<void> {
@@ -88,13 +70,9 @@ async function attemptAll(rootDir: Awaited<ReturnType<typeof openRoot>>, payload
   ]);
 }
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { force: true, recursive: true })));
-});
-
 describe("adversarial boundary payloads", () => {
   it("never reads, writes, or deletes outside the root for a generated traversal corpus", async () => {
-    const layout = await makeTempLayout("fs-safe-adversarial-corpus");
+    const layout = await makeTempLayout("fs-safe-adversarial-corpus", tempDirs);
     await fsp.mkdir(path.join(layout.root, "nested"), { recursive: true });
     await fsp.mkdir(path.join(layout.root, "safe"), { recursive: true });
     const safeRoot = await openRoot(layout.root);
@@ -102,12 +80,12 @@ describe("adversarial boundary payloads", () => {
     const payloads = buildPayloadCorpus().slice(0, 96);
     for (const payload of payloads) {
       await attemptAll(safeRoot, payload);
-      await expectOutsideUntouched(layout);
+      await expectNoOutsideWrite(layout);
     }
   }, 30_000);
 
   it("rejects chained symlink parent escapes across read and write surfaces", async () => {
-    const layout = await makeTempLayout("fs-safe-symlink-chain");
+    const layout = await makeTempLayout("fs-safe-symlink-chain", tempDirs);
     await fsp.mkdir(path.join(layout.root, "a"), { recursive: true });
     await fsp.symlink(path.join(layout.root, "a"), path.join(layout.root, "link-a"), "dir");
     await fsp.symlink(layout.outside, path.join(layout.root, "a", "link-out"), "dir");
@@ -118,11 +96,11 @@ describe("adversarial boundary payloads", () => {
       await expect(safeRoot.write(payload, "pwned"), `write ${payload}`).rejects.toBeTruthy();
       await expect(safeRoot.remove(payload), `remove ${payload}`).rejects.toBeTruthy();
     }
-    await expectOutsideUntouched(layout);
+    await expectNoOutsideWrite(layout);
   });
 
   it("does not clobber outside files when copy and move payloads mix source and destination attacks", async () => {
-    const layout = await makeTempLayout("fs-safe-copy-move-corpus");
+    const layout = await makeTempLayout("fs-safe-copy-move-corpus", tempDirs);
     const source = path.join(layout.root, "source.txt");
     await fsp.writeFile(source, "source");
     await fsp.symlink(layout.outsideFile, path.join(layout.root, "outside-link.txt"), "file");
@@ -137,7 +115,7 @@ describe("adversarial boundary payloads", () => {
         safeRoot.move(payload, "moved.txt", { overwrite: true }),
         safeRoot.move("outside-link.txt", "moved-link.txt", { overwrite: true }),
       ]);
-      await expectOutsideUntouched(layout);
+      await expectNoOutsideWrite(layout);
       await fsp.writeFile(source, "source");
     }
   }, 30_000);

--- a/test/api-coverage.test.ts
+++ b/test/api-coverage.test.ts
@@ -1,11 +1,12 @@
 import fs from "node:fs/promises";
 import { realpathSync } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import JSZip from "jszip";
 import * as tar from "tar";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { extractArchive } from "../src/archive.js";
 import { loadZipArchiveWithPreflight, readZipCentralDirectoryEntryCount } from "../src/archive-zip-preflight.js";
 import { createAsyncLock } from "../src/async-lock.js";
@@ -17,51 +18,15 @@ import {
   safeDirName,
   safePathSegmentHashed,
 } from "../src/install-path.js";
-import {
-  readJson,
-  readJsonIfExists,
-  readJsonSync,
-  tryReadJson,
-  tryReadJsonSync,
-  writeJson,
-  writeJsonSync,
-} from "../src/json.js";
+import * as json from "../src/json.js";
 import { jsonStore } from "../src/json-store.js";
-import {
-  assertNoWindowsNetworkPath,
-  basenameFromMediaSource,
-  hasEncodedFileUrlSeparator,
-  isWindowsDriveLetterPath,
-  safeFileURLToPath,
-  trySafeFileURLToPath,
-} from "../src/local-file-access.js";
+import * as localFile from "../src/local-file-access.js";
 import { resolveLocalPathFromRootsSync } from "../src/local-roots.js";
 import { movePathWithCopyFallback } from "../src/move-path.js";
-import {
-  assertNoNulPathInput,
-  hasNodeErrorCode,
-  isNotFoundPathError,
-  isPathInside,
-  isPathInsideWithRealpath,
-  isSymlinkOpenError,
-  normalizeWindowsPathForComparison,
-  resolveSafeBaseDir,
-  resolveSafeRelativePath,
-  safeRealpathSync,
-  safeStatSync,
-  splitSafeRelativePath,
-} from "../src/path.js";
+import * as safePath from "../src/path.js";
 import { assertNoHardlinkedFinalPath, assertNoPathAliasEscape } from "../src/path-policy.js";
 import { ROOT_PATH_ALIAS_POLICIES, resolveRootPath, resolveRootPathSync } from "../src/root-path.js";
-import {
-  ensureDirectoryWithinRoot,
-  pathScope,
-  resolveExistingPathsWithinRoot,
-  resolvePathsWithinRoot,
-  resolvePathWithinRoot,
-  resolveStrictExistingPathsWithinRoot,
-  resolveWritablePathWithinRoot,
-} from "../src/root-paths.js";
+import * as rootPaths from "../src/root-paths.js";
 import { replaceDirectoryAtomic } from "../src/replace-directory.js";
 import { openLocalFileSafely, readLocalFileSafely, root as openRoot } from "../src/root.js";
 import {
@@ -71,15 +36,7 @@ import {
 } from "../src/secret-file.js";
 import { resolveSecureTempRoot } from "../src/secure-temp-dir.js";
 import { assertNoSymlinkParents, assertNoSymlinkParentsSync } from "../src/symlink-parents.js";
-import {
-  appendRegularFile,
-  appendRegularFileSync,
-  readRegularFile,
-  readRegularFileSync,
-  resolveRegularFileAppendFlags,
-  statRegularFile,
-  statRegularFileSync,
-} from "../src/regular-file.js";
+import * as regularFile from "../src/regular-file.js";
 import {
   buildRandomTempFilePath,
   sanitizeTempFileName,
@@ -94,20 +51,9 @@ import {
 } from "../src/private-temp-workspace.js";
 import { withTimeout } from "../src/timing.js";
 
-const tempDirs = new Set<string>();
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.add(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  for (const dir of tempDirs) {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
-  tempDirs.clear();
-});
 
 describe("root handle coverage", () => {
   it("covers root reads, absolute reads, append newline logic, and writable handles", async () => {
@@ -165,23 +111,19 @@ describe("root handle coverage", () => {
 
     await scoped.copyIn("copied/source.txt", source, { maxBytes: 16, mode: 0o600 });
     await expect(scoped.readText("copied/source.txt")).resolves.toBe("copy me");
-    await expect(scoped.copyIn("too-large.txt", source, { maxBytes: 3 })).rejects.toMatchObject({
-      code: "too-large",
-    });
+    await expectFsSafeError(scoped.copyIn("too-large.txt", source, { maxBytes: 3 }), "too-large");
     await expect(scoped.copyIn("bad.txt", sourceDir)).rejects.toMatchObject({ code: "not-file" });
 
     await scoped.writeJson("json/state.json", { ok: true }, { trailingNewline: false });
     await expect(scoped.readJson("json/state.json")).resolves.toEqual({ ok: true });
     await scoped.createJson("json/new.json", { value: 1 }, { space: 0 });
-    await expect(scoped.create("json/new.json", "again")).rejects.toMatchObject({
-      code: "already-exists",
-    });
+    await expectFsSafeError(scoped.create("json/new.json", "again"), "already-exists");
     await expect(scoped.read("missing.txt")).rejects.toMatchObject({ code: "not-found" });
     await expect(scoped.open("json")).rejects.toMatchObject({ code: "not-file" });
     await expect(scoped.mkdir(".")).rejects.toMatchObject({ code: "outside-workspace" });
   });
 
-  it.runIf(process.platform !== "win32")("covers root symlink, hardlink, local read, and writable rejection paths", async () => {
+  itPosix("covers root symlink, hardlink, local read, and writable rejection paths", async () => {
     const rootDir = await tempRoot("fs-safe-root-errors-");
     const outside = await tempRoot("fs-safe-root-errors-outside-");
     const scoped = await openRoot(rootDir);
@@ -210,19 +152,13 @@ describe("root handle coverage", () => {
 
     await fs.mkdir(path.join(rootDir, "dir"));
     await expect(scoped.openWritable("dir")).rejects.toMatchObject({ code: "not-file" });
-    await expect(scoped.openWritable("inside-hardlink.txt")).rejects.toMatchObject({
-      code: "path-alias",
-    });
-    await expect(scoped.openWritable("inside-link.txt")).rejects.toMatchObject({
-      code: "path-alias",
-    });
+    await expectFsSafeError(scoped.openWritable("inside-hardlink.txt"), "path-alias");
+    await expectFsSafeError(scoped.openWritable("inside-link.txt"), "path-alias");
 
     const outsideFile = path.join(outside, "outside.txt");
     await fs.writeFile(outsideFile, "outside", "utf8");
     await fs.symlink(outsideFile, path.join(rootDir, "outside-link.txt"));
-    await expect(scoped.openWritable("outside-link.txt")).rejects.toMatchObject({
-      code: "path-alias",
-    });
+    await expectFsSafeError(scoped.openWritable("outside-link.txt"), "path-alias");
   });
 });
 
@@ -233,39 +169,39 @@ describe("path helpers", () => {
     await fs.writeFile(file, "ok", "utf8");
     const cache = new Map<string, string>();
 
-    expect(normalizeWindowsPathForComparison("\\\\?\\UNC\\Server\\Share\\A/../B")).toContain(
+    expect(safePath.normalizeWindowsPathForComparison("\\\\?\\UNC\\Server\\Share\\A/../B")).toContain(
       "\\\\server\\share",
     );
-    expect(hasNodeErrorCode(Object.assign(new Error("x"), { code: "ENOENT" }), "ENOENT")).toBe(
+    expect(safePath.hasNodeErrorCode(Object.assign(new Error("x"), { code: "ENOENT" }), "ENOENT")).toBe(
       true,
     );
-    expect(isNotFoundPathError(Object.assign(new Error("x"), { code: "ENOTDIR" }))).toBe(true);
-    expect(isSymlinkOpenError(Object.assign(new Error("x"), { code: "ELOOP" }))).toBe(true);
-    expect(isPathInside(root, file)).toBe(true);
-    expect(resolveSafeBaseDir(root)).toBe(`${path.resolve(root)}${path.sep}`);
+    expect(safePath.isNotFoundPathError(Object.assign(new Error("x"), { code: "ENOTDIR" }))).toBe(true);
+    expect(safePath.isSymlinkOpenError(Object.assign(new Error("x"), { code: "ELOOP" }))).toBe(true);
+    expect(safePath.isPathInside(root, file)).toBe(true);
+    expect(safePath.resolveSafeBaseDir(root)).toBe(`${path.resolve(root)}${path.sep}`);
     // Use the sync realpath to compare against safeRealpathSync. On windows
     // fs.realpathSync and fs.realpath (async) sometimes disagree on 8.3
     // short-name canonicalization (e.g. "RUNNER~1" vs "runneradmin").
-    expect(safeRealpathSync(file, cache)).toBe(realpathSync(file));
-    expect(safeRealpathSync(file, cache)).toBe(realpathSync(file));
-    expect(safeRealpathSync(path.join(root, "missing"), cache)).toBeNull();
-    expect(isPathInsideWithRealpath(root, file, { cache })).toBe(true);
-    expect(isPathInsideWithRealpath(root, path.join(root, "missing"), { requireRealpath: false }))
+    expect(safePath.safeRealpathSync(file, cache)).toBe(realpathSync(file));
+    expect(safePath.safeRealpathSync(file, cache)).toBe(realpathSync(file));
+    expect(safePath.safeRealpathSync(path.join(root, "missing"), cache)).toBeNull();
+    expect(safePath.isPathInsideWithRealpath(root, file, { cache })).toBe(true);
+    expect(safePath.isPathInsideWithRealpath(root, path.join(root, "missing"), { requireRealpath: false }))
       .toBe(true);
-    expect(isPathInsideWithRealpath(root, path.join(root, "missing"))).toBe(false);
-    expect(safeStatSync(file)?.isFile()).toBe(true);
-    expect(safeStatSync(path.join(root, "missing"))).toBeNull();
-    expect(() => assertNoNulPathInput("a\0b")).toThrow("NUL");
-    expect(splitSafeRelativePath("./a//b")).toEqual(["a", "b"]);
+    expect(safePath.isPathInsideWithRealpath(root, path.join(root, "missing"))).toBe(false);
+    expect(safePath.safeStatSync(file)?.isFile()).toBe(true);
+    expect(safePath.safeStatSync(path.join(root, "missing"))).toBeNull();
+    expect(() => safePath.assertNoNulPathInput("a\0b")).toThrow("NUL");
+    expect(safePath.splitSafeRelativePath("./a//b")).toEqual(["a", "b"]);
     for (const bad of ["../x", "/x", "C:\\x", "C:evil", "C:..", "a/C:b", "a\\b", "a\0b"]) {
-      expect(() => splitSafeRelativePath(bad)).toThrow();
+      expect(() => safePath.splitSafeRelativePath(bad)).toThrow();
     }
-    expect(resolveSafeRelativePath(root, "a/b")).toBe(path.join(root, "a", "b"));
+    expect(safePath.resolveSafeRelativePath(root, "a/b")).toBe(path.join(root, "a", "b"));
   });
 });
 
 describe("root path resolution helpers", () => {
-  it.runIf(process.platform !== "win32")("covers canonical aliases and final symlink policies", async () => {
+  itPosix("covers canonical aliases and final symlink policies", async () => {
     const base = await tempRoot("fs-safe-root-path-extra-");
     const root = path.join(base, "root");
     const outside = path.join(base, "outside");
@@ -327,14 +263,14 @@ describe("root path resolution helpers", () => {
     await fs.mkdir(path.join(root, "dir"));
 
     expect(
-      resolvePathWithinRoot({
+      rootPaths.resolvePathWithinRoot({
         rootDir: root,
         requestedPath: " ",
         scopeLabel: "uploads",
       }),
     ).toEqual({ ok: false, error: "path is required" });
     expect(
-      resolvePathWithinRoot({
+      rootPaths.resolvePathWithinRoot({
         rootDir: root,
         requestedPath: " ",
         defaultFileName: "default.txt",
@@ -342,28 +278,28 @@ describe("root path resolution helpers", () => {
       }),
     ).toEqual({ ok: true, path: path.join(root, "default.txt") });
     expect(
-      resolvePathsWithinRoot({
+      rootPaths.resolvePathsWithinRoot({
         rootDir: root,
         requestedPaths: ["file.txt", "../escape.txt"],
         scopeLabel: "uploads",
       }),
     ).toMatchObject({ ok: false });
     await expect(
-      resolveWritablePathWithinRoot({
+      rootPaths.resolveWritablePathWithinRoot({
         rootDir: file,
         requestedPath: "new.txt",
         scopeLabel: "uploads",
       }),
     ).resolves.toMatchObject({ ok: false });
     await expect(
-      resolveWritablePathWithinRoot({
+      rootPaths.resolveWritablePathWithinRoot({
         rootDir: root,
         requestedPath: "dir",
         scopeLabel: "uploads",
       }),
     ).resolves.toMatchObject({ ok: false });
     await expect(
-      ensureDirectoryWithinRoot({
+      rootPaths.ensureDirectoryWithinRoot({
         rootDir: root,
         requestedPath: "made/nested",
         scopeLabel: "uploads",
@@ -371,28 +307,28 @@ describe("root path resolution helpers", () => {
       }),
     ).resolves.toMatchObject({ ok: true, path: path.join(root, "made", "nested") });
     await expect(
-      ensureDirectoryWithinRoot({
+      rootPaths.ensureDirectoryWithinRoot({
         rootDir: root,
         requestedPath: "file.txt",
         scopeLabel: "uploads",
       }),
     ).resolves.toMatchObject({ ok: false });
     await expect(
-      resolveExistingPathsWithinRoot({
+      rootPaths.resolveExistingPathsWithinRoot({
         rootDir: path.join(base, "missing-root"),
         requestedPaths: ["missing.txt"],
         scopeLabel: "uploads",
       }),
     ).resolves.toMatchObject({ ok: true });
     await expect(
-      resolveStrictExistingPathsWithinRoot({
+      rootPaths.resolveStrictExistingPathsWithinRoot({
         rootDir: root,
         requestedPaths: ["dir"],
         scopeLabel: "uploads",
       }),
     ).resolves.toMatchObject({ ok: false });
 
-    const scope = pathScope(root, { label: "uploads" });
+    const scope = rootPaths.pathScope(root, { label: "uploads" });
     expect(scope.resolve(" ", { defaultName: "fallback.txt" })).toEqual({
       ok: true,
       path: path.join(root, "fallback.txt"),
@@ -416,18 +352,18 @@ describe("URL, install, and local-root helpers", () => {
     await fs.writeFile(file, "ok", "utf8");
     const fileUrl = new URL(`file://${file}`).href;
 
-    expect(hasEncodedFileUrlSeparator("file:///tmp/a%2Fb")).toBe(true);
-    expect(safeFileURLToPath(fileUrl)).toBe(file);
-    expect(trySafeFileURLToPath("https://example.com/file")).toBeUndefined();
-    expect(basenameFromMediaSource(fileUrl)).toBe("hello world.txt");
-    expect(basenameFromMediaSource("plain/name.txt")).toBe("name.txt");
-    expect(() => safeFileURLToPath("file://remote/share/file.txt")).toThrow("remote hosts");
-    expect(isWindowsDriveLetterPath("C:\\Users\\demo", "win32")).toBe(true);
-    expect(isWindowsDriveLetterPath("C:\\Users\\demo", "linux")).toBe(false);
+    expect(localFile.hasEncodedFileUrlSeparator("file:///tmp/a%2Fb")).toBe(true);
+    expect(localFile.safeFileURLToPath(fileUrl)).toBe(file);
+    expect(localFile.trySafeFileURLToPath("https://example.com/file")).toBeUndefined();
+    expect(localFile.basenameFromMediaSource(fileUrl)).toBe("hello world.txt");
+    expect(localFile.basenameFromMediaSource("plain/name.txt")).toBe("name.txt");
+    expect(() => localFile.safeFileURLToPath("file://remote/share/file.txt")).toThrow("remote hosts");
+    expect(localFile.isWindowsDriveLetterPath("C:\\Users\\demo", "win32")).toBe(true);
+    expect(localFile.isWindowsDriveLetterPath("C:\\Users\\demo", "linux")).toBe(false);
     if (process.platform === "win32") {
-      expect(() => assertNoWindowsNetworkPath("\\\\server\\share", "Media")).toThrow();
+      expect(() => localFile.assertNoWindowsNetworkPath("\\\\server\\share", "Media")).toThrow();
     } else {
-      expect(() => assertNoWindowsNetworkPath("\\\\server\\share", "Media")).not.toThrow();
+      expect(() => localFile.assertNoWindowsNetworkPath("\\\\server\\share", "Media")).not.toThrow();
     }
 
     expect(safeDirName(" bad/name? ")).toBe("bad__name?");
@@ -592,22 +528,22 @@ describe("JSON and regular-file helpers", () => {
   it("covers JSON success, parse, read, and lock behavior", async () => {
     const root = await tempRoot("fs-safe-json-extra-");
     const file = path.join(root, "state", "value.json");
-    await writeJson(file, { ok: true }, { trailingNewline: true });
-    await expect(readJson(file)).resolves.toEqual({ ok: true });
-    await expect(readJsonIfExists(path.join(root, "missing.json"))).resolves.toBeNull();
-    await expect(tryReadJson(file)).resolves.toEqual({ ok: true });
+    await json.writeJson(file, { ok: true }, { trailingNewline: true });
+    await expect(json.readJson(file)).resolves.toEqual({ ok: true });
+    await expect(json.readJsonIfExists(path.join(root, "missing.json"))).resolves.toBeNull();
+    await expect(json.tryReadJson(file)).resolves.toEqual({ ok: true });
     await fs.writeFile(file, "{bad", "utf8");
-    await expect(readJson(file)).rejects.toMatchObject({ reason: "parse" });
-    await expect(readJson(path.join(root, "missing.json"))).rejects.toMatchObject({
+    await expect(json.readJson(file)).rejects.toMatchObject({ reason: "parse" });
+    await expect(json.readJson(path.join(root, "missing.json"))).rejects.toMatchObject({
       reason: "read",
     });
-    await expect(readJsonIfExists(file)).rejects.toMatchObject({ reason: "parse" });
-    await expect(tryReadJson(file)).resolves.toBeNull();
+    await expect(json.readJsonIfExists(file)).rejects.toMatchObject({ reason: "parse" });
+    await expect(json.tryReadJson(file)).resolves.toBeNull();
 
     const syncFile = path.join(root, "sync", "value.json");
-    writeJsonSync(syncFile, { sync: true });
-    expect(readJsonSync(syncFile)).toEqual({ sync: true });
-    expect(tryReadJsonSync(syncFile)).toEqual({ sync: true });
+    json.writeJsonSync(syncFile, { sync: true });
+    expect(json.readJsonSync(syncFile)).toEqual({ sync: true });
+    expect(json.tryReadJsonSync(syncFile)).toEqual({ sync: true });
     await writeTextAtomic(path.join(root, "text.txt"), "text", { trailingNewline: false });
 
     const calls: string[] = [];
@@ -655,24 +591,24 @@ describe("JSON and regular-file helpers", () => {
     await fs.mkdir(dir);
     await fs.writeFile(file, "abc", "utf8");
 
-    expect(resolveRegularFileAppendFlags({ O_APPEND: 8, O_CREAT: 512, O_WRONLY: 1 })).toBe(521);
-    await expect(statRegularFile(path.join(root, "missing.txt"))).resolves.toEqual({
+    expect(regularFile.resolveRegularFileAppendFlags({ O_APPEND: 8, O_CREAT: 512, O_WRONLY: 1 })).toBe(521);
+    await expect(regularFile.statRegularFile(path.join(root, "missing.txt"))).resolves.toEqual({
       missing: true,
     });
-    expect(statRegularFileSync(path.join(root, "missing.txt"))).toEqual({ missing: true });
-    await expect(statRegularFile(dir)).rejects.toThrow("regular file");
-    expect(() => statRegularFileSync(dir)).toThrow("regular file");
-    await expect(readRegularFile({ filePath: file, maxBytes: 8 })).resolves.toMatchObject({
+    expect(regularFile.statRegularFileSync(path.join(root, "missing.txt"))).toEqual({ missing: true });
+    await expect(regularFile.statRegularFile(dir)).rejects.toThrow("regular file");
+    expect(() => regularFile.statRegularFileSync(dir)).toThrow("regular file");
+    await expect(regularFile.readRegularFile({ filePath: file, maxBytes: 8 })).resolves.toMatchObject({
       buffer: Buffer.from("abc"),
     });
-    await expect(readRegularFile({ filePath: file, maxBytes: 2 })).rejects.toThrow("exceeds");
-    expect(readRegularFileSync({ filePath: file, maxBytes: 8 }).buffer).toEqual(Buffer.from("abc"));
-    expect(() => readRegularFileSync({ filePath: file, maxBytes: 2 })).toThrow("exceeds");
+    await expect(regularFile.readRegularFile({ filePath: file, maxBytes: 2 })).rejects.toThrow("exceeds");
+    expect(regularFile.readRegularFileSync({ filePath: file, maxBytes: 8 }).buffer).toEqual(Buffer.from("abc"));
+    expect(() => regularFile.readRegularFileSync({ filePath: file, maxBytes: 2 })).toThrow("exceeds");
 
-    await appendRegularFile({ filePath: file, content: "d", maxFileBytes: 10 });
-    await appendRegularFile({ filePath: file, content: "skip", maxFileBytes: 2 });
-    appendRegularFileSync({ filePath: file, content: Buffer.from("e"), maxFileBytes: 10 });
-    appendRegularFileSync({ filePath: file, content: "skip", maxFileBytes: 2 });
+    await regularFile.appendRegularFile({ filePath: file, content: "d", maxFileBytes: 10 });
+    await regularFile.appendRegularFile({ filePath: file, content: "skip", maxFileBytes: 2 });
+    regularFile.appendRegularFileSync({ filePath: file, content: Buffer.from("e"), maxFileBytes: 10 });
+    regularFile.appendRegularFileSync({ filePath: file, content: "skip", maxFileBytes: 2 });
     await expect(fs.readFile(file, "utf8")).resolves.toBe("abcde");
   });
 });
@@ -729,7 +665,7 @@ describe("temporary workspace and symlink parent helpers", () => {
     ).toBe("value");
   });
 
-  it.runIf(process.platform !== "win32")("covers symlink parent policies", async () => {
+  itPosix("covers symlink parent policies", async () => {
     const root = await tempRoot("fs-safe-symlink-parent-extra-");
     const outside = await tempRoot("fs-safe-symlink-parent-outside-");
     await fs.mkdir(path.join(root, "real"));
@@ -807,18 +743,14 @@ describe("file stores and private stores", () => {
       path.join(root, "state.json"),
     );
     await expect(store.readJson("state.json")).resolves.toEqual({ ok: true });
-    await expect(store.write("too-large.txt", Buffer.alloc(65))).rejects.toMatchObject({
-      code: "too-large",
-    });
+    await expectFsSafeError(store.write("too-large.txt", Buffer.alloc(65)), "too-large");
     await store.writeStream("stream.txt", Readable.from(["hello"]));
     await expect(fs.readFile(path.join(root, "stream.txt"), "utf8")).resolves.toBe("hello");
-    await expect(store.writeStream("stream-too-large.txt", Readable.from(["123", "456"]), {
+    await expectFsSafeError(store.writeStream("stream-too-large.txt", Readable.from(["123", "456"]), {
       maxBytes: 4,
-    })).rejects.toMatchObject({ code: "too-large" });
+    }), "too-large");
     await expect(store.copyIn("copied.txt", source)).resolves.toBe(path.join(root, "copied.txt"));
-    await expect(store.copyIn("bad.txt", sourceRoot))
-      .rejects
-      .toMatchObject({ code: "not-file" });
+    await expectFsSafeError(store.copyIn("bad.txt", sourceRoot), "not-file");
     await expect(store.exists("copied.txt")).resolves.toBe(true);
     await store.remove("copied.txt");
     await expect(store.exists("copied.txt")).resolves.toBe(false);

--- a/test/archive-policy.test.ts
+++ b/test/archive-policy.test.ts
@@ -1,34 +1,28 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import JSZip from "jszip";
 import * as tar from "tar";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { extractArchive, readArchiveEntry } from "../src/archive.js";
 import {
   __resetFsSafeNativeConfigForTest,
   configureFsSafeNative,
 } from "../src/native-config.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
 beforeEach(() => {
   configureFsSafeNative({ mode: "off" });
 });
 
-async function tempRoot(prefix: string): Promise<string> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(directory);
-  return directory;
-}
 
 afterEach(async () => {
   __resetFsSafeNativeConfigForTest();
-  await Promise.all(tempDirs.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
 });
 
 describe("archive entry policy", () => {
-  it.runIf(process.platform !== "win32")("clamps ZIP modes by default and preserves safe permission bits on request", async () => {
+  itPosix("clamps ZIP modes by default and preserves safe permission bits on request", async () => {
     const root = await tempRoot("fs-safe-archive-policy-");
     const archivePath = path.join(root, "package.zip");
     const zip = new JSZip();
@@ -84,7 +78,7 @@ describe("archive entry policy", () => {
     await expect(fs.access(path.join(skipped, "skip.txt"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("applies TAR mode and filtering policy in staging", async () => {
+  itPosix("applies TAR mode and filtering policy in staging", async () => {
     const root = await tempRoot("fs-safe-tar-policy-");
     const input = path.join(root, "input");
     await fs.mkdir(input);

--- a/test/archive-staging.test.ts
+++ b/test/archive-staging.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { itPosix } from "./helpers/vitest.js";
 import {
   ArchiveSecurityError,
   createArchiveSymlinkTraversalError,
@@ -43,26 +44,23 @@ describe("archive-staging helpers", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects symlink and non-directory archive destinations",
-    async () => {
-      await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
-        const realDestDir = path.join(rootDir, "real-dest");
-        const symlinkDestDir = path.join(rootDir, "dest-link");
-        const fileDest = path.join(rootDir, "dest.txt");
-        await fs.mkdir(realDestDir, { recursive: true });
-        await fs.symlink(realDestDir, symlinkDestDir, directorySymlinkType);
-        await fs.writeFile(fileDest, "nope", "utf8");
+  itPosix("rejects symlink and non-directory archive destinations", async () => {
+    await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
+      const realDestDir = path.join(rootDir, "real-dest");
+      const symlinkDestDir = path.join(rootDir, "dest-link");
+      const fileDest = path.join(rootDir, "dest.txt");
+      await fs.mkdir(realDestDir, { recursive: true });
+      await fs.symlink(realDestDir, symlinkDestDir, directorySymlinkType);
+      await fs.writeFile(fileDest, "nope", "utf8");
 
-        await expect(prepareArchiveDestinationDir(symlinkDestDir)).rejects.toMatchObject({
-          code: "destination-symlink",
-        } satisfies Partial<ArchiveSecurityError>);
-        await expect(prepareArchiveDestinationDir(fileDest)).rejects.toMatchObject({
-          code: "destination-not-directory",
-        } satisfies Partial<ArchiveSecurityError>);
-      });
-    },
-  );
+      await expect(prepareArchiveDestinationDir(symlinkDestDir)).rejects.toMatchObject({
+        code: "destination-symlink",
+      } satisfies Partial<ArchiveSecurityError>);
+      await expect(prepareArchiveDestinationDir(fileDest)).rejects.toMatchObject({
+        code: "destination-not-directory",
+      } satisfies Partial<ArchiveSecurityError>);
+    });
+  });
 
   it("creates in-destination parent directories for file outputs", async () => {
     await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
@@ -88,33 +86,30 @@ describe("archive-staging helpers", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects output paths that traverse a destination symlink",
-    async () => {
-      await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
-        const destDir = path.join(rootDir, "dest");
-        const outsideDir = path.join(rootDir, "outside");
-        const linkDir = path.join(destDir, "escape");
-        await fs.mkdir(destDir, { recursive: true });
-        await fs.mkdir(outsideDir, { recursive: true });
-        await fs.symlink(outsideDir, linkDir, directorySymlinkType);
-        const destinationRealDir = await prepareArchiveDestinationDir(destDir);
+  itPosix("rejects output paths that traverse a destination symlink", async () => {
+    await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
+      const destDir = path.join(rootDir, "dest");
+      const outsideDir = path.join(rootDir, "outside");
+      const linkDir = path.join(destDir, "escape");
+      await fs.mkdir(destDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.symlink(outsideDir, linkDir, directorySymlinkType);
+      const destinationRealDir = await prepareArchiveDestinationDir(destDir);
 
-        await expect(
-          prepareArchiveOutputPath({
-            destinationDir: destDir,
-            destinationRealDir,
-            relPath: "escape/payload.txt",
-            outPath: path.join(linkDir, "payload.txt"),
-            originalPath: "escape/payload.txt",
-            isDirectory: false,
-          }),
-        ).rejects.toMatchObject({
-          code: "destination-symlink-traversal",
-        } satisfies Partial<ArchiveSecurityError>);
-      });
-    },
-  );
+      await expect(
+        prepareArchiveOutputPath({
+          destinationDir: destDir,
+          destinationRealDir,
+          relPath: "escape/payload.txt",
+          outPath: path.join(linkDir, "payload.txt"),
+          originalPath: "escape/payload.txt",
+          isDirectory: false,
+        }),
+      ).rejects.toMatchObject({
+        code: "destination-symlink-traversal",
+      } satisfies Partial<ArchiveSecurityError>);
+    });
+  });
 
   it("cleans up staged archive directories after success and failure", async () => {
     await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
@@ -169,65 +164,59 @@ describe("archive-staging helpers", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "merges staged trees and rejects symlink entries from the source",
-    async () => {
-      await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
-        const sourceDir = path.join(rootDir, "source");
-        const sourceNestedDir = path.join(sourceDir, "nested");
-        const destDir = path.join(rootDir, "dest");
-        const outsideDir = path.join(rootDir, "outside");
-        await fs.mkdir(sourceNestedDir, { recursive: true });
-        await fs.mkdir(destDir, { recursive: true });
-        await fs.mkdir(outsideDir, { recursive: true });
-        await fs.writeFile(path.join(sourceNestedDir, "payload.txt"), "hi", "utf8");
+  itPosix("merges staged trees and rejects symlink entries from the source", async () => {
+    await withTempDir("fs-safe-archive-staging-", async (rootDir) => {
+      const sourceDir = path.join(rootDir, "source");
+      const sourceNestedDir = path.join(sourceDir, "nested");
+      const destDir = path.join(rootDir, "dest");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(sourceNestedDir, { recursive: true });
+      await fs.mkdir(destDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(path.join(sourceNestedDir, "payload.txt"), "hi", "utf8");
 
-        const destinationRealDir = await prepareArchiveDestinationDir(destDir);
-        await mergeExtractedTreeIntoDestination({
+      const destinationRealDir = await prepareArchiveDestinationDir(destDir);
+      await mergeExtractedTreeIntoDestination({
+        sourceDir,
+        destinationDir: destDir,
+        destinationRealDir,
+      });
+      await expect(
+        fs.readFile(path.join(destDir, "nested", "payload.txt"), "utf8"),
+      ).resolves.toBe("hi");
+
+      await fs.symlink(outsideDir, path.join(sourceDir, "escape"), directorySymlinkType);
+      await expect(
+        mergeExtractedTreeIntoDestination({
           sourceDir,
           destinationDir: destDir,
           destinationRealDir,
-        });
-        await expect(
-          fs.readFile(path.join(destDir, "nested", "payload.txt"), "utf8"),
-        ).resolves.toBe("hi");
+        }),
+      ).rejects.toMatchObject({
+        code: "destination-symlink-traversal",
+      } satisfies Partial<ArchiveSecurityError>);
+    });
+  });
 
-        await fs.symlink(outsideDir, path.join(sourceDir, "escape"), directorySymlinkType);
-        await expect(
-          mergeExtractedTreeIntoDestination({
-            sourceDir,
-            destinationDir: destDir,
-            destinationRealDir,
-          }),
-        ).rejects.toMatchObject({
-          code: "destination-symlink-traversal",
-        } satisfies Partial<ArchiveSecurityError>);
-      });
-    },
-  );
+  itPosix("reports dangling staged symlinks as archive security errors", async () => {
+    await withTempDir("fs-safe-archive-staging-dangling-", async (rootDir) => {
+      const sourceDir = path.join(rootDir, "source");
+      const destDir = path.join(rootDir, "dest");
+      await fs.mkdir(sourceDir, { recursive: true });
+      await fs.mkdir(destDir, { recursive: true });
+      await fs.symlink(path.join(rootDir, "missing"), path.join(sourceDir, "dangling"));
 
-  it.runIf(process.platform !== "win32")(
-    "reports dangling staged symlinks as archive security errors",
-    async () => {
-      await withTempDir("fs-safe-archive-staging-dangling-", async (rootDir) => {
-        const sourceDir = path.join(rootDir, "source");
-        const destDir = path.join(rootDir, "dest");
-        await fs.mkdir(sourceDir, { recursive: true });
-        await fs.mkdir(destDir, { recursive: true });
-        await fs.symlink(path.join(rootDir, "missing"), path.join(sourceDir, "dangling"));
-
-        await expect(
-          mergeExtractedTreeIntoDestination({
-            sourceDir,
-            destinationDir: destDir,
-            destinationRealDir: await prepareArchiveDestinationDir(destDir),
-          }),
-        ).rejects.toMatchObject({
-          code: "destination-symlink-traversal",
-        } satisfies Partial<ArchiveSecurityError>);
-      });
-    },
-  );
+      await expect(
+        mergeExtractedTreeIntoDestination({
+          sourceDir,
+          destinationDir: destDir,
+          destinationRealDir: await prepareArchiveDestinationDir(destDir),
+        }),
+      ).rejects.toMatchObject({
+        code: "destination-symlink-traversal",
+      } satisfies Partial<ArchiveSecurityError>);
+    });
+  });
 
   it("builds a typed archive symlink traversal error", () => {
     const error = createArchiveSymlinkTraversalError("nested/payload.txt");

--- a/test/archive-stress-regression.test.ts
+++ b/test/archive-stress-regression.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import JSZip from "jszip";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
 import {
   ARCHIVE_LIMIT_ERROR_CODE,
   ArchiveFormatError,
@@ -14,22 +14,14 @@ import {
   configureFsSafeNative,
 } from "../src/native-config.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
 beforeEach(() => configureFsSafeNative({ mode: "off" }));
 
 afterEach(async () => {
   __resetFsSafeNativeConfigForTest();
-  await Promise.all(
-    tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })),
-  );
 });
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 function duplicateOnlyZipEntry(bytes: Buffer): Buffer {
   const eocd = bytes.indexOf(Buffer.from([0x50, 0x4b, 0x05, 0x06]));

--- a/test/archive.test.ts
+++ b/test/archive.test.ts
@@ -1,10 +1,10 @@
 import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import JSZip from "jszip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import {
   ARCHIVE_LIMIT_ERROR_CODE,
   type ArchiveSecurityError,
@@ -21,17 +21,12 @@ import {
   withTempFile,
 } from "../src/temp-target.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
 beforeEach(() => {
   configureFsSafeNative({ mode: "off" });
 });
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 async function createRebindableDirectoryAlias(params: {
   aliasPath: string;
@@ -78,7 +73,6 @@ async function withRealpathSymlinkRebindRace<T>(params: {
 afterEach(async () => {
   __resetFsSafeNativeConfigForTest();
   __setFsSafeTestHooksForTest(undefined);
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
 });
 
 describe("archive extraction", () => {
@@ -198,7 +192,7 @@ describe("archive extraction", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")("preserves executable zip entry modes", async () => {
+  itPosix("preserves executable zip entry modes", async () => {
     const root = await tempRoot("fs-safe-archive-mode-");
     const archivePath = path.join(root, "pkg.zip");
     const destDir = path.join(root, "dest");
@@ -282,7 +276,7 @@ describe("archive extraction", () => {
     await expect(fs.stat(conflictDir)).resolves.toSatisfy((stat) => stat.isDirectory());
   });
 
-  it.runIf(process.platform !== "win32")("rejects zip symlink entries", async () => {
+  itPosix("rejects zip symlink entries", async () => {
     const root = await tempRoot("fs-safe-archive-link-");
     const archivePath = path.join(root, "pkg.zip");
     const destDir = path.join(root, "dest");
@@ -304,151 +298,139 @@ describe("archive extraction", () => {
     await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside");
   });
 
-  it.runIf(process.platform !== "win32")(
-    "does not clobber out-of-destination file when parent dir is symlink-rebound",
-    async () => {
-      const root = await tempRoot("fs-safe-archive-rebind-");
-      const archivePath = path.join(root, "pkg.zip");
-      const destDir = path.join(root, "dest");
-      const outsideDir = path.join(root, "outside");
-      const slotDir = path.join(destDir, "slot");
-      await fs.mkdir(slotDir, { recursive: true });
-      await fs.mkdir(outsideDir, { recursive: true });
-      const outsideTarget = path.join(outsideDir, "target.txt");
-      await fs.writeFile(outsideTarget, "SAFE", "utf8");
+  itPosix("does not clobber out-of-destination file when parent dir is symlink-rebound", async () => {
+    const root = await tempRoot("fs-safe-archive-rebind-");
+    const archivePath = path.join(root, "pkg.zip");
+    const destDir = path.join(root, "dest");
+    const outsideDir = path.join(root, "outside");
+    const slotDir = path.join(destDir, "slot");
+    await fs.mkdir(slotDir, { recursive: true });
+    await fs.mkdir(outsideDir, { recursive: true });
+    const outsideTarget = path.join(outsideDir, "target.txt");
+    await fs.writeFile(outsideTarget, "SAFE", "utf8");
 
-      const zip = new JSZip();
-      zip.file("slot/target.txt", "owned");
-      await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+    const zip = new JSZip();
+    zip.file("slot/target.txt", "owned");
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
 
-      await withRealpathSymlinkRebindRace({
-        shouldFlip: (realpathInput) => realpathInput === slotDir,
-        symlinkPath: slotDir,
-        symlinkTarget: outsideDir,
-        run: async () => {
-          await expect(
-            extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 }),
-          ).rejects.toMatchObject({
-            code: "destination-symlink-traversal",
-          } satisfies Partial<ArchiveSecurityError>);
-        },
-      });
-
-      await expect(fs.readFile(outsideTarget, "utf8")).resolves.toBe("SAFE");
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "does not cleanup through a swapped zip entry parent before commit",
-    async () => {
-      const root = await tempRoot("fs-safe-archive-cleanup-race-");
-      const archivePath = path.join(root, "pkg.zip");
-      const destDir = path.join(root, "dest");
-      const outsideDir = path.join(root, "outside");
-      const outsideFile = path.join(outsideDir, "payload.txt");
-      await fs.mkdir(destDir);
-      await fs.mkdir(outsideDir);
-      await fs.writeFile(outsideFile, "outside");
-      const zip = new JSZip();
-      zip.file("nested/payload.txt", "inside");
-      await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
-      const realMkdir = fs.mkdir.bind(fs);
-      let swapped = false;
-      vi.spyOn(fs, "mkdir").mockImplementation(async (...args: Parameters<typeof fs.mkdir>) => {
-        const candidate = String(args[0]);
-        if (!swapped && path.basename(candidate) === "nested" && await fs.lstat(candidate).then(() => true, () => false)) {
-          swapped = true;
-          await fs.rename(candidate, path.join(path.dirname(candidate), "nested-real"));
-          await fs.symlink(outsideDir, candidate, "dir");
-        }
-        return await realMkdir(...args);
-      });
-
-      await expect(extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 }))
-        .rejects.toBeTruthy();
-      await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("outside");
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "rejects zip extraction when a hardlink appears after write",
-    async () => {
-      const root = await tempRoot("fs-safe-archive-hardlink-");
-      const archivePath = path.join(root, "pkg.zip");
-      const destDir = path.join(root, "dest");
-      const outsideDir = path.join(root, "outside");
-      const outsideAlias = path.join(outsideDir, "payload.bin");
-      const extractedPath = path.join(destDir, "package", "payload.bin");
-      await fs.mkdir(destDir, { recursive: true });
-      await fs.mkdir(outsideDir, { recursive: true });
-      const extractedRealPath = path.join(await fs.realpath(destDir), "package", "payload.bin");
-
-      const zip = new JSZip();
-      zip.file("package/payload.bin", "owned");
-      await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
-
-      const realLstat = fs.lstat.bind(fs);
-      let linked = false;
-      const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-        if (!linked && String(args[0]) === extractedRealPath) {
-          await fs.link(extractedRealPath, outsideAlias);
-          linked = true;
-        }
-        return await realLstat(...args);
-      });
-
-      try {
+    await withRealpathSymlinkRebindRace({
+      shouldFlip: (realpathInput) => realpathInput === slotDir,
+      symlinkPath: slotDir,
+      symlinkTarget: outsideDir,
+      run: async () => {
         await expect(
           extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 }),
         ).rejects.toMatchObject({
           code: "destination-symlink-traversal",
         } satisfies Partial<ArchiveSecurityError>);
-      } finally {
-        lstatSpy.mockRestore();
+      },
+    });
+
+    await expect(fs.readFile(outsideTarget, "utf8")).resolves.toBe("SAFE");
+  });
+
+  itPosix("does not cleanup through a swapped zip entry parent before commit", async () => {
+    const root = await tempRoot("fs-safe-archive-cleanup-race-");
+    const archivePath = path.join(root, "pkg.zip");
+    const destDir = path.join(root, "dest");
+    const outsideDir = path.join(root, "outside");
+    const outsideFile = path.join(outsideDir, "payload.txt");
+    await fs.mkdir(destDir);
+    await fs.mkdir(outsideDir);
+    await fs.writeFile(outsideFile, "outside");
+    const zip = new JSZip();
+    zip.file("nested/payload.txt", "inside");
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+    const realMkdir = fs.mkdir.bind(fs);
+    let swapped = false;
+    vi.spyOn(fs, "mkdir").mockImplementation(async (...args: Parameters<typeof fs.mkdir>) => {
+      const candidate = String(args[0]);
+      if (!swapped && path.basename(candidate) === "nested" && await fs.lstat(candidate).then(() => true, () => false)) {
+        swapped = true;
+        await fs.rename(candidate, path.join(path.dirname(candidate), "nested-real"));
+        await fs.symlink(outsideDir, candidate, "dir");
       }
+      return await realMkdir(...args);
+    });
 
-      await expect(fs.readFile(outsideAlias, "utf8")).resolves.toBe("owned");
-      await expect(fs.stat(extractedPath)).rejects.toMatchObject({ code: "ENOENT" });
-    },
-  );
+    await expect(extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 }))
+      .rejects.toBeTruthy();
+    await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("outside");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "pins the archive file before extraction",
-    async () => {
-      const root = await tempRoot("fs-safe-archive-input-race-");
-      const archivePath = path.join(root, "pkg.zip");
-      const replacementPath = path.join(root, "replacement.zip");
-      const destDir = path.join(root, "dest");
-      await fs.mkdir(destDir, { recursive: true });
+  itPosix("rejects zip extraction when a hardlink appears after write", async () => {
+    const root = await tempRoot("fs-safe-archive-hardlink-");
+    const archivePath = path.join(root, "pkg.zip");
+    const destDir = path.join(root, "dest");
+    const outsideDir = path.join(root, "outside");
+    const outsideAlias = path.join(outsideDir, "payload.bin");
+    const extractedPath = path.join(destDir, "package", "payload.bin");
+    await fs.mkdir(destDir, { recursive: true });
+    await fs.mkdir(outsideDir, { recursive: true });
+    const extractedRealPath = path.join(await fs.realpath(destDir), "package", "payload.bin");
 
-      const zip = new JSZip();
-      zip.file("safe.txt", "safe");
-      await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
-      const replacement = new JSZip();
-      replacement.file("owned.txt", "owned");
-      await fs.writeFile(replacementPath, await replacement.generateAsync({ type: "nodebuffer" }));
+    const zip = new JSZip();
+    zip.file("package/payload.bin", "owned");
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
 
-      const realLstat = fs.lstat.bind(fs);
-      let swapped = false;
-      const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-        const stat = await realLstat(...args);
-        if (!swapped && String(args[0]) === archivePath) {
-          swapped = true;
-          await fs.rename(replacementPath, archivePath);
-        }
-        return stat;
-      });
-
-      try {
-        await expect(
-          extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 }),
-        ).rejects.toThrow("archive changed during validation");
-      } finally {
-        lstatSpy.mockRestore();
+    const realLstat = fs.lstat.bind(fs);
+    let linked = false;
+    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      if (!linked && String(args[0]) === extractedRealPath) {
+        await fs.link(extractedRealPath, outsideAlias);
+        linked = true;
       }
-      await expect(fs.readdir(destDir)).resolves.toEqual([]);
-    },
-  );
+      return await realLstat(...args);
+    });
+
+    try {
+      await expect(
+        extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 }),
+      ).rejects.toMatchObject({
+        code: "destination-symlink-traversal",
+      } satisfies Partial<ArchiveSecurityError>);
+    } finally {
+      lstatSpy.mockRestore();
+    }
+
+    await expect(fs.readFile(outsideAlias, "utf8")).resolves.toBe("owned");
+    await expect(fs.stat(extractedPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  itPosix("pins the archive file before extraction", async () => {
+    const root = await tempRoot("fs-safe-archive-input-race-");
+    const archivePath = path.join(root, "pkg.zip");
+    const replacementPath = path.join(root, "replacement.zip");
+    const destDir = path.join(root, "dest");
+    await fs.mkdir(destDir, { recursive: true });
+
+    const zip = new JSZip();
+    zip.file("safe.txt", "safe");
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+    const replacement = new JSZip();
+    replacement.file("owned.txt", "owned");
+    await fs.writeFile(replacementPath, await replacement.generateAsync({ type: "nodebuffer" }));
+
+    const realLstat = fs.lstat.bind(fs);
+    let swapped = false;
+    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      const stat = await realLstat(...args);
+      if (!swapped && String(args[0]) === archivePath) {
+        swapped = true;
+        await fs.rename(replacementPath, archivePath);
+      }
+      return stat;
+    });
+
+    try {
+      await expect(
+        extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 }),
+      ).rejects.toThrow("archive changed during validation");
+    } finally {
+      lstatSpy.mockRestore();
+    }
+    await expect(fs.readdir(destDir)).resolves.toEqual([]);
+  });
 });
 
 describe("temp file targets", () => {

--- a/test/atomic-dirmode-regression.test.ts
+++ b/test/atomic-dirmode-regression.test.ts
@@ -1,161 +1,147 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { replaceFileAtomic, replaceFileAtomicSync } from "../src/atomic.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 function isDirectoryOpen(flags: string | number): boolean {
   return typeof flags === "number" && (flags & fsSync.constants.O_DIRECTORY) !== 0;
 }
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
-});
 
 describe("atomic parent-directory descriptor modes", () => {
-  it.runIf(process.platform !== "win32")(
-    "keeps an async directory mode bound to the opened directory across a pathname swap",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-dirmode-race-");
-      const targetDir = path.join(root, "target");
-      const displacedDir = path.join(root, "displaced");
-      const victimDir = path.join(root, "victim");
-      const filePath = path.join(targetDir, "state.txt");
-      await Promise.all([fs.mkdir(targetDir), fs.mkdir(victimDir)]);
-      await Promise.all([fs.chmod(targetDir, 0o755), fs.chmod(victimDir, 0o755)]);
-      let swapped = false;
+  itPosix("keeps an async directory mode bound to the opened directory across a pathname swap", async () => {
+    const root = await tempRoot("fs-safe-atomic-dirmode-race-");
+    const targetDir = path.join(root, "target");
+    const displacedDir = path.join(root, "displaced");
+    const victimDir = path.join(root, "victim");
+    const filePath = path.join(targetDir, "state.txt");
+    await Promise.all([fs.mkdir(targetDir), fs.mkdir(victimDir)]);
+    await Promise.all([fs.chmod(targetDir, 0o755), fs.chmod(victimDir, 0o755)]);
+    let swapped = false;
 
-      const swap = async () => {
-        await fs.rename(targetDir, displacedDir);
-        await fs.symlink(victimDir, targetDir, "dir");
-        swapped = true;
-      };
-      const restore = async () => {
-        await fs.unlink(targetDir);
-        await fs.rename(displacedDir, targetDir);
-        swapped = false;
-      };
-      const injectedPromises = {
-        ...fs,
-        chmod: async (candidate: fsSync.PathLike, mode: fsSync.Mode) => {
-          if (!swapped && path.resolve(String(candidate)) === targetDir) {
-            await swap();
-          }
-          await fs.chmod(candidate, mode);
-        },
-        open: (async (...args: Parameters<typeof fs.open>) => {
-          const [candidate, flags] = args;
-          if (swapped && flags === "wx") {
-            await restore();
-          }
-          const handle = await fs.open(...args);
-          if (
-            !swapped &&
-            path.resolve(String(candidate)) === targetDir &&
-            isDirectoryOpen(flags)
-          ) {
-            await swap();
-          }
-          return handle;
-        }) as typeof fs.open,
-      };
+    const swap = async () => {
+      await fs.rename(targetDir, displacedDir);
+      await fs.symlink(victimDir, targetDir, "dir");
+      swapped = true;
+    };
+    const restore = async () => {
+      await fs.unlink(targetDir);
+      await fs.rename(displacedDir, targetDir);
+      swapped = false;
+    };
+    const injectedPromises = {
+      ...fs,
+      chmod: async (candidate: fsSync.PathLike, mode: fsSync.Mode) => {
+        if (!swapped && path.resolve(String(candidate)) === targetDir) {
+          await swap();
+        }
+        await fs.chmod(candidate, mode);
+      },
+      open: (async (...args: Parameters<typeof fs.open>) => {
+        const [candidate, flags] = args;
+        if (swapped && flags === "wx") {
+          await restore();
+        }
+        const handle = await fs.open(...args);
+        if (
+          !swapped &&
+          path.resolve(String(candidate)) === targetDir &&
+          isDirectoryOpen(flags)
+        ) {
+          await swap();
+        }
+        return handle;
+      }) as typeof fs.open,
+    };
 
-      const previousUmask = process.umask(0o077);
-      try {
-        await replaceFileAtomic({
-          filePath,
-          content: "async",
-          dirMode: 0o751,
-          fileSystem: { promises: injectedPromises },
-        });
-      } finally {
-        process.umask(previousUmask);
-      }
+    const previousUmask = process.umask(0o077);
+    try {
+      await replaceFileAtomic({
+        filePath,
+        content: "async",
+        dirMode: 0o751,
+        fileSystem: { promises: injectedPromises },
+      });
+    } finally {
+      process.umask(previousUmask);
+    }
 
-      expect({
-        targetMode: (await fs.stat(targetDir)).mode & 0o777,
-        victimMode: (await fs.stat(victimDir)).mode & 0o777,
-        content: await fs.readFile(filePath, "utf8"),
-      }).toEqual({ targetMode: 0o751, victimMode: 0o755, content: "async" });
-    },
-  );
+    expect({
+      targetMode: (await fs.stat(targetDir)).mode & 0o777,
+      victimMode: (await fs.stat(victimDir)).mode & 0o777,
+      content: await fs.readFile(filePath, "utf8"),
+    }).toEqual({ targetMode: 0o751, victimMode: 0o755, content: "async" });
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "keeps a sync directory mode bound to the opened directory across a pathname swap",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-dirmode-race-sync-");
-      const targetDir = path.join(root, "target");
-      const displacedDir = path.join(root, "displaced");
-      const victimDir = path.join(root, "victim");
-      const filePath = path.join(targetDir, "state.txt");
-      fsSync.mkdirSync(targetDir);
-      fsSync.mkdirSync(victimDir);
-      fsSync.chmodSync(targetDir, 0o755);
-      fsSync.chmodSync(victimDir, 0o755);
-      let swapped = false;
+  itPosix("keeps a sync directory mode bound to the opened directory across a pathname swap", async () => {
+    const root = await tempRoot("fs-safe-atomic-dirmode-race-sync-");
+    const targetDir = path.join(root, "target");
+    const displacedDir = path.join(root, "displaced");
+    const victimDir = path.join(root, "victim");
+    const filePath = path.join(targetDir, "state.txt");
+    fsSync.mkdirSync(targetDir);
+    fsSync.mkdirSync(victimDir);
+    fsSync.chmodSync(targetDir, 0o755);
+    fsSync.chmodSync(victimDir, 0o755);
+    let swapped = false;
 
-      const swap = () => {
-        fsSync.renameSync(targetDir, displacedDir);
-        fsSync.symlinkSync(victimDir, targetDir, "dir");
-        swapped = true;
-      };
-      const restore = () => {
-        fsSync.unlinkSync(targetDir);
-        fsSync.renameSync(displacedDir, targetDir);
-        swapped = false;
-      };
-      const injectedFileSystem = {
-        ...fsSync,
-        chmodSync: ((candidate: fsSync.PathLike, mode: fsSync.Mode) => {
-          if (!swapped && path.resolve(String(candidate)) === targetDir) {
-            swap();
-          }
-          fsSync.chmodSync(candidate, mode);
-        }) as typeof fsSync.chmodSync,
-        openSync: ((candidate, flags, mode) => {
-          if (swapped && flags === "wx") {
-            restore();
-          }
-          const fd = fsSync.openSync(candidate, flags, mode);
-          if (
-            !swapped &&
-            path.resolve(String(candidate)) === targetDir &&
-            isDirectoryOpen(flags)
-          ) {
-            swap();
-          }
-          return fd;
-        }) as typeof fsSync.openSync,
-      };
+    const swap = () => {
+      fsSync.renameSync(targetDir, displacedDir);
+      fsSync.symlinkSync(victimDir, targetDir, "dir");
+      swapped = true;
+    };
+    const restore = () => {
+      fsSync.unlinkSync(targetDir);
+      fsSync.renameSync(displacedDir, targetDir);
+      swapped = false;
+    };
+    const injectedFileSystem = {
+      ...fsSync,
+      chmodSync: ((candidate: fsSync.PathLike, mode: fsSync.Mode) => {
+        if (!swapped && path.resolve(String(candidate)) === targetDir) {
+          swap();
+        }
+        fsSync.chmodSync(candidate, mode);
+      }) as typeof fsSync.chmodSync,
+      openSync: ((candidate, flags, mode) => {
+        if (swapped && flags === "wx") {
+          restore();
+        }
+        const fd = fsSync.openSync(candidate, flags, mode);
+        if (
+          !swapped &&
+          path.resolve(String(candidate)) === targetDir &&
+          isDirectoryOpen(flags)
+        ) {
+          swap();
+        }
+        return fd;
+      }) as typeof fsSync.openSync,
+    };
 
-      const previousUmask = process.umask(0o077);
-      try {
-        replaceFileAtomicSync({
-          filePath,
-          content: "sync",
-          dirMode: 0o751,
-          fileSystem: injectedFileSystem,
-        });
-      } finally {
-        process.umask(previousUmask);
-      }
+    const previousUmask = process.umask(0o077);
+    try {
+      replaceFileAtomicSync({
+        filePath,
+        content: "sync",
+        dirMode: 0o751,
+        fileSystem: injectedFileSystem,
+      });
+    } finally {
+      process.umask(previousUmask);
+    }
 
-      expect({
-        targetMode: fsSync.statSync(targetDir).mode & 0o777,
-        victimMode: fsSync.statSync(victimDir).mode & 0o777,
-        content: fsSync.readFileSync(filePath, "utf8"),
-      }).toEqual({ targetMode: 0o751, victimMode: 0o755, content: "sync" });
-    },
-  );
+    expect({
+      targetMode: fsSync.statSync(targetDir).mode & 0o777,
+      victimMode: fsSync.statSync(victimDir).mode & 0o777,
+      content: fsSync.readFileSync(filePath, "utf8"),
+    }).toEqual({ targetMode: 0o751, victimMode: 0o755, content: "sync" });
+  });
 
   it("accepts plain node:fs injection with explicit async and sync dirMode", async () => {
     const root = await tempRoot("fs-safe-atomic-dirmode-node-fs-");
@@ -190,42 +176,36 @@ describe("atomic parent-directory descriptor modes", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")(
-    "fails before mutation when an injected sync filesystem cannot honor dirMode",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-dirmode-fchmod-missing-");
-      const filePath = path.join(root, "missing", "state.txt");
-      const { fchmodSync: _fchmodSync, ...syncWithoutFchmod } = fsSync;
+  itPosix("fails before mutation when an injected sync filesystem cannot honor dirMode", async () => {
+    const root = await tempRoot("fs-safe-atomic-dirmode-fchmod-missing-");
+    const filePath = path.join(root, "missing", "state.txt");
+    const { fchmodSync: _fchmodSync, ...syncWithoutFchmod } = fsSync;
 
-      expect(() => replaceFileAtomicSync({
-        filePath,
-        content: "sync",
-        dirMode: 0o751,
-        fileSystem: syncWithoutFchmod,
-      })).toThrow("fileSystem.fchmodSync is required");
-      await expect(fs.access(path.dirname(filePath))).rejects.toMatchObject({ code: "ENOENT" });
-    },
-  );
+    expect(() => replaceFileAtomicSync({
+      filePath,
+      content: "sync",
+      dirMode: 0o751,
+      fileSystem: syncWithoutFchmod,
+    })).toThrow("fileSystem.fchmodSync is required");
+    await expect(fs.access(path.dirname(filePath))).rejects.toMatchObject({ code: "ENOENT" });
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a symlinked parent with a sync adapter that omits fchmodSync",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-dirmode-symlink-");
-      const outside = await tempRoot("fs-safe-atomic-dirmode-outside-");
-      const linkedDir = path.join(root, "linked");
-      const filePath = path.join(linkedDir, "state.txt");
-      const { fchmodSync: _fchmodSync, ...syncWithoutFchmod } = fsSync;
-      await fs.symlink(outside, linkedDir, "dir");
+  itPosix("rejects a symlinked parent with a sync adapter that omits fchmodSync", async () => {
+    const root = await tempRoot("fs-safe-atomic-dirmode-symlink-");
+    const outside = await tempRoot("fs-safe-atomic-dirmode-outside-");
+    const linkedDir = path.join(root, "linked");
+    const filePath = path.join(linkedDir, "state.txt");
+    const { fchmodSync: _fchmodSync, ...syncWithoutFchmod } = fsSync;
+    await fs.symlink(outside, linkedDir, "dir");
 
-      expect(() => replaceFileAtomicSync({
-        filePath,
-        content: "must not escape",
-        fileSystem: syncWithoutFchmod,
-      })).toThrow("Atomic replace parent must be a real directory");
+    expect(() => replaceFileAtomicSync({
+      filePath,
+      content: "must not escape",
+      fileSystem: syncWithoutFchmod,
+    })).toThrow("Atomic replace parent must be a real directory");
 
-      await expect(fs.access(path.join(outside, "state.txt"))).rejects.toMatchObject({
-        code: "ENOENT",
-      });
-    },
-  );
+    await expect(fs.access(path.join(outside, "state.txt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
 });

--- a/test/atomic-fchmod-regression.test.ts
+++ b/test/atomic-fchmod-regression.test.ts
@@ -1,21 +1,13 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { itPosix, itWin32, useTempDirs } from "./helpers/vitest.js";
 import { replaceFileAtomic, replaceFileAtomicSync } from "../src/atomic.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
-});
 
 async function runAsyncFallbackOrderProbe(root: string): Promise<{
   filePath: string;
@@ -100,335 +92,302 @@ function runSyncFallbackOrderProbe(root: string): {
 }
 
 describe("atomic descriptor modes", () => {
-  it.runIf(process.platform !== "win32")(
-    "does not chmod an async destination swapped for a symlink after rename",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-chmod-race-");
-      const filePath = path.join(root, "state.txt");
-      const victimPath = path.join(root, "victim.txt");
-      const chmodPaths: string[] = [];
-      let publishedMode: number | undefined;
-      await fs.writeFile(victimPath, "victim", { mode: 0o644 });
-      await fs.chmod(victimPath, 0o644);
+  itPosix("does not chmod an async destination swapped for a symlink after rename", async () => {
+    const root = await tempRoot("fs-safe-atomic-chmod-race-");
+    const filePath = path.join(root, "state.txt");
+    const victimPath = path.join(root, "victim.txt");
+    const chmodPaths: string[] = [];
+    let publishedMode: number | undefined;
+    await fs.writeFile(victimPath, "victim", { mode: 0o644 });
+    await fs.chmod(victimPath, 0o644);
 
-      const previousUmask = process.umask(0o077);
-      try {
-        await replaceFileAtomic({
-          filePath,
-          content: "new",
-          mode: 0o600,
-          fileSystem: {
-            promises: {
-              ...fs,
-              chmod: async (candidate, mode) => {
-                chmodPaths.push(String(candidate));
-                await fs.chmod(candidate, mode);
-              },
-              rename: async (source, destination) => {
-                await fs.rename(source, destination);
-                publishedMode = (await fs.stat(destination)).mode & 0o777;
-                await fs.unlink(destination);
-                await fs.symlink(victimPath, destination);
-              },
-            },
-          },
-        });
-      } finally {
-        process.umask(previousUmask);
-      }
-
-      expect({
-        chmodPaths,
-        publishedMode,
-        victimMode: (await fs.stat(victimPath)).mode & 0o777,
-      }).toEqual({ chmodPaths: [], publishedMode: 0o600, victimMode: 0o644 });
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "does not chmod a sync destination swapped for a symlink after rename",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-chmod-race-sync-");
-      const filePath = path.join(root, "state.txt");
-      const victimPath = path.join(root, "victim.txt");
-      const chmodPaths: string[] = [];
-      let publishedMode: number | undefined;
-      await fs.writeFile(victimPath, "victim", { mode: 0o644 });
-      await fs.chmod(victimPath, 0o644);
-      const fileSystem = {
-        ...fsSync,
-        chmodSync: ((candidate: fsSync.PathLike, mode: fsSync.Mode) => {
-          chmodPaths.push(String(candidate));
-          fsSync.chmodSync(candidate, mode);
-        }) as typeof fsSync.chmodSync,
-        renameSync: ((source: fsSync.PathLike, destination: fsSync.PathLike) => {
-          fsSync.renameSync(source, destination);
-          publishedMode = fsSync.statSync(destination).mode & 0o777;
-          fsSync.unlinkSync(destination);
-          fsSync.symlinkSync(victimPath, destination);
-        }) as typeof fsSync.renameSync,
-      };
-
-      const previousUmask = process.umask(0o077);
-      try {
-        replaceFileAtomicSync({ filePath, content: "new", mode: 0o600, fileSystem });
-      } finally {
-        process.umask(previousUmask);
-      }
-
-      expect({
-        chmodPaths,
-        publishedMode,
-        victimMode: fsSync.statSync(victimPath).mode & 0o777,
-      }).toEqual({ chmodPaths: [], publishedMode: 0o600, victimMode: 0o644 });
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "applies exact async and sync modes through temp descriptors despite umask",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-fchmod-mode-");
-      const asyncPath = path.join(root, "async.txt");
-      const syncPath = path.join(root, "sync.txt");
-
-      const previousUmask = process.umask(0o077);
-      try {
-        await replaceFileAtomic({ filePath: asyncPath, content: "async", mode: 0o666 });
-        replaceFileAtomicSync({ filePath: syncPath, content: "sync", mode: 0o666 });
-      } finally {
-        process.umask(previousUmask);
-      }
-
-      expect((await fs.stat(asyncPath)).mode & 0o777).toBe(0o666);
-      expect(fsSync.statSync(syncPath).mode & 0o777).toBe(0o666);
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "keeps explicit and preserved modes exact across restrictive umasks",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-fchmod-umasks-");
-      const previousUmask = process.umask();
-      try {
-        for (const mask of [0o000, 0o022, 0o077, 0o777]) {
-          process.umask(mask);
-          const suffix = mask.toString(8);
-          const asyncPath = path.join(root, `async-${suffix}.txt`);
-          const syncPath = path.join(root, `sync-${suffix}.txt`);
-          const preservedPath = path.join(root, `preserved-${suffix}.txt`);
-          const preservedSyncPath = path.join(root, `preserved-sync-${suffix}.txt`);
-          const missingPath = path.join(root, `missing-${suffix}.txt`);
-          const missingSyncPath = path.join(root, `missing-sync-${suffix}.txt`);
-          await Promise.all([
-            fs.writeFile(preservedPath, "old"),
-            fs.writeFile(preservedSyncPath, "old"),
-          ]);
-          await Promise.all([
-            fs.chmod(preservedPath, 0o651),
-            fs.chmod(preservedSyncPath, 0o651),
-          ]);
-
-          await replaceFileAtomic({ filePath: asyncPath, content: "async", mode: 0o670 });
-          replaceFileAtomicSync({ filePath: syncPath, content: "sync", mode: 0o670 });
-          await replaceFileAtomic({
-            filePath: preservedPath,
-            content: "preserved",
-            preserveExistingMode: true,
-          });
-          await replaceFileAtomic({
-            filePath: missingPath,
-            content: "missing",
-            mode: 0o642,
-            preserveExistingMode: true,
-          });
-          replaceFileAtomicSync({
-            filePath: preservedSyncPath,
-            content: "preserved",
-            preserveExistingMode: true,
-          });
-          replaceFileAtomicSync({
-            filePath: missingSyncPath,
-            content: "missing",
-            mode: 0o642,
-            preserveExistingMode: true,
-          });
-
-          expect((await fs.stat(asyncPath)).mode & 0o777).toBe(0o670);
-          expect(fsSync.statSync(syncPath).mode & 0o777).toBe(0o670);
-          expect((await fs.stat(preservedPath)).mode & 0o777).toBe(0o651);
-          expect((await fs.stat(missingPath)).mode & 0o777).toBe(0o642);
-          expect(fsSync.statSync(preservedSyncPath).mode & 0o777).toBe(0o651);
-          expect(fsSync.statSync(missingSyncPath).mode & 0o777).toBe(0o642);
-        }
-      } finally {
-        process.umask(previousUmask);
-      }
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "preserves exact descriptor modes through async and sync copy fallback",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-fchmod-fallback-");
-      const asyncPath = path.join(root, "async.txt");
-      const syncPath = path.join(root, "sync.txt");
-      const renameDenied = () => Object.assign(new Error("rename denied"), { code: "EPERM" });
-
-      const previousUmask = process.umask(0o077);
-      try {
-        await replaceFileAtomic({
-          filePath: asyncPath,
-          content: "async",
-          mode: 0o666,
-          copyFallbackOnPermissionError: true,
-          fileSystem: {
-            promises: {
-              ...fs,
-              rename: async () => { throw renameDenied(); },
-            },
-          },
-        });
-        replaceFileAtomicSync({
-          filePath: syncPath,
-          content: "sync",
-          mode: 0o666,
-          copyFallbackOnPermissionError: true,
-          fileSystem: {
-            ...fsSync,
-            renameSync: () => { throw renameDenied(); },
-          },
-        });
-      } finally {
-        process.umask(previousUmask);
-      }
-
-      expect((await fs.stat(asyncPath)).mode & 0o777).toBe(0o666);
-      expect(fsSync.statSync(syncPath).mode & 0o777).toBe(0o666);
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "applies and syncs the final copy-fallback mode before closing the destination",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-");
-      const { filePath, operations } = await runAsyncFallbackOrderProbe(root);
-
-      expect(operations).toEqual(["chmod", "sync"]);
-      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o640);
-      expect(await fs.readFile(filePath, "utf8")).toBe("replacement");
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "keeps synchronous copy-fallback chmod before the final destination sync",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-sync-");
-      const { destinationFds, filePath, operations } = runSyncFallbackOrderProbe(root);
-
-      expect(operations).toEqual(["chmod", "sync"]);
-      expect(fsSync.statSync(filePath).mode & 0o777).toBe(0o640);
-      expect(fsSync.readFileSync(filePath, "utf8")).toBe("replacement");
-      expect(destinationFds.size).toBe(0);
-    },
-  );
-
-  it.runIf(process.platform === "win32")(
-    "publishes and syncs async copy fallback without claiming POSIX mode enforcement",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-win32-");
-      const { filePath, operations } = await runAsyncFallbackOrderProbe(root);
-
-      expect(operations).toEqual(["chmod", "sync"]);
-      expect(await fs.readFile(filePath, "utf8")).toBe("replacement");
-    },
-  );
-
-  it.runIf(process.platform === "win32")(
-    "publishes and syncs synchronous copy fallback without claiming POSIX mode enforcement",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-sync-win32-");
-      const { destinationFds, filePath, operations } = runSyncFallbackOrderProbe(root);
-
-      expect(operations).toEqual(["chmod", "sync"]);
-      expect(fsSync.readFileSync(filePath, "utf8")).toBe("replacement");
-      expect(destinationFds.size).toBe(0);
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "restores bytes and mode and closes descriptors when fallback chmod fails",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-fchmod-restore-");
-      const filePath = path.join(root, "state.txt");
-      const descriptorDirectory = process.platform === "linux" ? "/proc/self/fd" : "/dev/fd";
-      await fs.writeFile(filePath, "original");
-      await fs.chmod(filePath, 0o644);
-      const descriptorsBefore = (await fs.readdir(descriptorDirectory)).length;
-      let failMode = true;
-
-      await expect(replaceFileAtomic({
+    const previousUmask = process.umask(0o077);
+    try {
+      await replaceFileAtomic({
         filePath,
-        content: "replacement",
+        content: "new",
         mode: 0o600,
-        copyFallbackOnPermissionError: true,
-        copyFallbackRestore: "restore-original",
-        maxRestoreBytes: 1024,
         fileSystem: {
           promises: {
             ...fs,
-            rename: async () => {
-              throw Object.assign(new Error("rename denied"), { code: "EPERM" });
+            chmod: async (candidate, mode) => {
+              chmodPaths.push(String(candidate));
+              await fs.chmod(candidate, mode);
             },
-            open: (async (...args: Parameters<typeof fs.open>) => {
-              const handle = await fs.open(...args);
-              if (String(args[0]) === filePath) {
-                const chmod = handle.chmod.bind(handle);
-                handle.chmod = async (mode) => {
-                  if (failMode) {
-                    failMode = false;
-                    throw Object.assign(new Error("mode denied"), { code: "EPERM" });
-                  }
-                  await chmod(mode);
-                };
-              }
-              return handle;
-            }) as typeof fs.open,
+            rename: async (source, destination) => {
+              await fs.rename(source, destination);
+              publishedMode = (await fs.stat(destination)).mode & 0o777;
+              await fs.unlink(destination);
+              await fs.symlink(victimPath, destination);
+            },
           },
         },
-      })).rejects.toMatchObject({
-        code: "helper-failed",
-        details: { cleanup: "restored" },
       });
+    } finally {
+      process.umask(previousUmask);
+    }
 
-      expect(await fs.readFile(filePath, "utf8")).toBe("original");
-      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o644);
-      expect((await fs.readdir(root)).filter((entry) => entry.startsWith(".fs-safe-replace")))
-        .toEqual([]);
-      expect((await fs.readdir(descriptorDirectory)).length).toBe(descriptorsBefore);
-    },
-  );
+    expect({
+      chmodPaths,
+      publishedMode,
+      victimMode: (await fs.stat(victimPath)).mode & 0o777,
+    }).toEqual({ chmodPaths: [], publishedMode: 0o600, victimMode: 0o644 });
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "accepts node:fs injection with an explicit async mode",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-node-fs-");
-      const filePath = path.join(root, "state.txt");
-      const previousUmask = process.umask(0o077);
-      try {
+  itPosix("does not chmod a sync destination swapped for a symlink after rename", async () => {
+    const root = await tempRoot("fs-safe-atomic-chmod-race-sync-");
+    const filePath = path.join(root, "state.txt");
+    const victimPath = path.join(root, "victim.txt");
+    const chmodPaths: string[] = [];
+    let publishedMode: number | undefined;
+    await fs.writeFile(victimPath, "victim", { mode: 0o644 });
+    await fs.chmod(victimPath, 0o644);
+    const fileSystem = {
+      ...fsSync,
+      chmodSync: ((candidate: fsSync.PathLike, mode: fsSync.Mode) => {
+        chmodPaths.push(String(candidate));
+        fsSync.chmodSync(candidate, mode);
+      }) as typeof fsSync.chmodSync,
+      renameSync: ((source: fsSync.PathLike, destination: fsSync.PathLike) => {
+        fsSync.renameSync(source, destination);
+        publishedMode = fsSync.statSync(destination).mode & 0o777;
+        fsSync.unlinkSync(destination);
+        fsSync.symlinkSync(victimPath, destination);
+      }) as typeof fsSync.renameSync,
+    };
+
+    const previousUmask = process.umask(0o077);
+    try {
+      replaceFileAtomicSync({ filePath, content: "new", mode: 0o600, fileSystem });
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    expect({
+      chmodPaths,
+      publishedMode,
+      victimMode: fsSync.statSync(victimPath).mode & 0o777,
+    }).toEqual({ chmodPaths: [], publishedMode: 0o600, victimMode: 0o644 });
+  });
+
+  itPosix("applies exact async and sync modes through temp descriptors despite umask", async () => {
+    const root = await tempRoot("fs-safe-atomic-fchmod-mode-");
+    const asyncPath = path.join(root, "async.txt");
+    const syncPath = path.join(root, "sync.txt");
+
+    const previousUmask = process.umask(0o077);
+    try {
+      await replaceFileAtomic({ filePath: asyncPath, content: "async", mode: 0o666 });
+      replaceFileAtomicSync({ filePath: syncPath, content: "sync", mode: 0o666 });
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    expect((await fs.stat(asyncPath)).mode & 0o777).toBe(0o666);
+    expect(fsSync.statSync(syncPath).mode & 0o777).toBe(0o666);
+  });
+
+  itPosix("keeps explicit and preserved modes exact across restrictive umasks", async () => {
+    const root = await tempRoot("fs-safe-atomic-fchmod-umasks-");
+    const previousUmask = process.umask();
+    try {
+      for (const mask of [0o000, 0o022, 0o077, 0o777]) {
+        process.umask(mask);
+        const suffix = mask.toString(8);
+        const asyncPath = path.join(root, `async-${suffix}.txt`);
+        const syncPath = path.join(root, `sync-${suffix}.txt`);
+        const preservedPath = path.join(root, `preserved-${suffix}.txt`);
+        const preservedSyncPath = path.join(root, `preserved-sync-${suffix}.txt`);
+        const missingPath = path.join(root, `missing-${suffix}.txt`);
+        const missingSyncPath = path.join(root, `missing-sync-${suffix}.txt`);
+        await Promise.all([
+          fs.writeFile(preservedPath, "old"),
+          fs.writeFile(preservedSyncPath, "old"),
+        ]);
+        await Promise.all([
+          fs.chmod(preservedPath, 0o651),
+          fs.chmod(preservedSyncPath, 0o651),
+        ]);
+
+        await replaceFileAtomic({ filePath: asyncPath, content: "async", mode: 0o670 });
+        replaceFileAtomicSync({ filePath: syncPath, content: "sync", mode: 0o670 });
         await replaceFileAtomic({
-          filePath,
-          content: "injected",
-          mode: 0o666,
-          fileSystem: fsSync,
+          filePath: preservedPath,
+          content: "preserved",
+          preserveExistingMode: true,
         });
-      } finally {
-        process.umask(previousUmask);
-      }
+        await replaceFileAtomic({
+          filePath: missingPath,
+          content: "missing",
+          mode: 0o642,
+          preserveExistingMode: true,
+        });
+        replaceFileAtomicSync({
+          filePath: preservedSyncPath,
+          content: "preserved",
+          preserveExistingMode: true,
+        });
+        replaceFileAtomicSync({
+          filePath: missingSyncPath,
+          content: "missing",
+          mode: 0o642,
+          preserveExistingMode: true,
+        });
 
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("injected");
-      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o666);
-    },
-  );
+        expect((await fs.stat(asyncPath)).mode & 0o777).toBe(0o670);
+        expect(fsSync.statSync(syncPath).mode & 0o777).toBe(0o670);
+        expect((await fs.stat(preservedPath)).mode & 0o777).toBe(0o651);
+        expect((await fs.stat(missingPath)).mode & 0o777).toBe(0o642);
+        expect(fsSync.statSync(preservedSyncPath).mode & 0o777).toBe(0o651);
+        expect(fsSync.statSync(missingSyncPath).mode & 0o777).toBe(0o642);
+      }
+    } finally {
+      process.umask(previousUmask);
+    }
+  });
+
+  itPosix("preserves exact descriptor modes through async and sync copy fallback", async () => {
+    const root = await tempRoot("fs-safe-atomic-fchmod-fallback-");
+    const asyncPath = path.join(root, "async.txt");
+    const syncPath = path.join(root, "sync.txt");
+    const renameDenied = () => Object.assign(new Error("rename denied"), { code: "EPERM" });
+
+    const previousUmask = process.umask(0o077);
+    try {
+      await replaceFileAtomic({
+        filePath: asyncPath,
+        content: "async",
+        mode: 0o666,
+        copyFallbackOnPermissionError: true,
+        fileSystem: {
+          promises: {
+            ...fs,
+            rename: async () => { throw renameDenied(); },
+          },
+        },
+      });
+      replaceFileAtomicSync({
+        filePath: syncPath,
+        content: "sync",
+        mode: 0o666,
+        copyFallbackOnPermissionError: true,
+        fileSystem: {
+          ...fsSync,
+          renameSync: () => { throw renameDenied(); },
+        },
+      });
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    expect((await fs.stat(asyncPath)).mode & 0o777).toBe(0o666);
+    expect(fsSync.statSync(syncPath).mode & 0o777).toBe(0o666);
+  });
+
+  itPosix("applies and syncs the final copy-fallback mode before closing the destination", async () => {
+    const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-");
+    const { filePath, operations } = await runAsyncFallbackOrderProbe(root);
+
+    expect(operations).toEqual(["chmod", "sync"]);
+    expect((await fs.stat(filePath)).mode & 0o777).toBe(0o640);
+    expect(await fs.readFile(filePath, "utf8")).toBe("replacement");
+  });
+
+  itPosix("keeps synchronous copy-fallback chmod before the final destination sync", async () => {
+    const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-sync-");
+    const { destinationFds, filePath, operations } = runSyncFallbackOrderProbe(root);
+
+    expect(operations).toEqual(["chmod", "sync"]);
+    expect(fsSync.statSync(filePath).mode & 0o777).toBe(0o640);
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("replacement");
+    expect(destinationFds.size).toBe(0);
+  });
+
+  itWin32("publishes and syncs async copy fallback without claiming POSIX mode enforcement", async () => {
+    const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-win32-");
+    const { filePath, operations } = await runAsyncFallbackOrderProbe(root);
+
+    expect(operations).toEqual(["chmod", "sync"]);
+    expect(await fs.readFile(filePath, "utf8")).toBe("replacement");
+  });
+
+  itWin32("publishes and syncs synchronous copy fallback without claiming POSIX mode enforcement", async () => {
+    const root = await tempRoot("fs-safe-atomic-fchmod-fallback-order-sync-win32-");
+    const { destinationFds, filePath, operations } = runSyncFallbackOrderProbe(root);
+
+    expect(operations).toEqual(["chmod", "sync"]);
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("replacement");
+    expect(destinationFds.size).toBe(0);
+  });
+
+  itPosix("restores bytes and mode and closes descriptors when fallback chmod fails", async () => {
+    const root = await tempRoot("fs-safe-atomic-fchmod-restore-");
+    const filePath = path.join(root, "state.txt");
+    const descriptorDirectory = process.platform === "linux" ? "/proc/self/fd" : "/dev/fd";
+    await fs.writeFile(filePath, "original");
+    await fs.chmod(filePath, 0o644);
+    const descriptorsBefore = (await fs.readdir(descriptorDirectory)).length;
+    let failMode = true;
+
+    await expect(replaceFileAtomic({
+      filePath,
+      content: "replacement",
+      mode: 0o600,
+      copyFallbackOnPermissionError: true,
+      copyFallbackRestore: "restore-original",
+      maxRestoreBytes: 1024,
+      fileSystem: {
+        promises: {
+          ...fs,
+          rename: async () => {
+            throw Object.assign(new Error("rename denied"), { code: "EPERM" });
+          },
+          open: (async (...args: Parameters<typeof fs.open>) => {
+            const handle = await fs.open(...args);
+            if (String(args[0]) === filePath) {
+              const chmod = handle.chmod.bind(handle);
+              handle.chmod = async (mode) => {
+                if (failMode) {
+                  failMode = false;
+                  throw Object.assign(new Error("mode denied"), { code: "EPERM" });
+                }
+                await chmod(mode);
+              };
+            }
+            return handle;
+          }) as typeof fs.open,
+        },
+      },
+    })).rejects.toMatchObject({
+      code: "helper-failed",
+      details: { cleanup: "restored" },
+    });
+
+    expect(await fs.readFile(filePath, "utf8")).toBe("original");
+    expect((await fs.stat(filePath)).mode & 0o777).toBe(0o644);
+    expect((await fs.readdir(root)).filter((entry) => entry.startsWith(".fs-safe-replace")))
+      .toEqual([]);
+    expect((await fs.readdir(descriptorDirectory)).length).toBe(descriptorsBefore);
+  });
+
+  itPosix("accepts node:fs injection with an explicit async mode", async () => {
+    const root = await tempRoot("fs-safe-atomic-node-fs-");
+    const filePath = path.join(root, "state.txt");
+    const previousUmask = process.umask(0o077);
+    try {
+      await replaceFileAtomic({
+        filePath,
+        content: "injected",
+        mode: 0o666,
+        fileSystem: fsSync,
+      });
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("injected");
+    expect((await fs.stat(filePath)).mode & 0o777).toBe(0o666);
+  });
 
   it("fails closed before mutation when an injected sync filesystem cannot set an explicit mode", async () => {
     const root = await tempRoot("fs-safe-atomic-fchmod-missing-");

--- a/test/atomic.test.ts
+++ b/test/atomic.test.ts
@@ -1,8 +1,9 @@
 import fsSync from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { expectFsSafeError, expectFsSafeErrorSync } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import {
   replaceDirectoryAtomic,
   replaceFileAtomic,
@@ -14,17 +15,9 @@ import {
   registerTempPathForExit,
 } from "../src/temp-cleanup.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
-});
 
 describe("atomic helpers", () => {
   it("replaces a file through a sibling temp path", async () => {
@@ -137,59 +130,50 @@ describe("atomic helpers", () => {
     await expect(fs.readFile(filePath, "utf8")).resolves.toBe("new");
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a hardlinked destination from its pinned descriptor",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-hardlink-");
-      const filePath = path.join(root, "state.txt");
-      const otherPath = path.join(root, "other.txt");
-      await fs.writeFile(filePath, "old", "utf8");
-      await fs.link(filePath, otherPath);
+  itPosix("rejects a hardlinked destination from its pinned descriptor", async () => {
+    const root = await tempRoot("fs-safe-atomic-hardlink-");
+    const filePath = path.join(root, "state.txt");
+    const otherPath = path.join(root, "other.txt");
+    await fs.writeFile(filePath, "old", "utf8");
+    await fs.link(filePath, otherPath);
 
-      await expect(
-        replaceFileAtomic({
-          filePath,
-          content: "new",
-          destinationHardlinks: "reject",
-          fileSystem: {
-            promises: {
-              ...fs,
-              lstat: async (candidate) => {
-                const stat = await fs.lstat(candidate);
-                return candidate === filePath
-                  ? new Proxy(stat, { get: (target, property) => property === "nlink" ? 1 : Reflect.get(target, property) })
-                  : stat;
-              },
+    await expectFsSafeError(replaceFileAtomic({
+        filePath,
+        content: "new",
+        destinationHardlinks: "reject",
+        fileSystem: {
+          promises: {
+            ...fs,
+            lstat: async (candidate) => {
+              const stat = await fs.lstat(candidate);
+              return candidate === filePath
+                ? new Proxy(stat, { get: (target, property) => property === "nlink" ? 1 : Reflect.get(target, property) })
+                : stat;
             },
           },
-        }),
-      ).rejects.toMatchObject({ code: "hardlink" });
+        },
+      }), "hardlink");
 
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("old");
-      await expect(fs.readFile(otherPath, "utf8")).resolves.toBe("old");
-    },
-  );
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("old");
+    await expect(fs.readFile(otherPath, "utf8")).resolves.toBe("old");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a hardlinked destination in the synchronous variant",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-hardlink-sync-");
-      const filePath = path.join(root, "state.txt");
-      const otherPath = path.join(root, "other.txt");
-      await fs.writeFile(filePath, "old", "utf8");
-      await fs.link(filePath, otherPath);
+  itPosix("rejects a hardlinked destination in the synchronous variant", async () => {
+    const root = await tempRoot("fs-safe-atomic-hardlink-sync-");
+    const filePath = path.join(root, "state.txt");
+    const otherPath = path.join(root, "other.txt");
+    await fs.writeFile(filePath, "old", "utf8");
+    await fs.link(filePath, otherPath);
 
-      expect(() =>
-        replaceFileAtomicSync({
-          filePath,
-          content: "new",
-          destinationHardlinks: "reject",
-        }),
-      ).toThrow(expect.objectContaining({ code: "hardlink" }));
-      expect(fsSync.readFileSync(filePath, "utf8")).toBe("old");
-      expect(fsSync.readFileSync(otherPath, "utf8")).toBe("old");
-    },
-  );
+    expectFsSafeErrorSync(() =>
+      replaceFileAtomicSync({
+        filePath,
+        content: "new",
+        destinationHardlinks: "reject",
+      }), "hardlink");
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("old");
+    expect(fsSync.readFileSync(otherPath, "utf8")).toBe("old");
+  });
 
   it("restores a destination after a torn copy-fallback write", async () => {
     const root = await tempRoot("fs-safe-atomic-restore-");
@@ -308,8 +292,7 @@ describe("atomic helpers", () => {
     const filePath = path.join(root, "state.txt");
     await fs.writeFile(filePath, "original", "utf8");
 
-    await expect(
-      replaceFileAtomic({
+    await expectFsSafeError(replaceFileAtomic({
         filePath,
         content: "new",
         copyFallbackOnPermissionError: true,
@@ -323,8 +306,7 @@ describe("atomic helpers", () => {
             },
           },
         },
-      }),
-    ).rejects.toMatchObject({ code: "too-large" });
+      }), "too-large");
 
     await expect(fs.readFile(filePath, "utf8")).resolves.toBe("original");
   });
@@ -375,75 +357,69 @@ describe("atomic helpers", () => {
     expect(fsSync.readFileSync(filePath, "utf8")).toBe("original");
   });
 
-  it.runIf(process.platform !== "win32")(
-    "does not copy fallback through destination symlinks",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-link-");
-      const filePath = path.join(root, "state.txt");
-      const outsidePath = path.join(root, "outside.txt");
-      await fs.writeFile(outsidePath, "outside", "utf8");
-      await fs.symlink(outsidePath, filePath);
+  itPosix("does not copy fallback through destination symlinks", async () => {
+    const root = await tempRoot("fs-safe-atomic-link-");
+    const filePath = path.join(root, "state.txt");
+    const outsidePath = path.join(root, "outside.txt");
+    await fs.writeFile(outsidePath, "outside", "utf8");
+    await fs.symlink(outsidePath, filePath);
 
-      await expect(
-        replaceFileAtomic({
-          filePath,
-          content: "new",
-          copyFallbackOnPermissionError: true,
-          copyFallbackRestore: "restore-original",
-          maxRestoreBytes: 1024,
-          fileSystem: {
-            promises: {
-              ...fs,
-              rename: async () => {
-                const error = new Error("rename denied") as NodeJS.ErrnoException;
-                error.code = "EPERM";
-                throw error;
-              },
-            },
-          },
-        }),
-      ).rejects.toThrow("Refusing copy fallback through symlink destination");
-
-      await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside");
-      expect((await fs.lstat(filePath)).isSymbolicLink()).toBe(true);
-      expect((await fs.readdir(root)).filter((entry) => entry.startsWith(".fs-safe-replace")))
-        .toEqual([]);
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "does not sync-copy fallback through destination symlinks",
-    async () => {
-      const root = await tempRoot("fs-safe-atomic-link-sync-");
-      const filePath = path.join(root, "state.txt");
-      const outsidePath = path.join(root, "outside.txt");
-      await fs.writeFile(outsidePath, "outside", "utf8");
-      await fs.symlink(outsidePath, filePath);
-
-      expect(() =>
-        replaceFileAtomicSync({
-          filePath,
-          content: "new",
-          copyFallbackOnPermissionError: true,
-          copyFallbackRestore: "restore-original",
-          maxRestoreBytes: 1024,
-          fileSystem: {
-            ...fsSync,
-            renameSync: () => {
+    await expect(
+      replaceFileAtomic({
+        filePath,
+        content: "new",
+        copyFallbackOnPermissionError: true,
+        copyFallbackRestore: "restore-original",
+        maxRestoreBytes: 1024,
+        fileSystem: {
+          promises: {
+            ...fs,
+            rename: async () => {
               const error = new Error("rename denied") as NodeJS.ErrnoException;
               error.code = "EPERM";
               throw error;
             },
           },
-        }),
-      ).toThrow("Refusing copy fallback through symlink destination");
+        },
+      }),
+    ).rejects.toThrow("Refusing copy fallback through symlink destination");
 
-      await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside");
-      expect((await fs.lstat(filePath)).isSymbolicLink()).toBe(true);
-      expect((await fs.readdir(root)).filter((entry) => entry.startsWith(".fs-safe-replace")))
-        .toEqual([]);
-    },
-  );
+    await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside");
+    expect((await fs.lstat(filePath)).isSymbolicLink()).toBe(true);
+    expect((await fs.readdir(root)).filter((entry) => entry.startsWith(".fs-safe-replace")))
+      .toEqual([]);
+  });
+
+  itPosix("does not sync-copy fallback through destination symlinks", async () => {
+    const root = await tempRoot("fs-safe-atomic-link-sync-");
+    const filePath = path.join(root, "state.txt");
+    const outsidePath = path.join(root, "outside.txt");
+    await fs.writeFile(outsidePath, "outside", "utf8");
+    await fs.symlink(outsidePath, filePath);
+
+    expect(() =>
+      replaceFileAtomicSync({
+        filePath,
+        content: "new",
+        copyFallbackOnPermissionError: true,
+        copyFallbackRestore: "restore-original",
+        maxRestoreBytes: 1024,
+        fileSystem: {
+          ...fsSync,
+          renameSync: () => {
+            const error = new Error("rename denied") as NodeJS.ErrnoException;
+            error.code = "EPERM";
+            throw error;
+          },
+        },
+      }),
+    ).toThrow("Refusing copy fallback through symlink destination");
+
+    await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside");
+    expect((await fs.lstat(filePath)).isSymbolicLink()).toBe(true);
+    expect((await fs.readdir(root)).filter((entry) => entry.startsWith(".fs-safe-replace")))
+      .toEqual([]);
+  });
 
   it("supports the synchronous replace variant", async () => {
     const root = await tempRoot("fs-safe-atomic-");

--- a/test/bounded-read.test.ts
+++ b/test/bounded-read.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { expectFsSafeErrorSync } from "./helpers/security.js";
 import * as advanced from "../src/advanced.js";
 import {
   readFileDescriptorBounded,
@@ -59,9 +60,7 @@ describe("bounded descriptor reads", () => {
     const filePath = await tempFile("abcdef");
     const fd = fsSync.openSync(filePath, "r");
     try {
-      expect(() => readFileDescriptorBoundedSync(fd, 2)).toThrowError(
-        expect.objectContaining({ code: "too-large" }),
-      );
+      expectFsSafeErrorSync(() => readFileDescriptorBoundedSync(fd, 2), "too-large");
       const next = Buffer.alloc(1);
       expect(fsSync.readSync(fd, next, 0, 1, null)).toBe(1);
       expect(next.toString("utf8")).toBe("d");

--- a/test/clawpatch-regression.test.ts
+++ b/test/clawpatch-regression.test.ts
@@ -1,8 +1,9 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError, expectFsSafeErrorSync } from "./helpers/security.js";
+import { itPosix, itDarwin, useTempDirs } from "./helpers/vitest.js";
 import { prepareArchiveDestinationDir } from "../src/archive-staging.js";
 import { fileStoreSync } from "../src/file-store.js";
 import { writeJson, writeJsonSync } from "../src/json.js";
@@ -19,22 +20,16 @@ import { resolveExistingPathsWithinRoot, resolvePathWithinRoot } from "../src/ro
 import { readSecureFile } from "../src/secure-file.js";
 import { withTimeout } from "../src/timing.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 afterEach(async () => {
   vi.restoreAllMocks();
   configureFsSafeNative({ mode: "auto" });
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
 describe("clawpatch regression coverage", () => {
-  it.runIf(process.platform !== "win32")("rejects Windows drive-letter strings on POSIX secure reads", async () => {
+  itPosix("rejects Windows drive-letter strings on POSIX secure reads", async () => {
     const dir = await tempRoot("fs-safe-secure-drive-");
     const oldCwd = process.cwd();
     process.chdir(dir);
@@ -42,15 +37,13 @@ describe("clawpatch regression coverage", () => {
       const fileName = "C:\\tmp\\secret.txt";
       await fs.writeFile(fileName, "secret", { mode: 0o600 });
 
-      await expect(
-        readSecureFile({ filePath: fileName, permissions: { allowInsecure: true } }),
-      ).rejects.toMatchObject({ code: "invalid-path" });
+      await expectFsSafeError(readSecureFile({ filePath: fileName, permissions: { allowInsecure: true } }), "invalid-path");
     } finally {
       process.chdir(oldCwd);
     }
   });
 
-  it.runIf(process.platform !== "win32")("rejects missing fallback paths under symlinked parents", async () => {
+  itPosix("rejects missing fallback paths under symlinked parents", async () => {
     const base = await tempRoot("fs-safe-root-paths-missing-");
     const rootDir = path.join(base, "root");
     const outside = path.join(base, "outside");
@@ -81,18 +74,16 @@ describe("clawpatch regression coverage", () => {
     expect(resolveSafeRelativePath(rootDir, "tmp")).toBe(path.join(rootDir, "tmp"));
   });
 
-  it.runIf(process.platform !== "win32")("rejects hardlinked sync store reads by default", async () => {
+  itPosix("rejects hardlinked sync store reads by default", async () => {
     const rootDir = await tempRoot("fs-safe-sync-store-default-hardlink-");
     const filePath = path.join(rootDir, "value.txt");
     await fs.writeFile(filePath, "secret");
     await fs.link(filePath, path.join(rootDir, "alias.txt"));
 
-    expect(() => fileStoreSync({ rootDir }).readTextIfExists("alias.txt")).toThrow(
-      expect.objectContaining({ code: "path-mismatch" }),
-    );
+    expectFsSafeErrorSync(() => fileStoreSync({ rootDir }).readTextIfExists("alias.txt"), "path-mismatch");
   });
 
-  it.runIf(process.platform !== "win32")("rejects archive destinations swapped before realpath settles", async () => {
+  itPosix("rejects archive destinations swapped before realpath settles", async () => {
     const base = await tempRoot("fs-safe-archive-root-swap-");
     const dest = path.join(base, "dest");
     const outside = path.join(base, "outside");
@@ -114,7 +105,7 @@ describe("clawpatch regression coverage", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")("rejects archive destinations swapped only during realpath", async () => {
+  itPosix("rejects archive destinations swapped only during realpath", async () => {
     const base = await tempRoot("fs-safe-archive-root-swap-back-");
     const dest = path.join(base, "dest");
     const outside = path.join(base, "outside");
@@ -216,7 +207,7 @@ describe("clawpatch regression coverage", () => {
     await expect(store.updateOr(1, (value) => (value === null ? 2 : value))).resolves.toBe(2);
   });
 
-  it.runIf(process.platform !== "win32")("tightens pre-existing durable queue directory modes", async () => {
+  itPosix("tightens pre-existing durable queue directory modes", async () => {
     const rootDir = await tempRoot("fs-safe-queue-mode-");
     const queueDir = path.join(rootDir, "queue");
     const failedDir = path.join(rootDir, "failed");
@@ -242,7 +233,7 @@ describe("clawpatch regression coverage", () => {
     expect((await fs.stat(failedDir)).isDirectory()).toBe(true);
   });
 
-  it.runIf(process.platform === "darwin")("allows durable queue dirs below a symlinked missing prefix", async () => {
+  itDarwin("allows durable queue dirs below a symlinked missing prefix", async () => {
     const prefix = "/tmp";
     if (!(await fs.lstat(prefix)).isSymbolicLink()) {
       return;
@@ -260,7 +251,7 @@ describe("clawpatch regression coverage", () => {
     }
   });
 
-  it.runIf(process.platform === "darwin")("allows durable queue sibling dirs directly below /tmp", async () => {
+  itDarwin("allows durable queue sibling dirs directly below /tmp", async () => {
     const prefix = "/tmp";
     if (!(await fs.lstat(prefix)).isSymbolicLink()) {
       return;
@@ -278,7 +269,7 @@ describe("clawpatch regression coverage", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlinked durable queue directories without chmoding targets", async () => {
+  itPosix("rejects symlinked durable queue directories without chmoding targets", async () => {
     const rootDir = await tempRoot("fs-safe-queue-symlink-mode-");
     const outsideDir = path.join(rootDir, "outside");
     const queueDir = path.join(rootDir, "queue");
@@ -292,7 +283,7 @@ describe("clawpatch regression coverage", () => {
     expect((await fs.stat(outsideDir)).mode & 0o777).toBe(0o755);
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlinked durable queue parents before mkdir", async () => {
+  itPosix("rejects symlinked durable queue parents before mkdir", async () => {
     const rootDir = await tempRoot("fs-safe-queue-symlink-parent-");
     const outsideDir = path.join(rootDir, "outside");
     const queueParent = path.join(rootDir, "link");
@@ -310,7 +301,7 @@ describe("clawpatch regression coverage", () => {
     expect((await fs.stat(outsideDir)).mode & 0o777).toBe(0o755);
   });
 
-  it.runIf(process.platform !== "win32")("rejects missing durable queue dirs under shared symlink parents", async () => {
+  itPosix("rejects missing durable queue dirs under shared symlink parents", async () => {
     const rootDir = await tempRoot("fs-safe-queue-shared-symlink-parent-");
     const outsideDir = path.join(rootDir, "outside");
     const queueParent = path.join(rootDir, "link");
@@ -325,33 +316,36 @@ describe("clawpatch regression coverage", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")("rejects existing durable queue directories under symlinked parents", async () => {
+  itPosix("rejects existing durable queue directories under symlinked parents", async () => {
     const rootDir = await tempRoot("fs-safe-queue-existing-symlink-parent-");
     const outsideDir = path.join(rootDir, "outside");
     const queueParent = path.join(rootDir, "link");
     const queueDir = path.join(queueParent, "queue");
     const failedDir = path.join(rootDir, "failed");
-    await fs.mkdir(path.join(outsideDir, "queue"), { recursive: true });
+    await fs.mkdir(path.join(outsideDir, "queue"), { mode: 0o755, recursive: true });
     await fs.mkdir(failedDir);
     await fs.symlink(outsideDir, queueParent, "dir");
 
     await expect(ensureJsonDurableQueueDirs({ queueDir, failedDir })).rejects.toBeTruthy();
+    expect((await fs.stat(path.join(outsideDir, "queue"))).mode & 0o777).toBe(0o755);
   });
 
-  it.runIf(process.platform !== "win32")("rejects shared existing durable queue dirs under symlinked parents", async () => {
+  itPosix("rejects shared existing durable queue dirs under symlinked parents", async () => {
     const rootDir = await tempRoot("fs-safe-queue-shared-existing-symlink-parent-");
     const outsideDir = path.join(rootDir, "outside");
     const queueParent = path.join(rootDir, "link");
     const queueDir = path.join(queueParent, "state", "queue");
     const failedDir = path.join(queueParent, "state", "failed");
-    await fs.mkdir(path.join(outsideDir, "state", "queue"), { recursive: true });
-    await fs.mkdir(path.join(outsideDir, "state", "failed"), { recursive: true });
+    await fs.mkdir(path.join(outsideDir, "state", "queue"), { mode: 0o755, recursive: true });
+    await fs.mkdir(path.join(outsideDir, "state", "failed"), { mode: 0o755, recursive: true });
     await fs.symlink(outsideDir, queueParent, "dir");
 
     await expect(ensureJsonDurableQueueDirs({ queueDir, failedDir })).rejects.toBeTruthy();
+    expect((await fs.stat(path.join(outsideDir, "state", "queue"))).mode & 0o777).toBe(0o755);
+    expect((await fs.stat(path.join(outsideDir, "state", "failed"))).mode & 0o777).toBe(0o755);
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlinked durable queue failed directories during moves", async () => {
+  itPosix("rejects symlinked durable queue failed directories during moves", async () => {
     const rootDir = await tempRoot("fs-safe-queue-failed-symlink-");
     const queueDir = path.join(rootDir, "queue");
     const outsideDir = path.join(rootDir, "outside");
@@ -372,19 +366,17 @@ describe("clawpatch regression coverage", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")("uses atomic no-clobber writes for root create", async () => {
+  itPosix("uses atomic no-clobber writes for root create", async () => {
     configureFsSafeNative({ mode: "auto" });
     const rootDir = await tempRoot("fs-safe-root-create-noclobber-");
     const scoped = await openRoot(rootDir);
     await scoped.create("created.txt", "first");
 
-    await expect(scoped.create("created.txt", "second")).rejects.toMatchObject({
-      code: "already-exists",
-    });
+    await expectFsSafeError(scoped.create("created.txt", "second"), "already-exists");
     await expect(fs.readFile(path.join(rootDir, "created.txt"), "utf8")).resolves.toBe("first");
   });
 
-  it.runIf(process.platform !== "win32")("keeps already-exists for no-clobber creates in read-only parents", async () => {
+  itPosix("keeps already-exists for no-clobber creates in read-only parents", async () => {
     configureFsSafeNative({ mode: "auto" });
     const rootDir = await tempRoot("fs-safe-root-create-existing-readonly-");
     const parent = path.join(rootDir, "readonly");
@@ -394,15 +386,13 @@ describe("clawpatch regression coverage", () => {
     const scoped = await openRoot(rootDir);
 
     try {
-      await expect(scoped.create("readonly/created.txt", "second")).rejects.toMatchObject({
-        code: "already-exists",
-      });
+      await expectFsSafeError(scoped.create("readonly/created.txt", "second"), "already-exists");
     } finally {
       await fs.chmod(parent, 0o755).catch(() => undefined);
     }
   });
 
-  it.runIf(process.platform !== "win32")("rolls back no-clobber move links when source unlink fails", async () => {
+  itPosix("rolls back no-clobber move links when source unlink fails", async () => {
     configureFsSafeNative({ mode: "auto" });
     const rootDir = await tempRoot("fs-safe-root-move-link-rollback-");
     const srcDir = path.join(rootDir, "src");
@@ -424,7 +414,7 @@ describe("clawpatch regression coverage", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")("rejects no-clobber directory moves instead of racing rename", async () => {
+  itPosix("rejects no-clobber directory moves instead of racing rename", async () => {
     for (const mode of ["auto", "off"] as const) {
       configureFsSafeNative({ mode });
       const rootDir = await tempRoot(`fs-safe-root-move-dir-noclobber-${mode}-`);

--- a/test/coverage-gaps.test.ts
+++ b/test/coverage-gaps.test.ts
@@ -1,8 +1,9 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import {
   assertAbsolutePathInput,
   canonicalPathFromExistingAncestor,
@@ -45,20 +46,9 @@ import {
 } from "../src/string-coerce.js";
 import { movePathToTrash } from "../src/trash.js";
 
-const tempDirs = new Set<string>();
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.add(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  for (const dir of tempDirs) {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
-  tempDirs.clear();
-});
 
 describe("string coercion helpers", () => {
   it("normalizes optional string-like values", () => {
@@ -216,12 +206,10 @@ describe("absolute path helpers", () => {
       parentDir: nested,
       parentExists: true,
     });
-    await expect(resolveAbsolutePathForRead(path.join(root, "missing.txt"))).rejects.toMatchObject({
-      code: "not-found",
-    });
+    await expectFsSafeError(resolveAbsolutePathForRead(path.join(root, "missing.txt")), "not-found");
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlinked absolute paths by default", async () => {
+  itPosix("rejects symlinked absolute paths by default", async () => {
     const root = await tempRoot("fs-safe-absolute-link-");
     const realDir = path.join(root, "real");
     const linkDir = path.join(root, "link");
@@ -229,15 +217,11 @@ describe("absolute path helpers", () => {
     await fs.writeFile(path.join(realDir, "file.txt"), "ok", "utf8");
     await fs.symlink(realDir, linkDir);
 
-    await expect(resolveAbsolutePathForRead(path.join(linkDir, "file.txt"))).rejects.toMatchObject({
-      code: "symlink",
-    });
+    await expectFsSafeError(resolveAbsolutePathForRead(path.join(linkDir, "file.txt")), "symlink");
     await expect(
       resolveAbsolutePathForRead(path.join(linkDir, "file.txt"), { symlinks: "follow" }),
     ).resolves.toMatchObject({ canonicalPath: await fs.realpath(path.join(realDir, "file.txt")) });
-    await expect(resolveAbsolutePathForWrite(path.join(linkDir, "new.txt"))).rejects.toMatchObject({
-      code: "symlink",
-    });
+    await expectFsSafeError(resolveAbsolutePathForWrite(path.join(linkDir, "new.txt")), "symlink");
   });
 
 });

--- a/test/coverage-more.test.ts
+++ b/test/coverage-more.test.ts
@@ -1,9 +1,10 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { useTempDirs } from "./helpers/vitest.js";
 import { createBoundedReadStream, createMaxBytesTransform } from "../src/bounded-read-stream.js";
 import {
   assertAsyncDirectoryGuard,
@@ -31,13 +32,8 @@ type SecureDirStat = NonNullable<ResolveSecureTempRootOptions["lstatSync"]> exte
   ? Result
   : never;
 
-const tempDirs = new Set<string>();
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.add(dir);
-  return dir;
-}
 
 function nodeError(code: string): Error & { code: string } {
   return Object.assign(new Error(code), { code });
@@ -59,10 +55,6 @@ function dirStat(params?: {
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  for (const dir of tempDirs) {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
-  tempDirs.clear();
 });
 
 describe("secure temp root fallback coverage", () => {
@@ -156,11 +148,11 @@ describe("bounded streams and directory guard coverage", () => {
     const returned = createBoundedReadStream({ handle: { createReadStream: () => raw } }, undefined);
     expect(returned).toBe(raw);
 
-    await expect(async () => {
+    await expectFsSafeError((async () => {
       for await (const _chunk of Readable.from(["ab", "cd"]).pipe(createMaxBytesTransform(3))) {
         // Drain the stream so transform errors surface.
       }
-    }).rejects.toMatchObject({ code: "too-large" });
+    })(), "too-large");
   });
 
   it("detects changed or invalid directory guards", async () => {
@@ -175,9 +167,7 @@ describe("bounded streams and directory guard coverage", () => {
 
     const asyncGuard = await createAsyncDirectoryGuard(nested);
     const syncGuard = createSyncDirectoryGuard(nested);
-    await expect(assertAsyncDirectoryGuard({ ...asyncGuard, realPath: root })).rejects.toMatchObject({
-      code: "path-mismatch",
-    });
+    await expectFsSafeError(assertAsyncDirectoryGuard({ ...asyncGuard, realPath: root }), "path-mismatch");
     expect(() => assertSyncDirectoryGuard({ ...syncGuard, realPath: root })).toThrow(
       "directory changed",
     );
@@ -185,9 +175,7 @@ describe("bounded streams and directory guard coverage", () => {
     await fs.rm(nested, { recursive: true });
     await fs.writeFile(nested, "not a dir", "utf8");
 
-    await expect(assertAsyncDirectoryGuard(asyncGuard)).rejects.toMatchObject({
-      code: "not-file",
-    });
+    await expectFsSafeError(assertAsyncDirectoryGuard(asyncGuard), "not-file");
     expect(() => assertSyncDirectoryGuard(syncGuard)).toThrow("directory component");
 
     const nearest = await createNearestExistingDirectoryGuard(root, path.join(root, "missing", "x"));

--- a/test/deepsec-regression.test.ts
+++ b/test/deepsec-regression.test.ts
@@ -1,7 +1,8 @@
 import fsp from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { fileStore } from "../src/file-store.js";
 import { configureFsSafeNative, root as openRoot } from "../src/index.js";
 import { loadPendingJsonDurableQueueEntries } from "../src/json-durable-queue.js";
@@ -13,18 +14,12 @@ import { writeSecretFileAtomic } from "../src/secret-file.js";
 import { writeViaSiblingTempPath } from "../src/sibling-temp.js";
 import { buildRandomTempFilePath, tempFile } from "../src/temp-target.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 afterEach(async () => {
   vi.restoreAllMocks();
   configureFsSafeNative({ mode: "auto" });
-  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
 });
 
 describe("deepsec regressions", () => {
@@ -111,23 +106,20 @@ describe("deepsec regressions", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")(
-    "does not treat dangling symlinks as safe missing local-root paths",
-    async () => {
-      const base = await tempRoot("fs-safe-local-roots-");
-      const outside = await tempRoot("fs-safe-local-roots-outside-");
-      const linkPath = path.join(base, "dangling");
-      await fsp.symlink(path.join(outside, "missing.txt"), linkPath, "file");
+  itPosix("does not treat dangling symlinks as safe missing local-root paths", async () => {
+    const base = await tempRoot("fs-safe-local-roots-");
+    const outside = await tempRoot("fs-safe-local-roots-outside-");
+    const linkPath = path.join(base, "dangling");
+    await fsp.symlink(path.join(outside, "missing.txt"), linkPath, "file");
 
-      expect(
-        resolveLocalPathFromRootsSync({
-          filePath: linkPath,
-          roots: [base],
-          allowMissing: true,
-        }),
-      ).toBeNull();
-    },
-  );
+    expect(
+      resolveLocalPathFromRootsSync({
+        filePath: linkPath,
+        roots: [base],
+        allowMissing: true,
+      }),
+    ).toBeNull();
+  });
 
   it("preserves Root's default read cap for local-root reads", async () => {
     const base = await tempRoot("fs-safe-local-root-cap-");
@@ -143,7 +135,7 @@ describe("deepsec regressions", () => {
     expect(uncapped?.buffer.byteLength).toBe(16 * 1024 * 1024 + 1);
   });
 
-  it.runIf(process.platform !== "win32")("pins private copyIn sources after validation", async () => {
+  itPosix("pins private copyIn sources after validation", async () => {
     const base = await tempRoot("fs-safe-private-copyin-");
     const sourceDir = await tempRoot("fs-safe-private-copyin-source-");
     const outside = await tempRoot("fs-safe-private-copyin-outside-");
@@ -168,7 +160,7 @@ describe("deepsec regressions", () => {
     await expect(fsp.stat(path.join(base, "copied.txt"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("preserves private copyIn source error codes", async () => {
+  itPosix("preserves private copyIn source error codes", async () => {
     const base = await tempRoot("fs-safe-private-copyin-codes-");
     const sourceDir = await tempRoot("fs-safe-private-copyin-codes-source-");
     const source = path.join(sourceDir, "source.txt");
@@ -179,12 +171,10 @@ describe("deepsec regressions", () => {
 
     await expect(store.copyIn("dir.txt", sourceDir)).rejects.toMatchObject({ code: "not-file" });
     await expect(store.copyIn("link.txt", link)).rejects.toMatchObject({ code: "not-file" });
-    await expect(store.copyIn("large.txt", source, { maxBytes: 4 })).rejects.toMatchObject({
-      code: "too-large",
-    });
+    await expectFsSafeError(store.copyIn("large.txt", source, { maxBytes: 4 }), "too-large");
   });
 
-  it.runIf(process.platform !== "win32")("skips symlinked durable queue entries", async () => {
+  itPosix("skips symlinked durable queue entries", async () => {
     const base = await tempRoot("fs-safe-queue-symlink-");
     const queueDir = path.join(base, "queue");
     const outside = await tempRoot("fs-safe-queue-outside-");
@@ -208,7 +198,7 @@ describe("deepsec regressions", () => {
     ).resolves.toEqual([]);
   });
 
-  it.runIf(process.platform !== "win32")("rejects fallback writes when a missing parent is raced to a symlink", async () => {
+  itPosix("rejects fallback writes when a missing parent is raced to a symlink", async () => {
     configureFsSafeNative({ mode: "off" });
     const base = await tempRoot("fs-safe-fallback-mkdir-symlink-");
     const rootDir = path.join(base, "root");
@@ -231,7 +221,7 @@ describe("deepsec regressions", () => {
     await expect(fsp.lstat(path.join(outside, "nested"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("rejects private secret writes when the root path is swapped", async () => {
+  itPosix("rejects private secret writes when the root path is swapped", async () => {
     const base = await tempRoot("fs-safe-secret-root-swap-");
     const rootDir = path.join(base, "root");
     const originalRoot = path.join(base, "root-original");
@@ -256,7 +246,7 @@ describe("deepsec regressions", () => {
     await expect(fsp.lstat(path.join(outside, "nested"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("uses guarded private secret writes with native mode off", async () => {
+  itPosix("uses guarded private secret writes with native mode off", async () => {
     configureFsSafeNative({ mode: "off" });
     const base = await tempRoot("fs-safe-secret-native-off-");
     const rootDir = path.join(base, "root");
@@ -270,7 +260,7 @@ describe("deepsec regressions", () => {
     expect((await fsp.stat(secretPath)).mode & 0o777).toBe(0o600);
   });
 
-  it.runIf(process.platform !== "win32")("rejects private secret writes when the pinned parent is swapped", async () => {
+  itPosix("rejects private secret writes when the pinned parent is swapped", async () => {
     const base = await tempRoot("fs-safe-secret-parent-swap-");
     const rootDir = path.join(base, "root");
     const outside = path.join(base, "outside");
@@ -295,7 +285,7 @@ describe("deepsec regressions", () => {
     await expect(fsp.lstat(path.join(outside, "secret.txt"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("rejects private secret writes when the parent is swapped after commit", async () => {
+  itPosix("rejects private secret writes when the parent is swapped after commit", async () => {
     const base = await tempRoot("fs-safe-secret-parent-post-swap-");
     const rootDir = path.join(base, "root");
     const outside = path.join(base, "outside");
@@ -326,7 +316,7 @@ describe("deepsec regressions", () => {
     await expect(fsp.lstat(path.join(outside, "secret.txt"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("rejects private secret writes when the final path is swapped after commit", async () => {
+  itPosix("rejects private secret writes when the final path is swapped after commit", async () => {
     const base = await tempRoot("fs-safe-secret-final-post-swap-");
     const rootDir = path.join(base, "root");
     const outside = path.join(base, "outside");

--- a/test/deny-mutations.test.ts
+++ b/test/deny-mutations.test.ts
@@ -1,19 +1,15 @@
 import fs, { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveMutationComparablePaths } from "../src/deny-mutations.js";
+import { expectFsSafeError } from "./helpers/security.js";
+import { useTempDirs } from "./helpers/vitest.js";
 import { root as openRoot } from "../src/index.js";
 import { resolvePathViaExistingAncestor } from "../src/root-path-existing.js";
 
 const skipOnWindows = process.platform === "win32";
-const tempDirs: string[] = [];
+const { tempDirs, tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 afterEach(async () => {
   vi.restoreAllMocks();
@@ -72,21 +68,11 @@ describe("root denyMutations policies", () => {
       denyMutations: { prefixes: [deniedDir] },
     });
 
-    await expect(root.write("private/file.txt", "write")).rejects.toMatchObject({
-      code: "denied-path",
-    });
-    await expect(root.mkdir("private/nested")).rejects.toMatchObject({
-      code: "denied-path",
-    });
-    await expect(root.remove("private/seed.txt")).rejects.toMatchObject({
-      code: "denied-path",
-    });
-    await expect(root.move("safe.txt", "private/moved.txt")).rejects.toMatchObject({
-      code: "denied-path",
-    });
-    await expect(root.move("private/source.txt", "moved-out.txt")).rejects.toMatchObject({
-      code: "denied-path",
-    });
+    await expectFsSafeError(root.write("private/file.txt", "write"), "denied-path");
+    await expectFsSafeError(root.mkdir("private/nested"), "denied-path");
+    await expectFsSafeError(root.remove("private/seed.txt"), "denied-path");
+    await expectFsSafeError(root.move("safe.txt", "private/moved.txt"), "denied-path");
+    await expectFsSafeError(root.move("private/source.txt", "moved-out.txt"), "denied-path");
 
     await expect(readFile(path.join(rootPath, "safe.txt"), "utf8")).resolves.toBe("safe");
     await expect(readFile(path.join(deniedDir, "seed.txt"), "utf8")).resolves.toBe("seed");
@@ -101,17 +87,11 @@ describe("root denyMutations policies", () => {
       denyMutations: { paths: [rootDeniedPath] },
     });
 
-    await expect(
-      root.write("root-denied.txt", "write", { denyMutations: { paths: [] } }),
-    ).rejects.toMatchObject({ code: "denied-path" });
-    await expect(
-      root.write("call-denied.txt", "write", {
+    await expectFsSafeError(root.write("root-denied.txt", "write", { denyMutations: { paths: [] } }), "denied-path");
+    await expectFsSafeError(root.write("call-denied.txt", "write", {
         denyMutations: { paths: [callDeniedPath] },
-      }),
-    ).rejects.toMatchObject({ code: "denied-path" });
-    await expect(
-      root.ensureRoot({ denyMutations: { paths: [rootPath] } }),
-    ).rejects.toMatchObject({ code: "denied-path" });
+      }), "denied-path");
+    await expectFsSafeError(root.ensureRoot({ denyMutations: { paths: [rootPath] } }), "denied-path");
 
     await expect(
       root.write("allowed.txt", "ok", { denyMutations: { paths: [callDeniedPath] } }),
@@ -122,17 +102,13 @@ describe("root denyMutations policies", () => {
   it("rejects relative denyMutations entries", async () => {
     const root = await openRoot(await tempRoot("fs-safe-deny-relative-"));
 
-    await expect(
-      root.write("file.txt", "write", { denyMutations: { paths: ["file.txt"] } }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+    await expectFsSafeError(root.write("file.txt", "write", { denyMutations: { paths: ["file.txt"] } }), "invalid-path");
   });
 
   it("rejects empty denyMutations entries", async () => {
     const root = await openRoot(await tempRoot("fs-safe-deny-empty-"));
 
-    await expect(
-      root.write("file.txt", "write", { denyMutations: { paths: [""] } }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+    await expectFsSafeError(root.write("file.txt", "write", { denyMutations: { paths: [""] } }), "invalid-path");
   });
 
   it("preserves trailing whitespace in denied paths", async () => {
@@ -143,9 +119,7 @@ describe("root denyMutations policies", () => {
       denyMutations: { paths: [path.join(rootPath, deniedName)] },
     });
 
-    await expect(root.write(deniedName, "blocked")).rejects.toMatchObject({
-      code: "denied-path",
-    });
+    await expectFsSafeError(root.write(deniedName, "blocked"), "denied-path");
     await expect(root.write(trimmedName, "allowed")).resolves.toBeUndefined();
     await expect(readFile(path.join(rootPath, trimmedName), "utf8")).resolves.toBe("allowed");
   });
@@ -160,9 +134,7 @@ describe("root denyMutations policies", () => {
       denyMutations: { prefixes: [deniedDir] },
     });
 
-    await expect(root.write("private /file.txt", "blocked")).rejects.toMatchObject({
-      code: "denied-path",
-    });
+    await expectFsSafeError(root.write("private /file.txt", "blocked"), "denied-path");
     await expect(root.write("private/file.txt", "allowed")).resolves.toBeUndefined();
     await expect(readFile(path.join(trimmedDir, "file.txt"), "utf8")).resolves.toBe("allowed");
   });
@@ -189,9 +161,7 @@ describe("root denyMutations policies", () => {
       denyMutations: { prefixes: [path.join(rootPath, "parent", "locked")] },
     });
 
-    await expect(root.move("parent", "moved", { overwrite: true })).rejects.toMatchObject({
-      code: "denied-path",
-    });
+    await expectFsSafeError(root.move("parent", "moved", { overwrite: true }), "denied-path");
     await expect(readFile(path.join(rootPath, "parent", "locked", "secret.txt"), "utf8")).resolves.toBe(
       "secret",
     );
@@ -204,9 +174,7 @@ describe("root denyMutations policies", () => {
     });
 
     await expect(root.mkdir("parent")).resolves.toBeUndefined();
-    await expect(root.write("parent/secret.txt", "blocked")).rejects.toMatchObject({
-      code: "denied-path",
-    });
+    await expectFsSafeError(root.write("parent/secret.txt", "blocked"), "denied-path");
   });
 
   it.skipIf(skipOnWindows)("matches denyMutations through existing symlink ancestors", async () => {
@@ -218,8 +186,6 @@ describe("root denyMutations policies", () => {
       denyMutations: { prefixes: [deniedDir] },
     });
 
-    await expect(root.write("link/file.txt", "write")).rejects.toMatchObject({
-      code: "denied-path",
-    });
+    await expectFsSafeError(root.write("link/file.txt", "write"), "denied-path");
   });
 });

--- a/test/device-path.test.ts
+++ b/test/device-path.test.ts
@@ -1,6 +1,7 @@
 import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
 import {
   isUnsafeDeviceReadPath,
   matchUnsafeDeviceReadPath,
@@ -67,18 +68,12 @@ describe("unsafe device read paths", () => {
       throw new Error("open should not be called for unsafe device paths");
     });
     try {
-      await expect(readLocalFileSafely({ filePath: "/dev/zero" })).rejects.toMatchObject({
-        code: "device-path",
-      });
-      await expect(readRegularFile({ filePath: "/dev/zero" })).rejects.toMatchObject({
-        code: "device-path",
-      });
-      await expect(
-        readSecureFile({
+      await expectFsSafeError(readLocalFileSafely({ filePath: "/dev/zero" }), "device-path");
+      await expectFsSafeError(readRegularFile({ filePath: "/dev/zero" }), "device-path");
+      await expectFsSafeError(readSecureFile({
           filePath: "/dev/zero",
           permissions: { allowInsecure: true },
-        }),
-      ).rejects.toMatchObject({ code: "device-path" });
+        }), "device-path");
       expect(openSpy).not.toHaveBeenCalled();
     } finally {
       openSpy.mockRestore();
@@ -93,9 +88,7 @@ describe("unsafe device read paths", () => {
       const scoped = await root("/");
       // /dev/fd is normally a symlink on Linux. The explicit unsafe namespace
       // remains a device-path error instead of depending on that host layout.
-      await expect(scoped.read("dev/fd/0")).rejects.toMatchObject({
-        code: "device-path",
-      });
+      await expectFsSafeError(scoped.read("dev/fd/0"), "device-path");
       expect(openSpy).not.toHaveBeenCalled();
     } finally {
       openSpy.mockRestore();

--- a/test/directory-durability.test.ts
+++ b/test/directory-durability.test.ts
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process";
-import fsSync from "node:fs";
-import fs from "node:fs/promises";
-import os from "node:os";
+import fsSync, { type PathLike } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
 import {
   ensureDurableDirectory,
   pinDirectory,
@@ -14,19 +15,29 @@ import {
 } from "../src/directory-durability.js";
 import { FsSafeError } from "../src/errors.js";
 
-const tempDirs: string[] = [];
+const { tempDirs, tempRoot } = useRealTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(directory);
-  return await fs.realpath(directory);
-}
 
 function isDirectoryOpen(flags: string | number | undefined): boolean {
   return (
     flags === "r" ||
     (typeof flags === "number" && (flags & fsSync.constants.O_DIRECTORY) !== 0)
   );
+}
+
+function spyOnDirectoryOpen(
+  inspect: (opened: {
+    filePath: PathLike;
+    flags: string | number;
+    handle: FileHandle;
+  }) => Promise<void> | void,
+): void {
+  const open = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+    const handle = await open(filePath, flags, mode);
+    await inspect({ filePath, flags, handle });
+    return handle;
+  });
 }
 
 async function createFifo(filePath: string): Promise<void> {
@@ -45,9 +56,6 @@ async function createFifo(filePath: string): Promise<void> {
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  await Promise.all(
-    tempDirs.splice(0).map(async (directory) => fs.rm(directory, { force: true, recursive: true })),
-  );
 });
 
 describe("directory durability", () => {
@@ -82,40 +90,34 @@ describe("directory durability", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")(
-    "syncs every newly created parent edge through the nearest existing ancestor",
-    async () => {
-      const root = await tempRoot("fs-safe-durable-parent-");
-      const directoryPath = path.join(root, "one", "two", "three");
-      const syncedPaths: string[] = [];
-      const originalOpen = fs.open.bind(fs);
-      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        const handle = await originalOpen(filePath, flags, mode);
-        if (isDirectoryOpen(flags)) {
-          const resolvedPath = path.resolve(String(filePath));
-          const originalSync = handle.sync.bind(handle);
-          vi.spyOn(handle, "sync").mockImplementation(async () => {
-            syncedPaths.push(resolvedPath);
-            await originalSync();
-          });
-        }
-        return handle;
-      });
+  itPosix("syncs every newly created parent edge through the nearest existing ancestor", async () => {
+    const root = await tempRoot("fs-safe-durable-parent-");
+    const directoryPath = path.join(root, "one", "two", "three");
+    const syncedPaths: string[] = [];
+    spyOnDirectoryOpen(async ({ filePath, flags, handle }) => {
+      if (isDirectoryOpen(flags)) {
+        const resolvedPath = path.resolve(String(filePath));
+        const originalSync = handle.sync.bind(handle);
+        vi.spyOn(handle, "sync").mockImplementation(async () => {
+          syncedPaths.push(resolvedPath);
+          await originalSync();
+        });
+      }
+    });
 
-      const receipt = await ensureDurableDirectory({ directoryPath, mode: 0o700 });
+    const receipt = await ensureDurableDirectory({ directoryPath, mode: 0o700 });
 
-      expect(receipt).toMatchObject({
-        path: directoryPath,
-        parentSync: { status: "synced" },
-      });
-      expect(syncedPaths).toEqual([
-        path.join(root, "one", "two"),
-        path.join(root, "one"),
-        root,
-      ]);
-      expect((await fs.stat(directoryPath)).mode & 0o777).toBe(0o700);
-    },
-  );
+    expect(receipt).toMatchObject({
+      path: directoryPath,
+      parentSync: { status: "synced" },
+    });
+    expect(syncedPaths).toEqual([
+      path.join(root, "one", "two"),
+      path.join(root, "one"),
+      root,
+    ]);
+    expect((await fs.stat(directoryPath)).mode & 0o777).toBe(0o700);
+  });
 
   it("returns not-needed for an existing directory", async () => {
     const directoryPath = await tempRoot("fs-safe-durable-existing-");
@@ -143,33 +145,28 @@ describe("directory durability", () => {
     expect(create).toHaveBeenCalledWith(directoryPath);
   });
 
-  it.runIf(process.platform !== "win32")(
-    "does not follow a symlink planted in a missing directory chain",
-    async () => {
-      const root = await tempRoot("fs-safe-durable-symlink-chain-");
-      const outside = await tempRoot("fs-safe-durable-symlink-outside-");
-      const firstSegment = path.join(root, "one");
-      const displacedSegment = path.join(root, "displaced-one");
-      const directoryPath = path.join(firstSegment, "two");
-      const originalMkdir = fs.mkdir.bind(fs);
-      let swapped = false;
-      vi.spyOn(fs, "mkdir").mockImplementation(async (targetPath, options) => {
-        const result = await originalMkdir(targetPath, options);
-        if (!swapped && path.resolve(String(targetPath)) === firstSegment) {
-          swapped = true;
-          await fs.rename(firstSegment, displacedSegment);
-          await fs.symlink(outside, firstSegment);
-        }
-        return result;
-      });
+  itPosix("does not follow a symlink planted in a missing directory chain", async () => {
+    const root = await tempRoot("fs-safe-durable-symlink-chain-");
+    const outside = await tempRoot("fs-safe-durable-symlink-outside-");
+    const firstSegment = path.join(root, "one");
+    const displacedSegment = path.join(root, "displaced-one");
+    const directoryPath = path.join(firstSegment, "two");
+    const originalMkdir = fs.mkdir.bind(fs);
+    let swapped = false;
+    vi.spyOn(fs, "mkdir").mockImplementation(async (targetPath, options) => {
+      const result = await originalMkdir(targetPath, options);
+      if (!swapped && path.resolve(String(targetPath)) === firstSegment) {
+        swapped = true;
+        await fs.rename(firstSegment, displacedSegment);
+        await fs.symlink(outside, firstSegment);
+      }
+      return result;
+    });
 
-      await expect(ensureDurableDirectory({ directoryPath })).rejects.toMatchObject({
-        code: "symlink",
-      });
-      expect(swapped).toBe(true);
-      await expect(fs.readdir(outside)).resolves.toEqual([]);
-    },
-  );
+    await expectFsSafeError(ensureDurableDirectory({ directoryPath }), "symlink");
+    expect(swapped).toBe(true);
+    await expect(fs.readdir(outside)).resolves.toEqual([]);
+  });
 
   it("rejects a creator that does not produce the requested path", async () => {
     const root = await tempRoot("fs-safe-durable-missing-create-");
@@ -185,23 +182,18 @@ describe("directory durability", () => {
     const directoryPath = path.join(root, "missing");
     const identity = await fs.lstat(root);
 
-    await expect(
-      ensureDurableDirectory({ directoryPath, expectedExistingIdentity: identity }),
-    ).rejects.toMatchObject({ code: "path-mismatch" });
+    await expectFsSafeError(ensureDurableDirectory({ directoryPath, expectedExistingIdentity: identity }), "path-mismatch");
   });
 
   it("fails when a newly created parent edge cannot be synced", async () => {
     const root = await tempRoot("fs-safe-durable-failure-");
     const directoryPath = path.join(root, "one", "two");
-    const originalOpen = fs.open.bind(fs);
-    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      const handle = await originalOpen(filePath, flags, mode);
+    spyOnDirectoryOpen(async ({ filePath, flags, handle }) => {
       if (isDirectoryOpen(flags) && path.resolve(String(filePath)) === root) {
         vi.spyOn(handle, "sync").mockRejectedValue(
           Object.assign(new Error("parent sync failed"), { code: "EIO" }),
         );
       }
-      return handle;
     });
 
     await expect(ensureDurableDirectory({ directoryPath })).rejects.toMatchObject({
@@ -211,142 +203,123 @@ describe("directory durability", () => {
     expect((await fs.stat(directoryPath)).isDirectory()).toBe(true);
   });
 
-  it.runIf(process.platform !== "win32")(
-    "detects a created directory replaced while its parent edge is synced",
-    async () => {
-      const root = await tempRoot("fs-safe-durable-race-");
-      const directoryPath = path.join(root, "one", "two");
-      const displacedPath = path.join(root, "displaced-two");
-      const originalOpen = fs.open.bind(fs);
-      let replaced = false;
-      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        const handle = await originalOpen(filePath, flags, mode);
-        if (
-          isDirectoryOpen(flags) &&
-          path.resolve(String(filePath)) === path.join(root, "one")
-        ) {
-          const originalSync = handle.sync.bind(handle);
-          vi.spyOn(handle, "sync").mockImplementation(async () => {
-            replaced = true;
-            await fs.rename(directoryPath, displacedPath);
-            await fs.mkdir(directoryPath);
-            await originalSync();
-          });
-        }
-        return handle;
-      });
-
-      await expect(ensureDurableDirectory({ directoryPath })).rejects.toMatchObject({
-        code: "path-mismatch",
-      });
-      expect(replaced).toBe(true);
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "rejects an expected existing target replaced before it can be pinned",
-    async () => {
-      const directoryPath = await tempRoot("fs-safe-durable-existing-race-");
-      const displacedPath = `${directoryPath}.displaced`;
-      tempDirs.push(displacedPath);
-      const expectedIdentity = await fs.lstat(directoryPath);
-      const originalOpen = fs.open.bind(fs);
-      let replaced = false;
-      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        if (
-          !replaced &&
-          isDirectoryOpen(flags) &&
-          path.resolve(String(filePath)) === directoryPath
-        ) {
+  itPosix("detects a created directory replaced while its parent edge is synced", async () => {
+    const root = await tempRoot("fs-safe-durable-race-");
+    const directoryPath = path.join(root, "one", "two");
+    const displacedPath = path.join(root, "displaced-two");
+    const originalOpen = fs.open.bind(fs);
+    let replaced = false;
+    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      const handle = await originalOpen(filePath, flags, mode);
+      if (
+        isDirectoryOpen(flags) &&
+        path.resolve(String(filePath)) === path.join(root, "one")
+      ) {
+        const originalSync = handle.sync.bind(handle);
+        vi.spyOn(handle, "sync").mockImplementation(async () => {
           replaced = true;
           await fs.rename(directoryPath, displacedPath);
           await fs.mkdir(directoryPath);
-        }
-        return await originalOpen(filePath, flags, mode);
-      });
+          await originalSync();
+        });
+      }
+      return handle;
+    });
 
-      await expect(
-        ensureDurableDirectory({ directoryPath, expectedExistingIdentity: expectedIdentity }),
-      ).rejects.toMatchObject({ code: "path-mismatch" });
-      expect(replaced).toBe(true);
-    },
-  );
+    await expectFsSafeError(ensureDurableDirectory({ directoryPath }), "path-mismatch");
+    expect(replaced).toBe(true);
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a FIFO swapped into a directory path without blocking",
-    async () => {
-      const directoryPath = await tempRoot("fs-safe-durable-fifo-");
-      const displacedPath = `${directoryPath}.displaced`;
-      tempDirs.push(displacedPath);
-      const originalOpen = fs.open.bind(fs);
-      let replaced = false;
-      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        if (
-          !replaced &&
-          isDirectoryOpen(flags) &&
-          path.resolve(String(filePath)) === directoryPath
-        ) {
-          expect(typeof flags).toBe("number");
-          const numericFlags = flags as number;
-          expect(numericFlags & fsSync.constants.O_DIRECTORY).toBe(fsSync.constants.O_DIRECTORY);
-          expect(numericFlags & fsSync.constants.O_NOFOLLOW).toBe(fsSync.constants.O_NOFOLLOW);
-          expect(numericFlags & fsSync.constants.O_NONBLOCK).toBe(fsSync.constants.O_NONBLOCK);
-          replaced = true;
-          await fs.rename(directoryPath, displacedPath);
-          await createFifo(directoryPath);
-        }
-        return await originalOpen(filePath, flags, mode);
-      });
+  itPosix("rejects an expected existing target replaced before it can be pinned", async () => {
+    const directoryPath = await tempRoot("fs-safe-durable-existing-race-");
+    const displacedPath = `${directoryPath}.displaced`;
+    tempDirs.push(displacedPath);
+    const expectedIdentity = await fs.lstat(directoryPath);
+    const originalOpen = fs.open.bind(fs);
+    let replaced = false;
+    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      if (
+        !replaced &&
+        isDirectoryOpen(flags) &&
+        path.resolve(String(filePath)) === directoryPath
+      ) {
+        replaced = true;
+        await fs.rename(directoryPath, displacedPath);
+        await fs.mkdir(directoryPath);
+      }
+      return await originalOpen(filePath, flags, mode);
+    });
 
-      await expect(pinDirectory(directoryPath)).rejects.toBeDefined();
-      expect(replaced).toBe(true);
-      await fs.unlink(directoryPath).catch(() => undefined);
-    },
-  );
+    await expectFsSafeError(ensureDurableDirectory({ directoryPath, expectedExistingIdentity: expectedIdentity }), "path-mismatch");
+    expect(replaced).toBe(true);
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "syncs the pinned parent when its path is transiently replaced",
-    async () => {
-      const root = await tempRoot("fs-safe-durable-parent-race-");
-      const directoryPath = path.join(root, "one", "two");
-      const parentPath = path.dirname(directoryPath);
-      const displacedParentPath = path.join(root, "owned-parent");
-      const replacementParentPath = path.join(root, "replacement-parent");
-      const originalOpen = fs.open.bind(fs);
-      let swapped = false;
-      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        const handle = await originalOpen(filePath, flags, mode);
-        if (isDirectoryOpen(flags) && path.resolve(String(filePath)) === parentPath) {
-          const originalSync = handle.sync.bind(handle);
-          vi.spyOn(handle, "sync").mockImplementation(async () => {
-            swapped = true;
-            await fs.rename(parentPath, displacedParentPath);
-            await fs.mkdir(parentPath);
-            await originalSync();
-            await fs.rename(parentPath, replacementParentPath);
-            await fs.rename(displacedParentPath, parentPath);
-          });
-        }
-        return handle;
-      });
+  itPosix("rejects a FIFO swapped into a directory path without blocking", async () => {
+    const directoryPath = await tempRoot("fs-safe-durable-fifo-");
+    const displacedPath = `${directoryPath}.displaced`;
+    tempDirs.push(displacedPath);
+    const originalOpen = fs.open.bind(fs);
+    let replaced = false;
+    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      if (
+        !replaced &&
+        isDirectoryOpen(flags) &&
+        path.resolve(String(filePath)) === directoryPath
+      ) {
+        expect(typeof flags).toBe("number");
+        const numericFlags = flags as number;
+        expect(numericFlags & fsSync.constants.O_DIRECTORY).toBe(fsSync.constants.O_DIRECTORY);
+        expect(numericFlags & fsSync.constants.O_NOFOLLOW).toBe(fsSync.constants.O_NOFOLLOW);
+        expect(numericFlags & fsSync.constants.O_NONBLOCK).toBe(fsSync.constants.O_NONBLOCK);
+        replaced = true;
+        await fs.rename(directoryPath, displacedPath);
+        await createFifo(directoryPath);
+      }
+      return await originalOpen(filePath, flags, mode);
+    });
 
-      await expect(ensureDurableDirectory({ directoryPath })).resolves.toMatchObject({
-        parentSync: { status: "synced" },
-      });
-      expect(swapped).toBe(true);
-    },
-  );
+    await expect(pinDirectory(directoryPath)).rejects.toBeDefined();
+    expect(replaced).toBe(true);
+    await fs.unlink(directoryPath).catch(() => undefined);
+  });
+
+  itPosix("syncs the pinned parent when its path is transiently replaced", async () => {
+    const root = await tempRoot("fs-safe-durable-parent-race-");
+    const directoryPath = path.join(root, "one", "two");
+    const parentPath = path.dirname(directoryPath);
+    const displacedParentPath = path.join(root, "owned-parent");
+    const replacementParentPath = path.join(root, "replacement-parent");
+    const originalOpen = fs.open.bind(fs);
+    let swapped = false;
+    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+      const handle = await originalOpen(filePath, flags, mode);
+      if (isDirectoryOpen(flags) && path.resolve(String(filePath)) === parentPath) {
+        const originalSync = handle.sync.bind(handle);
+        vi.spyOn(handle, "sync").mockImplementation(async () => {
+          swapped = true;
+          await fs.rename(parentPath, displacedParentPath);
+          await fs.mkdir(parentPath);
+          await originalSync();
+          await fs.rename(parentPath, replacementParentPath);
+          await fs.rename(displacedParentPath, parentPath);
+        });
+      }
+      return handle;
+    });
+
+    await expect(ensureDurableDirectory({ directoryPath })).resolves.toMatchObject({
+      parentSync: { status: "synced" },
+    });
+    expect(swapped).toBe(true);
+  });
 
   it.each(["EINVAL", "ENOSYS", "ENOTSUP"] as const)(
     "propagates %s directory sync failures outside Windows",
     async (code) => {
       vi.spyOn(process, "platform", "get").mockReturnValue("linux");
       const directoryPath = await tempRoot("fs-safe-posix-sync-");
-      const originalOpen = fs.open.bind(fs);
-      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        const handle = await originalOpen(filePath, flags, mode);
+      spyOnDirectoryOpen(async ({ filePath, flags, handle }) => {
         vi.spyOn(handle, "sync").mockRejectedValue(Object.assign(new Error(code), { code }));
-        return handle;
       });
 
       await expect(syncDirectory(directoryPath)).rejects.toMatchObject({ code });
@@ -358,11 +331,8 @@ describe("directory durability", () => {
     async (code) => {
       vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       const directoryPath = await tempRoot("fs-safe-windows-sync-");
-      const originalOpen = fs.open.bind(fs);
-      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        const handle = await originalOpen(filePath, flags, mode);
+      spyOnDirectoryOpen(async ({ filePath, flags, handle }) => {
         vi.spyOn(handle, "sync").mockRejectedValue(Object.assign(new Error(code), { code }));
-        return handle;
       });
 
       await expect(syncDirectory(directoryPath)).resolves.toEqual({
@@ -416,27 +386,21 @@ describe("directory durability", () => {
     expect(syncDirectorySync(directoryPath)).toEqual({ status: "unsupported", code: "EISDIR" });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "detects a directory replaced during one-shot synchronization",
-    async () => {
-      const directoryPath = await tempRoot("fs-safe-one-shot-race-");
-      const displacedPath = `${directoryPath}.displaced`;
-      tempDirs.push(displacedPath);
-      const originalOpen = fs.open.bind(fs);
-      vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-        const handle = await originalOpen(filePath, flags, mode);
-        const originalSync = handle.sync.bind(handle);
-        vi.spyOn(handle, "sync").mockImplementation(async () => {
-          await fs.rename(directoryPath, displacedPath);
-          await fs.mkdir(directoryPath);
-          await originalSync();
-        });
-        return handle;
+  itPosix("detects a directory replaced during one-shot synchronization", async () => {
+    const directoryPath = await tempRoot("fs-safe-one-shot-race-");
+    const displacedPath = `${directoryPath}.displaced`;
+    tempDirs.push(displacedPath);
+    spyOnDirectoryOpen(async ({ filePath, flags, handle }) => {
+      const originalSync = handle.sync.bind(handle);
+      vi.spyOn(handle, "sync").mockImplementation(async () => {
+        await fs.rename(directoryPath, displacedPath);
+        await fs.mkdir(directoryPath);
+        await originalSync();
       });
+    });
 
-      await expect(syncDirectory(directoryPath)).rejects.toMatchObject({ code: "path-mismatch" });
-    },
-  );
+    await expect(syncDirectory(directoryPath)).rejects.toMatchObject({ code: "path-mismatch" });
+  });
 
   it("supports synchronous directory sync and best-effort variants", async () => {
     const directoryPath = await tempRoot("fs-safe-sync-variants-");
@@ -451,11 +415,8 @@ describe("directory durability", () => {
 
   it("keeps best-effort sync non-throwing for real I/O failures", async () => {
     const directoryPath = await tempRoot("fs-safe-sync-best-effort-");
-    const originalOpen = fs.open.bind(fs);
-    vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
-      const handle = await originalOpen(filePath, flags, mode);
+    spyOnDirectoryOpen(async ({ filePath, flags, handle }) => {
       vi.spyOn(handle, "sync").mockRejectedValue(Object.assign(new Error("I/O"), { code: "EIO" }));
-      return handle;
     });
 
     await expect(syncDirectoryBestEffort(directoryPath)).resolves.toBeUndefined();

--- a/test/documented-defaults.test.ts
+++ b/test/documented-defaults.test.ts
@@ -1,24 +1,16 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { replaceFileAtomic } from "../src/atomic.js";
 import { fileStore } from "../src/file-store.js";
 import { writeJson } from "../src/json.js";
 import { jsonStore } from "../src/json-store.js";
 import { DEFAULT_ROOT_MAX_BYTES, root } from "../src/root.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
-});
 
 describe("documented defaults observed on real files", () => {
   it("uses the Root read, write, move, JSON, and writable-open defaults", async () => {
@@ -74,20 +66,17 @@ describe("documented defaults observed on real files", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects symlinks and hardlinks by default",
-    async () => {
-      const rootDir = await tempRoot("fs-safe-doc-link-defaults-");
-      const filePath = path.join(rootDir, "file.txt");
-      await fs.writeFile(filePath, "data");
-      await fs.symlink(filePath, path.join(rootDir, "symlink.txt"));
-      await fs.link(filePath, path.join(rootDir, "hardlink.txt"));
-      const scoped = await root(rootDir);
+  itPosix("rejects symlinks and hardlinks by default", async () => {
+    const rootDir = await tempRoot("fs-safe-doc-link-defaults-");
+    const filePath = path.join(rootDir, "file.txt");
+    await fs.writeFile(filePath, "data");
+    await fs.symlink(filePath, path.join(rootDir, "symlink.txt"));
+    await fs.link(filePath, path.join(rootDir, "hardlink.txt"));
+    const scoped = await root(rootDir);
 
-      await expect(scoped.read("symlink.txt")).rejects.toMatchObject({ code: "symlink" });
-      await expect(scoped.read("hardlink.txt")).rejects.toMatchObject({ code: "hardlink" });
-    },
-  );
+    await expect(scoped.read("symlink.txt")).rejects.toMatchObject({ code: "symlink" });
+    await expect(scoped.read("hardlink.txt")).rejects.toMatchObject({ code: "hardlink" });
+  });
 
   it("uses distinct standalone and store JSON newline defaults", async () => {
     const rootDir = await tempRoot("fs-safe-doc-json-defaults-");
@@ -108,36 +97,30 @@ describe("documented defaults observed on real files", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")(
-    "applies the documented atomic and FileStore mode defaults",
-    async () => {
-      const rootDir = await tempRoot("fs-safe-doc-mode-defaults-");
-      const atomicPath = path.join(rootDir, "atomic/state.txt");
-      await replaceFileAtomic({ filePath: atomicPath, content: "state" });
-      expect((await fs.stat(path.dirname(atomicPath))).mode & 0o777).toBe(0o700);
-      expect((await fs.stat(atomicPath)).mode & 0o777).toBe(0o600);
+  itPosix("applies the documented atomic and FileStore mode defaults", async () => {
+    const rootDir = await tempRoot("fs-safe-doc-mode-defaults-");
+    const atomicPath = path.join(rootDir, "atomic/state.txt");
+    await replaceFileAtomic({ filePath: atomicPath, content: "state" });
+    expect((await fs.stat(path.dirname(atomicPath))).mode & 0o777).toBe(0o700);
+    expect((await fs.stat(atomicPath)).mode & 0o777).toBe(0o600);
 
-      const store = fileStore({ rootDir: path.join(rootDir, "store") });
-      const storedPath = await store.write("nested/value.txt", "value");
-      expect((await fs.stat(path.dirname(storedPath))).mode & 0o777).toBe(0o700);
-      expect((await fs.stat(storedPath)).mode & 0o777).toBe(0o600);
-    },
-  );
+    const store = fileStore({ rootDir: path.join(rootDir, "store") });
+    const storedPath = await store.write("nested/value.txt", "value");
+    expect((await fs.stat(path.dirname(storedPath))).mode & 0o777).toBe(0o700);
+    expect((await fs.stat(storedPath)).mode & 0o777).toBe(0o600);
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "uses 0o600 for a new Root file and preserves an existing mode",
-    async () => {
-      const rootDir = await tempRoot("fs-safe-doc-root-mode-");
-      const filePath = path.join(rootDir, "state.txt");
-      const scoped = await root(rootDir);
-      await scoped.write("state.txt", "new");
-      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o600);
+  itPosix("uses 0o600 for a new Root file and preserves an existing mode", async () => {
+    const rootDir = await tempRoot("fs-safe-doc-root-mode-");
+    const filePath = path.join(rootDir, "state.txt");
+    const scoped = await root(rootDir);
+    await scoped.write("state.txt", "new");
+    expect((await fs.stat(filePath)).mode & 0o777).toBe(0o600);
 
-      await fs.chmod(filePath, 0o644);
-      await scoped.write("state.txt", "replacement");
-      expect((await fs.stat(filePath)).mode & 0o777).toBe(0o644);
-    },
-  );
+    await fs.chmod(filePath, 0o644);
+    await scoped.write("state.txt", "replacement");
+    expect((await fs.stat(filePath)).mode & 0o777).toBe(0o644);
+  });
 
   it("classifies documented non-empty and reentrant-update errors by observation", async () => {
     const rootDir = await tempRoot("fs-safe-doc-error-defaults-");

--- a/test/edge-coverage.test.ts
+++ b/test/edge-coverage.test.ts
@@ -1,9 +1,10 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { FsSafeError } from "../src/errors.js";
 import {
   assertSyncDirectoryGuard,
@@ -27,20 +28,11 @@ import {
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 import { movePathToTrash } from "../src/trash.js";
 
-const tempDirs = new Set<string>();
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.add(dir);
-  return dir;
-}
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  for (const dir of tempDirs) {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
-  tempDirs.clear();
 });
 
 describe("root error helpers", () => {
@@ -186,13 +178,11 @@ describe("directory replacement and file store boundary helpers", () => {
     }
     await expect(fs.stat(path.dirname(staged.path))).rejects.toMatchObject({ code: "ENOENT" });
 
-    await expect(
-      writeStreamToTempSource({
+    await expectFsSafeError(writeStreamToTempSource({
         stream: Readable.from(["123", "456"]),
         maxBytes: 4,
         mode: 0o600,
-      }),
-    ).rejects.toMatchObject({ code: "too-large" });
+      }), "too-large");
   });
 });
 
@@ -288,7 +278,7 @@ describe("trash edge paths", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")("moves broken symlinks to trash", async () => {
+  itPosix("moves broken symlinks to trash", async () => {
     const root = await tempRoot("fs-safe-trash-broken-link-");
     const linkPath = path.join(root, "broken-link");
     const missingTarget = path.join(root, "missing-target");

--- a/test/extracted-helpers.test.ts
+++ b/test/extracted-helpers.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
 import {
   isWindowsDrivePath,
   normalizeArchiveEntryPath,
@@ -28,17 +28,9 @@ import {
   writeSecretFileAtomic,
 } from "../src/secret-file.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
-});
 
 describe("local file access helpers", () => {
   it("accepts local file URLs and rejects remote hosts or encoded separators", () => {

--- a/test/file-hash.test.ts
+++ b/test/file-hash.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix } from "./helpers/vitest.js";
 import { sha256File } from "../src/file-hash.js";
 import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
 import {
@@ -85,7 +86,7 @@ describe("sha256File", () => {
     expect(nativeHash).toHaveBeenCalledOnce();
   });
 
-  it.runIf(process.platform !== "win32")("rejects symbolic-link path inputs", async () => {
+  itPosix("rejects symbolic-link path inputs", async () => {
     const root = await tempRoot();
     const filePath = path.join(root, "payload.bin");
     const linkPath = path.join(root, "link.bin");
@@ -95,28 +96,25 @@ describe("sha256File", () => {
     await expect(sha256File(linkPath)).rejects.toMatchObject({ code: "symlink" });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a FIFO swapped in before open without blocking",
-    async () => {
-      const root = await tempRoot();
-      const filePath = path.join(root, "payload.bin");
-      const displacedPath = path.join(root, "payload.displaced");
-      await fs.writeFile(filePath, "payload");
-      configureFsSafeNative({ mode: "off" });
-      const originalOpen = fs.open.bind(fs);
-      vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
-        if (candidate === filePath) {
-          expect(typeof flags).toBe("number");
-          expect((flags as number) & fsSync.constants.O_NONBLOCK).toBe(
-            fsSync.constants.O_NONBLOCK,
-          );
-          await fs.rename(filePath, displacedPath);
-          await createFifo(filePath);
-        }
-        return await originalOpen(candidate, flags, mode);
-      });
+  itPosix("rejects a FIFO swapped in before open without blocking", async () => {
+    const root = await tempRoot();
+    const filePath = path.join(root, "payload.bin");
+    const displacedPath = path.join(root, "payload.displaced");
+    await fs.writeFile(filePath, "payload");
+    configureFsSafeNative({ mode: "off" });
+    const originalOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
+      if (candidate === filePath) {
+        expect(typeof flags).toBe("number");
+        expect((flags as number) & fsSync.constants.O_NONBLOCK).toBe(
+          fsSync.constants.O_NONBLOCK,
+        );
+        await fs.rename(filePath, displacedPath);
+        await createFifo(filePath);
+      }
+      return await originalOpen(candidate, flags, mode);
+    });
 
-      await expect(sha256File(filePath)).rejects.toMatchObject({ code: "not-file" });
-    },
-  );
+    await expect(sha256File(filePath)).rejects.toMatchObject({ code: "not-file" });
+  });
 });

--- a/test/file-lock-concurrency-stress.test.ts
+++ b/test/file-lock-concurrency-stress.test.ts
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { expectFsSafeErrorSync, expectFsSafeError } from "./helpers/security.js";
+import { useTempDirs } from "./helpers/vitest.js";
 import {
   acquireFileLock,
   acquireFileLockSync,
@@ -13,17 +14,9 @@ import { createSidecarLockManager } from "../src/sidecar-lock.js";
 
 const childTarget = process.env.FS_SAFE_STRESS_LOCK_TARGET;
 const childLog = process.env.FS_SAFE_STRESS_LOCK_LOG;
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
-});
 
-async function tempRoot(prefix: string): Promise<string> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(directory);
-  return directory;
-}
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve!: () => void;
@@ -41,24 +34,21 @@ describe("file-lock concurrency stress", () => {
     await fs.writeFile(lockPath, Buffer.alloc(1024 * 1024 + 1, 0x20));
     const manager = createSidecarLockManager(`fs-safe-payload-limit-${Date.now()}`);
 
-    await expect(
-      manager.acquire({
+    await expectFsSafeError(manager.acquire({
         targetPath,
         lockPath,
         staleMs: 1,
         timeoutMs: 0,
         retry: { retries: 0 },
         payload: async () => ({ createdAt: new Date().toISOString() }),
-      }),
-    ).rejects.toMatchObject({ code: "too-large" });
-    expect(() =>
+      }), "too-large");
+    expectFsSafeErrorSync(() =>
       acquireFileLockSync(targetPath, {
         staleMs: 1,
         timeoutMs: 0,
         retry: { retries: 0 },
         payload: () => ({ createdAt: new Date().toISOString() }),
-      }),
-    ).toThrow(expect.objectContaining({ code: "too-large" }));
+      }), "too-large");
   });
 
   it.runIf(!childTarget && process.platform !== "win32")(
@@ -68,22 +58,19 @@ describe("file-lock concurrency stress", () => {
       const targetPath = path.join(base, "state.json");
       await fs.symlink(path.join(base, "missing"), `${targetPath}.lock`);
 
-      await expect(
-        acquireFileLock(targetPath, {
+      await expectFsSafeError(acquireFileLock(targetPath, {
           staleMs: 1,
           timeoutMs: 0,
           retry: { retries: 0 },
           payload: async () => ({ createdAt: new Date().toISOString() }),
-        }),
-      ).rejects.toMatchObject({ code: "not-file" });
-      expect(() =>
+        }), "not-file");
+      expectFsSafeErrorSync(() =>
         acquireFileLockSync(targetPath, {
           staleMs: 1,
           timeoutMs: 0,
           retry: { retries: 0 },
           payload: () => ({ createdAt: new Date().toISOString() }),
-        }),
-      ).toThrow(expect.objectContaining({ code: "not-file" }));
+        }), "not-file");
     },
   );
 

--- a/test/file-lock-reentrancy.test.ts
+++ b/test/file-lock-reentrancy.test.ts
@@ -1,10 +1,10 @@
 import { spawn } from "node:child_process";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import {
   acquireFileLock,
   acquireFileLockSync,
@@ -12,13 +12,8 @@ import {
   withFileLockSync,
 } from "../src/file-lock.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(directory);
-  return directory;
-}
 
 function payload(): { pid: number; createdAt: string } {
   return { pid: process.pid, createdAt: new Date().toISOString() };
@@ -32,51 +27,45 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve };
 }
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
-});
 
 describe("owner-scoped file-lock reentrancy", () => {
-  it.runIf(process.platform !== "win32")(
-    "shares one reference-counted lock across symlinked target paths",
-    async () => {
-      const root = await tempRoot("fs-safe-reentrant-alias-");
-      const realDir = path.join(root, "real");
-      const linkDir = path.join(root, "link");
-      await fs.mkdir(realDir);
-      await fs.symlink(realDir, linkDir, "dir");
-      const realPath = path.join(realDir, "session.json");
-      const linkPath = path.join(linkDir, "session.json");
-      const managerKey = `alias-${Date.now()}-${Math.random()}`;
-      const reentrantOwner = "session:run-1";
-      const first = await acquireFileLock(realPath, {
-        managerKey,
-        reentrantOwner,
-        staleMs: 60_000,
-        payload,
-      });
-      const second = await acquireFileLock(linkPath, {
-        managerKey,
-        reentrantOwner,
-        staleMs: 60_000,
-        payload,
-      });
+  itPosix("shares one reference-counted lock across symlinked target paths", async () => {
+    const root = await tempRoot("fs-safe-reentrant-alias-");
+    const realDir = path.join(root, "real");
+    const linkDir = path.join(root, "link");
+    await fs.mkdir(realDir);
+    await fs.symlink(realDir, linkDir, "dir");
+    const realPath = path.join(realDir, "session.json");
+    const linkPath = path.join(linkDir, "session.json");
+    const managerKey = `alias-${Date.now()}-${Math.random()}`;
+    const reentrantOwner = "session:run-1";
+    const first = await acquireFileLock(realPath, {
+      managerKey,
+      reentrantOwner,
+      staleMs: 60_000,
+      payload,
+    });
+    const second = await acquireFileLock(linkPath, {
+      managerKey,
+      reentrantOwner,
+      staleMs: 60_000,
+      payload,
+    });
 
-      try {
-        expect(second.normalizedTargetPath).toBe(first.normalizedTargetPath);
-        expect(second.lockPath).toBe(first.lockPath);
-        await expect(fs.stat(`${realPath}.lock`)).resolves.toMatchObject({});
-        await expect(fs.stat(`${linkPath}.lock`)).resolves.toMatchObject({});
-        await first.release();
-        await expect(fs.stat(first.lockPath)).resolves.toMatchObject({});
-        await second.release();
-        await expect(fs.stat(first.lockPath)).rejects.toMatchObject({ code: "ENOENT" });
-      } finally {
-        await first.release();
-        await second.release();
-      }
-    },
-  );
+    try {
+      expect(second.normalizedTargetPath).toBe(first.normalizedTargetPath);
+      expect(second.lockPath).toBe(first.lockPath);
+      await expect(fs.stat(`${realPath}.lock`)).resolves.toMatchObject({});
+      await expect(fs.stat(`${linkPath}.lock`)).resolves.toMatchObject({});
+      await first.release();
+      await expect(fs.stat(first.lockPath)).resolves.toMatchObject({});
+      await second.release();
+      await expect(fs.stat(first.lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await first.release();
+      await second.release();
+    }
+  });
 
   it.each([
     ["different", "owner-b"],
@@ -234,30 +223,27 @@ describe("owner-scoped file-lock reentrancy", () => {
     expect(fsSync.existsSync(first.lockPath)).toBe(false);
   });
 
-  it.runIf(process.platform !== "win32")(
-    "provides synchronous canonical-alias parity",
-    async () => {
-      const root = await tempRoot("fs-safe-reentrant-sync-alias-");
-      const realDir = path.join(root, "real");
-      const linkDir = path.join(root, "link");
-      await fs.mkdir(realDir);
-      await fs.symlink(realDir, linkDir, "dir");
-      const options = {
-        reentrantOwner: "sync-session:aliased-run",
-        staleMs: 60_000,
-        timeoutMs: 0,
-        retry: { retries: 0 },
-        payload,
-      };
-      const first = acquireFileLockSync(path.join(realDir, "session.json"), options);
-      const second = acquireFileLockSync(path.join(linkDir, "session.json"), options);
+  itPosix("provides synchronous canonical-alias parity", async () => {
+    const root = await tempRoot("fs-safe-reentrant-sync-alias-");
+    const realDir = path.join(root, "real");
+    const linkDir = path.join(root, "link");
+    await fs.mkdir(realDir);
+    await fs.symlink(realDir, linkDir, "dir");
+    const options = {
+      reentrantOwner: "sync-session:aliased-run",
+      staleMs: 60_000,
+      timeoutMs: 0,
+      retry: { retries: 0 },
+      payload,
+    };
+    const first = acquireFileLockSync(path.join(realDir, "session.json"), options);
+    const second = acquireFileLockSync(path.join(linkDir, "session.json"), options);
 
-      expect(second.normalizedTargetPath).toBe(first.normalizedTargetPath);
-      expect(second.lockPath).toBe(first.lockPath);
-      first.release();
-      expect(fsSync.existsSync(first.lockPath)).toBe(true);
-      second.release();
-      expect(fsSync.existsSync(first.lockPath)).toBe(false);
-    },
-  );
+    expect(second.normalizedTargetPath).toBe(first.normalizedTargetPath);
+    expect(second.lockPath).toBe(first.lockPath);
+    first.release();
+    expect(fsSync.existsSync(first.lockPath)).toBe(true);
+    second.release();
+    expect(fsSync.existsSync(first.lockPath)).toBe(false);
+  });
 });

--- a/test/file-store-sync-read-validation.test.ts
+++ b/test/file-store-sync-read-validation.test.ts
@@ -1,21 +1,14 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { expectFsSafeErrorSync } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { fileStoreSync } from "../src/file-store.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
-});
 
 describe("sync file-store read validation failures", () => {
   it("surfaces directories as filesystem safety errors", async () => {
@@ -23,20 +16,16 @@ describe("sync file-store read validation failures", () => {
     await fs.mkdir(path.join(root, "not-a-file"));
     const store = fileStoreSync({ rootDir: root, private: true });
 
-    expect(() => store.readTextIfExists("not-a-file")).toThrow(
-      expect.objectContaining({ code: "path-mismatch" }),
-    );
+    expectFsSafeErrorSync(() => store.readTextIfExists("not-a-file"), "path-mismatch");
   });
 
-  it.runIf(process.platform !== "win32")("surfaces hardlinks as filesystem safety errors", async () => {
+  itPosix("surfaces hardlinks as filesystem safety errors", async () => {
     const root = await tempRoot("fs-safe-sync-store-hardlink-");
     const filePath = path.join(root, "value.txt");
     await fs.writeFile(filePath, "secret");
     fsSync.linkSync(filePath, path.join(root, "alias.txt"));
     const store = fileStoreSync({ rootDir: root, private: true });
 
-    expect(() => store.readTextIfExists("value.txt")).toThrow(
-      expect.objectContaining({ code: "path-mismatch" }),
-    );
+    expectFsSafeErrorSync(() => store.readTextIfExists("value.txt"), "path-mismatch");
   });
 });

--- a/test/findings-regression.test.ts
+++ b/test/findings-regression.test.ts
@@ -1,9 +1,9 @@
 import fsSync from "node:fs";
 import fsp from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import JSZip from "jszip";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { extractArchive } from "../src/archive.js";
 import { configureFsSafeNative, root as openRoot } from "../src/index.js";
 import { prepareArchiveDestinationDir, prepareArchiveOutputPath, mergeExtractedTreeIntoDestination } from "../src/archive-staging.js";
@@ -22,14 +22,9 @@ import { tempWorkspace, tempWorkspaceSync } from "../src/private-temp-workspace.
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 import { movePathToTrash } from "../src/trash.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 async function writeOldFile(filePath: string, content = "old"): Promise<void> {
   await fsp.writeFile(filePath, content);
@@ -42,11 +37,10 @@ afterEach(async () => {
   Object.defineProperty(process, "platform", originalPlatformDescriptor);
   configureFsSafeNative({ mode: "auto" });
   __setFsSafeTestHooksForTest(undefined);
-  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
 });
 
 describe("security finding regressions", () => {
-  it.runIf(process.platform !== "win32")("guards Root fallback mutators against parent swaps", async () => {
+  itPosix("guards Root fallback mutators against parent swaps", async () => {
     configureFsSafeNative({ mode: "off" });
     const base = await tempRoot("fs-safe-root-fallback-race-");
     const outside = await tempRoot("fs-safe-root-fallback-outside-");
@@ -91,7 +85,7 @@ describe("security finding regressions", () => {
     await expect(fsp.stat(path.join(outside, "moved.txt"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("does not create archive directories through a swapped destination", async () => {
+  itPosix("does not create archive directories through a swapped destination", async () => {
     const base = await tempRoot("fs-safe-archive-dir-race-");
     const dest = path.join(base, "dest");
     const outside = await tempRoot("fs-safe-archive-dir-outside-");
@@ -119,7 +113,7 @@ describe("security finding regressions", () => {
     await expect(fsp.stat(path.join(outside, "nested"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("does not chmod through an archive entry symlink swap", async () => {
+  itPosix("does not chmod through an archive entry symlink swap", async () => {
     const base = await tempRoot("fs-safe-archive-chmod-race-");
     const source = path.join(base, "source");
     const dest = path.join(base, "dest");
@@ -146,7 +140,7 @@ describe("security finding regressions", () => {
     expect((await fsp.stat(outsideFile)).mode & 0o777).toBe(0o600);
   });
 
-  it.runIf(process.platform !== "win32")("uses unguessable no-follow temp files in pinned write fallback", async () => {
+  itPosix("uses unguessable no-follow temp files in pinned write fallback", async () => {
     configureFsSafeNative({ mode: "off" });
     const base = await tempRoot("fs-safe-pinned-write-fallback-");
     const outside = await tempRoot("fs-safe-pinned-write-outside-");
@@ -170,7 +164,9 @@ describe("security finding regressions", () => {
 
   it("validates pinned write fallback payloads even when native mode is off", async () => {
     configureFsSafeNative({ mode: "off" });
-    const base = await tempRoot("fs-safe-pinned-write-validation-");
+    const parent = await tempRoot("fs-safe-pinned-write-validation-");
+    const base = path.join(parent, "root");
+    await fsp.mkdir(base);
     await expect(
       runPinnedWriteHelper({
         rootPath: base,
@@ -182,9 +178,12 @@ describe("security finding regressions", () => {
         input: { kind: "buffer", data: "bad" },
       }),
     ).rejects.toBeTruthy();
+    await expect(fsp.lstat(path.join(parent, "escape", "victim.txt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
-  it.runIf(process.platform !== "win32")("guards private sync store writes against parent swaps", async () => {
+  itPosix("guards private sync store writes against parent swaps", async () => {
     const base = await tempRoot("fs-safe-sync-private-write-");
     const outside = await tempRoot("fs-safe-sync-private-outside-");
     await fsp.mkdir(path.join(base, "nested"));
@@ -201,7 +200,7 @@ describe("security finding regressions", () => {
     await expect(fsp.stat(path.join(outside, "value.txt"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("pins sync store reads against final symlink swaps", async () => {
+  itPosix("pins sync store reads against final symlink swaps", async () => {
     const base = await tempRoot("fs-safe-sync-read-race-");
     const outside = await tempRoot("fs-safe-sync-read-outside-");
     const filePath = path.join(base, "value.txt");
@@ -224,7 +223,7 @@ describe("security finding regressions", () => {
     expect(fsSync.readFileSync(outsideFile, "utf8")).toBe("outside");
   });
 
-  it.runIf(process.platform !== "win32")("does not recurse prune through a swapped directory symlink", async () => {
+  itPosix("does not recurse prune through a swapped directory symlink", async () => {
     const base = await tempRoot("fs-safe-prune-race-");
     const outside = await tempRoot("fs-safe-prune-outside-");
     await fsp.mkdir(path.join(base, "cache"));
@@ -244,7 +243,7 @@ describe("security finding regressions", () => {
     await expect(fsp.readFile(path.join(outside, "old.txt"), "utf8")).resolves.toBe("outside");
   });
 
-  it.runIf(process.platform !== "win32")("does not copy JSON through a raced fallback symlink", async () => {
+  itPosix("does not copy JSON through a raced fallback symlink", async () => {
     const base = await tempRoot("fs-safe-json-fallback-race-");
     const outside = await tempRoot("fs-safe-json-fallback-outside-");
     const target = path.join(base, "state.json");
@@ -277,7 +276,7 @@ describe("security finding regressions", () => {
     await expect(fsp.readFile(target, "utf8")).resolves.toContain('"ok": true');
   });
 
-  it.runIf(process.platform !== "win32")("does not chmod existing parents during sync JSON writes", async () => {
+  itPosix("does not chmod existing parents during sync JSON writes", async () => {
     const base = await tempRoot("fs-safe-json-parent-mode-");
     const parent = path.join(base, "shared");
     await fsp.mkdir(parent, { mode: 0o755 });
@@ -288,7 +287,7 @@ describe("security finding regressions", () => {
     expect((await fsp.stat(parent)).mode & 0o777).toBe(0o755);
   });
 
-  it.runIf(process.platform !== "win32")("does not copy atomic fallback through a raced destination symlink", async () => {
+  itPosix("does not copy atomic fallback through a raced destination symlink", async () => {
     const base = await tempRoot("fs-safe-atomic-fallback-race-");
     const outside = await tempRoot("fs-safe-atomic-fallback-outside-");
     const target = path.join(base, "state.txt");
@@ -325,7 +324,7 @@ describe("security finding regressions", () => {
     await expect(fsp.readFile(target, "utf8")).resolves.toBe("new");
   });
 
-  it.runIf(process.platform !== "win32")("stages EXDEV file moves without buffering or chmodding parents", async () => {
+  itPosix("stages EXDEV file moves without buffering or chmodding parents", async () => {
     const base = await tempRoot("fs-safe-move-exdev-mode-");
     const source = path.join(base, "source.bin");
     const destDir = path.join(base, "public");
@@ -355,7 +354,7 @@ describe("security finding regressions", () => {
     expect((await fsp.readFile(dest)).byteLength).toBe(1024 * 1024);
   });
 
-  it.runIf(process.platform !== "win32")("preserves default directory modes for zip staging parents", async () => {
+  itPosix("preserves default directory modes for zip staging parents", async () => {
     const expectedDirectoryMode = 0o777 & ~process.umask();
     const base = await tempRoot("fs-safe-zip-dir-mode-");
     const archivePath = path.join(base, "pkg.zip");
@@ -376,6 +375,9 @@ describe("security finding regressions", () => {
     await expect(
       moveJsonDurableQueueEntryToFailed({ queueDir: base, failedDir: path.join(base, "failed"), id: "nested/escape" }),
     ).rejects.toBeTruthy();
+    await expect(fsp.lstat(path.join(base, "failed", "nested", "escape.json"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("keeps dot-only temp filenames inside the private temp directory", async () => {
@@ -404,7 +406,7 @@ describe("security finding regressions", () => {
     await expect(workspace.read(".env")).resolves.toEqual(Buffer.from("TOKEN=ok"));
   });
 
-  it.runIf(process.platform !== "win32")("pins sync temp workspace reads against final symlink swaps", async () => {
+  itPosix("pins sync temp workspace reads against final symlink swaps", async () => {
     const base = await tempRoot("fs-safe-temp-workspace-sync-read-");
     const outside = await tempRoot("fs-safe-temp-workspace-sync-outside-");
     const workspace = tempWorkspaceSync({ rootDir: base, prefix: "ws-" });
@@ -431,7 +433,7 @@ describe("security finding regressions", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")("writes sibling-temp content from a private temp path, not a swapped target parent", async () => {
+  itPosix("writes sibling-temp content from a private temp path, not a swapped target parent", async () => {
     const base = await tempRoot("fs-safe-sibling-temp-race-");
     const outside = await tempRoot("fs-safe-sibling-temp-outside-");
     await fsp.mkdir(path.join(base, "nested"));
@@ -455,7 +457,7 @@ describe("security finding regressions", () => {
     await expect(fsp.stat(path.join(outside, "out.txt"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("does not trash a different path after an allowed parent swap", async () => {
+  itPosix("does not trash a different path after an allowed parent swap", async () => {
     const base = await tempRoot("fs-safe-trash-race-");
     const outside = await tempRoot("fs-safe-trash-outside-");
     await fsp.mkdir(path.join(base, "dir"));

--- a/test/fs-safe.test.ts
+++ b/test/fs-safe.test.ts
@@ -1,8 +1,8 @@
 import { appendFileSync } from "node:fs";
 import { chmod, mkdtemp, readdir, readFile, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import {
   categorizeFsSafeError,
   configureFsSafeNative,
@@ -11,17 +11,12 @@ import {
 } from "../src/index.js";
 import { openLocalFileSafely, readLocalFileSafely } from "../src/root.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
-import { expectedFsSafeCode } from "./helpers/security.js";
+import { expectedFsSafeCode, expectFsSafeError } from "./helpers/security.js";
 
 const skipOnWindows = process.platform === "win32";
 
-const tempDirs: string[] = [];
+const { tempDirs, tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 afterEach(async () => {
   configureFsSafeNative({ mode: "auto" });
@@ -68,9 +63,7 @@ describe("@openclaw/fs-safe", () => {
     });
 
     await root.remove("nested/renamed.txt");
-    await expect(root.stat("nested/renamed.txt")).rejects.toMatchObject({
-      code: "not-found",
-    });
+    await expectFsSafeError(root.stat("nested/renamed.txt"), "not-found");
   });
 
   it("rejects non-directory roots before creating a capability", async () => {
@@ -126,9 +119,7 @@ describe("@openclaw/fs-safe", () => {
     const rootPath = await tempRoot("fs-safe-append-semantics-");
     const root = await openRoot(rootPath);
 
-    await expect(root.append("missing/file.txt", "x", { mkdir: false })).rejects.toMatchObject({
-      code: "not-found",
-    });
+    await expectFsSafeError(root.append("missing/file.txt", "x", { mkdir: false }), "not-found");
     await expect(root.exists("missing")).resolves.toBe(false);
 
     await root.write("utf16.txt", "alpha", { encoding: "utf16le" });
@@ -183,15 +174,11 @@ describe("@openclaw/fs-safe", () => {
     const root = await openRoot(rootPath);
 
     await expect(root.create("nested/file.txt", "first")).resolves.toBeUndefined();
-    await expect(root.create("nested/file.txt", "second")).rejects.toMatchObject({
-      code: "already-exists",
-    });
+    await expectFsSafeError(root.create("nested/file.txt", "second"), "already-exists");
     await expect(readFile(path.join(rootPath, "nested/file.txt"), "utf8")).resolves.toBe("first");
 
     await expect(root.createJson("state.json", { ok: true })).resolves.toBeUndefined();
-    await expect(root.createJson("state.json", { ok: false })).rejects.toMatchObject({
-      code: "already-exists",
-    });
+    await expectFsSafeError(root.createJson("state.json", { ok: false }), "already-exists");
     await expect(readFile(path.join(rootPath, "state.json"), "utf8")).resolves.toBe(
       '{"ok":true}\n',
     );
@@ -225,9 +212,7 @@ describe("@openclaw/fs-safe", () => {
       category: "policy",
       code: "outside-workspace",
     } satisfies Partial<FsSafeError>);
-    await expect(root.write("../write", "")).rejects.toMatchObject({
-      code: "outside-workspace",
-    });
+    await expectFsSafeError(root.write("../write", ""), "outside-workspace");
   });
 
   it("rejects NUL bytes with FsSafeError before reaching Node fs", async () => {
@@ -291,9 +276,7 @@ describe("@openclaw/fs-safe", () => {
     const outsidePath = path.join(outside, "secret.txt");
     await writeFile(outsidePath, "secret");
 
-    await expect(root.reader()(outsidePath)).rejects.toMatchObject({
-      code: "outside-workspace",
-    });
+    await expectFsSafeError(root.reader()(outsidePath), "outside-workspace");
   });
 
   it("rejects symlink parents", async () => {
@@ -303,9 +286,7 @@ describe("@openclaw/fs-safe", () => {
     await writeFile(path.join(outside, "secret.txt"), "secret");
     await symlink(outside, path.join(rootPath, "link"), "dir");
 
-    await expect(root.read("link/secret.txt")).rejects.toMatchObject({
-      code: "outside-workspace",
-    });
+    await expectFsSafeError(root.read("link/secret.txt"), "outside-workspace");
     await expect(root.list("link")).rejects.toMatchObject({ code: expectedFsSafeCode("path-alias") });
   });
 
@@ -331,9 +312,7 @@ describe("@openclaw/fs-safe", () => {
 
     await writeFile(path.join(outside, "secret.txt"), "secret");
     await symlink(path.join(outside, "secret.txt"), path.join(rootPath, "link"), "file");
-    await expect(root.move("link", "moved-link")).rejects.toMatchObject({
-      code: "path-alias",
-    });
+    await expectFsSafeError(root.move("link", "moved-link"), "path-alias");
   });
 
   it.skipIf(skipOnWindows)("requires explicit overwrite for moves that replace a target", async () => {
@@ -342,9 +321,7 @@ describe("@openclaw/fs-safe", () => {
     await root.write("from.txt", "source");
     await root.write("to.txt", "target");
 
-    await expect(root.move("from.txt", "to.txt")).rejects.toMatchObject({
-      code: "already-exists",
-    });
+    await expectFsSafeError(root.move("from.txt", "to.txt"), "already-exists");
     await expect(readFile(path.join(rootPath, "to.txt"), "utf8")).resolves.toBe("target");
 
     await root.move("from.txt", "to.txt", { overwrite: true });
@@ -367,14 +344,12 @@ describe("@openclaw/fs-safe", () => {
       },
     });
 
-    await expect(root.copyIn("copied.txt", sourcePath, { maxBytes: 4 })).rejects.toMatchObject({
-      code: "too-large",
-    });
+    await expectFsSafeError(root.copyIn("copied.txt", sourcePath, { maxBytes: 4 }), "too-large");
     await expect(root.exists("copied.txt")).resolves.toBe(false);
     await expect(readdir(rootPath)).resolves.toEqual([]);
   });
 
-  it.runIf(process.platform !== "win32")("rejects a copy when the source path is swapped after open", async () => {
+  itPosix("rejects a copy when the source path is swapped after open", async () => {
     const rootPath = await tempRoot("fs-safe-copy-source-swap-root-");
     const sourceRoot = await tempRoot("fs-safe-copy-source-swap-source-");
     const sourcePath = path.join(sourceRoot, "source.txt");
@@ -392,8 +367,7 @@ describe("@openclaw/fs-safe", () => {
       },
     });
     const scoped = await openRoot(rootPath);
-    await expect(scoped.copyIn("copied.txt", sourcePath, { maxBytes: 1024 })).rejects
-      .toMatchObject({ code: "path-mismatch" });
+    await expectFsSafeError(scoped.copyIn("copied.txt", sourcePath, { maxBytes: 1024 }), "path-mismatch");
     await expect(stat(path.join(rootPath, "copied.txt"))).rejects.toMatchObject({
       code: "ENOENT",
     });
@@ -470,7 +444,7 @@ describe("@openclaw/fs-safe", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")("honors mode on root text and JSON writes", async () => {
+  itPosix("honors mode on root text and JSON writes", async () => {
     const rootPath = await tempRoot("fs-safe-write-mode-");
     const root = await openRoot(rootPath);
 
@@ -483,7 +457,7 @@ describe("@openclaw/fs-safe", () => {
       .toBe(0o640);
   });
 
-  it.runIf(process.platform !== "win32")("honors default mode on root writes", async () => {
+  itPosix("honors default mode on root writes", async () => {
     const rootPath = await tempRoot("fs-safe-default-write-mode-");
     const root = await openRoot(rootPath, { mode: 0o640 });
 

--- a/test/guarded-mkdir-symlink-parent.test.ts
+++ b/test/guarded-mkdir-symlink-parent.test.ts
@@ -1,25 +1,16 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, expect, it } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { FsSafeError } from "../src/errors.js";
 import { mkdirPathComponentsWithGuards } from "../src/guarded-mkdir.js";
 import { configureFsSafeNative } from "../src/native-config.js";
 import { root } from "../src/root.js";
 
-const tempDirs = new Set<string>();
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.add(dir);
-  return dir;
-}
 
 afterEach(async () => {
-  for (const dir of tempDirs) {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
-  tempDirs.clear();
   configureFsSafeNative({ mode: "auto" });
 });
 
@@ -115,57 +106,51 @@ it("rejects a dangling symlink directory component with a typed FsSafeError, not
 // mkdirPathComponentsWithGuards returns, so the fix must flow the resolved
 // path back to the caller, not just resolve it internally. ---
 
-it.runIf(process.platform !== "win32")(
-  "writes a file through root().write() when the parent directory is an in-root symlink (mkdir: true)",
-  async () => {
-  // Force the JS fallback path deterministically, matching this repo's own
-  // convention in test/pinned-write-fallback-coverage.test.ts.
-  configureFsSafeNative({ mode: "off" });
+itPosix("writes a file through root().write() when the parent directory is an in-root symlink (mkdir: true)", async () => {
+// Force the JS fallback path deterministically, matching this repo's own
+// convention in test/pinned-write-fallback-coverage.test.ts.
+configureFsSafeNative({ mode: "off" });
 
-  const rootDir = await tempRoot("fs-safe-root-write-symlink-");
-  const realDir = path.join(rootDir, "skills-bank", "skills", "auth-doctor");
-  await fs.mkdir(realDir, { recursive: true });
-  await fs.writeFile(path.join(realDir, "SKILL.md"), "# old content\n", "utf8");
-  const skillsDir = path.join(rootDir, "skills");
-  await fs.mkdir(skillsDir, { recursive: true });
-  await fs.symlink(realDir, path.join(skillsDir, "auth-doctor"), "dir");
+const rootDir = await tempRoot("fs-safe-root-write-symlink-");
+const realDir = path.join(rootDir, "skills-bank", "skills", "auth-doctor");
+await fs.mkdir(realDir, { recursive: true });
+await fs.writeFile(path.join(realDir, "SKILL.md"), "# old content\n", "utf8");
+const skillsDir = path.join(rootDir, "skills");
+await fs.mkdir(skillsDir, { recursive: true });
+await fs.symlink(realDir, path.join(skillsDir, "auth-doctor"), "dir");
 
+const r = await root(rootDir);
+await expect(
+  r.write("skills/auth-doctor/SKILL.md", "# new content\n", {
+    encoding: "utf8",
+    mkdir: true,
+    overwrite: true,
+  }),
+).resolves.toBeUndefined();
+
+const written = await fs.readFile(path.join(realDir, "SKILL.md"), "utf8");
+expect(written).toBe("# new content\n");
+});
+
+itPosix("appends and opens writable files through an in-root symlinked parent", async () => {
+  const rootDir = await tempRoot("fs-safe-root-writable-symlink-");
+  const realDir = path.join(rootDir, "real-parent");
+  await fs.mkdir(realDir);
+  await fs.symlink(realDir, path.join(rootDir, "alias"), "dir");
   const r = await root(rootDir);
-  await expect(
-    r.write("skills/auth-doctor/SKILL.md", "# new content\n", {
-      encoding: "utf8",
-      mkdir: true,
-      overwrite: true,
-    }),
-  ).resolves.toBeUndefined();
 
-  const written = await fs.readFile(path.join(realDir, "SKILL.md"), "utf8");
-  expect(written).toBe("# new content\n");
-  },
-);
+  await r.append("alias/logs/app.log", "entry\n");
+  const opened = await r.openWritable("alias/output/result.txt");
+  try {
+    await opened.handle.writeFile("result\n");
+  } finally {
+    await opened.handle.close();
+  }
 
-it.runIf(process.platform !== "win32")(
-  "appends and opens writable files through an in-root symlinked parent",
-  async () => {
-    const rootDir = await tempRoot("fs-safe-root-writable-symlink-");
-    const realDir = path.join(rootDir, "real-parent");
-    await fs.mkdir(realDir);
-    await fs.symlink(realDir, path.join(rootDir, "alias"), "dir");
-    const r = await root(rootDir);
-
-    await r.append("alias/logs/app.log", "entry\n");
-    const opened = await r.openWritable("alias/output/result.txt");
-    try {
-      await opened.handle.writeFile("result\n");
-    } finally {
-      await opened.handle.close();
-    }
-
-    await expect(fs.readFile(path.join(realDir, "logs/app.log"), "utf8")).resolves.toBe(
-      "entry\n",
-    );
-    await expect(fs.readFile(path.join(realDir, "output/result.txt"), "utf8")).resolves.toBe(
-      "result\n",
-    );
-  },
-);
+  await expect(fs.readFile(path.join(realDir, "logs/app.log"), "utf8")).resolves.toBe(
+    "entry\n",
+  );
+  await expect(fs.readFile(path.join(realDir, "output/result.txt"), "utf8")).resolves.toBe(
+    "result\n",
+  );
+});

--- a/test/guarded-write-cleanup.test.ts
+++ b/test/guarded-write-cleanup.test.ts
@@ -1,17 +1,12 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { configureFsSafeNative } from "../src/native-config.js";
 import { runPinnedWriteHelper } from "../src/pinned-write.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 async function replaceParentAfterOpen(params: {
   targetPath: string;
@@ -40,13 +35,12 @@ afterEach(async () => {
   vi.restoreAllMocks();
   configureFsSafeNative({ mode: "auto" });
   Object.defineProperty(process, "platform", originalPlatformDescriptor);
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
 
 describe("guarded fallback write cleanup", () => {
-  it.runIf(process.platform !== "win32")("closes pinned no-overwrite handles when post guards fail", async () => {
+  itPosix("closes pinned no-overwrite handles when post guards fail", async () => {
     Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
     configureFsSafeNative({ mode: "off" });
     const base = await tempRoot("fs-safe-pinned-post-guard-");
@@ -80,7 +74,7 @@ describe("guarded fallback write cleanup", () => {
     await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("outside");
   });
 
-  it.runIf(process.platform !== "win32")("closes root no-overwrite handles when post guards fail", async () => {
+  itPosix("closes root no-overwrite handles when post guards fail", async () => {
     Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
     const { root: openRoot } = await import("../src/index.js");
     const base = await tempRoot("fs-safe-root-post-guard-");

--- a/test/helpers/security.ts
+++ b/test/helpers/security.ts
@@ -112,6 +112,32 @@ export function expectFsSafeCode(
   expect(accepted).toContain((error as FsSafeError).code);
 }
 
+export async function expectFsSafeError(
+  promise: PromiseLike<unknown>,
+  code: FsSafeError["code"],
+): Promise<void> {
+  const error = await promise.then(
+    () => undefined,
+    (reason: unknown) => reason,
+  );
+  expect(error).toBeInstanceOf(FsSafeError);
+  expect(error).toMatchObject({ code });
+}
+
+export function expectFsSafeErrorSync(
+  operation: () => unknown,
+  code: FsSafeError["code"],
+): void {
+  let error: unknown;
+  try {
+    operation();
+  } catch (reason) {
+    error = reason;
+  }
+  expect(error).toBeInstanceOf(FsSafeError);
+  expect(error).toMatchObject({ code });
+}
+
 export function expectedFsSafeCode(code: string): string {
   return code;
 }

--- a/test/helpers/vitest.ts
+++ b/test/helpers/vitest.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, it } from "vitest";
+
+export const itPosix = it.runIf(process.platform !== "win32");
+export const itWin32 = it.runIf(process.platform === "win32");
+export const itDarwin = it.runIf(process.platform === "darwin");
+
+export type TempDirsFixture = {
+  tempDirs: string[];
+  tempRoot(prefix: string): Promise<string>;
+};
+
+function useTempDirsFixture(realpath: boolean): TempDirsFixture {
+  const tempDirs: string[] = [];
+
+  // Register first: Vitest runs afterEach hooks in reverse order, so local mock
+  // restoration runs before this cleanup reaches the real filesystem.
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((directory) => fs.rm(directory, { force: true, recursive: true })),
+    );
+  });
+
+  return {
+    tempDirs,
+    async tempRoot(prefix: string): Promise<string> {
+      const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+      tempDirs.push(directory);
+      return realpath ? await fs.realpath(directory) : directory;
+    },
+  };
+}
+
+export function useTempDirs(): TempDirsFixture {
+  return useTempDirsFixture(false);
+}
+
+export function useRealTempDirs(): TempDirsFixture {
+  return useTempDirsFixture(true);
+}

--- a/test/json-durable-queue.test.ts
+++ b/test/json-durable-queue.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { itPosix } from "./helpers/vitest.js";
 import {
   ackJsonDurableQueueEntry,
   ensureJsonDurableQueueDirs,
@@ -95,7 +96,7 @@ describe("durable JSON queues", () => {
     expect(() => resolveJsonDurableQueueEntryPaths(queueDir, " job")).toThrow();
   });
 
-  it.runIf(process.platform !== "win32")("skips hardlinked pending entries", async () => {
+  itPosix("skips hardlinked pending entries", async () => {
     const queueDir = path.join(root, "queue");
     const failedDir = path.join(root, "failed");
     await ensureJsonDurableQueueDirs({ queueDir, failedDir });

--- a/test/json-store-concurrency.test.ts
+++ b/test/json-store-concurrency.test.ts
@@ -1,8 +1,8 @@
 import fsp from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import {
   createJsonStore,
   type JsonStore,
@@ -13,17 +13,9 @@ import { jsonStore } from "../src/json-store.js";
 type State = { count: number };
 type Mutation = "update" | "updateOr" | "write";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
-});
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve!: () => void;
@@ -149,57 +141,54 @@ describe("jsonStore mutation serialization", () => {
     expect(stored).toEqual({ count: 2 });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "shares one queue across canonical parent aliases",
-    async () => {
-      const root = await tempRoot("fs-safe-json-store-alias-");
-      const realDir = path.join(root, "real");
-      const aliasDir = path.join(root, "alias");
-      await fsp.mkdir(realDir);
-      await fsp.symlink(realDir, aliasDir, "dir");
-      let stored: State | undefined = { count: 0 };
-      let aliasRead = false;
-      const firstEntered = deferred();
-      const releaseFirst = deferred();
-      const adapter = (filePath: string, onRead: () => void): JsonStoreAdapter<State> => ({
-        filePath,
-        readIfExists: async () => {
-          onRead();
-          return stored && { ...stored };
-        },
-        readRequired: async () => {
-          onRead();
-          if (!stored) throw new Error("missing test state");
-          return { ...stored };
-        },
-        write: async (value) => {
-          stored = { ...value };
-        },
-      });
-      const realStore = createJsonStore(adapter(path.join(realDir, "state.json"), () => undefined));
-      const aliasStore = createJsonStore(
-        adapter(path.join(aliasDir, "state.json"), () => {
-          aliasRead = true;
-        }),
-      );
+  itPosix("shares one queue across canonical parent aliases", async () => {
+    const root = await tempRoot("fs-safe-json-store-alias-");
+    const realDir = path.join(root, "real");
+    const aliasDir = path.join(root, "alias");
+    await fsp.mkdir(realDir);
+    await fsp.symlink(realDir, aliasDir, "dir");
+    let stored: State | undefined = { count: 0 };
+    let aliasRead = false;
+    const firstEntered = deferred();
+    const releaseFirst = deferred();
+    const adapter = (filePath: string, onRead: () => void): JsonStoreAdapter<State> => ({
+      filePath,
+      readIfExists: async () => {
+        onRead();
+        return stored && { ...stored };
+      },
+      readRequired: async () => {
+        onRead();
+        if (!stored) throw new Error("missing test state");
+        return { ...stored };
+      },
+      write: async (value) => {
+        stored = { ...value };
+      },
+    });
+    const realStore = createJsonStore(adapter(path.join(realDir, "state.json"), () => undefined));
+    const aliasStore = createJsonStore(
+      adapter(path.join(aliasDir, "state.json"), () => {
+        aliasRead = true;
+      }),
+    );
 
-      const first = realStore.update(async () => {
-        firstEntered.resolve();
-        await releaseFirst.promise;
-        return { count: 1 };
-      });
-      await firstEntered.promise;
-      const second = aliasStore.update((current) => ({ count: (current?.count ?? 0) + 1 }));
-      try {
-        await delay(10);
-        expect(aliasRead).toBe(false);
-      } finally {
-        releaseFirst.resolve();
-      }
-      await Promise.all([first, second]);
-      expect(stored).toEqual({ count: 2 });
-    },
-  );
+    const first = realStore.update(async () => {
+      firstEntered.resolve();
+      await releaseFirst.promise;
+      return { count: 1 };
+    });
+    await firstEntered.promise;
+    const second = aliasStore.update((current) => ({ count: (current?.count ?? 0) + 1 }));
+    try {
+      await delay(10);
+      expect(aliasRead).toBe(false);
+    } finally {
+      releaseFirst.resolve();
+    }
+    await Promise.all([first, second]);
+    expect(stored).toEqual({ count: 2 });
+  });
 
   it("rejects nested updates with a typed error across a queueMicrotask boundary", async () => {
     const root = await tempRoot("fs-safe-json-store-reentrant-");

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { createAsyncLock } from "../src/async-lock.js";
 import { writeTextAtomic } from "../src/atomic.js";
 import {
@@ -16,17 +16,9 @@ import {
   writeJsonSync,
 } from "../src/json.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
-});
 
 function mockOpenForSyncCounting(): { readonly syncCalls: number; restore: () => void } {
   let syncCalls = 0;
@@ -192,7 +184,7 @@ describe("json file helpers", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")("replaces symlink leaves on sync writes", async () => {
+  itPosix("replaces symlink leaves on sync writes", async () => {
     const root = await tempRoot("fs-safe-json-link-");
     const outsidePath = path.join(root, "outside.json");
     const linkPath = path.join(root, "state.json");

--- a/test/move-path-fchmod-regression.test.ts
+++ b/test/move-path-fchmod-regression.test.ts
@@ -1,16 +1,11 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
 import { movePathWithCopyFallback } from "../src/move-path.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 async function installStagingModeSwap(params: {
   targetDir: string;
@@ -70,7 +65,6 @@ async function installStagingModeSwap(params: {
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
 });
 
 describe.runIf(process.platform !== "win32")("move staging descriptor modes", () => {

--- a/test/move-path-regression.test.ts
+++ b/test/move-path-regression.test.ts
@@ -1,19 +1,30 @@
 import fsp from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, itWin32, useTempDirs } from "./helpers/vitest.js";
 import {
   moveCopyFallbackReasonForRenameError,
   movePathWithCopyFallback,
 } from "../src/move-path.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
+type Rename = typeof fsp.rename;
+
+function spyOnRename(
+  implementation: (
+    from: Parameters<Rename>[0],
+    to: Parameters<Rename>[1],
+    rename: Rename,
+  ) => Promise<void>,
+): void {
+  const rename = fsp.rename.bind(fsp);
+  vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
+    await implementation(from, to, rename);
+  });
 }
+
 
 async function withProcessPlatform(platform: NodeJS.Platform, body: () => Promise<void>): Promise<void> {
   const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
@@ -30,7 +41,6 @@ async function withProcessPlatform(platform: NodeJS.Platform, body: () => Promis
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
 });
 
 describe("movePathWithCopyFallback regressions", () => {
@@ -64,9 +74,7 @@ describe("movePathWithCopyFallback regressions", () => {
     await fsp.link(source, hardlink);
     const rename = vi.spyOn(fsp, "rename");
 
-    await expect(
-      movePathWithCopyFallback({ from: source, sourceHardlinks: "reject", to: dest }),
-    ).rejects.toMatchObject({ code: "hardlink" });
+    await expectFsSafeError(movePathWithCopyFallback({ from: source, sourceHardlinks: "reject", to: dest }), "hardlink");
 
     expect(rename).not.toHaveBeenCalled();
     await expect(fsp.readFile(source, "utf8")).resolves.toBe("source");
@@ -107,9 +115,7 @@ describe("movePathWithCopyFallback regressions", () => {
       return stat;
     });
 
-    await expect(
-      movePathWithCopyFallback({ from: source, sourceHardlinks: "reject", to: dest }),
-    ).rejects.toMatchObject({ code: "hardlink" });
+    await expectFsSafeError(movePathWithCopyFallback({ from: source, sourceHardlinks: "reject", to: dest }), "hardlink");
 
     await expect(fsp.readFile(source, "utf8")).resolves.toBe("source");
     await expect(fsp.readFile(hardlink, "utf8")).resolves.toBe("source");
@@ -121,9 +127,7 @@ describe("movePathWithCopyFallback regressions", () => {
     await fsp.writeFile(path.join(source, "payload.txt"), "payload");
     const dest = path.join(source, "child");
 
-    await expect(
-      movePathWithCopyFallback({ from: source, sourceHardlinks: "reject", to: dest }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+    await expectFsSafeError(movePathWithCopyFallback({ from: source, sourceHardlinks: "reject", to: dest }), "invalid-path");
 
     await expect(fsp.readFile(path.join(source, "payload.txt"), "utf8")).resolves.toBe("payload");
     expect((await fsp.readdir(source)).toSorted()).toEqual(["payload.txt"]);
@@ -135,113 +139,97 @@ describe("movePathWithCopyFallback regressions", () => {
     await fsp.writeFile(path.join(source, "payload.txt"), "payload");
     const disguisedDest = path.join(source, "sub", "pivot", "..");
 
-    await expect(
-      movePathWithCopyFallback({
+    await expectFsSafeError(movePathWithCopyFallback({
         from: source,
         sourceHardlinks: "reject",
         to: disguisedDest,
-      }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+      }), "invalid-path");
 
     expect((await fsp.readdir(source)).toSorted()).toEqual(["payload.txt", "sub"]);
   });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects a self-descendant copy reached through a symlinked parent",
-    async () => {
-      const base = await tempRoot("fs-safe-move-self-symlink-");
-      const source = path.join(base, "source");
-      const alias = path.join(base, "alias");
-      await fsp.mkdir(source);
-      await fsp.writeFile(path.join(source, "payload.txt"), "payload");
-      await fsp.symlink(source, alias, "dir");
+  itPosix("rejects a self-descendant copy reached through a symlinked parent", async () => {
+    const base = await tempRoot("fs-safe-move-self-symlink-");
+    const source = path.join(base, "source");
+    const alias = path.join(base, "alias");
+    await fsp.mkdir(source);
+    await fsp.writeFile(path.join(source, "payload.txt"), "payload");
+    await fsp.symlink(source, alias, "dir");
 
-      await expect(
-        movePathWithCopyFallback({
-          from: source,
-          sourceHardlinks: "reject",
-          to: path.join(alias, "child"),
-        }),
-      ).rejects.toMatchObject({ code: "invalid-path" });
+    await expectFsSafeError(movePathWithCopyFallback({
+        from: source,
+        sourceHardlinks: "reject",
+        to: path.join(alias, "child"),
+      }), "invalid-path");
 
-      await expect(fsp.readFile(path.join(source, "payload.txt"), "utf8")).resolves.toBe(
-        "payload",
-      );
-      expect((await fsp.readdir(source)).toSorted()).toEqual(["payload.txt"]);
-    },
-  );
+    await expect(fsp.readFile(path.join(source, "payload.txt"), "utf8")).resolves.toBe(
+      "payload",
+    );
+    expect((await fsp.readdir(source)).toSorted()).toEqual(["payload.txt"]);
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "does not delete source entries replaced after an EXDEV copy",
-    async () => {
-      const base = await tempRoot("fs-safe-move-exdev-replaced-source-");
-      const source = path.join(base, "source-dir");
-      const dest = path.join(base, "dest-dir");
-      await fsp.mkdir(source);
-      await fsp.writeFile(path.join(source, "copied.txt"), "copied");
-      const realRename = fsp.rename;
-      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
-        if (from === source && to === dest) {
-          throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
-        }
-        await realRename(from, to);
-        if (to === dest && String(from).includes(".fs-safe-move-")) {
-          await fsp.rm(path.join(source, "copied.txt"));
-          await fsp.writeFile(path.join(source, "copied.txt"), "replacement");
-          await fsp.writeFile(path.join(source, "late.txt"), "late");
-        }
-      });
+  itPosix("does not delete source entries replaced after an EXDEV copy", async () => {
+    const base = await tempRoot("fs-safe-move-exdev-replaced-source-");
+    const source = path.join(base, "source-dir");
+    const dest = path.join(base, "dest-dir");
+    await fsp.mkdir(source);
+    await fsp.writeFile(path.join(source, "copied.txt"), "copied");
+    spyOnRename(async (from, to, rename) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+      }
+      await rename(from, to);
+      if (to === dest && String(from).includes(".fs-safe-move-")) {
+        await fsp.rm(path.join(source, "copied.txt"));
+        await fsp.writeFile(path.join(source, "copied.txt"), "replacement");
+        await fsp.writeFile(path.join(source, "late.txt"), "late");
+      }
+    });
 
-      await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
-        code: "ESTALE",
-      });
+    await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
+      code: "ESTALE",
+    });
 
-      await expect(fsp.readFile(path.join(dest, "copied.txt"), "utf8")).resolves.toBe("copied");
-      await expect(fsp.readFile(path.join(source, "copied.txt"), "utf8")).resolves.toBe(
-        "replacement",
-      );
-      await expect(fsp.readFile(path.join(source, "late.txt"), "utf8")).resolves.toBe("late");
-    },
-  );
+    await expect(fsp.readFile(path.join(dest, "copied.txt"), "utf8")).resolves.toBe("copied");
+    await expect(fsp.readFile(path.join(source, "copied.txt"), "utf8")).resolves.toBe(
+      "replacement",
+    );
+    await expect(fsp.readFile(path.join(source, "late.txt"), "utf8")).resolves.toBe("late");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "can reject hardlinked files during EXDEV move fallback",
-    async () => {
-      const base = await tempRoot("fs-safe-move-exdev-hardlink-");
-      const source = path.join(base, "source.txt");
-      const hardlink = path.join(base, "hardlink.txt");
-      const dest = path.join(base, "dest.txt");
-      await fsp.writeFile(source, "source");
-      await fsp.link(source, hardlink);
-      const realRename = fsp.rename;
-      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
-        if (from === source && to === dest) {
-          throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
-        }
-        return await realRename(from, to);
-      });
+  itPosix("can reject hardlinked files during EXDEV move fallback", async () => {
+    const base = await tempRoot("fs-safe-move-exdev-hardlink-");
+    const source = path.join(base, "source.txt");
+    const hardlink = path.join(base, "hardlink.txt");
+    const dest = path.join(base, "dest.txt");
+    await fsp.writeFile(source, "source");
+    await fsp.link(source, hardlink);
+    spyOnRename(async (from, to, rename) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+      }
+      return await rename(from, to);
+    });
 
-      await expect(
-        movePathWithCopyFallback({ from: source, sourceHardlinks: "reject", to: dest }),
-      ).rejects.toThrow("Refusing to move hardlinked file");
+    await expect(
+      movePathWithCopyFallback({ from: source, sourceHardlinks: "reject", to: dest }),
+    ).rejects.toThrow("Refusing to move hardlinked file");
 
-      await expect(fsp.readFile(source, "utf8")).resolves.toBe("source");
-      await expect(fsp.stat(dest)).rejects.toMatchObject({ code: "ENOENT" });
-    },
-  );
+    await expect(fsp.readFile(source, "utf8")).resolves.toBe("source");
+    await expect(fsp.stat(dest)).rejects.toMatchObject({ code: "ENOENT" });
+  });
 
-  it.runIf(process.platform === "win32")("falls back to copy/remove when rename is denied with EPERM", async () => {
+  itWin32("falls back to copy/remove when rename is denied with EPERM", async () => {
     const base = await tempRoot("fs-safe-move-eperm-");
     const source = path.join(base, "source.txt");
     const dest = path.join(base, "dest.txt");
     await fsp.writeFile(source, "windows lock fallback");
 
-    const realRename = fsp.rename;
-    vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
+    spyOnRename(async (from, to, rename) => {
       if (from === source && to === dest) {
         throw Object.assign(new Error("rename denied"), { code: "EPERM" });
       }
-      return await realRename(from, to);
+      return await rename(from, to);
     });
 
     await movePathWithCopyFallback({ from: source, to: dest });
@@ -250,202 +238,178 @@ describe("movePathWithCopyFallback regressions", () => {
     await expect(fsp.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "restores the source when a Windows EPERM fallback cannot commit the staged copy",
-    async () => {
-      const base = await tempRoot("fs-safe-move-eperm-dest-denied-");
-      const source = path.join(base, "source.txt");
-      const dest = path.join(base, "dest.txt");
-      await fsp.writeFile(source, "source");
+  itPosix("restores the source when a Windows EPERM fallback cannot commit the staged copy", async () => {
+    const base = await tempRoot("fs-safe-move-eperm-dest-denied-");
+    const source = path.join(base, "source.txt");
+    const dest = path.join(base, "dest.txt");
+    await fsp.writeFile(source, "source");
 
-      const realRename = fsp.rename;
-      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
-        if (from === source && to === dest) {
-          throw Object.assign(new Error("initial rename denied"), { code: "EPERM" });
-        }
-        if (String(from).includes(".fs-safe-move-") && to === dest) {
-          throw Object.assign(new Error("destination denied"), { code: "EPERM" });
-        }
-        return await realRename(from, to);
+    spyOnRename(async (from, to, rename) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("initial rename denied"), { code: "EPERM" });
+      }
+      if (String(from).includes(".fs-safe-move-") && to === dest) {
+        throw Object.assign(new Error("destination denied"), { code: "EPERM" });
+      }
+      return await rename(from, to);
+    });
+
+    await withProcessPlatform("win32", async () => {
+      await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
+        code: "EPERM",
       });
+    });
 
-      await withProcessPlatform("win32", async () => {
-        await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
-          code: "EPERM",
-        });
+    await expect(fsp.readFile(source, "utf8")).resolves.toBe("source");
+    await expect(fsp.stat(dest)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fsp.readdir(base)).resolves.toEqual(["source.txt"]);
+  });
+
+  itPosix("leaves the source visible when Windows EPERM cleanup fails after commit", async () => {
+    const base = await tempRoot("fs-safe-move-eperm-cleanup-denied-");
+    const source = path.join(base, "source.txt");
+    const dest = path.join(base, "dest.txt");
+    await fsp.writeFile(source, "source");
+
+    spyOnRename(async (from, to, rename) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("initial rename denied"), { code: "EPERM" });
+      }
+      return await rename(from, to);
+    });
+    const realUnlink = fsp.unlink;
+    vi.spyOn(fsp, "unlink").mockImplementation(async (target) => {
+      if (target === source) {
+        throw Object.assign(new Error("cleanup denied"), { code: "EBUSY" });
+      }
+      return await realUnlink(target);
+    });
+
+    await withProcessPlatform("win32", async () => {
+      await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
+        code: "EBUSY",
       });
+    });
 
-      await expect(fsp.readFile(source, "utf8")).resolves.toBe("source");
-      await expect(fsp.stat(dest)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fsp.readdir(base)).resolves.toEqual(["source.txt"]);
-    },
-  );
+    await expect(fsp.readFile(source, "utf8")).resolves.toBe("source");
+    await expect(fsp.readFile(dest, "utf8")).resolves.toBe("source");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "leaves the source visible when Windows EPERM cleanup fails after commit",
-    async () => {
-      const base = await tempRoot("fs-safe-move-eperm-cleanup-denied-");
-      const source = path.join(base, "source.txt");
-      const dest = path.join(base, "dest.txt");
-      await fsp.writeFile(source, "source");
+  itPosix("preserves late source children during Windows EPERM fallback cleanup", async () => {
+    const base = await tempRoot("fs-safe-move-eperm-late-child-");
+    const source = path.join(base, "source-dir");
+    const dest = path.join(base, "dest-dir");
+    await fsp.mkdir(source);
+    await fsp.writeFile(path.join(source, "copied.txt"), "copied");
 
-      const realRename = fsp.rename;
-      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
-        if (from === source && to === dest) {
-          throw Object.assign(new Error("initial rename denied"), { code: "EPERM" });
-        }
-        return await realRename(from, to);
-      });
-      const realUnlink = fsp.unlink;
-      vi.spyOn(fsp, "unlink").mockImplementation(async (target) => {
-        if (target === source) {
-          throw Object.assign(new Error("cleanup denied"), { code: "EBUSY" });
-        }
-        return await realUnlink(target);
-      });
+    spyOnRename(async (from, to, rename) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("initial rename denied"), { code: "EPERM" });
+      }
+      await rename(from, to);
+      if (String(from).includes(".fs-safe-move-") && to === dest) {
+        await fsp.writeFile(path.join(source, "late.txt"), "late");
+      }
+    });
 
-      await withProcessPlatform("win32", async () => {
-        await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
-          code: "EBUSY",
-        });
-      });
-
-      await expect(fsp.readFile(source, "utf8")).resolves.toBe("source");
-      await expect(fsp.readFile(dest, "utf8")).resolves.toBe("source");
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "preserves late source children during Windows EPERM fallback cleanup",
-    async () => {
-      const base = await tempRoot("fs-safe-move-eperm-late-child-");
-      const source = path.join(base, "source-dir");
-      const dest = path.join(base, "dest-dir");
-      await fsp.mkdir(source);
-      await fsp.writeFile(path.join(source, "copied.txt"), "copied");
-
-      const realRename = fsp.rename;
-      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
-        if (from === source && to === dest) {
-          throw Object.assign(new Error("initial rename denied"), { code: "EPERM" });
-        }
-        await realRename(from, to);
-        if (String(from).includes(".fs-safe-move-") && to === dest) {
-          await fsp.writeFile(path.join(source, "late.txt"), "late");
-        }
-      });
-
-      await withProcessPlatform("win32", async () => {
-        await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
-          code: "ESTALE",
-        });
-      });
-
-      await expect(fsp.readFile(path.join(dest, "copied.txt"), "utf8")).resolves.toBe("copied");
-      await expect(fsp.stat(path.join(source, "copied.txt"))).rejects.toMatchObject({
-        code: "ENOENT",
-      });
-      await expect(fsp.readFile(path.join(source, "late.txt"), "utf8")).resolves.toBe("late");
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "preserves directory modes during EXDEV move fallback",
-    async () => {
-      const base = await tempRoot("fs-safe-move-exdev-dir-mode-");
-      const source = path.join(base, "source-dir");
-      const dest = path.join(base, "dest-dir");
-      await fsp.mkdir(source);
-      await fsp.writeFile(path.join(source, "copied.txt"), "copied");
-      await fsp.chmod(source, 0o777);
-      const realRename = fsp.rename;
-      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
-        if (from === source && to === dest) {
-          throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
-        }
-        return await realRename(from, to);
-      });
-      const realMkdir = fsp.mkdir;
-      vi.spyOn(fsp, "mkdir").mockImplementation(async (target, options) => {
-        const result = await realMkdir(target, options as never);
-        if (String(target).includes(".fs-safe-move-")) {
-          await fsp.chmod(target, 0o700);
-        }
-        return result;
-      });
-
-      await movePathWithCopyFallback({ from: source, to: dest });
-
-      expect((await fsp.stat(dest)).mode & 0o777).toBe(0o777);
-      await expect(fsp.readFile(path.join(dest, "copied.txt"), "utf8")).resolves.toBe("copied");
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "removes unchanged copied children when source directory gains a late child",
-    async () => {
-      const base = await tempRoot("fs-safe-move-exdev-added-source-");
-      const source = path.join(base, "source-dir");
-      const dest = path.join(base, "dest-dir");
-      await fsp.mkdir(source);
-      await fsp.writeFile(path.join(source, "copied.txt"), "copied");
-      const realRename = fsp.rename;
-      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
-        if (from === source && to === dest) {
-          throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
-        }
-        await realRename(from, to);
-        if (to === dest && String(from).includes(".fs-safe-move-")) {
-          await fsp.writeFile(path.join(source, "late.txt"), "late");
-        }
-      });
-
+    await withProcessPlatform("win32", async () => {
       await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
         code: "ESTALE",
       });
+    });
 
-      await expect(fsp.readFile(path.join(dest, "copied.txt"), "utf8")).resolves.toBe("copied");
-      await expect(fsp.stat(path.join(source, "copied.txt"))).rejects.toMatchObject({
-        code: "ENOENT",
-      });
-      await expect(fsp.readFile(path.join(source, "late.txt"), "utf8")).resolves.toBe("late");
-    },
-  );
+    await expect(fsp.readFile(path.join(dest, "copied.txt"), "utf8")).resolves.toBe("copied");
+    await expect(fsp.stat(path.join(source, "copied.txt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(fsp.readFile(path.join(source, "late.txt"), "utf8")).resolves.toBe("late");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "does not commit bytes from a source swapped after validation",
-    async () => {
-      const base = await tempRoot("fs-safe-move-exdev-source-swap-");
-      const outside = await tempRoot("fs-safe-move-exdev-source-swap-outside-");
-      const source = path.join(base, "source.txt");
-      const dest = path.join(base, "dest.txt");
-      const outsideFile = path.join(outside, "secret.txt");
-      await fsp.writeFile(source, "inside");
-      await fsp.writeFile(outsideFile, "secret");
+  itPosix("preserves directory modes during EXDEV move fallback", async () => {
+    const base = await tempRoot("fs-safe-move-exdev-dir-mode-");
+    const source = path.join(base, "source-dir");
+    const dest = path.join(base, "dest-dir");
+    await fsp.mkdir(source);
+    await fsp.writeFile(path.join(source, "copied.txt"), "copied");
+    await fsp.chmod(source, 0o777);
+    spyOnRename(async (from, to, rename) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+      }
+      return await rename(from, to);
+    });
+    const realMkdir = fsp.mkdir;
+    vi.spyOn(fsp, "mkdir").mockImplementation(async (target, options) => {
+      const result = await realMkdir(target, options as never);
+      if (String(target).includes(".fs-safe-move-")) {
+        await fsp.chmod(target, 0o700);
+      }
+      return result;
+    });
 
-      const realRename = fsp.rename;
-      vi.spyOn(fsp, "rename").mockImplementation(async (from, to) => {
-        if (from === source && to === dest) {
-          throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
-        }
-        return await realRename(from, to);
-      });
-      const realLstat = fsp.lstat;
-      let swapped = false;
-      vi.spyOn(fsp, "lstat").mockImplementation(async (candidate, options) => {
-        const stat = await realLstat(candidate, options as never);
-        if (!swapped && candidate === source) {
-          swapped = true;
-          await fsp.rm(source);
-          await fsp.symlink(outsideFile, source, "file");
-        }
-        return stat;
-      });
+    await movePathWithCopyFallback({ from: source, to: dest });
 
-      await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
-        code: "ESTALE",
-      });
-      await expect(fsp.stat(dest)).rejects.toMatchObject({ code: "ENOENT" });
-    },
-  );
+    expect((await fsp.stat(dest)).mode & 0o777).toBe(0o777);
+    await expect(fsp.readFile(path.join(dest, "copied.txt"), "utf8")).resolves.toBe("copied");
+  });
+
+  itPosix("removes unchanged copied children when source directory gains a late child", async () => {
+    const base = await tempRoot("fs-safe-move-exdev-added-source-");
+    const source = path.join(base, "source-dir");
+    const dest = path.join(base, "dest-dir");
+    await fsp.mkdir(source);
+    await fsp.writeFile(path.join(source, "copied.txt"), "copied");
+    spyOnRename(async (from, to, rename) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+      }
+      await rename(from, to);
+      if (to === dest && String(from).includes(".fs-safe-move-")) {
+        await fsp.writeFile(path.join(source, "late.txt"), "late");
+      }
+    });
+
+    await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
+      code: "ESTALE",
+    });
+
+    await expect(fsp.readFile(path.join(dest, "copied.txt"), "utf8")).resolves.toBe("copied");
+    await expect(fsp.stat(path.join(source, "copied.txt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(fsp.readFile(path.join(source, "late.txt"), "utf8")).resolves.toBe("late");
+  });
+
+  itPosix("does not commit bytes from a source swapped after validation", async () => {
+    const base = await tempRoot("fs-safe-move-exdev-source-swap-");
+    const outside = await tempRoot("fs-safe-move-exdev-source-swap-outside-");
+    const source = path.join(base, "source.txt");
+    const dest = path.join(base, "dest.txt");
+    const outsideFile = path.join(outside, "secret.txt");
+    await fsp.writeFile(source, "inside");
+    await fsp.writeFile(outsideFile, "secret");
+
+    spyOnRename(async (from, to, rename) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+      }
+      return await rename(from, to);
+    });
+    const realLstat = fsp.lstat;
+    let swapped = false;
+    vi.spyOn(fsp, "lstat").mockImplementation(async (candidate, options) => {
+      const stat = await realLstat(candidate, options as never);
+      if (!swapped && candidate === source) {
+        swapped = true;
+        await fsp.rm(source);
+        await fsp.symlink(outsideFile, source, "file");
+      }
+      return stat;
+    });
+
+    await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
+      code: "ESTALE",
+    });
+    await expect(fsp.stat(dest)).rejects.toMatchObject({ code: "ENOENT" });
+  });
 });

--- a/test/native-archive-equivalence.test.ts
+++ b/test/native-archive-equivalence.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { expectFsSafeErrorSync } from "./helpers/security.js";
 import {
   ARCHIVE_LIMIT_ERROR_CODE,
   extractArchive,
@@ -483,8 +484,6 @@ describe.runIf(Boolean(native))("native-only compressed tar formats", () => {
 
   it("reports a typed actionable error when a native-only format is forced off", async () => {
     configureFsSafeNative({ mode: "off" });
-    expect(() => resolveArchiveKind("fixture.tar.zst")).toThrow(
-      expect.objectContaining({ code: "helper-unavailable" }),
-    );
+    expectFsSafeErrorSync(() => resolveArchiveKind("fixture.tar.zst"), "helper-unavailable");
   });
 });

--- a/test/native-integration.test.ts
+++ b/test/native-integration.test.ts
@@ -3,6 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itWin32 } from "./helpers/vitest.js";
 import { configureFsSafeNative } from "../src/native-config.js";
 import { acquireFileLock } from "../src/file-lock.js";
 import {
@@ -85,7 +87,7 @@ describe.runIf(native)("native filesystem primitives", () => {
     await expect(fs.readFile(path.join(root, "target"), "utf8")).resolves.toBe("source");
   });
 
-  it.runIf(process.platform === "win32")("rejects reparse-point directory components", async () => {
+  itWin32("rejects reparse-point directory components", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-reparse-"));
     roots.push(root);
     const real = path.join(root, "real");
@@ -189,7 +191,7 @@ describe.runIf(native)("native filesystem primitives", () => {
     const directory = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-identity-"));
     roots.push(directory);
     const identity = await fs.lstat(directory);
-    await expect(runPinnedWriteHelper({
+    await expectFsSafeError(runPinnedWriteHelper({
       rootPath: directory,
       relativeParentPath: "",
       basename: "value",
@@ -198,7 +200,7 @@ describe.runIf(native)("native filesystem primitives", () => {
       overwrite: false,
       input: { kind: "buffer", data: "value" },
       rootIdentity: { dev: identity.dev + 1, ino: identity.ino },
-    })).rejects.toMatchObject({ code: "path-mismatch" });
+    }), "path-mismatch");
   });
 
   it("creates sidecar locks through native exclusive open", async () => {
@@ -225,79 +227,73 @@ describe.runIf(native)("native filesystem primitives", () => {
     }
   });
 
-  it.runIf(process.platform === "win32")(
-    "retries a path-tagged native exclusive-open denial",
-    async () => {
-      let exclusiveOpenCalls = 0;
-      __setNativeLoaderForTest(() => ({
-        ...native!,
-        openBeneath(rootFd, relPath, flags) {
-          if (flags & fsSync.constants.O_EXCL) {
-            exclusiveOpenCalls += 1;
-            if (exclusiveOpenCalls === 1) {
-              // Match the binding's bare error: the TypeScript operation
-              // boundary is responsible for attaching the full lock path.
-              throw Object.assign(new Error("open relative path failed with Windows error 5"), {
-                code: "EPERM",
-              });
-            }
-          }
-          return native!.openBeneath(rootFd, relPath, flags);
-        },
-      }));
-      configureFsSafeNative({ mode: "require" });
-      const directory = await fs.realpath(
-        await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-lock-denial-")),
-      );
-      roots.push(directory);
-      const targetPath = path.join(directory, "state.json");
-      const lock = await acquireFileLock(targetPath, {
-        retry: { minTimeout: 1, maxTimeout: 2 },
-        payload: () => ({ pid: process.pid }),
-      });
-      try {
-        expect(exclusiveOpenCalls).toBe(2);
-        await expect(lock.verifyStillHeld()).resolves.toBe(true);
-      } finally {
-        await lock.release();
-      }
-    },
-  );
-
-  it.runIf(process.platform === "win32")(
-    "preserves a native exclusive-open denial after the bounded retry budget",
-    async () => {
-      let exclusiveOpenCalls = 0;
-      __setNativeLoaderForTest(() => ({
-        ...native!,
-        openBeneath(rootFd, relPath, flags) {
-          if (flags & fsSync.constants.O_EXCL) {
-            exclusiveOpenCalls += 1;
+  itWin32("retries a path-tagged native exclusive-open denial", async () => {
+    let exclusiveOpenCalls = 0;
+    __setNativeLoaderForTest(() => ({
+      ...native!,
+      openBeneath(rootFd, relPath, flags) {
+        if (flags & fsSync.constants.O_EXCL) {
+          exclusiveOpenCalls += 1;
+          if (exclusiveOpenCalls === 1) {
+            // Match the binding's bare error: the TypeScript operation
+            // boundary is responsible for attaching the full lock path.
             throw Object.assign(new Error("open relative path failed with Windows error 5"), {
               code: "EPERM",
             });
           }
-          return native!.openBeneath(rootFd, relPath, flags);
-        },
-      }));
-      configureFsSafeNative({ mode: "require" });
-      const directory = await fs.realpath(
-        await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-lock-permission-")),
-      );
-      roots.push(directory);
-      const targetPath = path.join(directory, "state.json");
-      const lockPath = `${targetPath}.lock`;
+        }
+        return native!.openBeneath(rootFd, relPath, flags);
+      },
+    }));
+    configureFsSafeNative({ mode: "require" });
+    const directory = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-lock-denial-")),
+    );
+    roots.push(directory);
+    const targetPath = path.join(directory, "state.json");
+    const lock = await acquireFileLock(targetPath, {
+      retry: { minTimeout: 1, maxTimeout: 2 },
+      payload: () => ({ pid: process.pid }),
+    });
+    try {
+      expect(exclusiveOpenCalls).toBe(2);
+      await expect(lock.verifyStillHeld()).resolves.toBe(true);
+    } finally {
+      await lock.release();
+    }
+  });
 
-      await expect(
-        acquireFileLock(targetPath, {
-          timeoutMs: 1_000,
-          retry: { retries: 20, minTimeout: 1, maxTimeout: 1 },
-          payload: () => ({ pid: process.pid }),
-        }),
-      ).rejects.toMatchObject({ code: "EPERM", path: lockPath });
-      expect(exclusiveOpenCalls).toBe(9);
-    },
-  );
+  itWin32("preserves a native exclusive-open denial after the bounded retry budget", async () => {
+    let exclusiveOpenCalls = 0;
+    __setNativeLoaderForTest(() => ({
+      ...native!,
+      openBeneath(rootFd, relPath, flags) {
+        if (flags & fsSync.constants.O_EXCL) {
+          exclusiveOpenCalls += 1;
+          throw Object.assign(new Error("open relative path failed with Windows error 5"), {
+            code: "EPERM",
+          });
+        }
+        return native!.openBeneath(rootFd, relPath, flags);
+      },
+    }));
+    configureFsSafeNative({ mode: "require" });
+    const directory = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-lock-permission-")),
+    );
+    roots.push(directory);
+    const targetPath = path.join(directory, "state.json");
+    const lockPath = `${targetPath}.lock`;
+
+    await expect(
+      acquireFileLock(targetPath, {
+        timeoutMs: 1_000,
+        retry: { retries: 20, minTimeout: 1, maxTimeout: 1 },
+        payload: () => ({ pid: process.pid }),
+      }),
+    ).rejects.toMatchObject({ code: "EPERM", path: lockPath });
+    expect(exclusiveOpenCalls).toBe(9);
+  });
 
   it("publishes by native rename without replacing an existing target", async () => {
     __setNativeLoaderForTest(() => native!);

--- a/test/native-loader.test.ts
+++ b/test/native-loader.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeErrorSync } from "./helpers/security.js";
 import {
   __resetFsSafeNativeConfigForTest,
   configureFsSafePython,
@@ -96,9 +97,7 @@ describe("native helper configuration", () => {
     expect(unavailable).toHaveBeenCalledTimes(1);
 
     configureFsSafeNative({ mode: "require" });
-    expect(() => getNativeBinding()).toThrowError(
-      expect.objectContaining({ code: "helper-unavailable" }),
-    );
+    expectFsSafeErrorSync(() => getNativeBinding(), "helper-unavailable");
     expect(unavailable).toHaveBeenCalledTimes(1);
   });
 

--- a/test/native-publish-equivalence.test.ts
+++ b/test/native-publish-equivalence.test.ts
@@ -5,6 +5,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itDarwin } from "./helpers/vitest.js";
 import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
 import {
   __resetNativeLoaderForTest,
@@ -85,32 +87,29 @@ describe.runIf(Boolean(native))("native publication primitives", () => {
     }
   });
 
-  it.runIf(process.platform === "darwin")(
-    "clones APFS files with xattrs and strips custom metadata from the target",
-    async () => {
-      const root = await tempRoot();
-      const sourcePath = path.join(root, "source-xattr");
-      const targetPath = path.join(root, "target-xattr");
-      await fs.writeFile(sourcePath, "clone-with-xattr");
-      execFileSync("xattr", ["-w", "com.openclaw.fs-safe-test", "fixture", sourcePath]);
-      const source = await fs.open(sourcePath, "r");
-      const directory = await fs.open(
-        root,
-        fsSync.constants.O_RDONLY | fsSync.constants.O_DIRECTORY,
-      );
-      try {
-        const clonedFd = native!.cloneFileExclusive(source.fd, directory.fd, "target-xattr");
-        fsSync.closeSync(clonedFd);
-      } finally {
-        await source.close();
-        await directory.close();
-      }
-      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("clone-with-xattr");
-      expect(execFileSync("xattr", [targetPath], { encoding: "utf8" })).not.toContain(
-        "com.openclaw.fs-safe-test",
-      );
-    },
-  );
+  itDarwin("clones APFS files with xattrs and strips custom metadata from the target", async () => {
+    const root = await tempRoot();
+    const sourcePath = path.join(root, "source-xattr");
+    const targetPath = path.join(root, "target-xattr");
+    await fs.writeFile(sourcePath, "clone-with-xattr");
+    execFileSync("xattr", ["-w", "com.openclaw.fs-safe-test", "fixture", sourcePath]);
+    const source = await fs.open(sourcePath, "r");
+    const directory = await fs.open(
+      root,
+      fsSync.constants.O_RDONLY | fsSync.constants.O_DIRECTORY,
+    );
+    try {
+      const clonedFd = native!.cloneFileExclusive(source.fd, directory.fd, "target-xattr");
+      fsSync.closeSync(clonedFd);
+    } finally {
+      await source.close();
+      await directory.close();
+    }
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("clone-with-xattr");
+    expect(execFileSync("xattr", [targetPath], { encoding: "utf8" })).not.toContain(
+      "com.openclaw.fs-safe-test",
+    );
+  });
 
   it("fences a native clone result by identity and hash", async () => {
     const root = await tempRoot();
@@ -163,9 +162,7 @@ describe.runIf(Boolean(native))("native publication primitives", () => {
     }));
     configureFsSafeNative({ mode: "require" });
 
-    await expect(
-      publishFileExclusive({ sourcePath, targetPath, strategy: "link-or-copy" }),
-    ).rejects.toMatchObject({ code: "path-mismatch" });
+    await expectFsSafeError(publishFileExclusive({ sourcePath, targetPath, strategy: "link-or-copy" }), "path-mismatch");
     await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
@@ -186,27 +183,24 @@ describe.runIf(Boolean(native))("native publication primitives", () => {
     }
   });
 
-  it.runIf(process.platform === "darwin")(
-    "falls back for ACL-bearing sources without inheriting the ACL",
-    async () => {
-    const root = await tempRoot();
-    const sourcePath = path.join(root, "source-acl");
-    const targetPath = path.join(root, "target-acl");
-    await fs.writeFile(sourcePath, "private", { mode: 0o600 });
-    execFileSync("chmod", ["+a", "everyone allow read", sourcePath]);
-    __setNativeLoaderForTest(() => ({
-      ...native!,
-      linkBeneath() {
-        throw Object.assign(new Error("force copy"), { code: "EXDEV" });
-      },
-    }));
-    configureFsSafeNative({ mode: "require" });
-    await publishFileExclusive({ sourcePath, targetPath, strategy: "link-or-copy" });
-    expect(execFileSync("ls", ["-lde", targetPath], { encoding: "utf8" })).not.toContain(
-      "everyone:allow read",
-    );
+  itDarwin("falls back for ACL-bearing sources without inheriting the ACL", async () => {
+  const root = await tempRoot();
+  const sourcePath = path.join(root, "source-acl");
+  const targetPath = path.join(root, "target-acl");
+  await fs.writeFile(sourcePath, "private", { mode: 0o600 });
+  execFileSync("chmod", ["+a", "everyone allow read", sourcePath]);
+  __setNativeLoaderForTest(() => ({
+    ...native!,
+    linkBeneath() {
+      throw Object.assign(new Error("force copy"), { code: "EXDEV" });
     },
+  }));
+  configureFsSafeNative({ mode: "require" });
+  await publishFileExclusive({ sourcePath, targetPath, strategy: "link-or-copy" });
+  expect(execFileSync("ls", ["-lde", targetPath], { encoding: "utf8" })).not.toContain(
+    "everyone:allow read",
   );
+  });
 });
 
 const publishBackends = native

--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, itWin32 } from "./helpers/vitest.js";
 import {
   appendRegularFile,
   appendRegularFileSync,
@@ -170,9 +172,7 @@ describe("file store", () => {
   it("rejects escaped paths and size limit violations", async () => {
     const store = fileStore({ rootDir: root, maxBytes: 3 });
     await expect(store.write("../escape.txt", "nope")).rejects.toThrow();
-    await expect(store.write("too-large.txt", "four")).rejects.toMatchObject({
-      code: "too-large",
-    });
+    await expectFsSafeError(store.write("too-large.txt", "four"), "too-large");
   });
 });
 
@@ -199,7 +199,7 @@ describe("json store", () => {
 });
 
 describe("secure file reads", () => {
-  it.runIf(process.platform !== "win32")("reads from a validated file handle", async () => {
+  itPosix("reads from a validated file handle", async () => {
     const filePath = path.join(root, "secret.json");
     await fs.writeFile(filePath, '{"token":"ok"}', { mode: 0o600 });
     await fs.chmod(filePath, 0o600).catch(() => undefined);
@@ -214,50 +214,42 @@ describe("secure file reads", () => {
     expect(result.realPath).toBe(await fs.realpath(filePath));
   });
 
-  it.runIf(process.platform === "win32")(
-    "reads from a validated Windows ACL and owner",
-    async () => {
-      const filePath = path.join(root, "secret.json");
-      await fs.writeFile(filePath, '{"token":"ok"}', { mode: 0o600 });
-      await secureWindowsTestFile(filePath);
+  itWin32("reads from a validated Windows ACL and owner", async () => {
+    const filePath = path.join(root, "secret.json");
+    await fs.writeFile(filePath, '{"token":"ok"}', { mode: 0o600 });
+    await secureWindowsTestFile(filePath);
 
-      const result = await readSecureFile({
-        filePath,
-        label: "test secret",
-        io: { maxBytes: 1024 },
-      });
+    const result = await readSecureFile({
+      filePath,
+      label: "test secret",
+      io: { maxBytes: 1024 },
+    });
 
-      expect(result.buffer.toString("utf8")).toBe('{"token":"ok"}');
-      expect(result.permissions).toMatchObject({
-        source: "windows-acl",
-        ownerTrusted: true,
-      });
-    },
-    15_000,
-  );
+    expect(result.buffer.toString("utf8")).toBe('{"token":"ok"}');
+    expect(result.permissions).toMatchObject({
+      source: "windows-acl",
+      ownerTrusted: true,
+    });
+  }, 15_000);
 
-  it.runIf(process.platform === "win32")(
-    "treats an extended-length local Windows path as local",
-    async () => {
-      const filePath = path.join(root, "extended-secret.json");
-      await fs.writeFile(filePath, '{"token":"ok"}', { mode: 0o600 });
-      await secureWindowsTestFile(filePath);
-      const extendedPath = `\\\\?\\${path.resolve(filePath)}`;
+  itWin32("treats an extended-length local Windows path as local", async () => {
+    const filePath = path.join(root, "extended-secret.json");
+    await fs.writeFile(filePath, '{"token":"ok"}', { mode: 0o600 });
+    await secureWindowsTestFile(filePath);
+    const extendedPath = `\\\\?\\${path.resolve(filePath)}`;
 
-      const result = await readSecureFile({
-        filePath: extendedPath,
-        label: "extended-path secret",
-        io: { maxBytes: 1024 },
-      });
+    const result = await readSecureFile({
+      filePath: extendedPath,
+      label: "extended-path secret",
+      io: { maxBytes: 1024 },
+    });
 
-      expect(result.buffer.toString("utf8")).toBe('{"token":"ok"}');
-      expect(result.permissions).toMatchObject({
-        source: "windows-acl",
-        ownerTrusted: true,
-      });
-    },
-    15_000,
-  );
+    expect(result.buffer.toString("utf8")).toBe('{"token":"ok"}');
+    expect(result.permissions).toMatchObject({
+      source: "windows-acl",
+      ownerTrusted: true,
+    });
+  }, 15_000);
 
   it("rejects symlinks and files outside trusted dirs", async () => {
     const trusted = path.join(root, "trusted");
@@ -272,24 +264,19 @@ describe("secure file reads", () => {
     await fs.symlink(outsideFile, link);
 
     await expect(readSecureFile({ filePath: link })).rejects.toMatchObject({ code: "symlink" });
-    await expect(
-      readSecureFile({ filePath: outsideFile, trust: { trustedDirs: [trusted] } }),
-    ).rejects.toMatchObject({ code: "outside-workspace" });
+    await expectFsSafeError(readSecureFile({ filePath: outsideFile, trust: { trustedDirs: [trusted] } }), "outside-workspace");
   });
 
   it("rejects network paths unless explicitly trusted", async () => {
-    await expect(readSecureFile({ filePath: String.raw`\\server\share\secret.txt` })).rejects
-      .toMatchObject({ code: "invalid-path" });
+    await expectFsSafeError(readSecureFile({ filePath: String.raw`\\server\share\secret.txt` }), "invalid-path");
   });
 
-  it.runIf(process.platform !== "win32")("rejects overly broad POSIX permissions", async () => {
+  itPosix("rejects overly broad POSIX permissions", async () => {
     const filePath = path.join(root, "too-open.txt");
     await fs.writeFile(filePath, "secret", { mode: 0o644 });
     await fs.chmod(filePath, 0o644);
 
-    await expect(readSecureFile({ filePath })).rejects.toMatchObject({
-      code: "insecure-permissions",
-    });
+    await expectFsSafeError(readSecureFile({ filePath }), "insecure-permissions");
   });
 
   it("covers symlink, directory, size, and trusted-dir secure read branches", async () => {
@@ -302,17 +289,13 @@ describe("secure file reads", () => {
     await fs.mkdir(trusted);
     await fs.mkdir(outsideTrusted);
 
-    await expect(readSecureFile({ filePath: "relative.txt" })).rejects.toMatchObject({
-      code: "invalid-path",
-    });
+    await expectFsSafeError(readSecureFile({ filePath: "relative.txt" }), "invalid-path");
     await expect(readSecureFile({ filePath: root })).rejects.toMatchObject({ code: "not-file" });
-    await expect(
-      readSecureFile({
+    await expectFsSafeError(readSecureFile({
         filePath: link,
         trust: { allowSymlink: true, trustedDirs: [outsideTrusted] },
         permissions: { allowInsecure: true },
-      }),
-    ).rejects.toMatchObject({ code: "outside-workspace" });
+      }), "outside-workspace");
 
     const result = await readSecureFile({
       filePath: link,
@@ -322,13 +305,11 @@ describe("secure file reads", () => {
     });
     expect(result.buffer.toString("utf8")).toBe("secret");
 
-    await expect(
-      readSecureFile({
+    await expectFsSafeError(readSecureFile({
         filePath: target,
         permissions: { allowInsecure: true },
         io: { maxBytes: 2 },
-      }),
-    ).rejects.toMatchObject({ code: "too-large" });
+      }), "too-large");
   });
 
   it("uses Windows ACL permission checks for secure reads when requested", async () => {
@@ -364,12 +345,10 @@ describe("secure file reads", () => {
         stderr: "",
       })
       .mockResolvedValueOnce({ stdout: "Everyone:(R)\n", stderr: "" });
-    await expect(
-      readSecureFile({
+    await expectFsSafeError(readSecureFile({
         filePath,
         inject: { platform: "win32", exec: unsafeExec },
-      }),
-    ).rejects.toMatchObject({ code: "insecure-permissions" });
+      }), "insecure-permissions");
 
     const foreignOwnerExec = vi
       .fn()
@@ -381,21 +360,17 @@ describe("secure file reads", () => {
         stderr: "",
       })
       .mockResolvedValueOnce({ stdout: "*S-1-5-21-999:(R)\n", stderr: "" });
-    await expect(
-      readSecureFile({
+    await expectFsSafeError(readSecureFile({
         filePath,
         inject: { platform: "win32", exec: foreignOwnerExec },
         permissions: { allowReadableByOthers: true },
-      }),
-    ).rejects.toMatchObject({ code: "not-owned" });
+      }), "not-owned");
 
     const failedExec = vi.fn().mockRejectedValue(new Error("icacls failed"));
-    await expect(
-      readSecureFile({
+    await expectFsSafeError(readSecureFile({
         filePath,
         inject: { platform: "win32", exec: failedExec },
-      }),
-    ).rejects.toMatchObject({ code: "permission-unverified" });
+      }), "permission-unverified");
   });
 
   it("parses icacls output into ACL entries", () => {
@@ -845,7 +820,7 @@ describe("directory walking", () => {
     expect(truncated.scannedEntryCount).toBe(1);
   });
 
-  it.runIf(process.platform !== "win32")("does not recurse forever through followed symlink cycles", async () => {
+  itPosix("does not recurse forever through followed symlink cycles", async () => {
     await fs.mkdir(path.join(root, "a"), { recursive: true });
     await fs.writeFile(path.join(root, "a", "file.txt"), "1");
     await fs.symlink(root, path.join(root, "a", "loop"));
@@ -867,100 +842,88 @@ describe("directory walking", () => {
     expect(walkDirectorySync(root).failedDirs).toEqual([]);
   });
 
-  it.runIf(process.platform !== "win32")(
-    "reports an unreadable subtree in failedDirs without dropping readable siblings",
-    async () => {
-      await fs.mkdir(path.join(root, "readable"), { recursive: true });
-      await fs.writeFile(path.join(root, "readable", "ok.txt"), "1");
-      const blocked = path.join(root, "blocked");
-      await fs.mkdir(blocked, { recursive: true });
-      await fs.writeFile(path.join(blocked, "hidden.txt"), "secret");
-      await fs.chmod(blocked, 0o000);
-      try {
-        const scan = await walkDirectory(root, { include: (entry) => entry.kind === "file" });
+  itPosix("reports an unreadable subtree in failedDirs without dropping readable siblings", async () => {
+    await fs.mkdir(path.join(root, "readable"), { recursive: true });
+    await fs.writeFile(path.join(root, "readable", "ok.txt"), "1");
+    const blocked = path.join(root, "blocked");
+    await fs.mkdir(blocked, { recursive: true });
+    await fs.writeFile(path.join(blocked, "hidden.txt"), "secret");
+    await fs.chmod(blocked, 0o000);
+    try {
+      const scan = await walkDirectory(root, { include: (entry) => entry.kind === "file" });
 
-        // The readable sibling is still enumerated.
-        expect(scan.entries.map((entry) => entry.relativePath)).toContain(
-          path.join("readable", "ok.txt"),
-        );
-        // The unreadable subtree contributes no entries.
-        expect(scan.entries.map((entry) => entry.relativePath)).not.toContain(
-          path.join("blocked", "hidden.txt"),
-        );
-        // ...but the failure is reported, not silently swallowed.
-        expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual(["blocked"]);
-        expect(scan.failedDirs[0]).toMatchObject({ path: blocked, depth: 1 });
-        expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
-      } finally {
-        await fs.chmod(blocked, 0o755);
-      }
-    },
-  );
+      // The readable sibling is still enumerated.
+      expect(scan.entries.map((entry) => entry.relativePath)).toContain(
+        path.join("readable", "ok.txt"),
+      );
+      // The unreadable subtree contributes no entries.
+      expect(scan.entries.map((entry) => entry.relativePath)).not.toContain(
+        path.join("blocked", "hidden.txt"),
+      );
+      // ...but the failure is reported, not silently swallowed.
+      expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual(["blocked"]);
+      expect(scan.failedDirs[0]).toMatchObject({ path: blocked, depth: 1 });
+      expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
+    } finally {
+      await fs.chmod(blocked, 0o755);
+    }
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "reports an unreadable walk root in failedDirs with an empty listing",
-    async () => {
-      const scanRoot = path.join(root, "scan");
-      await fs.mkdir(scanRoot, { recursive: true });
-      await fs.writeFile(path.join(scanRoot, "file.txt"), "1");
-      await fs.chmod(scanRoot, 0o000);
-      try {
-        const scan = await walkDirectory(scanRoot);
+  itPosix("reports an unreadable walk root in failedDirs with an empty listing", async () => {
+    const scanRoot = path.join(root, "scan");
+    await fs.mkdir(scanRoot, { recursive: true });
+    await fs.writeFile(path.join(scanRoot, "file.txt"), "1");
+    await fs.chmod(scanRoot, 0o000);
+    try {
+      const scan = await walkDirectory(scanRoot);
 
-        expect(scan.entries).toEqual([]);
-        expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual([""]);
-        expect(scan.failedDirs[0]).toMatchObject({ path: scanRoot, depth: 0 });
-        expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
-      } finally {
-        await fs.chmod(scanRoot, 0o755);
-      }
-    },
-  );
+      expect(scan.entries).toEqual([]);
+      expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual([""]);
+      expect(scan.failedDirs[0]).toMatchObject({ path: scanRoot, depth: 0 });
+      expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
+    } finally {
+      await fs.chmod(scanRoot, 0o755);
+    }
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "reports unreadable directories from the synchronous walk too",
-    async () => {
-      await fs.mkdir(path.join(root, "readable"), { recursive: true });
-      await fs.writeFile(path.join(root, "readable", "ok.txt"), "1");
-      const blocked = path.join(root, "blocked");
-      await fs.mkdir(blocked, { recursive: true });
-      await fs.chmod(blocked, 0o000);
-      try {
-        const scan = walkDirectorySync(root, { include: (entry) => entry.kind === "file" });
+  itPosix("reports unreadable directories from the synchronous walk too", async () => {
+    await fs.mkdir(path.join(root, "readable"), { recursive: true });
+    await fs.writeFile(path.join(root, "readable", "ok.txt"), "1");
+    const blocked = path.join(root, "blocked");
+    await fs.mkdir(blocked, { recursive: true });
+    await fs.chmod(blocked, 0o000);
+    try {
+      const scan = walkDirectorySync(root, { include: (entry) => entry.kind === "file" });
 
-        expect(scan.entries.map((entry) => entry.relativePath)).toContain(
-          path.join("readable", "ok.txt"),
-        );
-        expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual(["blocked"]);
-        expect(scan.failedDirs[0]).toMatchObject({ path: blocked, depth: 1 });
-        expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
-      } finally {
-        await fs.chmod(blocked, 0o755);
-      }
-    },
-  );
+      expect(scan.entries.map((entry) => entry.relativePath)).toContain(
+        path.join("readable", "ok.txt"),
+      );
+      expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual(["blocked"]);
+      expect(scan.failedDirs[0]).toMatchObject({ path: blocked, depth: 1 });
+      expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
+    } finally {
+      await fs.chmod(blocked, 0o755);
+    }
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "reports nested failed directory depth relative to the walk root",
-    async () => {
-      const parent = path.join(root, "parent");
-      const blocked = path.join(parent, "blocked");
-      await fs.mkdir(blocked, { recursive: true });
-      await fs.writeFile(path.join(blocked, "hidden.txt"), "secret");
-      await fs.chmod(blocked, 0o000);
-      try {
-        const scan = await walkDirectory(root);
+  itPosix("reports nested failed directory depth relative to the walk root", async () => {
+    const parent = path.join(root, "parent");
+    const blocked = path.join(parent, "blocked");
+    await fs.mkdir(blocked, { recursive: true });
+    await fs.writeFile(path.join(blocked, "hidden.txt"), "secret");
+    await fs.chmod(blocked, 0o000);
+    try {
+      const scan = await walkDirectory(root);
 
-        expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual([
-          path.join("parent", "blocked"),
-        ]);
-        expect(scan.failedDirs[0]).toMatchObject({ path: blocked, depth: 2 });
-        expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
-      } finally {
-        await fs.chmod(blocked, 0o755);
-      }
-    },
-  );
+      expect(scan.failedDirs.map((failure) => failure.relativePath)).toEqual([
+        path.join("parent", "blocked"),
+      ]);
+      expect(scan.failedDirs[0]).toMatchObject({ path: blocked, depth: 2 });
+      expect((scan.failedDirs[0]?.error as NodeJS.ErrnoException).code).toBe("EACCES");
+    } finally {
+      await fs.chmod(blocked, 0o755);
+    }
+  });
 });
 
 describe("private file store mode", () => {
@@ -1091,7 +1054,7 @@ describe("regular file append", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlink leaves synchronously", async () => {
+  itPosix("rejects symlink leaves synchronously", async () => {
     const target = path.join(root, "target.txt");
     const link = path.join(root, "link.txt");
     await fs.writeFile(target, "secret", "utf8");
@@ -1101,7 +1064,7 @@ describe("regular file append", () => {
     expect(await fs.readFile(target, "utf8")).toBe("secret");
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlink parents", async () => {
+  itPosix("rejects symlink parents", async () => {
     const targetDir = path.join(root, "target");
     const linkDir = path.join(root, "link");
     await fs.mkdir(targetDir);
@@ -1250,7 +1213,7 @@ describe("atomic file replacement", () => {
     expect(entries.filter((entry) => entry.startsWith(".cron-store"))).toEqual([]);
   });
 
-  it.runIf(process.platform !== "win32")("applies requested directory and file modes", async () => {
+  itPosix("applies requested directory and file modes", async () => {
     const filePath = path.join(root, "nested", "mode.txt");
     await replaceFileAtomic({
       filePath,

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -1,23 +1,13 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { writeExternalFileWithinRoot } from "../src/output.js";
 
-const tempDirs = new Set<string>();
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.add(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  for (const dir of tempDirs) {
-    await fs.rm(dir, { force: true, recursive: true });
-  }
-  tempDirs.clear();
-});
 
 describe("writeExternalFileWithinRoot", () => {
   it("stages an external writer in private temp storage and finalizes under the root", async () => {
@@ -93,8 +83,7 @@ describe("writeExternalFileWithinRoot", () => {
     const targetPath = path.join(rootDir, "output.bin");
     await fs.writeFile(targetPath, "old", "utf8");
 
-    await expect(
-      writeExternalFileWithinRoot({
+    await expectFsSafeError(writeExternalFileWithinRoot({
         rootDir,
         path: "output.bin",
         staging: "sibling",
@@ -102,8 +91,7 @@ describe("writeExternalFileWithinRoot", () => {
         write: async (candidate) => {
           await fs.writeFile(candidate, "too large", "utf8");
         },
-      }),
-    ).rejects.toMatchObject({ code: "too-large" });
+      }), "too-large");
 
     await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("old");
     expect((await fs.readdir(rootDir)).filter((name) => name.startsWith(".fs-safe-output-")))
@@ -201,21 +189,19 @@ describe("writeExternalFileWithinRoot", () => {
     const rootDir = await tempRoot("fs-safe-output-max-bytes-");
     const targetPath = path.join(rootDir, "too-large.bin");
 
-    await expect(
-      writeExternalFileWithinRoot({
+    await expectFsSafeError(writeExternalFileWithinRoot({
         rootDir,
         path: "too-large.bin",
         maxBytes: 3,
         write: async (candidate) => {
           await fs.writeFile(candidate, "larger", "utf8");
         },
-      }),
-    ).rejects.toMatchObject({ code: "too-large" });
+      }), "too-large");
 
     await expect(fs.stat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("applies the requested final file mode", async () => {
+  itPosix("applies the requested final file mode", async () => {
     const rootDir = await tempRoot("fs-safe-output-mode-");
     const targetPath = path.join(rootDir, "private.txt");
 
@@ -236,16 +222,14 @@ describe("writeExternalFileWithinRoot", () => {
     const rootDir = await tempRoot("fs-safe-output-default-");
     let called = false;
 
-    await expect(
-      writeExternalFileWithinRoot({
+    await expectFsSafeError(writeExternalFileWithinRoot({
         rootDir,
         path: "",
         write: async (candidate) => {
           called = true;
           await fs.writeFile(candidate, "named", "utf8");
         },
-      }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+      }), "invalid-path");
 
     expect(called).toBe(false);
   });
@@ -256,16 +240,14 @@ describe("writeExternalFileWithinRoot", () => {
     const outsidePath = path.join(outsideDir, "pwned.txt");
     let called = false;
 
-    await expect(
-      writeExternalFileWithinRoot({
+    await expectFsSafeError(writeExternalFileWithinRoot({
         rootDir,
         path: outsidePath,
         write: async (candidate) => {
           called = true;
           await fs.writeFile(candidate, "pwned", "utf8");
         },
-      }),
-    ).rejects.toMatchObject({ code: "outside-workspace" });
+      }), "outside-workspace");
 
     expect(called).toBe(false);
     await expect(fs.stat(outsidePath)).rejects.toMatchObject({ code: "ENOENT" });
@@ -275,16 +257,14 @@ describe("writeExternalFileWithinRoot", () => {
     const rootDir = await tempRoot("fs-safe-output-traversal-root-");
     let called = false;
 
-    await expect(
-      writeExternalFileWithinRoot({
+    await expectFsSafeError(writeExternalFileWithinRoot({
         rootDir,
         path: "../../../pwned.txt",
         write: async (candidate) => {
           called = true;
           await fs.writeFile(candidate, "pwned", "utf8");
         },
-      }),
-    ).rejects.toMatchObject({ code: "outside-workspace" });
+      }), "outside-workspace");
 
     expect(called).toBe(false);
   });
@@ -293,16 +273,14 @@ describe("writeExternalFileWithinRoot", () => {
     const rootDir = await tempRoot("fs-safe-output-root-target-");
     let called = false;
 
-    await expect(
-      writeExternalFileWithinRoot({
+    await expectFsSafeError(writeExternalFileWithinRoot({
         rootDir,
         path: rootDir,
         write: async (candidate) => {
           called = true;
           await fs.writeFile(candidate, "not a file target", "utf8");
         },
-      }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+      }), "invalid-path");
 
     expect(called).toBe(false);
   });
@@ -311,16 +289,14 @@ describe("writeExternalFileWithinRoot", () => {
     const rootDir = await tempRoot("fs-safe-output-dir-target-");
     let called = false;
 
-    await expect(
-      writeExternalFileWithinRoot({
+    await expectFsSafeError(writeExternalFileWithinRoot({
         rootDir,
         path: "nested/",
         write: async (candidate) => {
           called = true;
           await fs.writeFile(candidate, "not a file target", "utf8");
         },
-      }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+      }), "invalid-path");
 
     expect(called).toBe(false);
   });
@@ -329,95 +305,84 @@ describe("writeExternalFileWithinRoot", () => {
     const rootDir = await tempRoot("fs-safe-output-absolute-dir-target-");
     let called = false;
 
-    await expect(
-      writeExternalFileWithinRoot({
+    await expectFsSafeError(writeExternalFileWithinRoot({
         rootDir,
         path: path.join(rootDir, "nested") + path.sep,
         write: async (candidate) => {
           called = true;
           await fs.writeFile(candidate, "not a file target", "utf8");
         },
-      }),
-    ).rejects.toMatchObject({ code: "invalid-path" });
+      }), "invalid-path");
 
     expect(called).toBe(false);
   });
 
-  it.runIf(process.platform !== "win32")(
-    "does not let symlinked target parents redirect the external temp write",
-    async () => {
-      const rootDir = await tempRoot("fs-safe-output-link-root-");
-      const outsideDir = await tempRoot("fs-safe-output-link-outside-");
-      await fs.symlink(outsideDir, path.join(rootDir, "link"), "dir");
-      let tempPath = "";
+  itPosix("does not let symlinked target parents redirect the external temp write", async () => {
+    const rootDir = await tempRoot("fs-safe-output-link-root-");
+    const outsideDir = await tempRoot("fs-safe-output-link-outside-");
+    await fs.symlink(outsideDir, path.join(rootDir, "link"), "dir");
+    let tempPath = "";
 
-      await expect(
-        writeExternalFileWithinRoot({
-          rootDir,
-          path: "link/out.txt",
-          write: async (candidate) => {
-            tempPath = candidate;
-            await fs.writeFile(candidate, "pwned", "utf8");
-          },
-        }),
-      ).rejects.toBeTruthy();
-
-      await expect(fs.stat(tempPath)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.readdir(outsideDir)).resolves.toEqual([]);
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "atomically replaces a symlink destination without following it",
-    async () => {
-      const rootDir = await tempRoot("fs-safe-output-sibling-link-root-");
-      const outsideDir = await tempRoot("fs-safe-output-sibling-link-outside-");
-      const outsidePath = path.join(outsideDir, "outside.txt");
-      const targetPath = path.join(rootDir, "output.txt");
-      await fs.writeFile(outsidePath, "outside", "utf8");
-      await fs.symlink(outsidePath, targetPath);
-      let called = false;
-
-      await writeExternalFileWithinRoot({
+    await expect(
+      writeExternalFileWithinRoot({
         rootDir,
-        path: "output.txt",
-        staging: "sibling",
+        path: "link/out.txt",
         write: async (candidate) => {
-          called = true;
+          tempPath = candidate;
+          await fs.writeFile(candidate, "pwned", "utf8");
+        },
+      }),
+    ).rejects.toBeTruthy();
+
+    await expect(fs.stat(tempPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readdir(outsideDir)).resolves.toEqual([]);
+  });
+
+  itPosix("atomically replaces a symlink destination without following it", async () => {
+    const rootDir = await tempRoot("fs-safe-output-sibling-link-root-");
+    const outsideDir = await tempRoot("fs-safe-output-sibling-link-outside-");
+    const outsidePath = path.join(outsideDir, "outside.txt");
+    const targetPath = path.join(rootDir, "output.txt");
+    await fs.writeFile(outsidePath, "outside", "utf8");
+    await fs.symlink(outsidePath, targetPath);
+    let called = false;
+
+    await writeExternalFileWithinRoot({
+      rootDir,
+      path: "output.txt",
+      staging: "sibling",
+      write: async (candidate) => {
+        called = true;
+        await fs.writeFile(candidate, "replacement", "utf8");
+      },
+    });
+
+    expect(called).toBe(true);
+    await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside");
+    expect((await fs.lstat(targetPath)).isSymbolicLink()).toBe(false);
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("replacement");
+  });
+
+  itPosix("rejects hardlinked final targets and preserves the existing file", async () => {
+    const rootDir = await tempRoot("fs-safe-output-hardlink-");
+    const sourcePath = path.join(rootDir, "source.txt");
+    const hardlinkPath = path.join(rootDir, "hardlink.txt");
+    await fs.writeFile(sourcePath, "original", "utf8");
+    await fs.link(sourcePath, hardlinkPath);
+
+    await expect(
+      writeExternalFileWithinRoot({
+        rootDir,
+        path: "hardlink.txt",
+        write: async (candidate) => {
           await fs.writeFile(candidate, "replacement", "utf8");
         },
-      });
+      }),
+    ).rejects.toBeTruthy();
 
-      expect(called).toBe(true);
-      await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside");
-      expect((await fs.lstat(targetPath)).isSymbolicLink()).toBe(false);
-      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("replacement");
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "rejects hardlinked final targets and preserves the existing file",
-    async () => {
-      const rootDir = await tempRoot("fs-safe-output-hardlink-");
-      const sourcePath = path.join(rootDir, "source.txt");
-      const hardlinkPath = path.join(rootDir, "hardlink.txt");
-      await fs.writeFile(sourcePath, "original", "utf8");
-      await fs.link(sourcePath, hardlinkPath);
-
-      await expect(
-        writeExternalFileWithinRoot({
-          rootDir,
-          path: "hardlink.txt",
-          write: async (candidate) => {
-            await fs.writeFile(candidate, "replacement", "utf8");
-          },
-        }),
-      ).rejects.toBeTruthy();
-
-      await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe("original");
-      await expect(fs.readFile(hardlinkPath, "utf8")).resolves.toBe("original");
-    },
-  );
+    await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe("original");
+    await expect(fs.readFile(hardlinkPath, "utf8")).resolves.toBe("original");
+  });
 
   it("cleans private temp files when the external writer fails", async () => {
     const rootDir = await tempRoot("fs-safe-output-fail-root-");

--- a/test/owner-dacl.test.ts
+++ b/test/owner-dacl.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { itPosix } from "./helpers/vitest.js";
 import { readOwnerAndDacl } from "../src/owner-dacl.js";
 import { __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
 import {
@@ -24,14 +25,14 @@ afterEach(() => {
 });
 
 describe("readOwnerAndDacl", () => {
-  it.runIf(process.platform !== "win32")("returns a typed unsupported result off Windows", () => {
+  itPosix("returns a typed unsupported result off Windows", () => {
     expect(readOwnerAndDacl("/tmp/example")).toEqual({
       status: "unsupported-platform",
       platform: process.platform,
     });
   });
 
-  it.runIf(process.platform !== "win32")("returns ACE facts without applying trust policy", () => {
+  itPosix("returns ACE facts without applying trust policy", () => {
     __setNativeLoaderForTest(
       () =>
         ({

--- a/test/path-stress-regression.test.ts
+++ b/test/path-stress-regression.test.ts
@@ -1,20 +1,16 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { spawn } from "node:child_process";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { expectFsSafeError, expectFsSafeErrorSync } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { fileStore, fileStoreSync } from "../src/file-store.js";
 import { root as openRoot } from "../src/root.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 async function createFifo(filePath: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
@@ -29,46 +25,33 @@ async function createFifo(filePath: string): Promise<void> {
 
 afterEach(async () => {
   __setFsSafeTestHooksForTest(undefined);
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
 describe("path stress regressions", () => {
-  it.runIf(process.platform !== "win32")(
-    "rejects stable intermediate symlinks unless following is explicit",
-    async () => {
-      const rootDir = await tempRoot("fs-safe-intermediate-symlink-");
-      await fs.mkdir(path.join(rootDir, "real"));
-      await fs.writeFile(path.join(rootDir, "real", "value.txt"), "inside");
-      await fs.symlink("real", path.join(rootDir, "alias"), "dir");
-      const scoped = await openRoot(rootDir);
+  itPosix("rejects stable intermediate symlinks unless following is explicit", async () => {
+    const rootDir = await tempRoot("fs-safe-intermediate-symlink-");
+    await fs.mkdir(path.join(rootDir, "real"));
+    await fs.writeFile(path.join(rootDir, "real", "value.txt"), "inside");
+    await fs.symlink("real", path.join(rootDir, "alias"), "dir");
+    const scoped = await openRoot(rootDir);
 
-      await expect(scoped.readText("alias/value.txt")).rejects.toMatchObject({
-        code: "symlink",
-      });
-      await expect(
-        scoped.readText("alias/value.txt", { symlinks: "follow-within-root" }),
-      ).resolves.toBe("inside");
+    await expectFsSafeError(scoped.readText("alias/value.txt"), "symlink");
+    await expect(
+      scoped.readText("alias/value.txt", { symlinks: "follow-within-root" }),
+    ).resolves.toBe("inside");
 
-      const syncStore = fileStoreSync({ rootDir });
-      expect(() => syncStore.readTextIfExists("alias/value.txt")).toThrow(
-        expect.objectContaining({ code: "path-mismatch" }),
-      );
-    },
-  );
+    const syncStore = fileStoreSync({ rootDir });
+    expectFsSafeErrorSync(() => syncStore.readTextIfExists("alias/value.txt"), "path-mismatch");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "reports an intermediate symlink loop as a symlink failure when following",
-    async () => {
-      const rootDir = await tempRoot("fs-safe-symlink-loop-");
-      await fs.symlink("loop-b", path.join(rootDir, "loop-a"), "dir");
-      await fs.symlink("loop-a", path.join(rootDir, "loop-b"), "dir");
-      const scoped = await openRoot(rootDir);
+  itPosix("reports an intermediate symlink loop as a symlink failure when following", async () => {
+    const rootDir = await tempRoot("fs-safe-symlink-loop-");
+    await fs.symlink("loop-b", path.join(rootDir, "loop-a"), "dir");
+    await fs.symlink("loop-a", path.join(rootDir, "loop-b"), "dir");
+    const scoped = await openRoot(rootDir);
 
-      await expect(
-        scoped.readText("loop-a/value.txt", { symlinks: "follow-within-root" }),
-      ).rejects.toMatchObject({ code: "symlink" });
-    },
-  );
+    await expectFsSafeError(scoped.readText("loop-a/value.txt", { symlinks: "follow-within-root" }), "symlink");
+  });
 
   it("detects an in-root parent-directory swap between lstat and open", async () => {
     const rootDir = await tempRoot("fs-safe-parent-swap-");
@@ -93,39 +76,34 @@ describe("path stress regressions", () => {
       },
     });
 
-    await expect(scoped.readText("target/value.txt")).rejects.toMatchObject({
-      code: "path-mismatch",
-    });
+    await expectFsSafeError(scoped.readText("target/value.txt"), "path-mismatch");
     await expect(fs.readFile(path.join(displacedDir, "value.txt"), "utf8")).resolves.toBe(
       "trusted",
     );
   });
 
-  it.runIf(process.platform !== "win32")(
-    "opens reads nonblocking so a raced FIFO is rejected without hanging",
-    async () => {
-      const rootDir = await tempRoot("fs-safe-root-fifo-swap-");
-      const scoped = await openRoot(rootDir);
-      const filePath = path.join(scoped.rootReal, "value.txt");
-      const displacedPath = path.join(scoped.rootReal, "value.displaced");
-      await fs.writeFile(filePath, "regular");
-      let swapped = false;
-      __setFsSafeTestHooksForTest({
-        async beforeOpen(openedPath, flags) {
-          if (swapped || openedPath !== filePath) {
-            return;
-          }
-          expect(flags & fsSync.constants.O_NONBLOCK).toBe(fsSync.constants.O_NONBLOCK);
-          swapped = true;
-          await fs.rename(filePath, displacedPath);
-          await createFifo(filePath);
-        },
-      });
+  itPosix("opens reads nonblocking so a raced FIFO is rejected without hanging", async () => {
+    const rootDir = await tempRoot("fs-safe-root-fifo-swap-");
+    const scoped = await openRoot(rootDir);
+    const filePath = path.join(scoped.rootReal, "value.txt");
+    const displacedPath = path.join(scoped.rootReal, "value.displaced");
+    await fs.writeFile(filePath, "regular");
+    let swapped = false;
+    __setFsSafeTestHooksForTest({
+      async beforeOpen(openedPath, flags) {
+        if (swapped || openedPath !== filePath) {
+          return;
+        }
+        expect(flags & fsSync.constants.O_NONBLOCK).toBe(fsSync.constants.O_NONBLOCK);
+        swapped = true;
+        await fs.rename(filePath, displacedPath);
+        await createFifo(filePath);
+      },
+    });
 
-      await expect(scoped.readText("value.txt")).rejects.toMatchObject({ code: "not-file" });
-      expect(swapped).toBe(true);
-    },
-  );
+    await expect(scoped.readText("value.txt")).rejects.toMatchObject({ code: "not-file" });
+    expect(swapped).toBe(true);
+  });
 
   it("does not canonicalize whitespace-padded FileStore keys onto another key", async () => {
     const rootDir = await tempRoot("fs-safe-store-whitespace-");
@@ -134,25 +112,16 @@ describe("path stress regressions", () => {
     await asyncStore.writeText("value.txt", "kept");
 
     for (const key of [" value.txt", "value.txt "]) {
-      expect(() => asyncStore.path(key), key).toThrow(
-        expect.objectContaining({ code: "invalid-path" }),
-      );
-      expect(() => syncStore.path(key), key).toThrow(
-        expect.objectContaining({ code: "invalid-path" }),
-      );
+      expectFsSafeErrorSync(() => asyncStore.path(key), "invalid-path");
+      expectFsSafeErrorSync(() => syncStore.path(key), "invalid-path");
     }
     expect(fsSync.readFileSync(path.join(rootDir, "value.txt"), "utf8")).toBe("kept");
   });
 
-  it.runIf(process.platform !== "win32")(
-    "classifies an OS-rejected overlong root path as invalid input rather than an escape",
-    async () => {
-      const rootDir = await tempRoot("fs-safe-overlong-path-");
-      const scoped = await openRoot(rootDir);
+  itPosix("classifies an OS-rejected overlong root path as invalid input rather than an escape", async () => {
+    const rootDir = await tempRoot("fs-safe-overlong-path-");
+    const scoped = await openRoot(rootDir);
 
-      await expect(scoped.readText("x".repeat(10_000))).rejects.toMatchObject({
-        code: "invalid-path",
-      });
-    },
-  );
+    await expectFsSafeError(scoped.readText("x".repeat(10_000)), "invalid-path");
+  });
 });

--- a/test/permissions-exec.test.ts
+++ b/test/permissions-exec.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
 import {
   DEFAULT_PERMISSION_EXEC_TIMEOUT_MS,
   executePermissionCommand,
@@ -97,16 +98,14 @@ describe("Windows permission command execution", () => {
       error: expect.stringContaining("could not be verified"),
     });
 
-    await expect(
-      readSecureFile({
+    await expectFsSafeError(readSecureFile({
         filePath: target,
         inject: {
           platform: "win32",
           env: { SystemRoot: "C:\\Windows" },
           exec,
         },
-      }),
-    ).rejects.toMatchObject({ code: "permission-unverified" });
+      }), "permission-unverified");
   });
 
   it("inspects permissions once for one secure read", async () => {

--- a/test/pinned-write-fallback-coverage.test.ts
+++ b/test/pinned-write-fallback-coverage.test.ts
@@ -1,9 +1,10 @@
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, itWin32, useTempDirs } from "./helpers/vitest.js";
 
 vi.mock("node:child_process", () => {
   return {
@@ -22,113 +23,99 @@ vi.mock("node:child_process", () => {
   };
 });
 
-const tempDirs = new Set<string>();
+const { tempRoot } = useTempDirs();
 const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.add(dir);
-  return dir;
-}
 
 afterEach(async () => {
   vi.restoreAllMocks();
   if (originalPlatform) {
     Object.defineProperty(process, "platform", originalPlatform);
   }
-  for (const dir of tempDirs) {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
-  tempDirs.clear();
 });
 
 describe("pinned write fallback coverage", () => {
-  it.runIf(process.platform !== "win32")(
-    "writes buffers, creates only when missing, streams, and enforces limits when native mode is off",
-    async () => {
-      const { configureFsSafeNative } = await import("../src/native-config.js");
-      const { runPinnedWriteHelper } = await import("../src/pinned-write.js");
-      configureFsSafeNative({ mode: "off" });
-      const root = await tempRoot("fs-safe-pinned-write-fallback-");
+  itPosix("writes buffers, creates only when missing, streams, and enforces limits when native mode is off", async () => {
+    const { configureFsSafeNative } = await import("../src/native-config.js");
+    const { runPinnedWriteHelper } = await import("../src/pinned-write.js");
+    configureFsSafeNative({ mode: "off" });
+    const root = await tempRoot("fs-safe-pinned-write-fallback-");
 
-      const created = await runPinnedWriteHelper({
+    const created = await runPinnedWriteHelper({
+      rootPath: root,
+      relativeParentPath: "nested",
+      basename: "created.txt",
+      mkdir: true,
+      mode: 0o600,
+      overwrite: false,
+      input: { kind: "buffer", data: "created", encoding: "utf8" },
+    });
+    expect(created.ino).toBeGreaterThan(0);
+    await expect(fs.readFile(path.join(root, "nested", "created.txt"), "utf8")).resolves.toBe(
+      "created",
+    );
+    await expect(
+      runPinnedWriteHelper({
         rootPath: root,
         relativeParentPath: "nested",
         basename: "created.txt",
         mkdir: true,
         mode: 0o600,
         overwrite: false,
-        input: { kind: "buffer", data: "created", encoding: "utf8" },
-      });
-      expect(created.ino).toBeGreaterThan(0);
-      await expect(fs.readFile(path.join(root, "nested", "created.txt"), "utf8")).resolves.toBe(
-        "created",
-      );
-      await expect(
-        runPinnedWriteHelper({
-          rootPath: root,
-          relativeParentPath: "nested",
-          basename: "created.txt",
-          mkdir: true,
-          mode: 0o600,
-          overwrite: false,
-          input: { kind: "buffer", data: "again" },
-        }),
-      ).rejects.toMatchObject({ code: "EEXIST" });
+        input: { kind: "buffer", data: "again" },
+      }),
+    ).rejects.toMatchObject({ code: "EEXIST" });
 
-      const realOpen = fs.open;
-      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
-        const handle = await realOpen(...args);
-        if (String(args[0]).includes("streamed.txt")) {
-          const realWrite = handle.write.bind(handle);
-          vi.spyOn(handle, "write").mockImplementation((async (
-            buffer: Buffer,
-            offset = 0,
-            length = buffer.byteLength - offset,
-            position?: number | null,
-          ) => {
-            const partialLength = Math.max(1, Math.ceil(length / 2));
-            const result = await realWrite(buffer, offset, partialLength, position);
-            return { bytesWritten: result.bytesWritten, buffer };
-          }) as typeof handle.write);
-        }
-        return handle;
-      });
+    const realOpen = fs.open;
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      if (String(args[0]).includes("streamed.txt")) {
+        const realWrite = handle.write.bind(handle);
+        vi.spyOn(handle, "write").mockImplementation((async (
+          buffer: Buffer,
+          offset = 0,
+          length = buffer.byteLength - offset,
+          position?: number | null,
+        ) => {
+          const partialLength = Math.max(1, Math.ceil(length / 2));
+          const result = await realWrite(buffer, offset, partialLength, position);
+          return { bytesWritten: result.bytesWritten, buffer };
+        }) as typeof handle.write);
+      }
+      return handle;
+    });
 
-      const streamed = await runPinnedWriteHelper({
+    const streamed = await runPinnedWriteHelper({
+      rootPath: root,
+      relativeParentPath: "nested",
+      basename: "streamed.txt",
+      mkdir: true,
+      mode: 0o600,
+      overwrite: true,
+      maxBytes: 16,
+      input: { kind: "stream", stream: Readable.from(["stream", "ed"]) },
+    });
+    expect(streamed.dev).toBeGreaterThan(0);
+    await expect(fs.readFile(path.join(root, "nested", "streamed.txt"), "utf8")).resolves.toBe(
+      "streamed",
+    );
+
+    await expectFsSafeError(runPinnedWriteHelper({
         rootPath: root,
         relativeParentPath: "nested",
-        basename: "streamed.txt",
+        basename: "too-large.txt",
         mkdir: true,
         mode: 0o600,
         overwrite: true,
-        maxBytes: 16,
-        input: { kind: "stream", stream: Readable.from(["stream", "ed"]) },
-      });
-      expect(streamed.dev).toBeGreaterThan(0);
-      await expect(fs.readFile(path.join(root, "nested", "streamed.txt"), "utf8")).resolves.toBe(
-        "streamed",
-      );
+        maxBytes: 2,
+        input: { kind: "buffer", data: Buffer.from("large") },
+      }), "too-large");
+    await expect(fs.stat(path.join(root, "nested", "too-large.txt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
 
-      await expect(
-        runPinnedWriteHelper({
-          rootPath: root,
-          relativeParentPath: "nested",
-          basename: "too-large.txt",
-          mkdir: true,
-          mode: 0o600,
-          overwrite: true,
-          maxBytes: 2,
-          input: { kind: "buffer", data: Buffer.from("large") },
-        }),
-      ).rejects.toMatchObject({ code: "too-large" });
-      await expect(fs.stat(path.join(root, "nested", "too-large.txt"))).rejects.toMatchObject({
-        code: "ENOENT",
-      });
-    },
-  );
-
-  it.runIf(process.platform !== "win32")("uses the guarded fallback when native mode is off", async () => {
+  itPosix("uses the guarded fallback when native mode is off", async () => {
     const { configureFsSafeNative } = await import("../src/native-config.js");
     const { runPinnedWriteHelper } = await import("../src/pinned-write.js");
     configureFsSafeNative({ mode: "off" });
@@ -150,23 +137,20 @@ describe("pinned write fallback coverage", () => {
     );
   });
 
-  it.runIf(process.platform === "win32")(
-    "falls back on windows",
-    async () => {
-      const { runPinnedWriteHelper } = await import("../src/pinned-write.js");
-      const root = await tempRoot("fs-safe-pinned-write-fallback-");
-      await expect(runPinnedWriteHelper({
-        rootPath: root,
-        relativeParentPath: "nested",
-        basename: "created.txt",
-        mkdir: true,
-        mode: 0o600,
-        overwrite: false,
-        input: { kind: "buffer", data: "created", encoding: "utf8" },
-      })).resolves.toMatchObject({ dev: expect.any(Number), ino: expect.any(Number) });
-      await expect(fs.readFile(path.join(root, "nested", "created.txt"), "utf8")).resolves.toBe(
-        "created",
-      );
-    },
-  );
+  itWin32("falls back on windows", async () => {
+    const { runPinnedWriteHelper } = await import("../src/pinned-write.js");
+    const root = await tempRoot("fs-safe-pinned-write-fallback-");
+    await expect(runPinnedWriteHelper({
+      rootPath: root,
+      relativeParentPath: "nested",
+      basename: "created.txt",
+      mkdir: true,
+      mode: 0o600,
+      overwrite: false,
+      input: { kind: "buffer", data: "created", encoding: "utf8" },
+    })).resolves.toMatchObject({ dev: expect.any(Number), ino: expect.any(Number) });
+    await expect(fs.readFile(path.join(root, "nested", "created.txt"), "utf8")).resolves.toBe(
+      "created",
+    );
+  });
 });

--- a/test/pinned-write-fsync.test.ts
+++ b/test/pinned-write-fsync.test.ts
@@ -1,52 +1,42 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { configureFsSafeNative } from "../src/index.js";
 import { runPinnedWriteHelper } from "../src/pinned-write.js";
 
-const tempDirs = new Set<string>();
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.add(dir);
-  return dir;
-}
 
 afterEach(async () => {
   vi.restoreAllMocks();
   configureFsSafeNative({ mode: "auto" });
-  await Promise.all([...tempDirs].map((dir) => fs.rm(dir, { recursive: true, force: true })));
-  tempDirs.clear();
 });
 
 describe("pinned write fsync compatibility", () => {
-  it.runIf(process.platform !== "win32")(
-    "treats EPERM from fallback file sync as best effort",
-    async () => {
-      configureFsSafeNative({ mode: "off" });
-      const root = await tempRoot("fs-safe-pinned-write-fsync-eperm-");
-      const realOpen = fs.open.bind(fs);
-      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
-        const handle = await realOpen(...args);
-        vi.spyOn(handle, "sync").mockRejectedValueOnce(
-          Object.assign(new Error("operation not permitted"), { code: "EPERM" }),
-        );
-        return handle;
-      });
+  itPosix("treats EPERM from fallback file sync as best effort", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const root = await tempRoot("fs-safe-pinned-write-fsync-eperm-");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      vi.spyOn(handle, "sync").mockRejectedValueOnce(
+        Object.assign(new Error("operation not permitted"), { code: "EPERM" }),
+      );
+      return handle;
+    });
 
-      await expect(
-        runPinnedWriteHelper({
-          rootPath: root,
-          relativeParentPath: "",
-          basename: "created.txt",
-          mkdir: true,
-          mode: 0o600,
-          overwrite: true,
-          input: { kind: "buffer", data: "created", encoding: "utf8" },
-        }),
-      ).resolves.toMatchObject({ dev: expect.any(Number), ino: expect.any(Number) });
-      await expect(fs.readFile(path.join(root, "created.txt"), "utf8")).resolves.toBe("created");
-    },
-  );
+    await expect(
+      runPinnedWriteHelper({
+        rootPath: root,
+        relativeParentPath: "",
+        basename: "created.txt",
+        mkdir: true,
+        mode: 0o600,
+        overwrite: true,
+        input: { kind: "buffer", data: "created", encoding: "utf8" },
+      }),
+    ).resolves.toMatchObject({ dev: expect.any(Number), ino: expect.any(Number) });
+    await expect(fs.readFile(path.join(root, "created.txt"), "utf8")).resolves.toBe("created");
+  });
 });

--- a/test/platform-fallback-coverage.test.ts
+++ b/test/platform-fallback-coverage.test.ts
@@ -1,16 +1,11 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 
-const tempDirs = new Set<string>();
+const { tempRoot } = useTempDirs();
 const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.add(dir);
-  return dir;
-}
 
 async function importRootForPlatform(platform: NodeJS.Platform) {
   vi.resetModules();
@@ -27,10 +22,6 @@ afterEach(async () => {
     Object.defineProperty(process, "platform", platformDescriptor);
   }
   vi.resetModules();
-  for (const dir of tempDirs) {
-    await fs.rm(dir, { recursive: true, force: true });
-  }
-  tempDirs.clear();
 });
 
 describe("platform fallback coverage", () => {
@@ -81,8 +72,9 @@ describe("platform fallback coverage", () => {
     await expect(fs.readFile(path.join(rootDir, "nested", "copied.txt"), "utf8")).resolves.toBe(
       "copied",
     );
-    await expect(scoped.copyIn("nested/too-large.txt", source, { maxBytes: 3 })).rejects
-      .toMatchObject({ code: "too-large" });
+    await expect(scoped.copyIn("nested/too-large.txt", source, { maxBytes: 3 })).rejects.toMatchObject({
+      code: "too-large",
+    });
 
     await scoped.remove("nested/copied.txt");
     await expect(fs.stat(path.join(rootDir, "nested", "copied.txt"))).rejects.toMatchObject({
@@ -107,7 +99,7 @@ describe("platform fallback coverage", () => {
     await expect(fs.stat(path.join(rootDir, "old"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlinked missing mkdir components in fallback", async () => {
+  itPosix("rejects symlinked missing mkdir components in fallback", async () => {
     const { root: openRoot } = await importRootForPlatform("win32");
     const { __setFsSafeTestHooksForTest } = await import("../src/test-hooks.js");
     const rootDir = await tempRoot("fs-safe-win-mkdir-race-");

--- a/test/private-directory.test.ts
+++ b/test/private-directory.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix } from "./helpers/vitest.js";
 import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
 import {
   __resetNativeLoaderForTest,
@@ -34,12 +36,10 @@ afterEach(async () => {
 });
 
 describe("createPrivateDirectory", () => {
-  it.runIf(process.platform !== "win32")("fails closed without mutating POSIX paths", async () => {
+  itPosix("fails closed without mutating POSIX paths", async () => {
     const root = await tempRoot();
     const target = path.join(root, "private");
-    await expect(createPrivateDirectory(target)).rejects.toMatchObject({
-      code: "helper-unavailable",
-    });
+    await expectFsSafeError(createPrivateDirectory(target), "helper-unavailable");
     await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
@@ -47,9 +47,7 @@ describe("createPrivateDirectory", () => {
     const root = await tempRoot();
     const target = path.join(root, "fallback");
     configureFsSafeNative({ mode: "off" });
-    await expect(createPrivateDirectory(target, { platform: "win32" })).rejects.toMatchObject({
-      code: "helper-unavailable",
-    });
+    await expectFsSafeError(createPrivateDirectory(target, { platform: "win32" }), "helper-unavailable");
     await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
   });
 

--- a/test/rename-identity-policy.test.ts
+++ b/test/rename-identity-policy.test.ts
@@ -3,6 +3,8 @@ import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix } from "./helpers/vitest.js";
 import { configureFsSafeNative, root as openRoot } from "../src/index.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 
@@ -39,139 +41,106 @@ afterEach(async () => {
 });
 
 describe("rename identity policy", () => {
-  it.runIf(process.platform !== "win32")(
-    "keeps strict post-rename identity verification as the default",
-    async () => {
-      configureFsSafeNative({ mode: "off" });
-      const rootDir = await makeTempRoot("fs-safe-rename-id-strict-");
-      replaceTargetAfterFallbackRename();
+  itPosix("keeps strict post-rename identity verification as the default", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const rootDir = await makeTempRoot("fs-safe-rename-id-strict-");
+    replaceTargetAfterFallbackRename();
 
-      const fs = await openRoot(rootDir);
-      await expect(fs.write("file.txt", "hello")).rejects.toMatchObject({
-        code: "path-mismatch",
-      });
-    },
-  );
+    const fs = await openRoot(rootDir);
+    await expectFsSafeError(fs.write("file.txt", "hello"), "path-mismatch");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "accepts matching content under the explicit compatibility lock",
-    async () => {
-      configureFsSafeNative({ mode: "off" });
-      const rootDir = await makeTempRoot("fs-safe-rename-id-lock-");
-      const targetPath = path.join(rootDir, "file.txt");
-      replaceTargetAfterFallbackRename();
+  itPosix("accepts matching content under the explicit compatibility lock", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const rootDir = await makeTempRoot("fs-safe-rename-id-lock-");
+    const targetPath = path.join(rootDir, "file.txt");
+    replaceTargetAfterFallbackRename();
 
-      const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
-      await expect(fs.write("file.txt", "hello")).resolves.toBeUndefined();
-      await expect(fsp.readFile(targetPath, "utf8")).resolves.toBe("hello");
-      await expect(fsp.stat(compatibilityLockPath(rootDir))).rejects.toMatchObject({
-        code: "ENOENT",
-      });
-    },
-  );
+    const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
+    await expect(fs.write("file.txt", "hello")).resolves.toBeUndefined();
+    await expect(fsp.readFile(targetPath, "utf8")).resolves.toBe("hello");
+    await expect(fsp.stat(compatibilityLockPath(rootDir))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "rejects replacement content despite the compatibility lock",
-    async () => {
-      configureFsSafeNative({ mode: "off" });
-      const rootDir = await makeTempRoot("fs-safe-rename-id-attack-");
-      replaceTargetAfterFallbackRename("attacker-content");
+  itPosix("rejects replacement content despite the compatibility lock", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const rootDir = await makeTempRoot("fs-safe-rename-id-attack-");
+    replaceTargetAfterFallbackRename("attacker-content");
 
-      const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
-      await expect(fs.write("file.txt", "hello")).rejects.toMatchObject({
-        code: "path-mismatch",
-      });
-    },
-  );
+    const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
+    await expectFsSafeError(fs.write("file.txt", "hello"), "path-mismatch");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "supports a per-call compatibility override",
-    async () => {
-      configureFsSafeNative({ mode: "off" });
-      const rootDir = await makeTempRoot("fs-safe-rename-id-per-call-");
-      replaceTargetAfterFallbackRename();
+  itPosix("supports a per-call compatibility override", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const rootDir = await makeTempRoot("fs-safe-rename-id-per-call-");
+    replaceTargetAfterFallbackRename();
 
-      const fs = await openRoot(rootDir);
-      await expect(
-        fs.write("file.txt", "per-call", {
-          renameIdentity: "verify-content-with-lock",
-        }),
-      ).resolves.toBeUndefined();
-    },
-  );
+    const fs = await openRoot(rootDir);
+    await expect(
+      fs.write("file.txt", "per-call", {
+        renameIdentity: "verify-content-with-lock",
+      }),
+    ).resolves.toBeUndefined();
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "deliberately keeps compatibility writes on the guarded JavaScript path",
-    async () => {
-      configureFsSafeNative({ mode: "off" });
-      const rootDir = await makeTempRoot("fs-safe-rename-id-native-");
-      replaceTargetAfterFallbackRename();
+  itPosix("deliberately keeps compatibility writes on the guarded JavaScript path", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const rootDir = await makeTempRoot("fs-safe-rename-id-native-");
+    replaceTargetAfterFallbackRename();
 
-      const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
-      await expect(fs.write("file.txt", "hello")).resolves.toBeUndefined();
-      await expect(fsp.readFile(path.join(rootDir, "file.txt"), "utf8")).resolves.toBe("hello");
-    },
-  );
+    const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
+    await expect(fs.write("file.txt", "hello")).resolves.toBeUndefined();
+    await expect(fsp.readFile(path.join(rootDir, "file.txt"), "utf8")).resolves.toBe("hello");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "preserves already-exists errors for create",
-    async () => {
-      configureFsSafeNative({ mode: "off" });
-      const rootDir = await makeTempRoot("fs-safe-rename-id-create-");
-      await fsp.writeFile(path.join(rootDir, "file.txt"), "existing");
+  itPosix("preserves already-exists errors for create", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const rootDir = await makeTempRoot("fs-safe-rename-id-create-");
+    await fsp.writeFile(path.join(rootDir, "file.txt"), "existing");
 
-      const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
-      await expect(fs.create("file.txt", "new")).rejects.toMatchObject({
-        code: "already-exists",
-      });
-    },
-  );
+    const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
+    await expectFsSafeError(fs.create("file.txt", "new"), "already-exists");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "does not create a missing parent when mkdir is disabled",
-    async () => {
-      configureFsSafeNative({ mode: "off" });
-      const rootDir = await makeTempRoot("fs-safe-rename-id-no-mkdir-");
-      const parentPath = path.join(rootDir, "missing");
+  itPosix("does not create a missing parent when mkdir is disabled", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const rootDir = await makeTempRoot("fs-safe-rename-id-no-mkdir-");
+    const parentPath = path.join(rootDir, "missing");
 
-      const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
-      await expect(fs.write("missing/file.txt", "hello", { mkdir: false })).rejects.toBeDefined();
-      await expect(fsp.stat(parentPath)).rejects.toMatchObject({ code: "ENOENT" });
-    },
-  );
+    const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
+    await expect(fs.write("missing/file.txt", "hello", { mkdir: false })).rejects.toBeDefined();
+    await expect(fsp.stat(parentPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "fails closed without deleting a stale sidecar lock",
-    async () => {
-      const rootDir = await makeTempRoot("fs-safe-rename-id-stale-");
-      const lockPath = compatibilityLockPath(rootDir);
-      await fsp.writeFile(
-        lockPath,
-        `${JSON.stringify({ pid: 9_999_999, createdAt: "2000-01-01T00:00:00.000Z" })}\n`,
-      );
+  itPosix("fails closed without deleting a stale sidecar lock", async () => {
+    const rootDir = await makeTempRoot("fs-safe-rename-id-stale-");
+    const lockPath = compatibilityLockPath(rootDir);
+    await fsp.writeFile(
+      lockPath,
+      `${JSON.stringify({ pid: 9_999_999, createdAt: "2000-01-01T00:00:00.000Z" })}\n`,
+    );
 
-      const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
-      await expect(fs.write("file.txt", "hello")).rejects.toMatchObject({
-        code: "file_lock_stale",
-      });
-      await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("9999999");
-    },
-  );
+    const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
+    await expect(fs.write("file.txt", "hello")).rejects.toMatchObject({
+      code: "file_lock_stale",
+    });
+    await expect(fsp.readFile(lockPath, "utf8")).resolves.toContain("9999999");
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "works on a normal POSIX filesystem and releases the lock",
-    async () => {
-      configureFsSafeNative({ mode: "off" });
-      const rootDir = await makeTempRoot("fs-safe-rename-id-posix-");
+  itPosix("works on a normal POSIX filesystem and releases the lock", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const rootDir = await makeTempRoot("fs-safe-rename-id-posix-");
 
-      const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
-      await expect(fs.write("file.txt", "content")).resolves.toBeUndefined();
-      await expect(fsp.readFile(path.join(rootDir, "file.txt"), "utf8")).resolves.toBe(
-        "content",
-      );
-      await expect(fsp.stat(compatibilityLockPath(rootDir))).rejects.toMatchObject({
-        code: "ENOENT",
-      });
-    },
-  );
+    const fs = await openRoot(rootDir, { renameIdentity: "verify-content-with-lock" });
+    await expect(fs.write("file.txt", "content")).resolves.toBeUndefined();
+    await expect(fsp.readFile(path.join(rootDir, "file.txt"), "utf8")).resolves.toBe(
+      "content",
+    );
+    await expect(fsp.stat(compatibilityLockPath(rootDir))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
 });

--- a/test/root-paths.test.ts
+++ b/test/root-paths.test.ts
@@ -3,6 +3,7 @@ import { realpathSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { itPosix } from "./helpers/vitest.js";
 import { readLocalFileFromRoots, resolveLocalPathFromRootsSync } from "../src/local-roots.js";
 import {
   ensureDirectoryWithinRoot,
@@ -93,7 +94,7 @@ describe("root path list helpers", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlink escapes", async () => {
+  itPosix("rejects symlink escapes", async () => {
     await withFixtureRoot(async ({ baseDir, uploadsDir }) => {
       const outsideDir = path.join(baseDir, "outside");
       await fs.mkdir(outsideDir, { recursive: true });
@@ -180,7 +181,7 @@ describe("local roots helpers", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")("rejects symlink escapes while reading", async () => {
+  itPosix("rejects symlink escapes while reading", async () => {
     await withFixtureRoot(async ({ baseDir, uploadsDir }) => {
       const outsideDir = path.join(baseDir, "outside");
       await fs.mkdir(outsideDir, { recursive: true });

--- a/test/secret-file.test.ts
+++ b/test/secret-file.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { FsSafeError } from "../src/errors.js";
 import {
   PRIVATE_SECRET_DIR_MODE,
@@ -11,17 +11,9 @@ import {
   writeSecretFileAtomic,
 } from "../src/secret-file.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
-});
 
 function expectSecretReadCode(run: () => string, code: FsSafeError["code"]): void {
   try {
@@ -85,7 +77,7 @@ describe("secret file helpers", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")("rejects hardlinked secret files by default", async () => {
+  itPosix("rejects hardlinked secret files by default", async () => {
     const root = await tempRoot("fs-safe-secret-hardlink-");
     const target = path.join(root, "target.txt");
     const link = path.join(root, "alias.txt");
@@ -128,7 +120,7 @@ describe("secret file helpers", () => {
     }
   });
 
-  it.runIf(process.platform !== "win32")("keeps private secret file mode under restrictive umask", async () => {
+  itPosix("keeps private secret file mode under restrictive umask", async () => {
     const root = await tempRoot("fs-safe-secret-umask-");
     const filePath = path.join(root, "token.txt");
     const oldUmask = process.umask(0o777);

--- a/test/sidecar-lock-ownership-token.test.ts
+++ b/test/sidecar-lock-ownership-token.test.ts
@@ -1,8 +1,8 @@
 import fsSync from "node:fs";
 import fsp from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
 import { createSidecarLockManager } from "../src/sidecar-lock.js";
 import { configureFsSafeNative } from "../src/native-config.js";
 import {
@@ -12,18 +12,12 @@ import {
   sidecarLockSnapshotMatches,
 } from "../src/sidecar-lock-reclaim.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 afterEach(async () => {
   configureFsSafeNative({ mode: "auto" });
   vi.restoreAllMocks();
-  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
 });
 
 describe("sidecar lock ownership tokens", () => {

--- a/test/sidecar-lock-regression.test.ts
+++ b/test/sidecar-lock-regression.test.ts
@@ -1,20 +1,16 @@
 import fsp from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { fileStore } from "../src/file-store.js";
 import { acquireFileLock, acquireFileLockSync } from "../src/file-lock.js";
 import { configureFsSafeLocks, getFsSafeLockConfig } from "../src/lock-config.js";
 import { createSidecarLockManager } from "../src/sidecar-lock.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 afterEach(async () => {
   __setFsSafeTestHooksForTest();
@@ -25,7 +21,6 @@ afterEach(async () => {
     staleRecovery: "fail-closed",
     timeoutMs: undefined,
   });
-  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
 });
 
 describe("sidecar lock regressions", () => {
@@ -424,52 +419,47 @@ describe("sidecar lock regressions", () => {
     ).rejects.toMatchObject({ code: "EACCES" });
   });
 
-  it.runIf(process.platform !== "win32")(
-    "does not follow a sidecar replaced with a symlink during inspection",
-    async () => {
-      const base = await tempRoot("fs-safe-sidecar-snapshot-symlink-");
-      const targetPath = path.join(base, "state.json");
-      const lockPath = `${targetPath}.lock`;
-      const oldLockPath = `${lockPath}.old`;
-      const secretPath = path.join(base, "secret.json");
-      await fsp.writeFile(
+  itPosix("does not follow a sidecar replaced with a symlink during inspection", async () => {
+    const base = await tempRoot("fs-safe-sidecar-snapshot-symlink-");
+    const targetPath = path.join(base, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const oldLockPath = `${lockPath}.old`;
+    const secretPath = path.join(base, "secret.json");
+    await fsp.writeFile(
+      lockPath,
+      JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z", owner: "original" }),
+    );
+    await fsp.writeFile(
+      secretPath,
+      JSON.stringify({ createdAt: "2999-01-01T00:00:00.000Z", secret: "do-not-read" }),
+    );
+
+    let swapped = false;
+    __setFsSafeTestHooksForTest({
+      beforeSidecarLockSnapshotOpen: async (inspectedPath) => {
+        if (swapped || inspectedPath !== lockPath) return;
+        swapped = true;
+        await fsp.rename(lockPath, oldLockPath);
+        await fsp.symlink(secretPath, lockPath);
+      },
+    });
+    const observedPayloads: unknown[] = [];
+    const manager = createSidecarLockManager(`fs-safe-snapshot-symlink-${Date.now()}`);
+
+    await expectFsSafeError(manager.acquire({
+        targetPath,
         lockPath,
-        JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z", owner: "original" }),
-      );
-      await fsp.writeFile(
-        secretPath,
-        JSON.stringify({ createdAt: "2999-01-01T00:00:00.000Z", secret: "do-not-read" }),
-      );
-
-      let swapped = false;
-      __setFsSafeTestHooksForTest({
-        beforeSidecarLockSnapshotOpen: async (inspectedPath) => {
-          if (swapped || inspectedPath !== lockPath) return;
-          swapped = true;
-          await fsp.rename(lockPath, oldLockPath);
-          await fsp.symlink(secretPath, lockPath);
+        staleMs: 1,
+        timeoutMs: 1,
+        retry: { retries: 0 },
+        payload: async () => ({ createdAt: new Date().toISOString() }),
+        shouldReclaim: async ({ payload }) => {
+          observedPayloads.push(payload);
+          return false;
         },
-      });
-      const observedPayloads: unknown[] = [];
-      const manager = createSidecarLockManager(`fs-safe-snapshot-symlink-${Date.now()}`);
-
-      await expect(
-        manager.acquire({
-          targetPath,
-          lockPath,
-          staleMs: 1,
-          timeoutMs: 1,
-          retry: { retries: 0 },
-          payload: async () => ({ createdAt: new Date().toISOString() }),
-          shouldReclaim: async ({ payload }) => {
-            observedPayloads.push(payload);
-            return false;
-          },
-        }),
-      ).rejects.toMatchObject({ code: "not-file" });
-      expect(observedPayloads).toEqual([]);
-    },
-  );
+      }), "not-file");
+    expect(observedPayloads).toEqual([]);
+  });
 
   it("keeps lock config as explicit defaults, not global auto-locking", async () => {
     const base = await tempRoot("fs-safe-lock-config-");

--- a/test/sidecar-lock-windows-denial.test.ts
+++ b/test/sidecar-lock-windows-denial.test.ts
@@ -1,22 +1,16 @@
 import fsp from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
 import { acquireFileLock } from "../src/file-lock.js";
 import { configureFsSafeNative } from "../src/native-config.js";
 
-const tempDirs: string[] = [];
+const { tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
-}
 
 afterEach(async () => {
   vi.restoreAllMocks();
   configureFsSafeNative({ mode: "auto" });
-  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
 });
 
 describe.runIf(process.platform === "win32")("Windows sidecar lock denials", () => {

--- a/test/stage1-primitives.test.ts
+++ b/test/stage1-primitives.test.ts
@@ -1,8 +1,9 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import {
   isHardlinkFallbackError,
   publishFileExclusive,
@@ -23,19 +24,13 @@ import { configureFsSafeNative } from "../src/native-config.js";
 import { FsSafeError } from "../src/errors.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 
-const tempDirs: string[] = [];
+const { tempDirs, tempRoot } = useTempDirs();
 
-async function tempRoot(prefix: string): Promise<string> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(directory);
-  return directory;
-}
 
 afterEach(async () => {
   configureFsSafeNative({ mode: "auto" });
   __setFsSafeTestHooksForTest();
   vi.restoreAllMocks();
-  await Promise.all(tempDirs.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
 });
 
 describe("exclusive file publication", () => {
@@ -232,44 +227,41 @@ describe("exclusive file publication", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")(
-    "detects parent replacement inside the shared directory-sync boundary",
-    async () => {
-      configureFsSafeNative({ mode: "off" });
-      const directory = await tempRoot("fs-safe-publish-parent-drift-");
-      const movedDirectory = `${directory}.moved`;
-      tempDirs.push(movedDirectory);
-      const sourcePath = path.join(directory, "source");
-      const targetPath = path.join(directory, "target");
-      await fs.writeFile(sourcePath, "complete-archive");
-      __setFsSafeTestHooksForTest({
-        async beforePublishDirectorySync() {
-          await fs.rename(directory, movedDirectory);
-          await fs.mkdir(directory);
-          await fs.writeFile(targetPath, "replacement");
-        },
-      });
+  itPosix("detects parent replacement inside the shared directory-sync boundary", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-publish-parent-drift-");
+    const movedDirectory = `${directory}.moved`;
+    tempDirs.push(movedDirectory);
+    const sourcePath = path.join(directory, "source");
+    const targetPath = path.join(directory, "target");
+    await fs.writeFile(sourcePath, "complete-archive");
+    __setFsSafeTestHooksForTest({
+      async beforePublishDirectorySync() {
+        await fs.rename(directory, movedDirectory);
+        await fs.mkdir(directory);
+        await fs.writeFile(targetPath, "replacement");
+      },
+    });
 
-      await expect(
-        publishFileExclusive({
-          sourcePath,
-          targetPath,
-          strategy: "link-required",
-          onSyncFailure: "rollback",
-        }),
-      ).rejects.toMatchObject({
-        details: {
-          phase: "directory-sync",
-          cleanup: "preserved",
-          directorySync: { status: "failed", code: "path-mismatch" },
-        },
-      });
-      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("replacement");
-      await expect(fs.readFile(path.join(movedDirectory, "target"), "utf8")).resolves.toBe(
-        "complete-archive",
-      );
-    },
-  );
+    await expect(
+      publishFileExclusive({
+        sourcePath,
+        targetPath,
+        strategy: "link-required",
+        onSyncFailure: "rollback",
+      }),
+    ).rejects.toMatchObject({
+      details: {
+        phase: "directory-sync",
+        cleanup: "preserved",
+        directorySync: { status: "failed", code: "path-mismatch" },
+      },
+    });
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readFile(path.join(movedDirectory, "target"), "utf8")).resolves.toBe(
+      "complete-archive",
+    );
+  });
 });
 
 describe("secret file additions", () => {
@@ -279,9 +271,7 @@ describe("secret file additions", () => {
     await createSecretFileAtomic({ rootDir: directory, filePath, content: " token\n" });
     await expect(readSecretFile(filePath, "token")).resolves.toBe("token");
     await expect(tryReadSecretFile(path.join(directory, "missing"), "token")).resolves.toBeUndefined();
-    await expect(
-      createSecretFileAtomic({ rootDir: directory, filePath, content: "replacement" }),
-    ).rejects.toMatchObject({ code: "secret-exists" });
+    await expectFsSafeError(createSecretFileAtomic({ rootDir: directory, filePath, content: "replacement" }), "secret-exists");
     await expect(fs.readFile(filePath, "utf8")).resolves.toBe(" token\n");
   });
 });
@@ -330,13 +320,11 @@ describe("file lock additions", () => {
     await lock.release();
     await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("replacement");
 
-    await expect(
-      acquireFileLock(path.join(directory, "other.json"), {
+    await expectFsSafeError(acquireFileLock(path.join(directory, "other.json"), {
         lockPath: path.join(directory, "outside.lock"),
         lockRoot,
         payload: () => ({}),
-      }),
-    ).rejects.toMatchObject({ code: "outside-workspace" });
+      }), "outside-workspace");
   });
 
   it("lets application parsers drive guarded legacy payload reclaim", async () => {
@@ -383,7 +371,7 @@ describe("root walk and temp receipts", () => {
       { relativePath: "nested", kind: "directory", size: expect.any(Number) },
       { relativePath: "nested", kind: "truncated", size: 0 },
     ]);
-    await expect(async () => {
+    await expectFsSafeError((async () => {
       for await (const _entry of capability.walk("", {
         maxEntries: 0,
         symlinkPolicy: "skip",
@@ -391,10 +379,10 @@ describe("root walk and temp receipts", () => {
       })) {
         // Consume the iterator.
       }
-    }).rejects.toMatchObject({ code: "too-large" });
+    })(), "too-large");
   });
 
-  it.runIf(process.platform !== "win32")("follows only symlinks that remain inside the walk root", async () => {
+  itPosix("follows only symlinks that remain inside the walk root", async () => {
     const directory = await tempRoot("fs-safe-root-walk-links-");
     const outside = await tempRoot("fs-safe-root-walk-outside-");
     await fs.mkdir(path.join(directory, "real"));

--- a/test/symlink-dotdot-escape.test.ts
+++ b/test/symlink-dotdot-escape.test.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { afterEach, describe, expect, it } from "vitest";
+import { itPosix } from "./helpers/vitest.js";
 import { configureFsSafeNative, FsSafeError, root, type Root } from "../src/index.js";
 import {
   __resetNativeLoaderForTest,
@@ -74,7 +75,7 @@ describe("static symlink + dot-dot boundary escape", () => {
   const backends = native ? (["javascript", "native"] as const) : (["javascript"] as const);
 
   describe.each(backends)("%s path", (backend) => {
-    it.runIf(process.platform !== "win32").each(operations)(
+    itPosix.each(operations)(
       "blocks $name",
       async ({ run }) => {
         if (backend === "native") {
@@ -98,46 +99,40 @@ describe("static symlink + dot-dot boundary escape", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")(
-    "reports best-effort containment for JavaScript root results",
-    async () => {
-      __setNativeLoaderForTest(() => {
-        throw Object.assign(new Error("native helper disabled for fallback proof"), {
-          code: "MODULE_NOT_FOUND",
-        });
+  itPosix("reports best-effort containment for JavaScript root results", async () => {
+    __setNativeLoaderForTest(() => {
+      throw Object.assign(new Error("native helper disabled for fallback proof"), {
+        code: "MODULE_NOT_FOUND",
       });
-      configureFsSafeNative({ mode: "auto" });
-      const base = await mkdtemp(path.join(fixtureParent, "fs-safe-containment-result-"));
-      tempDirs.push(base);
-      await writeFile(path.join(base, "input.txt"), "input");
-      const scoped = await root(base);
+    });
+    configureFsSafeNative({ mode: "auto" });
+    const base = await mkdtemp(path.join(fixtureParent, "fs-safe-containment-result-"));
+    tempDirs.push(base);
+    await writeFile(path.join(base, "input.txt"), "input");
+    const scoped = await root(base);
 
-      const opened = await scoped.open("input.txt");
-      expect(opened.containment).toBe("best-effort");
-      await opened.handle.close();
-      await expect(scoped.read("input.txt")).resolves.toMatchObject({
-        containment: "best-effort",
-      });
-      const writable = await scoped.openWritable("output.txt");
-      expect(writable.containment).toBe("best-effort");
-      await writable.handle.close();
-    },
-  );
+    const opened = await scoped.open("input.txt");
+    expect(opened.containment).toBe("best-effort");
+    await opened.handle.close();
+    await expect(scoped.read("input.txt")).resolves.toMatchObject({
+      containment: "best-effort",
+    });
+    const writable = await scoped.openWritable("output.txt");
+    expect(writable.containment).toBe("best-effort");
+    await writable.handle.close();
+  });
 
-  it.runIf(process.platform !== "win32")(
-    "walks aliases before dot-dot in async and sync root-path resolution",
-    async () => {
-      const fixture = await makeStaticEscapeFixture();
-      const absolutePath = `${fixture.rootDir}/${escapePath}`;
-      const params = {
-        rootPath: fixture.rootDir,
-        rootCanonicalPath: fixture.rootDir,
-        absolutePath,
-        boundaryLabel: "root",
-      } as const;
+  itPosix("walks aliases before dot-dot in async and sync root-path resolution", async () => {
+    const fixture = await makeStaticEscapeFixture();
+    const absolutePath = `${fixture.rootDir}/${escapePath}`;
+    const params = {
+      rootPath: fixture.rootDir,
+      rootCanonicalPath: fixture.rootDir,
+      absolutePath,
+      boundaryLabel: "root",
+    } as const;
 
-      await expect(resolveRootPath(params)).rejects.toThrow("outside root");
-      expect(() => resolveRootPathSync(params)).toThrow("outside root");
-    },
-  );
+    await expect(resolveRootPath(params)).rejects.toThrow("outside root");
+    expect(() => resolveRootPathSync(params)).toThrow("outside root");
+  });
 });

--- a/test/temp-fixture.test.ts
+++ b/test/temp-fixture.test.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs/promises";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
+
+describe("temp directory fixture", () => {
+  const { tempRoot } = useTempDirs();
+  let createdDirectory = "";
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await expect(fs.lstat(createdDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("cleans up after local mock restoration", async () => {
+    createdDirectory = await tempRoot("fs-safe-temp-fixture-order-");
+    const rm = vi.spyOn(fs, "rm").mockRejectedValue(new Error("mocked rm must be restored first"));
+
+    expect(rm).not.toHaveBeenCalled();
+  });
+});

--- a/test/windows-path.test.ts
+++ b/test/windows-path.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { describe, expect, it } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
 import { fileStore, fileStoreSync } from "../src/file-store.js";
 import { isWindowsNetworkPath } from "../src/local-file-access.js";
 import {
@@ -231,9 +232,7 @@ describe("drive-relative relative paths", () => {
       const store = fileStore({ rootDir });
       await store.writeText("secret.txt", "real");
 
-      await expect(store.writeText("C:secret.txt", "aliased")).rejects.toMatchObject({
-        code: "invalid-path",
-      });
+      await expectFsSafeError(store.writeText("C:secret.txt", "aliased"), "invalid-path");
       await expect(readFile(path.join(rootDir, "secret.txt"), "utf8")).resolves.toBe("real");
     } finally {
       await rm(rootDir, { force: true, recursive: true });

--- a/test/write-boundary-bypass.test.ts
+++ b/test/write-boundary-bypass.test.ts
@@ -2,20 +2,10 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
+import { itPosix } from "./helpers/vitest.js";
 import { fileStore, fileStoreSync } from "../src/file-store.js";
 import { configureFsSafeNative, root as openRoot } from "../src/index.js";
-import {
-  ESCAPING_DIRECTORY_PAYLOADS,
-  ESCAPING_WRITE_PAYLOADS,
-  expectFsSafeCode,
-  expectNoOutsideWrite,
-  LITERAL_SUSPICIOUS_DIRECTORY_PAYLOADS,
-  LITERAL_SUSPICIOUS_WRITE_PAYLOADS,
-  makeTempLayout as makeSecurityTempLayout,
-  POSIX_LITERAL_SUSPICIOUS_WRITE_PAYLOADS,
-  SAFE_REJECTED_SUSPICIOUS_DIRECTORY_PAYLOADS,
-  WINDOWS_REJECTED_SUSPICIOUS_DIRECTORY_PAYLOADS,
-} from "./helpers/security.js";
+import { ESCAPING_DIRECTORY_PAYLOADS, ESCAPING_WRITE_PAYLOADS, expectFsSafeCode, expectNoOutsideWrite, LITERAL_SUSPICIOUS_DIRECTORY_PAYLOADS, LITERAL_SUSPICIOUS_WRITE_PAYLOADS, makeTempLayout as makeSecurityTempLayout, POSIX_LITERAL_SUSPICIOUS_WRITE_PAYLOADS, SAFE_REJECTED_SUSPICIOUS_DIRECTORY_PAYLOADS, WINDOWS_REJECTED_SUSPICIOUS_DIRECTORY_PAYLOADS, expectFsSafeError } from "./helpers/security.js";
 
 const tempDirs: string[] = [];
 
@@ -93,7 +83,7 @@ describe("write, move, and delete boundary bypass attempts", () => {
     await expectNoOutsideWrite(layout);
   });
 
-  it.runIf(process.platform !== "win32")("rejects file store symlink parent writes", async () => {
+  itPosix("rejects file store symlink parent writes", async () => {
     const layout = await makeTempLayout("fs-safe-file-store-symlink-parent");
     const source = path.join(layout.root, "source.txt");
     await fsp.writeFile(source, "source");
@@ -170,8 +160,7 @@ describe("write, move, and delete boundary bypass attempts", () => {
 
     await expect(safeRoot.move("source-link.txt", "moved.txt")).rejects.toBeTruthy();
     if (process.platform === "win32") {
-      await expect(safeRoot.move("from.txt", "dest-link.txt", { overwrite: true })).rejects
-        .toMatchObject({ code: "path-alias" });
+      await expectFsSafeError(safeRoot.move("from.txt", "dest-link.txt", { overwrite: true }), "path-alias");
       await expectNoOutsideWrite(layout);
       return;
     }
@@ -240,7 +229,7 @@ describe("write, move, and delete boundary bypass attempts", () => {
     await expectNoOutsideWrite(layout);
   }, 15000);
 
-  it.runIf(process.platform !== "win32")("keeps literal '..'-prefixed read paths available when the helper is disabled", async () => {
+  itPosix("keeps literal '..'-prefixed read paths available when the helper is disabled", async () => {
     configureFsSafeNative({ mode: "off" });
     const layout = await makeTempLayout("fs-safe-write-helper-off-literal");
     const safeRoot = await openRoot(layout.root);
@@ -258,7 +247,7 @@ describe("write, move, and delete boundary bypass attempts", () => {
     await expectNoOutsideWrite(layout);
   });
 
-  it.runIf(process.platform !== "win32")("does not create directories outside the root when append races a parent symlink swap", async () => {
+  itPosix("does not create directories outside the root when append races a parent symlink swap", async () => {
     const layout = await makeTempLayout("fs-safe-append-mkdir-swap");
     const safeRoot = await openRoot(layout.root);
     const swapPath = path.join(layout.root, "data");
@@ -285,7 +274,7 @@ describe("write, move, and delete boundary bypass attempts", () => {
     await expectNoOutsideWrite(layout);
   }, 30000);
 
-  it.runIf(process.platform !== "win32")("does not create directories outside the root when openWritable races a parent symlink swap", async () => {
+  itPosix("does not create directories outside the root when openWritable races a parent symlink swap", async () => {
     const layout = await makeTempLayout("fs-safe-open-writable-mkdir-swap");
     const safeRoot = await openRoot(layout.root);
     const swapPath = path.join(layout.root, "data");
@@ -313,7 +302,7 @@ describe("write, move, and delete boundary bypass attempts", () => {
     await expectNoOutsideWrite(layout);
   }, 30000);
 
-  it.runIf(process.platform !== "win32")("does not create directories outside the root when copyIn fallback races a parent symlink swap", async () => {
+  itPosix("does not create directories outside the root when copyIn fallback races a parent symlink swap", async () => {
     configureFsSafeNative({ mode: "off" });
     const layout = await makeTempLayout("fs-safe-copy-in-mkdir-swap");
     const safeRoot = await openRoot(layout.root);


### PR DESCRIPTION
## Summary

- strengthen four boundary-escape tests with outside-path side-effect checks
- extract platform aliases, temp fixtures, and typed filesystem safety error assertions
- reuse shared security layouts, add local spy factories, and compact API coverage imports
- preserve every existing test and add one fixture-ordering regression

## Verification

- pnpm check
- pnpm test:security
- two consecutive pnpm test runs: 740 passed, 42 skipped
- git diff --check
- Codex autoreview: clean

Coverage improved from 84.11% to 84.21% lines. The coverage command remains below the configured global thresholds in this checkout, as it was before this test-only refactor.