### PR TITLE
test: cover queue lock and publication failures

### DIFF
--- a/test/file-lock-sync-failure.test.ts
+++ b/test/file-lock-sync-failure.test.ts
@@ -2,7 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import { itPosix, itWin32, useTempDirs } from "./helpers/vitest.js";
 import { acquireFileLockSync } from "../src/file-lock.js";
 import { root } from "../src/root.js";
 
@@ -177,7 +177,7 @@ describe("synchronous file-lock failure handling", () => {
     expect(fsSync.existsSync(lock.lockPath)).toBe(false);
   });
 
-  it("bounds synchronous lock paths through a Root capability", async () => {
+  itPosix("bounds synchronous lock paths through a Root capability", async () => {
     const directory = await tempRoot("fs-safe-sync-lock-root-");
     const lockDirectory = path.join(directory, "locks");
     await fs.mkdir(lockDirectory);
@@ -194,6 +194,21 @@ describe("synchronous file-lock failure handling", () => {
       lockPath: path.join(directory, "outside.lock"),
       lockRoot,
     })).toThrow(expect.objectContaining({ code: "outside-workspace" }));
+  });
+
+  itWin32("fails closed when a synchronous lock parent cannot match the Root canonical path", async () => {
+    const directory = await tempRoot("fs-safe-sync-lock-root-win32-");
+    const lockDirectory = path.join(directory, "locks");
+    const lockPath = path.join(lockDirectory, "state.lock");
+    await fs.mkdir(lockDirectory);
+    const lockRoot = await root(lockDirectory);
+
+    expect(() => acquireFileLockSync(path.join(directory, "state.json"), {
+      ...lockOptions(),
+      lockPath,
+      lockRoot,
+    })).toThrow(expect.objectContaining({ code: "outside-workspace" }));
+    expect(fsSync.existsSync(lockPath)).toBe(false);
   });
 
   it("sleeps for a bounded retry before timing out on an in-process holder", async () => {

--- a/test/file-lock-sync-failure.test.ts
+++ b/test/file-lock-sync-failure.test.ts
@@ -1,0 +1,245 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import { acquireFileLockSync } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function lockOptions() {
+  return {
+    payload: () => ({ createdAt: new Date().toISOString() }),
+    timeoutMs: 0,
+    retry: { retries: 0 },
+  } as const;
+}
+
+describe("synchronous file-lock failure handling", () => {
+  it("removes a partially-created lock when payload persistence fails", async () => {
+    const root = await tempRoot("fs-safe-sync-lock-write-failure-");
+    const targetPath = path.join(root, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const failure = Object.assign(new Error("disk write failed"), { code: "EIO" });
+    vi.spyOn(fsSync, "writeFileSync").mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    expect(() => acquireFileLockSync(targetPath, lockOptions())).toThrow(failure);
+    expect(fsSync.existsSync(lockPath)).toBe(false);
+  });
+
+  it("removes a partially-created lock when fsync fails", async () => {
+    const root = await tempRoot("fs-safe-sync-lock-fsync-failure-");
+    const targetPath = path.join(root, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const failure = Object.assign(new Error("fsync failed"), { code: "EIO" });
+    vi.spyOn(fsSync, "fsyncSync").mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    expect(() => acquireFileLockSync(targetPath, lockOptions())).toThrow(failure);
+    expect(fsSync.existsSync(lockPath)).toBe(false);
+  });
+
+  it("fails closed on stale locks unless unchanged removal is explicitly approved", async () => {
+    const root = await tempRoot("fs-safe-sync-lock-stale-");
+    const targetPath = path.join(root, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    await fs.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
+
+    expect(() =>
+      acquireFileLockSync(targetPath, {
+        ...lockOptions(),
+        staleMs: 1,
+        staleRecovery: "remove-if-unchanged",
+        shouldReclaim: () => true,
+        shouldRemoveStaleLock: () => false,
+      }),
+    ).toThrow(expect.objectContaining({ code: "file_lock_stale" }));
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toContain("2000");
+
+    const lock = acquireFileLockSync(targetPath, {
+      ...lockOptions(),
+      staleMs: 1,
+      staleRecovery: "remove-if-unchanged",
+      shouldReclaim: () => true,
+      shouldRemoveStaleLock: (snapshot) => snapshot.raw.includes("2000"),
+    });
+    expect(lock.verifyStillHeld()).toBe(true);
+    lock.release();
+    expect(fsSync.existsSync(lockPath)).toBe(false);
+  });
+
+  it("uses file age for corrupt legacy locks and preserves them on stale failure", async () => {
+    const root = await tempRoot("fs-safe-sync-lock-corrupt-");
+    const targetPath = path.join(root, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    await fs.writeFile(lockPath, "{");
+    await fs.utimes(lockPath, new Date(0), new Date(0));
+
+    expect(() =>
+      acquireFileLockSync(targetPath, { ...lockOptions(), staleMs: 1 }),
+    ).toThrow(expect.objectContaining({ code: "file_lock_stale" }));
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("{");
+  });
+
+  it("fails closed if stale-lock metadata cannot be inspected", async () => {
+    const root = await tempRoot("fs-safe-sync-lock-stat-failure-");
+    const targetPath = path.join(await fs.realpath(root), "state.json");
+    const lockPath = `${targetPath}.lock`;
+    await fs.writeFile(lockPath, "{}");
+    const realStat = fsSync.statSync.bind(fsSync);
+    vi.spyOn(fsSync, "statSync").mockImplementation((filePath, options) => {
+      if (String(filePath) === lockPath) {
+        throw Object.assign(new Error("inspection denied"), { code: "EACCES" });
+      }
+      return realStat(filePath, options as never);
+    });
+
+    expect(() =>
+      acquireFileLockSync(targetPath, { ...lockOptions(), staleMs: 60_000 }),
+    ).toThrow(expect.objectContaining({ code: "file_lock_stale" }));
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("{}");
+  });
+
+  it("propagates reclaim-guard creation failures and leaves the stale lock intact", async () => {
+    const root = await tempRoot("fs-safe-sync-lock-reclaim-failure-");
+    const targetPath = path.join(await fs.realpath(root), "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const reclaimPath = `${lockPath}.reclaim`;
+    await fs.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
+    const realMkdir = fsSync.mkdirSync.bind(fsSync);
+    vi.spyOn(fsSync, "mkdirSync").mockImplementation((directory, options) => {
+      if (String(directory) === reclaimPath) {
+        throw Object.assign(new Error("reclaim guard denied"), { code: "EACCES" });
+      }
+      return realMkdir(directory, options as never);
+    });
+
+    expect(() =>
+      acquireFileLockSync(targetPath, {
+        ...lockOptions(),
+        staleMs: 1,
+        staleRecovery: "remove-if-unchanged",
+        shouldReclaim: () => true,
+        shouldRemoveStaleLock: () => true,
+      }),
+    ).toThrow(expect.objectContaining({ code: "EACCES" }));
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toContain("2000");
+  });
+
+  it("reports compromised ownership and preserves the replacement on release", async () => {
+    const root = await tempRoot("fs-safe-sync-lock-compromised-");
+    const targetPath = path.join(root, "state.json");
+    let compromised: { lockPath: string; normalizedTargetPath: string } | undefined;
+    const lock = acquireFileLockSync(targetPath, {
+      ...lockOptions(),
+      compromiseCheckIntervalMs: 2,
+      onCompromised: (info) => {
+        compromised = info;
+      },
+    });
+    await fs.writeFile(lock.lockPath, "replacement");
+
+    await vi.waitFor(() => expect(compromised).toEqual({
+      lockPath: lock.lockPath,
+      normalizedTargetPath: lock.normalizedTargetPath,
+    }));
+    expect(lock.verifyStillHeld()).toBe(false);
+    lock.release();
+    await expect(fs.readFile(lock.lockPath, "utf8")).resolves.toBe("replacement");
+  });
+
+  it("falls back to the resolved target when parent realpath lookup fails", async () => {
+    const root = await tempRoot("fs-safe-sync-lock-realpath-failure-");
+    const targetPath = path.join(root, "state.json");
+    vi.spyOn(fsSync, "realpathSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("realpath unavailable"), { code: "EIO" });
+    });
+
+    const lock = acquireFileLockSync(targetPath, lockOptions());
+    expect(lock.normalizedTargetPath).toBe(path.resolve(targetPath));
+    lock.release();
+  });
+
+  it("makes repeated release and disposal idempotent", async () => {
+    const root = await tempRoot("fs-safe-sync-lock-release-");
+    const lock = acquireFileLockSync(path.join(root, "state.json"), lockOptions());
+    lock.release();
+    lock.release();
+    lock[Symbol.dispose]();
+    expect(fsSync.existsSync(lock.lockPath)).toBe(false);
+  });
+
+  it("bounds synchronous lock paths through a Root capability", async () => {
+    const directory = await tempRoot("fs-safe-sync-lock-root-");
+    const lockDirectory = path.join(directory, "locks");
+    await fs.mkdir(lockDirectory);
+    const lockRoot = await root(lockDirectory);
+    const targetPath = path.join(directory, "state.json");
+    const lock = acquireFileLockSync(targetPath, {
+      ...lockOptions(),
+      lockPath: path.join(lockDirectory, "state.lock"),
+      lockRoot,
+    });
+    lock.release();
+    expect(() => acquireFileLockSync(targetPath, {
+      ...lockOptions(),
+      lockPath: path.join(directory, "outside.lock"),
+      lockRoot,
+    })).toThrow(expect.objectContaining({ code: "outside-workspace" }));
+  });
+
+  it("sleeps for a bounded retry before timing out on an in-process holder", async () => {
+    const directory = await tempRoot("fs-safe-sync-lock-retry-");
+    const targetPath = path.join(directory, "state.json");
+    const held = acquireFileLockSync(targetPath, lockOptions());
+    expect(() => acquireFileLockSync(targetPath, {
+      payload: () => ({}),
+      retry: { retries: 1, minTimeout: 1, maxTimeout: 1 },
+    })).toThrow(expect.objectContaining({ code: "file_lock_timeout" }));
+    held.release();
+  });
+
+  it("propagates reclaim-guard inspection failures", async () => {
+    const directory = await tempRoot("fs-safe-sync-lock-guard-inspect-");
+    const targetPath = path.join(await fs.realpath(directory), "state.json");
+    const guardPath = `${targetPath}.lock.reclaim`;
+    const realLstat = fsSync.lstatSync.bind(fsSync);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((pathname, options) => {
+      if (String(pathname) === guardPath) {
+        throw Object.assign(new Error("guard inspection denied"), { code: "EACCES" });
+      }
+      return realLstat(pathname, options as never);
+    });
+    expect(() => acquireFileLockSync(targetPath, lockOptions())).toThrow(
+      expect.objectContaining({ code: "EACCES" }),
+    );
+  });
+
+  itPosix("rejects a lexically-contained lock parent that resolves outside lockRoot", async () => {
+    const directory = await tempRoot("fs-safe-sync-lock-root-parent-swap-");
+    const lockDirectory = path.join(directory, "locks");
+    const outside = path.join(directory, "outside");
+    const linkedParent = path.join(lockDirectory, "linked");
+    await fs.mkdir(lockDirectory);
+    await fs.mkdir(outside);
+    await fs.symlink(outside, linkedParent);
+    const lockRoot = await root(lockDirectory);
+
+    expect(() => acquireFileLockSync(path.join(directory, "state.json"), {
+      ...lockOptions(),
+      lockPath: path.join(linkedParent, "state.lock"),
+      lockRoot,
+    })).toThrow(expect.objectContaining({ code: "outside-workspace" }));
+    await expect(fs.access(path.join(outside, "state.lock"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});

--- a/test/json-durable-queue-failure.test.ts
+++ b/test/json-durable-queue-failure.test.ts
@@ -1,0 +1,214 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import {
+  ackJsonDurableQueueEntry,
+  ensureJsonDurableQueueDirs,
+  jsonDurableQueueEntryExists,
+  loadJsonDurableQueueEntry,
+  loadPendingJsonDurableQueueEntries,
+  moveJsonDurableQueueEntryToFailed,
+  readJsonDurableQueueEntry,
+  resolveJsonDurableQueueEntryPaths,
+  unlinkBestEffort,
+} from "../src/json-durable-queue.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("durable JSON queue failure recovery", () => {
+  it("resumes valid entries while discarding crash markers and refusing corrupt state", async () => {
+    const root = await tempRoot("fs-safe-queue-resume-");
+    const queueDir = path.join(root, "queue");
+    const failedDir = path.join(root, "failed");
+    await ensureJsonDurableQueueDirs({ queueDir, failedDir });
+
+    await fs.writeFile(path.join(queueDir, "ready.json"), JSON.stringify({ version: 1 }));
+    await fs.writeFile(path.join(queueDir, "truncated.json"), "{\"version\":");
+    await fs.mkdir(path.join(queueDir, "directory.json"));
+    await fs.writeFile(path.join(queueDir, "already.delivered"), "stale");
+    const freshTmp = path.join(queueDir, "fresh.tmp");
+    await fs.writeFile(freshTmp, "incomplete");
+
+    await expect(
+      loadPendingJsonDurableQueueEntries<{ version: number }>({
+        queueDir,
+        tempPrefix: "queue",
+        cleanupTmpMaxAgeMs: 60_000,
+        read: async (entry) => ({ entry: { version: entry.version + 1 }, migrated: true }),
+      }),
+    ).resolves.toEqual([{ version: 2 }]);
+    await expect(fs.readFile(path.join(queueDir, "ready.json"), "utf8")).resolves.toContain(
+      "\"version\": 2",
+    );
+    await expect(fs.access(path.join(queueDir, "already.delivered"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(fs.readFile(freshTmp, "utf8")).resolves.toBe("incomplete");
+    await expect(fs.readFile(path.join(queueDir, "truncated.json"), "utf8")).resolves.toBe(
+      "{\"version\":",
+    );
+  });
+
+  it("treats missing queue and ack state as an idempotent crash-resume boundary", async () => {
+    const root = await tempRoot("fs-safe-queue-missing-");
+    const queueDir = path.join(root, "missing");
+    const paths = resolveJsonDurableQueueEntryPaths(queueDir, "job");
+
+    await expect(
+      loadPendingJsonDurableQueueEntries({ queueDir, tempPrefix: "queue" }),
+    ).resolves.toEqual([]);
+    await expect(
+      loadJsonDurableQueueEntry({ paths, tempPrefix: "queue" }),
+    ).resolves.toBeNull();
+    await fs.mkdir(queueDir);
+    await fs.writeFile(paths.deliveredPath, "crash residue");
+    await ackJsonDurableQueueEntry(paths);
+    await expect(fs.access(paths.deliveredPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(jsonDurableQueueEntryExists(paths.jsonPath)).resolves.toBe(false);
+  });
+
+  it("propagates inspection failures instead of treating them as missing", async () => {
+    const root = await tempRoot("fs-safe-queue-inspect-");
+    const queueDir = path.join(root, "queue");
+    await fs.mkdir(queueDir);
+    const filePath = path.join(queueDir, "job.json");
+    await fs.writeFile(filePath, "{}");
+    const denied = Object.assign(new Error("inspection denied"), { code: "EACCES" });
+    vi.spyOn(fs, "lstat").mockRejectedValueOnce(denied);
+    await expect(jsonDurableQueueEntryExists(filePath)).rejects.toBe(denied);
+
+    const readdirDenied = Object.assign(new Error("listing denied"), { code: "EACCES" });
+    vi.spyOn(fs, "readdir").mockRejectedValueOnce(readdirDenied);
+    await expect(
+      loadPendingJsonDurableQueueEntries({ queueDir, tempPrefix: "queue" }),
+    ).rejects.toBe(readdirDenied);
+  });
+
+  it("rejects non-files, oversized state, and growth after the initial size check", async () => {
+    const root = await tempRoot("fs-safe-queue-bounded-");
+    const directoryPath = path.join(root, "entry.json");
+    const oversizedPath = path.join(root, "oversized.json");
+    const growingPath = path.join(root, "growing.json");
+    await fs.mkdir(directoryPath);
+    await fs.writeFile(oversizedPath, "1234");
+    await fs.writeFile(growingPath, "{}");
+
+    await expect(readJsonDurableQueueEntry(directoryPath)).rejects.toThrow(
+      "queue entry is not a regular file",
+    );
+    await expect(readJsonDurableQueueEntry(oversizedPath, { maxBytes: 3 })).rejects.toThrow(
+      "queue entry exceeds 3 bytes",
+    );
+
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      await fs.appendFile(growingPath, "1234");
+      return handle;
+    });
+    await expect(readJsonDurableQueueEntry(growingPath, { maxBytes: 3 })).rejects.toThrow(
+      "queue entry exceeds 3 bytes",
+    );
+  });
+
+  itPosix("rejects symlink and hardlink queue entries without reading their contents", async () => {
+    const root = await tempRoot("fs-safe-queue-links-");
+    const target = path.join(root, "target.json");
+    const symlink = path.join(root, "symlink.json");
+    const hardlink = path.join(root, "hardlink.json");
+    await fs.writeFile(target, JSON.stringify({ secret: true }));
+    await fs.symlink(target, symlink);
+    await fs.link(target, hardlink);
+
+    await expect(readJsonDurableQueueEntry(symlink)).rejects.toThrow(
+      "queue entry is not a regular file",
+    );
+    await expect(readJsonDurableQueueEntry(hardlink)).rejects.toThrow(
+      "queue entry hardlinks are not allowed",
+    );
+  });
+
+  itPosix("refuses queue directories and failed destinations reached through symlinks", async () => {
+    const root = await tempRoot("fs-safe-queue-dir-links-");
+    const realQueue = path.join(root, "real-queue");
+    const queueDir = path.join(root, "queue");
+    const failedDir = path.join(root, "failed");
+    await fs.mkdir(realQueue);
+    await fs.symlink(realQueue, queueDir);
+
+    await expect(ensureJsonDurableQueueDirs({ queueDir, failedDir })).rejects.toThrow(
+      "durable queue path is not a directory",
+    );
+    await fs.unlink(queueDir);
+    await fs.mkdir(queueDir);
+    await fs.writeFile(path.join(queueDir, "job.json"), "{}");
+    await fs.symlink(realQueue, failedDir);
+    await expect(
+      moveJsonDurableQueueEntryToFailed({ queueDir, failedDir, id: "job" }),
+    ).rejects.toThrow("durable queue path is not a directory");
+  });
+
+  it("returns null for a non-file direct entry but propagates corrupt JSON", async () => {
+    const root = await tempRoot("fs-safe-queue-direct-");
+    const queueDir = path.join(root, "queue");
+    await fs.mkdir(queueDir);
+    const paths = resolveJsonDurableQueueEntryPaths(queueDir, "job");
+    await fs.mkdir(paths.jsonPath);
+    await expect(loadJsonDurableQueueEntry({ paths, tempPrefix: "queue" })).resolves.toBeNull();
+    await fs.rm(paths.jsonPath, { recursive: true });
+    await fs.writeFile(paths.jsonPath, "{");
+    await expect(loadJsonDurableQueueEntry({ paths, tempPrefix: "queue" })).rejects.toThrow(
+      SyntaxError,
+    );
+  });
+
+  it("does not mask a non-ENOENT ack failure", async () => {
+    const root = await tempRoot("fs-safe-queue-ack-error-");
+    const paths = resolveJsonDurableQueueEntryPaths(root, "job");
+    await fs.writeFile(paths.jsonPath, "{}");
+    const denied = Object.assign(new Error("rename denied"), { code: "EACCES" });
+    vi.spyOn(fs, "rename").mockRejectedValueOnce(denied);
+    await expect(ackJsonDurableQueueEntry(paths)).rejects.toBe(denied);
+    expect(fsSync.existsSync(paths.jsonPath)).toBe(true);
+  });
+
+  it("ignores missing best-effort cleanup but propagates stale-temp inspection failures", async () => {
+    const root = await tempRoot("fs-safe-queue-cleanup-failure-");
+    const queueDir = path.join(root, "queue");
+    await fs.mkdir(queueDir);
+    const missing = path.join(queueDir, "missing.delivered");
+    await expect(unlinkBestEffort(missing)).resolves.toBeUndefined();
+    const tempPath = path.join(queueDir, "orphan.tmp");
+    await fs.writeFile(tempPath, "tmp");
+    const denied = Object.assign(new Error("temp inspection denied"), { code: "EACCES" });
+    vi.spyOn(fs, "stat").mockRejectedValueOnce(denied);
+    await expect(loadPendingJsonDurableQueueEntries({
+      queueDir,
+      tempPrefix: "queue",
+      cleanupTmpMaxAgeMs: 0,
+    })).rejects.toBe(denied);
+  });
+
+  it("detects a queue entry swapped after its descriptor is opened", async () => {
+    const root = await tempRoot("fs-safe-queue-read-swap-");
+    const filePath = path.join(root, "entry.json");
+    const oldPath = path.join(root, "old.json");
+    await fs.writeFile(filePath, "{}");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      await fs.rename(filePath, oldPath);
+      await fs.writeFile(filePath, "{}");
+      return handle;
+    });
+    await expect(readJsonDurableQueueEntry(filePath)).rejects.toThrow(
+      "queue entry changed during read",
+    );
+  });
+});

--- a/test/publish-file-failure.test.ts
+++ b/test/publish-file-failure.test.ts
@@ -1,0 +1,340 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import {
+  configureFsSafeNative,
+  __resetFsSafeNativeConfigForTest,
+} from "../src/native-config.js";
+import {
+  __loadBundledNativeForTest,
+  __resetNativeLoaderForTest,
+  __setNativeLoaderForTest,
+  type NativeBinding,
+} from "../src/native.js";
+import { publishFileExclusive } from "../src/publish-file.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+
+const { tempRoot } = useTempDirs();
+let native: NativeBinding | undefined;
+try {
+  native = __loadBundledNativeForTest();
+} catch {
+  // JS-only checks do not stage the binding; native-built coverage does.
+}
+
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+  __setFsSafeTestHooksForTest();
+  vi.restoreAllMocks();
+});
+
+describe("exclusive publication failure fencing", () => {
+  itPosix("rejects source directories and symlinks before creating a target", async () => {
+    const root = await tempRoot("fs-safe-publish-source-refusal-");
+    const source = path.join(root, "source");
+    const link = path.join(root, "link");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "content");
+    await fs.symlink(source, link);
+
+    await expect(
+      publishFileExclusive({ sourcePath: root, targetPath: target, strategy: "link-required" }),
+    ).rejects.toMatchObject({ code: "not-file" });
+    await expect(
+      publishFileExclusive({ sourcePath: link, targetPath: target, strategy: "link-required" }),
+    ).rejects.toMatchObject({ code: "not-file" });
+    await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects a mismatched parent receipt and expected source identity", async () => {
+    const root = await tempRoot("fs-safe-publish-receipt-");
+    const source = path.join(root, "source");
+    const other = path.join(root, "other");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "source");
+    await fs.writeFile(other, "other");
+
+    await expect(
+      publishFileExclusive({
+        sourcePath: source,
+        targetPath: target,
+        strategy: "link-required",
+        parentReceipt: { path: path.join(root, "wrong") } as never,
+      }),
+    ).rejects.toMatchObject({ code: "path-mismatch" });
+    await expect(
+      publishFileExclusive({
+        sourcePath: source,
+        targetPath: target,
+        strategy: "link-required",
+        expectedSourceIdentity: await fs.stat(other),
+      }),
+    ).rejects.toMatchObject({ code: "path-mismatch" });
+    await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves an attacker replacement discovered after hardlink creation", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const root = await tempRoot("fs-safe-publish-target-swap-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    const created = path.join(root, "created");
+    await fs.writeFile(source, "source");
+    __setFsSafeTestHooksForTest({
+      async afterPublishTargetCreated(method) {
+        expect(method).toBe("hardlink");
+        await fs.rename(target, created);
+        await fs.writeFile(target, "replacement");
+      },
+    });
+
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-required" }),
+    ).rejects.toMatchObject({
+      code: "path-mismatch",
+      details: { phase: "hardlink-verify", cleanup: "preserved", targetCreated: true },
+    });
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readFile(created, "utf8")).resolves.toBe("source");
+  });
+
+  it("rolls back a hardlink if the pinned source path changes after creation", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const root = await tempRoot("fs-safe-publish-source-swap-");
+    const source = path.join(root, "source");
+    const oldSource = path.join(root, "old-source");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "source");
+    __setFsSafeTestHooksForTest({
+      async afterPublishTargetCreated() {
+        await fs.rename(source, oldSource);
+        await fs.writeFile(source, "replacement");
+      },
+    });
+
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-required" }),
+    ).rejects.toMatchObject({
+      code: "path-mismatch",
+      details: { phase: "hardlink-verify", cleanup: "removed", targetCreated: true },
+    });
+    await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(source, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readFile(oldSource, "utf8")).resolves.toBe("source");
+  });
+
+  it("preserves a replacement discovered during exclusive-copy verification", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const root = await tempRoot("fs-safe-publish-copy-swap-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    const created = path.join(root, "created");
+    await fs.writeFile(source, "copy source");
+    vi.spyOn(fs, "link").mockRejectedValueOnce(
+      Object.assign(new Error("cross-device"), { code: "EXDEV" }),
+    );
+    __setFsSafeTestHooksForTest({
+      async afterPublishTargetCreated(method) {
+        expect(method).toBe("exclusive-copy");
+        await fs.rename(target, created);
+        await fs.writeFile(target, "replacement");
+      },
+    });
+
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-or-copy" }),
+    ).rejects.toMatchObject({
+      code: "path-mismatch",
+      details: { phase: "copy-verify", cleanup: "preserved", targetCreated: true },
+    });
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readFile(created, "utf8")).resolves.toBe("copy source");
+  });
+
+  it("rolls back an exclusive-copy target when the post-create hook fails", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const root = await tempRoot("fs-safe-publish-copy-hook-failure-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "copy source");
+    vi.spyOn(fs, "link").mockRejectedValueOnce(
+      Object.assign(new Error("cross-device"), { code: "EXDEV" }),
+    );
+    __setFsSafeTestHooksForTest({
+      afterPublishTargetCreated(method) {
+        expect(method).toBe("exclusive-copy");
+        throw new Error("verification unavailable");
+      },
+    });
+
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-or-copy" }),
+    ).rejects.toMatchObject({
+      code: "helper-failed",
+      details: { phase: "copy-verify", cleanup: "removed", targetCreated: true },
+    });
+    await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(Boolean(native))("preserves the only remaining name after a post-rename verification failure", async () => {
+    const root = await tempRoot("fs-safe-publish-rename-failure-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "content");
+    __setFsSafeTestHooksForTest({
+      afterPublishTargetCreated(method) {
+        expect(method).toBe("rename-noreplace");
+        throw new Error("post-rename verification unavailable");
+      },
+    });
+
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "rename-noreplace" }),
+    ).rejects.toMatchObject({
+      code: "helper-failed",
+      details: { phase: "rename-verify", cleanup: "preserved", targetCreated: true },
+    });
+    await expect(fs.access(source)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("content");
+  });
+
+  it.runIf(Boolean(native))("preserves a replacement target detected after native rename", async () => {
+    const root = await tempRoot("fs-safe-publish-rename-swap-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    const renamed = path.join(root, "renamed");
+    await fs.writeFile(source, "content");
+    __setFsSafeTestHooksForTest({
+      async afterPublishTargetCreated() {
+        await fs.rename(target, renamed);
+        await fs.writeFile(target, "replacement");
+      },
+    });
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "rename-noreplace" }),
+    ).rejects.toMatchObject({
+      code: "path-mismatch",
+      details: { phase: "rename-verify", cleanup: "preserved" },
+    });
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readFile(renamed, "utf8")).resolves.toBe("content");
+  });
+
+  it.runIf(Boolean(native))("fails if the source name unexpectedly survives native rename", async () => {
+    const root = await tempRoot("fs-safe-publish-rename-source-survives-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "content");
+    __setFsSafeTestHooksForTest({
+      async afterPublishTargetCreated() {
+        await fs.writeFile(source, "replacement");
+      },
+    });
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "rename-noreplace" }),
+    ).rejects.toMatchObject({
+      code: "path-mismatch",
+      details: { phase: "rename-verify", cleanup: "preserved" },
+    });
+    await expect(fs.readFile(source, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("content");
+  });
+
+  it.runIf(Boolean(native))("falls through both classified native-copy failures to the fenced JS copy", async () => {
+    const root = await tempRoot("fs-safe-publish-native-fallbacks-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "content");
+    __setNativeLoaderForTest(() => ({
+      ...native!,
+      linkBeneath() {
+        throw Object.assign(new Error("force copy"), { code: "EXDEV" });
+      },
+      cloneFileExclusive() {
+        throw Object.assign(new Error("clone unsupported"), { code: "ENOTSUP" });
+      },
+      async copyFileRangeExclusive() {
+        return { fd: -1, bytes: 0, errorCode: "EOPNOTSUPP", errorMessage: "range unsupported" };
+      },
+    }));
+    configureFsSafeNative({ mode: "require" });
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-or-copy" }),
+    ).resolves.toMatchObject({ method: "exclusive-copy" });
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("content");
+  });
+
+  it.runIf(Boolean(native))("propagates an unclassified native clone failure without leaving a target", async () => {
+    const root = await tempRoot("fs-safe-publish-native-failure-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "content");
+    __setNativeLoaderForTest(() => ({
+      ...native!,
+      linkBeneath() {
+        throw Object.assign(new Error("force copy"), { code: "EXDEV" });
+      },
+      cloneFileExclusive() {
+        throw Object.assign(new Error("clone I/O failure"), { code: "EIO" });
+      },
+    }));
+    configureFsSafeNative({ mode: "require" });
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-or-copy" }),
+    ).rejects.toMatchObject({ code: "EIO" });
+    await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rolls back when an exclusive copy cannot make write progress", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const root = await tempRoot("fs-safe-publish-copy-no-progress-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "content");
+    vi.spyOn(fs, "link").mockRejectedValueOnce(Object.assign(new Error("force copy"), { code: "EXDEV" }));
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      if (String(args[0]) === target && args[1] === "wx+") {
+        vi.spyOn(handle, "write").mockResolvedValueOnce({ bytesWritten: 0, buffer: Buffer.alloc(0) });
+      }
+      return handle;
+    });
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-or-copy" }),
+    ).rejects.toMatchObject({ code: "helper-failed", details: { cleanup: "removed" } });
+    await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(Boolean(native))("closes a native clone descriptor when target identity verification fails", async () => {
+    const root = await tempRoot("fs-safe-publish-native-target-swap-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    const created = path.join(root, "created");
+    await fs.writeFile(source, "content");
+    __setNativeLoaderForTest(() => ({
+      ...native!,
+      linkBeneath() {
+        throw Object.assign(new Error("force clone"), { code: "EXDEV" });
+      },
+      cloneFileExclusive() {
+        fsSync.copyFileSync(source, target, fsSync.constants.COPYFILE_EXCL);
+        return fsSync.openSync(target, "r+");
+      },
+    }));
+    configureFsSafeNative({ mode: "require" });
+    __setFsSafeTestHooksForTest({
+      async afterPublishTargetCreated() {
+        await fs.rename(target, created);
+        await fs.writeFile(target, "replacement");
+      },
+    });
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-or-copy" }),
+    ).rejects.toMatchObject({ code: "path-mismatch", details: { cleanup: "preserved" } });
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("replacement");
+  });
+});

--- a/test/regular-file-failure.test.ts
+++ b/test/regular-file-failure.test.ts
@@ -1,0 +1,309 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import {
+  appendRegularFile,
+  appendRegularFileSync,
+  readRegularFile,
+  readRegularFileSync,
+  resolveRegularFileAppendFlags,
+  statRegularFile,
+  statRegularFileSync,
+} from "../src/regular-file.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("regular file refusal and race handling", () => {
+  it("distinguishes missing paths from inspection errors and non-files", async () => {
+    const root = await tempRoot("fs-safe-regular-stat-");
+    const missing = path.join(root, "missing");
+    await expect(statRegularFile(missing)).resolves.toEqual({ missing: true });
+    expect(statRegularFileSync(missing)).toEqual({ missing: true });
+    await expect(statRegularFile(root)).rejects.toThrow("path must be a regular file");
+    expect(() => statRegularFileSync(root)).toThrow("path must be a regular file");
+
+    const denied = Object.assign(new Error("inspection denied"), { code: "EACCES" });
+    vi.spyOn(fs, "lstat").mockRejectedValueOnce(denied);
+    await expect(statRegularFile(missing)).rejects.toBe(denied);
+    vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => {
+      throw denied;
+    });
+    expect(() => statRegularFileSync(missing)).toThrow(denied);
+  });
+
+  it("reads at the exact cap and rejects missing paths in both APIs", async () => {
+    const root = await tempRoot("fs-safe-regular-read-");
+    const filePath = path.join(root, "value");
+    const missing = path.join(root, "missing");
+    await fs.writeFile(filePath, "abc");
+
+    await expect(readRegularFile({ filePath, maxBytes: 3 })).resolves.toMatchObject({
+      buffer: Buffer.from("abc"),
+    });
+    expect(readRegularFileSync({ filePath }).buffer).toEqual(Buffer.from("abc"));
+    await expect(readRegularFile({ filePath: missing })).rejects.toMatchObject({ code: "ENOENT" });
+    expect(() => readRegularFileSync({ filePath: missing })).toThrow(
+      expect.objectContaining({ code: "ENOENT" }),
+    );
+  });
+
+  it("reports a vanished file as a path mismatch after the preview check", async () => {
+    const root = await tempRoot("fs-safe-regular-vanish-");
+    const filePath = path.join(root, "value");
+    await fs.writeFile(filePath, "abc");
+    const missing = Object.assign(new Error("vanished"), { code: "ENOENT" });
+    vi.spyOn(fs, "open").mockRejectedValueOnce(missing);
+    await expect(readRegularFile({ filePath })).rejects.toMatchObject({ code: "path-mismatch" });
+
+    const realLstat = fs.lstat.bind(fs);
+    let calls = 0;
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      if (String(args[0]) === filePath && ++calls === 2) throw missing;
+      return await realLstat(...args);
+    });
+    await expect(readRegularFile({ filePath })).rejects.toMatchObject({ code: "path-mismatch" });
+  });
+
+  it("preserves unexpected bounded-read errors instead of relabeling them", async () => {
+    const root = await tempRoot("fs-safe-regular-read-error-");
+    const filePath = path.join(root, "value");
+    await fs.writeFile(filePath, "abc");
+    const realOpen = fs.open.bind(fs);
+    const failure = Object.assign(new Error("read failed"), { code: "EIO" });
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      vi.spyOn(handle, "read").mockRejectedValueOnce(failure);
+      return handle;
+    });
+    await expect(readRegularFile({ filePath, maxBytes: 3 })).rejects.toBe(failure);
+  });
+
+  it("does not create or extend a file beyond its configured maximum", async () => {
+    const root = await tempRoot("fs-safe-regular-append-limit-");
+    const asyncPath = path.join(root, "async");
+    const syncPath = path.join(root, "sync");
+    await appendRegularFile({ filePath: asyncPath, content: "abcd", maxFileBytes: 3 });
+    appendRegularFileSync({ filePath: syncPath, content: Buffer.from("abcd"), maxFileBytes: 3 });
+    await expect(fs.access(asyncPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(fsSync.existsSync(syncPath)).toBe(false);
+
+    await fs.writeFile(asyncPath, "ab");
+    await fs.writeFile(syncPath, "ab");
+    await appendRegularFile({ filePath: asyncPath, content: "cd", maxFileBytes: 3 });
+    appendRegularFileSync({ filePath: syncPath, content: "cd", maxFileBytes: 3 });
+    await expect(fs.readFile(asyncPath, "utf8")).resolves.toBe("ab");
+    expect(fsSync.readFileSync(syncPath, "utf8")).toBe("ab");
+  });
+
+  itPosix("refuses symlink, directory, and hardlink append targets", async () => {
+    const root = await tempRoot("fs-safe-regular-append-refuse-");
+    const target = path.join(root, "target");
+    const symlink = path.join(root, "symlink");
+    const hardlink = path.join(root, "hardlink");
+    await fs.writeFile(target, "original");
+    await fs.symlink(target, symlink);
+    await fs.link(target, hardlink);
+
+    await expect(appendRegularFile({ filePath: symlink, content: "x" })).rejects.toThrow(
+      "Refusing to append through symlink",
+    );
+    expect(() => appendRegularFileSync({ filePath: symlink, content: "x" })).toThrow(
+      "Refusing to append through symlink",
+    );
+    await expect(appendRegularFile({ filePath: root, content: "x" })).rejects.toThrow(
+      "Refusing to append to non-file",
+    );
+    expect(() => appendRegularFileSync({ filePath: root, content: "x" })).toThrow(
+      "Refusing to append to non-file",
+    );
+    await expect(appendRegularFile({ filePath: hardlink, content: "x" })).rejects.toThrow(
+      "Refusing to append to hardlinked file",
+    );
+    expect(() => appendRegularFileSync({ filePath: hardlink, content: "x" })).toThrow(
+      "Refusing to append to hardlinked file",
+    );
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("original");
+  });
+
+  it("refuses an async append if the path is replaced before open", async () => {
+    const root = await tempRoot("fs-safe-regular-append-swap-");
+    const filePath = path.join(root, "value");
+    const oldPath = path.join(root, "old");
+    await fs.writeFile(filePath, "original");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      await fs.rename(filePath, oldPath);
+      await fs.writeFile(filePath, "replacement");
+      return await realOpen(...args);
+    });
+
+    await expect(appendRegularFile({ filePath, content: "x" })).rejects.toThrow(
+      "Refusing to append after file changed",
+    );
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readFile(oldPath, "utf8")).resolves.toBe("original");
+  });
+
+  itPosix("rejects symlinked append parents when requested", async () => {
+    const root = await tempRoot("fs-safe-regular-parent-");
+    const realDir = path.join(root, "real");
+    const linkDir = path.join(root, "link");
+    await fs.mkdir(realDir);
+    await fs.symlink(realDir, linkDir);
+    const filePath = path.join(linkDir, "value");
+
+    await expect(
+      appendRegularFile({ filePath, content: "x", rejectSymlinkParents: true }),
+    ).rejects.toThrow("Refusing to append under");
+    expect(() =>
+      appendRegularFileSync({ filePath, content: "x", rejectSymlinkParents: true }),
+    ).toThrow("Refusing to append under");
+    await expect(fs.access(path.join(realDir, "value"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("omits O_NOFOLLOW when the platform constants do not provide it", () => {
+    expect(
+      resolveRegularFileAppendFlags({ O_APPEND: 1, O_CREAT: 2, O_WRONLY: 4 }),
+    ).toBe(7);
+  });
+
+  it("rechecks the async size limit after opening the file", async () => {
+    const root = await tempRoot("fs-safe-regular-post-open-size-");
+    const filePath = path.join(root, "value");
+    await fs.writeFile(filePath, "ab");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      await fs.appendFile(filePath, "cd");
+      return handle;
+    });
+    await expect(readRegularFile({ filePath, maxBytes: 3 })).rejects.toMatchObject({
+      code: "too-large",
+    });
+  });
+
+  it("rechecks append limits after a concurrent growth", async () => {
+    const root = await tempRoot("fs-safe-regular-post-open-append-");
+    const asyncPath = path.join(root, "async");
+    const syncPath = path.join(root, "sync");
+    await fs.writeFile(asyncPath, "a");
+    await fs.writeFile(syncPath, "a");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      await fs.appendFile(asyncPath, "bc");
+      return handle;
+    });
+    await appendRegularFile({ filePath: asyncPath, content: "d", maxFileBytes: 3 });
+    await expect(fs.readFile(asyncPath, "utf8")).resolves.toBe("abc");
+
+    const realOpenSync = fsSync.openSync.bind(fsSync);
+    vi.spyOn(fsSync, "openSync").mockImplementationOnce((...args) => {
+      const fd = realOpenSync(...args);
+      fsSync.appendFileSync(syncPath, "bc");
+      return fd;
+    });
+    appendRegularFileSync({ filePath: syncPath, content: "d", maxFileBytes: 3 });
+    expect(fsSync.readFileSync(syncPath, "utf8")).toBe("abc");
+  });
+
+  it("wraps bounded-read growth with the compatibility error", async () => {
+    const root = await tempRoot("fs-safe-regular-bounded-growth-");
+    const filePath = path.join(root, "value");
+    await fs.writeFile(filePath, "abc");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      vi.spyOn(handle, "read").mockImplementationOnce(async (buffer) => {
+        Buffer.from("abcd").copy(buffer as Buffer);
+        return { bytesRead: 4, buffer };
+      });
+      return handle;
+    });
+    await expect(readRegularFile({ filePath, maxBytes: 3 })).rejects.toMatchObject({
+      code: "too-large",
+      message: `File exceeds 3 bytes: ${filePath}`,
+      cause: expect.objectContaining({ code: "too-large" }),
+    });
+  });
+
+  it("preserves an unexpected post-open path inspection error", async () => {
+    const root = await tempRoot("fs-safe-regular-post-open-inspect-");
+    const filePath = path.join(root, "value");
+    await fs.writeFile(filePath, "abc");
+    const denied = Object.assign(new Error("inspection denied"), { code: "EACCES" });
+    const realLstat = fs.lstat.bind(fs);
+    let calls = 0;
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      if (String(args[0]) === filePath && ++calls === 2) throw denied;
+      return await realLstat(...args);
+    });
+    await expect(readRegularFile({ filePath })).rejects.toBe(denied);
+  });
+
+  it("preserves an unexpected uncapped handle read error", async () => {
+    const root = await tempRoot("fs-safe-regular-uncapped-read-error-");
+    const filePath = path.join(root, "value");
+    await fs.writeFile(filePath, "abc");
+    const failure = Object.assign(new Error("read failed"), { code: "EIO" });
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      vi.spyOn(handle, "readFile").mockRejectedValueOnce(failure);
+      return handle;
+    });
+    await expect(readRegularFile({ filePath })).rejects.toBe(failure);
+  });
+
+  it("refuses a path swapped to a directory after its descriptor opens", async () => {
+    const root = await tempRoot("fs-safe-regular-read-directory-swap-");
+    const filePath = path.join(root, "value");
+    const oldPath = path.join(root, "old");
+    await fs.writeFile(filePath, "abc");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      await fs.rename(filePath, oldPath);
+      await fs.mkdir(filePath);
+      return handle;
+    });
+    await expect(readRegularFile({ filePath })).rejects.toThrow("File is not a regular file");
+  });
+
+  it("rechecks the sync size limit after opening the descriptor", async () => {
+    const root = await tempRoot("fs-safe-regular-sync-post-open-size-");
+    const filePath = path.join(root, "value");
+    await fs.writeFile(filePath, "ab");
+    const realOpen = fsSync.openSync.bind(fsSync);
+    vi.spyOn(fsSync, "openSync").mockImplementationOnce((...args) => {
+      const fd = realOpen(...args);
+      fsSync.appendFileSync(filePath, "cd");
+      return fd;
+    });
+    expect(() => readRegularFileSync({ filePath, maxBytes: 3 })).toThrow(
+      expect.objectContaining({ code: "too-large" }),
+    );
+  });
+
+  it("refuses an append descriptor reported as a non-file", async () => {
+    const root = await tempRoot("fs-safe-regular-append-opened-type-");
+    const filePath = path.join(root, "value");
+    await fs.writeFile(filePath, "abc");
+    const directoryStat = await fs.stat(root);
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      vi.spyOn(handle, "stat").mockResolvedValueOnce(directoryStat);
+      return handle;
+    });
+    await expect(appendRegularFile({ filePath, content: "d" })).rejects.toThrow(
+      "Refusing to append to non-file",
+    );
+  });
+});

--- a/test/secret-file-failure.test.ts
+++ b/test/secret-file-failure.test.ts
@@ -2,7 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import { itPosix, itWin32, useTempDirs } from "./helpers/vitest.js";
 import {
   readSecretFileSync,
   tryReadSecretFileSync,
@@ -145,7 +145,7 @@ describe("secret file refusal paths", () => {
     ).rejects.toMatchObject({ code: "path-mismatch" });
   });
 
-  it("rejects an insecure mode reported after post-write chmod", async () => {
+  itPosix("rejects an insecure mode reported after post-write chmod", async () => {
     const root = await tempRoot("fs-safe-secret-write-mode-");
     const filePath = path.join(root, "token");
     const realOpen = fs.open.bind(fs);
@@ -162,5 +162,16 @@ describe("secret file refusal paths", () => {
     await expect(
       writeSecretFileAtomic({ rootDir: root, filePath, content: "secret" }),
     ).rejects.toThrow("has insecure permissions 644");
+  });
+
+  itWin32("publishes the secret when POSIX mode enforcement is unavailable", async () => {
+    const root = await tempRoot("fs-safe-secret-write-mode-win32-");
+    const filePath = path.join(root, "token");
+
+    await expect(
+      writeSecretFileAtomic({ rootDir: root, filePath, content: "secret" }),
+    ).resolves.toBeUndefined();
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("secret");
+    expect(readSecretFileSync(filePath, "token")).toBe("secret");
   });
 });

--- a/test/secret-file-failure.test.ts
+++ b/test/secret-file-failure.test.ts
@@ -1,0 +1,166 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import {
+  readSecretFileSync,
+  tryReadSecretFileSync,
+  writeSecretFileAtomic,
+} from "../src/secret-file.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("secret file refusal paths", () => {
+  it("does not convert inspection failures into optional missing secrets", async () => {
+    const root = await tempRoot("fs-safe-secret-inspect-failure-");
+    const filePath = path.join(root, "token");
+    await fs.writeFile(filePath, "secret");
+    const denied = Object.assign(new Error("inspection denied"), { code: "EACCES" });
+    vi.spyOn(fsSync, "lstatSync").mockImplementation(() => {
+      throw denied;
+    });
+
+    expect(() => tryReadSecretFileSync(filePath, "token")).toThrow(
+      expect.objectContaining({ code: "invalid-path", cause: denied }),
+    );
+    expect(() => readSecretFileSync(filePath, "token")).toThrow(
+      expect.objectContaining({ code: "invalid-path", cause: denied }),
+    );
+    expect(tryReadSecretFileSync("   ", "token")).toBeUndefined();
+  });
+
+  itPosix("rejects a broken allowed symlink when its target inspection fails", async () => {
+    const root = await tempRoot("fs-safe-secret-broken-link-");
+    const link = path.join(root, "token");
+    await fs.symlink(path.join(root, "missing"), link);
+    expect(() => readSecretFileSync(link, "token")).toThrow(
+      expect.objectContaining({ code: "not-found" }),
+    );
+  });
+
+  itPosix("refuses symlinked roots and nested secret directories", async () => {
+    const root = await tempRoot("fs-safe-secret-write-link-");
+    const realRoot = path.join(root, "real");
+    const linkedRoot = path.join(root, "linked-root");
+    await fs.mkdir(realRoot);
+    await fs.symlink(realRoot, linkedRoot);
+    await expect(
+      writeSecretFileAtomic({
+        rootDir: linkedRoot,
+        filePath: path.join(linkedRoot, "token"),
+        content: "secret",
+      }),
+    ).rejects.toThrow("must not be a symlink");
+
+    const nestedLink = path.join(realRoot, "nested");
+    await fs.symlink(root, nestedLink);
+    await expect(
+      writeSecretFileAtomic({
+        rootDir: realRoot,
+        filePath: path.join(nestedLink, "token"),
+        content: "secret",
+      }),
+    ).rejects.toThrow("must not be a symlink");
+  });
+
+  it("refuses non-directory roots and nested directory components", async () => {
+    const root = await tempRoot("fs-safe-secret-write-nondir-");
+    const rootFile = path.join(root, "root-file");
+    await fs.writeFile(rootFile, "not a directory");
+    await expect(
+      writeSecretFileAtomic({
+        rootDir: rootFile,
+        filePath: path.join(rootFile, "token"),
+        content: "secret",
+      }),
+    ).rejects.toThrow();
+
+    const component = path.join(root, "component");
+    await fs.writeFile(component, "not a directory");
+    await expect(
+      writeSecretFileAtomic({
+        rootDir: root,
+        filePath: path.join(component, "token"),
+        content: "secret",
+      }),
+    ).rejects.toThrow("must be a directory");
+  });
+
+  it("refuses overwriting a directory at the final secret path", async () => {
+    const root = await tempRoot("fs-safe-secret-write-target-");
+    const filePath = path.join(root, "token");
+    await fs.mkdir(filePath);
+    await expect(
+      writeSecretFileAtomic({ rootDir: root, filePath, content: "secret" }),
+    ).rejects.toThrow("must be a regular file");
+    expect((await fs.stat(filePath)).isDirectory()).toBe(true);
+  });
+
+  itPosix("refuses overwriting a symlink at the final secret path", async () => {
+    const root = await tempRoot("fs-safe-secret-write-target-link-");
+    const outside = await tempRoot("fs-safe-secret-write-outside-");
+    const outsideFile = path.join(outside, "token");
+    const filePath = path.join(root, "token");
+    await fs.writeFile(outsideFile, "outside");
+    await fs.symlink(outsideFile, filePath);
+    await expect(
+      writeSecretFileAtomic({ rootDir: root, filePath, content: "replacement" }),
+    ).rejects.toThrow("must not be a symlink");
+    await expect(fs.readFile(outsideFile, "utf8")).resolves.toBe("outside");
+  });
+
+  it("maps a vanished path between preview and pinned open to not-found", async () => {
+    const root = await tempRoot("fs-safe-secret-open-vanish-");
+    const filePath = path.join(root, "token");
+    await fs.writeFile(filePath, "secret");
+    vi.spyOn(fsSync, "realpathSync").mockImplementationOnce(() => {
+      throw Object.assign(new Error("vanished"), { code: "ENOENT" });
+    });
+    expect(() => readSecretFileSync(filePath, "token")).toThrow(
+      expect.objectContaining({ code: "not-found" }),
+    );
+  });
+
+  it("rejects a different descriptor identity during post-write verification", async () => {
+    const root = await tempRoot("fs-safe-secret-write-identity-");
+    const filePath = path.join(root, "token");
+    const otherPath = path.join(root, "other");
+    await fs.writeFile(otherPath, "other");
+    const otherStat = await fs.stat(otherPath);
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      if (path.basename(String(args[0])) === "token" && typeof args[1] === "number") {
+        vi.spyOn(handle, "stat").mockResolvedValueOnce(otherStat);
+      }
+      return handle;
+    });
+    await expect(
+      writeSecretFileAtomic({ rootDir: root, filePath, content: "secret" }),
+    ).rejects.toMatchObject({ code: "path-mismatch" });
+  });
+
+  it("rejects an insecure mode reported after post-write chmod", async () => {
+    const root = await tempRoot("fs-safe-secret-write-mode-");
+    const filePath = path.join(root, "token");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      if (path.basename(String(args[0])) === "token" && typeof args[1] === "number") {
+        const actual = await handle.stat();
+        vi.spyOn(handle, "stat")
+          .mockResolvedValueOnce(actual)
+          .mockResolvedValueOnce({ ...actual, mode: 0o100644 } as never);
+      }
+      return handle;
+    });
+    await expect(
+      writeSecretFileAtomic({ rootDir: root, filePath, content: "secret" }),
+    ).rejects.toThrow("has insecure permissions 644");
+  });
+});

--- a/test/secure-file-failure.test.ts
+++ b/test/secure-file-failure.test.ts
@@ -1,0 +1,150 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import { readSecureFile } from "../src/secure-file.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("secure file inspection failures", () => {
+  it("wraps missing-file inspection with the requested label", async () => {
+    const root = await tempRoot("fs-safe-secure-missing-");
+    const filePath = path.join(root, "missing");
+    await expect(readSecureFile({ filePath, label: "Signing key" })).rejects.toMatchObject({
+      code: "not-found",
+      message: `Signing key is not readable: ${filePath}`,
+    });
+  });
+
+  it("preserves non-symlink open failures", async () => {
+    const root = await tempRoot("fs-safe-secure-open-failure-");
+    const filePath = path.join(root, "secret");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    const denied = Object.assign(new Error("open denied"), { code: "EACCES" });
+    vi.spyOn(fs, "open").mockRejectedValueOnce(denied);
+    await expect(readSecureFile({ filePath })).rejects.toBe(denied);
+  });
+
+  itPosix("classifies an ELOOP open race as a symlink refusal", async () => {
+    const root = await tempRoot("fs-safe-secure-open-symlink-");
+    const filePath = path.join(root, "secret");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    vi.spyOn(fs, "open").mockRejectedValueOnce(Object.assign(new Error("loop"), { code: "ELOOP" }));
+    await expect(readSecureFile({ filePath })).rejects.toMatchObject({ code: "symlink" });
+  });
+
+  itPosix("refuses a path swapped to a symlink after the handle opens", async () => {
+    const root = await tempRoot("fs-safe-secure-path-swap-");
+    const filePath = path.join(root, "secret");
+    const oldPath = path.join(root, "old");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      await fs.rename(filePath, oldPath);
+      await fs.symlink(oldPath, filePath);
+      return handle;
+    });
+    await expect(readSecureFile({ filePath })).rejects.toMatchObject({ code: "symlink" });
+  });
+
+  it("refuses a different file swapped under an opened handle", async () => {
+    const root = await tempRoot("fs-safe-secure-identity-swap-");
+    const filePath = path.join(root, "secret");
+    const oldPath = path.join(root, "old");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      await fs.rename(filePath, oldPath);
+      await fs.writeFile(filePath, "replacement", { mode: 0o600 });
+      return handle;
+    });
+    await expect(readSecureFile({ filePath })).rejects.toMatchObject({ code: "path-mismatch" });
+  });
+
+  it("fails closed when permission inspection cannot complete", async () => {
+    const root = await tempRoot("fs-safe-secure-permission-inspect-");
+    const filePath = path.join(root, "secret");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    const realLstat = fs.lstat.bind(fs);
+    let calls = 0;
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      calls += 1;
+      if (calls === 3) throw Object.assign(new Error("permission inspection denied"), { code: "EACCES" });
+      return await realLstat(...args);
+    });
+    await expect(
+      readSecureFile({ filePath, inject: { platform: "win32" } }),
+    ).rejects.toMatchObject({ code: "permission-unverified" });
+  });
+
+  it("times out a stalled read and closes its pinned handle", async () => {
+    const root = await tempRoot("fs-safe-secure-timeout-");
+    const filePath = path.join(root, "secret");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      vi.spyOn(handle, "readFile").mockImplementation(() => new Promise(() => undefined));
+      return handle;
+    });
+    await expect(
+      readSecureFile({ filePath, permissions: { allowInsecure: true }, io: { timeoutMs: 1 } }),
+    ).rejects.toMatchObject({ code: "timeout" });
+  });
+
+  it("rejects a descriptor that does not identify a regular file", async () => {
+    const root = await tempRoot("fs-safe-secure-descriptor-type-");
+    const filePath = path.join(root, "secret");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    const directoryStat = await fs.stat(root);
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      vi.spyOn(handle, "stat").mockResolvedValueOnce(directoryStat);
+      return handle;
+    });
+    await expect(readSecureFile({ filePath })).rejects.toMatchObject({ code: "not-file" });
+  });
+
+  it("rejects a realpath identity that differs from the opened descriptor", async () => {
+    const root = await tempRoot("fs-safe-secure-realpath-identity-");
+    const filePath = path.join(root, "secret");
+    const otherPath = path.join(root, "other");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    await fs.writeFile(otherPath, "other", { mode: 0o600 });
+    const otherStat = await fs.stat(otherPath);
+    const realStat = fs.stat.bind(fs);
+    let calls = 0;
+    vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
+      if (++calls === 1) return otherStat;
+      return await realStat(...args);
+    });
+    await expect(readSecureFile({ filePath })).rejects.toMatchObject({ code: "path-mismatch" });
+  });
+
+  itPosix("rejects a descriptor reported as owned by another uid", async () => {
+    const root = await tempRoot("fs-safe-secure-owner-");
+    const filePath = path.join(root, "secret");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      const actual = await handle.stat();
+      vi.spyOn(handle, "stat").mockResolvedValueOnce({
+        ...actual,
+        uid: (process.getuid?.() ?? actual.uid) + 1,
+        isDirectory: () => false,
+        isFile: () => true,
+        isSymbolicLink: () => false,
+      } as never);
+      return handle;
+    });
+    await expect(readSecureFile({ filePath })).rejects.toMatchObject({ code: "not-owned" });
+  });
+});

--- a/test/sidecar-lock-acquire-failure.test.ts
+++ b/test/sidecar-lock-acquire-failure.test.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
+import { configureFsSafeNative } from "../src/native-config.js";
+import { root } from "../src/root.js";
+import { createSidecarLockManager, withSidecarLock } from "../src/sidecar-lock.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  configureFsSafeNative({ mode: "auto" });
+  vi.restoreAllMocks();
+});
+
+describe("asynchronous sidecar lock acquisition failures", () => {
+  it("removes a partially-written lock when payload persistence fails", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-sidecar-write-failure-");
+    const targetPath = path.join(directory, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const realOpen = fs.open.bind(fs);
+    const failure = Object.assign(new Error("lock write failed"), { code: "EIO" });
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      vi.spyOn(handle, "writeFile").mockRejectedValueOnce(failure);
+      return handle;
+    });
+
+    const manager = createSidecarLockManager(`write-failure-${Date.now()}-${Math.random()}`);
+    await expect(manager.acquire({ targetPath, payload: async () => ({ owner: "one" }) }))
+      .rejects.toBe(failure);
+    await expect(fs.access(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(manager.heldEntries()).toEqual([]);
+  });
+
+  it("falls back to a resolved target when parent realpath lookup fails", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-sidecar-realpath-failure-");
+    const targetPath = path.join(directory, "state.json");
+    vi.spyOn(fs, "realpath").mockRejectedValueOnce(Object.assign(new Error("unavailable"), { code: "EIO" }));
+    const manager = createSidecarLockManager(`realpath-failure-${Date.now()}-${Math.random()}`);
+    const lock = await manager.acquire({ targetPath, payload: async () => ({ owner: "one" }) });
+    expect(lock.normalizedTargetPath).toBe(path.resolve(targetPath));
+    await lock.release();
+  });
+
+  it("maps a lockRoot create collision to contention without weakening confinement", async () => {
+    const directory = await tempRoot("fs-safe-sidecar-root-collision-");
+    const lockDirectory = path.join(directory, "locks");
+    await fs.mkdir(lockDirectory);
+    const lockRoot = await root(lockDirectory);
+    const targetPath = path.join(directory, "state.json");
+    const lockPath = path.join(lockDirectory, "state.lock");
+    const firstManager = createSidecarLockManager(`root-first-${Date.now()}-${Math.random()}`);
+    const secondManager = createSidecarLockManager(`root-second-${Date.now()}-${Math.random()}`);
+    const first = await firstManager.acquire({
+      targetPath,
+      lockPath,
+      lockRoot,
+      payload: async () => ({ createdAt: new Date().toISOString(), owner: "first" }),
+    });
+    await expect(secondManager.acquire({
+      targetPath,
+      lockPath,
+      lockRoot,
+      timeoutMs: 0,
+      retry: { retries: 0 },
+      payload: async () => ({ owner: "second" }),
+    })).rejects.toMatchObject({ code: "file_lock_timeout" });
+    await first.release();
+  });
+
+  it("releases a newly-created lock if reclaim-guard cleanup cannot complete", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-sidecar-guard-release-failure-");
+    const targetPath = path.join(await fs.realpath(directory), "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const guardPath = `${lockPath}.reclaim`;
+    await fs.writeFile(lockPath, JSON.stringify({ createdAt: "2000-01-01T00:00:00.000Z" }));
+    const realRmdir = fs.rmdir.bind(fs);
+    vi.spyOn(fs, "rmdir").mockImplementation(async (pathname, options) => {
+      if (String(pathname) === guardPath) {
+        throw Object.assign(new Error("guard cleanup denied"), { code: "EACCES" });
+      }
+      return await realRmdir(pathname, options);
+    });
+
+    const manager = createSidecarLockManager(`guard-release-${Date.now()}-${Math.random()}`);
+    await expect(manager.acquire({
+      targetPath,
+      staleMs: 1,
+      staleRecovery: "remove-if-unchanged",
+      payload: async () => ({ createdAt: new Date().toISOString() }),
+      shouldReclaim: async () => true,
+      shouldRemoveStaleLock: async () => true,
+    })).rejects.toMatchObject({ code: "EACCES" });
+    await expect(fs.access(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await fs.stat(guardPath)).isDirectory()).toBe(true);
+    expect(manager.heldEntries()).toEqual([]);
+  });
+
+  it("releases withSidecarLock after callback failure and exposes force-release entries", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-sidecar-lifecycle-");
+    const targetPath = path.join(directory, "state.json");
+    await expect(withSidecarLock(
+      targetPath,
+      { managerKey: `with-lock-${Date.now()}-${Math.random()}`, payload: async () => ({}) },
+      async () => {
+        throw new Error("callback failed");
+      },
+    )).rejects.toThrow("callback failed");
+    await expect(fs.access(`${targetPath}.lock`)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const manager = createSidecarLockManager(`lifecycle-${Date.now()}-${Math.random()}`);
+    await manager.acquire({ targetPath, metadata: { purpose: "test" }, payload: async () => ({}) });
+    const [entry] = manager.heldEntries();
+    expect(entry?.metadata).toEqual({ purpose: "test" });
+    await entry?.forceRelease();
+    expect(manager.heldEntries()).toEqual([]);
+    await manager.drain();
+    manager.reset();
+  });
+
+  it("clears a compromise timer when its lock is released normally", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-sidecar-timer-release-");
+    const manager = createSidecarLockManager(`timer-release-${Date.now()}-${Math.random()}`);
+    const compromised = vi.fn();
+    const lock = await manager.acquire({
+      targetPath: path.join(directory, "state.json"),
+      payload: async () => ({}),
+      compromiseCheckIntervalMs: 60_000,
+      onCompromised: compromised,
+    });
+    await lock.release();
+    expect(compromised).not.toHaveBeenCalled();
+  });
+
+  it("reset fails closed across malformed held-lock snapshots and reclaim guards", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-sidecar-reset-");
+    const managerKey = `reset-${Date.now()}-${Math.random()}`;
+    const manager = createSidecarLockManager(managerKey);
+    const targetPath = path.join(directory, "state.json");
+    const lock = await manager.acquire({ targetPath, payload: async () => ({ owner: "reset" }) });
+    await fs.writeFile(lock.lockPath, "replacement-with-a-different-size");
+
+    const states = Reflect.get(globalThis, Symbol.for("fsSafe.sidecarLockManagers")) as Map<
+      string,
+      { reclaimGuards: Set<string> }
+    >;
+    const guardPath = `${lock.lockPath}.manual-reclaim`;
+    await fs.mkdir(guardPath);
+    states.get(managerKey)?.reclaimGuards.add(guardPath);
+    manager.reset();
+
+    await expect(fs.readFile(lock.lockPath, "utf8")).resolves.toBe(
+      "replacement-with-a-different-size",
+    );
+    await expect(fs.access(guardPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(manager.heldEntries()).toEqual([]);
+  });
+});

--- a/test/sidecar-lock-helpers-failure.test.ts
+++ b/test/sidecar-lock-helpers-failure.test.ts
@@ -1,0 +1,217 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
+import { root } from "../src/root.js";
+import {
+  parseSidecarLockPayload,
+  readSidecarLockSnapshot,
+  readSidecarLockSnapshotSync,
+  releaseSidecarReclaimGuard,
+  removeSidecarLockIfUnchanged,
+  removeSidecarLockIfUnchangedSync,
+  removeStaleSidecarLockIfAllowed,
+  serializeSidecarLockPayload,
+  sidecarLockSnapshotMatches,
+  sidecarLockSnapshotStillPresent,
+  sidecarReclaimGuardExists,
+  tryAcquireSidecarReclaimGuard,
+} from "../src/sidecar-lock-reclaim.js";
+import {
+  computeSidecarLockDelayMs,
+  defaultSidecarLockShouldReclaim,
+  sidecarLockPayloadCreatedAtMs,
+  sidecarLockPayloadIsStale,
+} from "../src/sidecar-lock-policy.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("sidecar lock helper failure handling", () => {
+  it("parses only object payloads unless an application parser is supplied", () => {
+    expect(parseSidecarLockPayload('{"owner":"one"}')).toEqual({ owner: "one" });
+    expect(parseSidecarLockPayload("[]")).toBeNull();
+    expect(parseSidecarLockPayload("null")).toBeNull();
+    expect(parseSidecarLockPayload("{" )).toBeNull();
+    expect(parseSidecarLockPayload("legacy=7", (raw) => ({ raw }))).toEqual({ raw: "legacy=7" });
+  });
+
+  it("treats missing snapshots as absent but rejects non-file state on request", async () => {
+    const root = await tempRoot("fs-safe-sidecar-snapshot-helper-");
+    const missing = path.join(root, "missing.lock");
+    const directory = path.join(root, "directory.lock");
+    await fs.mkdir(directory);
+
+    await expect(readSidecarLockSnapshot(missing)).resolves.toBeNull();
+    expect(readSidecarLockSnapshotSync(missing)).toBeNull();
+    await expect(readSidecarLockSnapshot(directory)).resolves.toBeNull();
+    expect(readSidecarLockSnapshotSync(directory)).toBeNull();
+    await expect(
+      readSidecarLockSnapshot(directory, { rejectNonFile: true }),
+    ).rejects.toMatchObject({ code: "not-file" });
+    expect(() => readSidecarLockSnapshotSync(directory, undefined, { rejectNonFile: true }))
+      .toThrow(expect.objectContaining({ code: "not-file" }));
+  });
+
+  it("removes a lock only while the observed snapshot still matches", async () => {
+    const root = await tempRoot("fs-safe-sidecar-remove-helper-");
+    const lockPath = path.join(root, "state.lock");
+    const { raw } = serializeSidecarLockPayload({ owner: "one" });
+    await fs.writeFile(lockPath, raw);
+    const snapshot = await readSidecarLockSnapshot(lockPath);
+    expect(snapshot).not.toBeNull();
+    expect(await sidecarLockSnapshotStillPresent(lockPath, snapshot)).toBe(true);
+    expect(await sidecarLockSnapshotStillPresent(lockPath, null)).toBe(false);
+
+    await fs.writeFile(lockPath, "replacement");
+    expect(await removeSidecarLockIfUnchanged(lockPath, snapshot)).toBe(false);
+    expect(removeSidecarLockIfUnchangedSync(lockPath, snapshot!)).toBe(false);
+    await fs.writeFile(lockPath, raw);
+    const current = readSidecarLockSnapshotSync(lockPath);
+    expect(removeSidecarLockIfUnchangedSync(lockPath, current!)).toBe(true);
+    expect(fsSync.existsSync(lockPath)).toBe(false);
+  });
+
+  it("covers identity, raw, token, and stat-only snapshot comparisons", async () => {
+    const root = await tempRoot("fs-safe-sidecar-match-helper-");
+    const first = path.join(root, "first");
+    const second = path.join(root, "second");
+    await fs.writeFile(first, "one");
+    await fs.writeFile(second, "two");
+    const firstStat = await fs.stat(first);
+    const secondStat = await fs.stat(second);
+    expect(sidecarLockSnapshotMatches({ payload: null, stat: secondStat }, { payload: null, stat: firstStat })).toBe(false);
+    expect(sidecarLockSnapshotMatches({ payload: null, raw: "one" }, { payload: null, raw: "one" })).toBe(true);
+    expect(sidecarLockSnapshotMatches({ payload: null, raw: "two" }, { payload: null, raw: "one" })).toBe(false);
+    expect(sidecarLockSnapshotMatches({ payload: null, stat: firstStat }, { payload: null, stat: firstStat })).toBe(true);
+    expect(sidecarLockSnapshotMatches({ payload: null }, { payload: null })).toBe(false);
+
+    const serialized = serializeSidecarLockPayload({ owner: "token" });
+    const observed = { payload: null, raw: serialized.raw, ownershipToken: serialized.ownershipToken };
+    expect(sidecarLockSnapshotMatches({ payload: null, raw: serialized.raw, stat: firstStat }, observed)).toBe(true);
+    expect(sidecarLockSnapshotMatches({ payload: null, raw: `${serialized.raw}x`, stat: firstStat }, observed)).toBe(false);
+  });
+
+  it("fails closed on reclaim-guard inspection and creation errors", async () => {
+    const root = await tempRoot("fs-safe-sidecar-guard-helper-");
+    const guard = path.join(root, "state.lock.reclaim");
+    const guards = new Set<string>();
+    await expect(sidecarReclaimGuardExists(guard)).resolves.toBe(false);
+    await expect(tryAcquireSidecarReclaimGuard(guards, guard)).resolves.toBe(true);
+    await expect(sidecarReclaimGuardExists(guard)).resolves.toBe(true);
+    await expect(tryAcquireSidecarReclaimGuard(guards, guard)).resolves.toBe(false);
+    await releaseSidecarReclaimGuard(guards, guard);
+    expect(guards.has(guard)).toBe(false);
+
+    const denied = Object.assign(new Error("guard denied"), { code: "EACCES" });
+    vi.spyOn(fs, "lstat").mockRejectedValueOnce(denied);
+    await expect(sidecarReclaimGuardExists(guard)).rejects.toBe(denied);
+    vi.spyOn(fs, "mkdir").mockRejectedValueOnce(denied);
+    await expect(tryAcquireSidecarReclaimGuard(guards, guard)).rejects.toBe(denied);
+  });
+
+  it("requires explicit stale removal approval and detects both replacement races", async () => {
+    const root = await tempRoot("fs-safe-sidecar-stale-helper-");
+    const lockPath = path.join(root, "state.lock");
+    await fs.writeFile(lockPath, "old");
+    const snapshot = await readSidecarLockSnapshot(lockPath);
+    const base = { lockPath, normalizedTargetPath: path.join(root, "state"), snapshot: snapshot! };
+
+    await expect(removeStaleSidecarLockIfAllowed(base)).resolves.toBe("not-approved");
+    await expect(
+      removeStaleSidecarLockIfAllowed({ ...base, shouldRemoveStaleLock: () => false }),
+    ).resolves.toBe("not-approved");
+    await fs.writeFile(lockPath, "changed");
+    await expect(
+      removeStaleSidecarLockIfAllowed({ ...base, shouldRemoveStaleLock: () => true }),
+    ).resolves.toBe("changed");
+
+    await fs.writeFile(lockPath, "old");
+    const second = await readSidecarLockSnapshot(lockPath);
+    await expect(
+      removeStaleSidecarLockIfAllowed({
+        ...base,
+        snapshot: second!,
+        shouldRemoveStaleLock: async () => {
+          await fs.writeFile(lockPath, "replacement");
+          return true;
+        },
+      }),
+    ).resolves.toBe("changed");
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("replacement");
+  });
+
+  it("classifies a vanished stale lock as changed and propagates other removal failures", async () => {
+    const root = await tempRoot("fs-safe-sidecar-stale-remove-helper-");
+    const lockPath = path.join(root, "state.lock");
+    await fs.writeFile(lockPath, "old");
+    const snapshot = await readSidecarLockSnapshot(lockPath);
+    const params = {
+      lockPath,
+      normalizedTargetPath: path.join(root, "state"),
+      snapshot: snapshot!,
+      shouldRemoveStaleLock: () => true,
+    };
+    vi.spyOn(fs, "rm").mockRejectedValueOnce(Object.assign(new Error("gone"), { code: "ENOENT" }));
+    await expect(removeStaleSidecarLockIfAllowed(params)).resolves.toBe("changed");
+    vi.spyOn(fs, "rm").mockRejectedValueOnce(Object.assign(new Error("denied"), { code: "EACCES" }));
+    await expect(removeStaleSidecarLockIfAllowed(params)).rejects.toMatchObject({ code: "EACCES" });
+  });
+
+  it("covers retry policy boundaries and fail-closed timestamp fallback", async () => {
+    expect(computeSidecarLockDelayMs({ minTimeout: 2, maxTimeout: 5, factor: 2 }, 0)).toBe(2);
+    expect(computeSidecarLockDelayMs({ minTimeout: 2, maxTimeout: 5, factor: 2 }, 3)).toBe(5);
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    expect(computeSidecarLockDelayMs({ minTimeout: 2, maxTimeout: 10, randomize: true }, 0)).toBe(3);
+    expect(sidecarLockPayloadCreatedAtMs({ createdAt: "2000-01-01T00:00:00.000Z" })).toBeTypeOf("number");
+    expect(sidecarLockPayloadCreatedAtMs({ createdAt: "invalid" })).toBeNull();
+    expect(sidecarLockPayloadCreatedAtMs(null)).toBeNull();
+    expect(sidecarLockPayloadIsStale({ createdAt: "2000-01-01T00:00:00.000Z" }, 1, Date.now())).toBe(true);
+    expect(sidecarLockPayloadIsStale({}, 1, Date.now())).toBe(false);
+
+    const missing = path.join(await tempRoot("fs-safe-sidecar-policy-"), "missing.lock");
+    await expect(defaultSidecarLockShouldReclaim({ lockPath: missing, payload: {}, staleMs: 60_000, nowMs: Date.now() })).resolves.toBe(true);
+  });
+
+  it("rejects a snapshot whose opened descriptor is not a regular file", async () => {
+    const rootDir = await tempRoot("fs-safe-sidecar-opened-type-");
+    const lockPath = path.join(rootDir, "state.lock");
+    await fs.writeFile(lockPath, "{}");
+    const directoryStat = await fs.stat(rootDir);
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      vi.spyOn(handle, "stat").mockResolvedValueOnce(directoryStat);
+      return handle;
+    });
+    await expect(readSidecarLockSnapshot(lockPath)).resolves.toBeNull();
+
+    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+      const handle = await realOpen(...args);
+      vi.spyOn(handle, "stat").mockResolvedValueOnce(directoryStat);
+      return handle;
+    });
+    await expect(readSidecarLockSnapshot(lockPath, { rejectNonFile: true }))
+      .rejects.toMatchObject({ code: "not-file" });
+  });
+
+  it("removes an approved stale lock through a Root capability", async () => {
+    const rootDir = await tempRoot("fs-safe-sidecar-root-remove-");
+    const capability = await root(rootDir);
+    const lockPath = path.join(rootDir, "state.lock");
+    await capability.create("state.lock", "old");
+    const snapshot = await readSidecarLockSnapshot(lockPath, { lockRoot: capability });
+    await expect(removeStaleSidecarLockIfAllowed({
+      lockPath,
+      normalizedTargetPath: path.join(rootDir, "state"),
+      snapshot: snapshot!,
+      lockRoot: capability,
+      shouldRemoveStaleLock: () => true,
+    })).resolves.toBe("removed");
+    await expect(fs.access(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
## Summary

- add crash-resume and corrupt/truncated-state coverage for durable JSON queues
- exercise synchronous lock partial-create cleanup, stale reclaim, Root confinement, compromise detection, and retry failures
- cover publication rollback/preservation across hardlink, native rename, native-copy fallback, and zero-progress copy failures
- add regular, secret, secure, and sidecar refusal/race tests, including post-open and post-write identity checks

## Coverage

Native-built whole-project coverage:

| Metric | Before | After |
| --- | ---: | ---: |
| Statements | 86.03% | 88.34% |
| Branches | 78.01% | 80.77% |
| Functions | 87.24% | 87.98% |
| Lines | 87.72% | 90.00% |

Notable target line coverage: `json-durable-queue.ts` 79.12% → 89.56%, `file-lock-sync.ts` 67.46% → 96.82%, `publish-file.ts` 84.47% → 96.89%, `regular-file.ts` 76.92% → 97.69%, `secret-file.ts` 89.80% → 94.26%, and `secure-file.ts` 85.54% → 100%.

## Verification

- `pnpm check`
- `pnpm test:security`
- `pnpm native:build && pnpm test:coverage` (875 passed, 21 skipped)
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings
