### PR TITLE
fix: reject oversized base-256 tar sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Reject negative, malformed, and oversized base-256 TAR sizes using the full encoded field, preventing high-order size bytes from bypassing archive metadata metering.
 - Pin synchronous file-store roots across every parent-walk segment, so private and non-private writes reject a store root replaced during directory creation, and route deny-mutation ancestor canonicalization through the shared root resolver on Windows and POSIX.
 - Keep the POSIX parent-directory no-follow identity check active for synchronous atomic-replacement adapters that omit `fchmodSync`, preventing the documented default adapter path from writing through a symlinked parent.
 - Synchronize the actual destination after descriptor-bound mode application when atomic rename uses copy fallback, and include both bytes and mode in bounded fallback restoration.

--- a/src/archive-input.ts
+++ b/src/archive-input.ts
@@ -17,7 +17,7 @@ async function closeFileHandle(handle: FileHandle | undefined): Promise<void> {
   if (handle) await handle.close().catch(() => undefined);
 }
 
-async function writeFileHandleFully(params: {
+export async function writeFileHandleFully(params: {
   handle: FileHandle;
   buffer: Buffer;
   bytes: number;

--- a/src/archive-tar-meta.ts
+++ b/src/archive-tar-meta.ts
@@ -26,7 +26,13 @@ class TarMetadataMeter extends Transform {
   private parseSize(): number {
     const field = this.block.subarray(124, 136);
     if ((field[0] ?? 0) & 0x80) {
-      const value = field.readBigUInt64BE(4);
+      if (field[0] !== 0x80) {
+        throw this.invalid("base-256 size is negative or malformed");
+      }
+      let value = 0n;
+      for (const byte of field.subarray(1)) {
+        value = (value << 8n) | BigInt(byte);
+      }
       if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
         throw this.invalid("base-256 size exceeds the safe integer range");
       }

--- a/test/archive-adjacent-errors.test.ts
+++ b/test/archive-adjacent-errors.test.ts
@@ -1,0 +1,241 @@
+import type { FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import {
+  createPipelineTimeoutError,
+  waitForDeadline,
+  withExtractionDeadline,
+  type ExtractionDeadline,
+} from "../src/archive-deadline.js";
+import { writeFileHandleFully } from "../src/archive-file-io.js";
+import { stageArchiveFileForExtraction } from "../src/archive-input.js";
+import { resolveExtractLimits } from "../src/archive-limits.js";
+import { archiveEntryKindFromTarType, resolveArchiveEntryMode } from "../src/archive-policy.js";
+import { readZipCentralDirectoryEntryCount } from "../src/archive-zip-preflight.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function deadline(): ExtractionDeadline {
+  return {
+    signal: new AbortController().signal,
+    check: vi.fn(),
+    dispose: vi.fn(),
+  };
+}
+
+function zip64Fixture(totalEntries: bigint): Buffer {
+  const zip64 = Buffer.alloc(56);
+  zip64.writeUInt32LE(0x06064b50, 0);
+  zip64.writeBigUInt64LE(totalEntries, 32);
+  zip64.writeBigUInt64LE(0n, 40);
+  zip64.writeBigUInt64LE(76n, 48);
+  const locator = Buffer.alloc(20);
+  locator.writeUInt32LE(0x07064b50, 0);
+  locator.writeBigUInt64LE(0n, 8);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0xffff, 10);
+  eocd.writeUInt32LE(0xffffffff, 12);
+  eocd.writeUInt32LE(0xffffffff, 16);
+  return Buffer.concat([zip64, locator, eocd]);
+}
+
+function malformedCentralDirectory(params: {
+  bytes: number;
+  signature?: number;
+  nameLength?: number;
+}): Buffer {
+  const central = Buffer.alloc(params.bytes);
+  if (params.signature !== undefined && central.length >= 4) {
+    central.writeUInt32LE(params.signature, 0);
+  }
+  if (params.nameLength !== undefined && central.length >= 30) {
+    central.writeUInt16LE(params.nameLength, 28);
+  }
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(central.length, 12);
+  eocd.writeUInt32LE(0, 16);
+  return Buffer.concat([central, eocd]);
+}
+
+describe("archive deadline edge cases", () => {
+  it("supports disabled deadlines without installing a timer", async () => {
+    await expect(withExtractionDeadline(0, "disabled", async (value) => {
+      value.check();
+      expect(value.signal.aborted).toBe(false);
+      return "done";
+    })).resolves.toBe("done");
+    await expect(withExtractionDeadline(Number.POSITIVE_INFINITY, "disabled", async () => "done"))
+      .resolves.toBe("done");
+  });
+
+  it("rejects immediately when handed an already-aborted deadline", async () => {
+    const controller = new AbortController();
+    const reason = new Error("deadline elapsed");
+    controller.abort(reason);
+    const value = { signal: controller.signal, check: vi.fn(), dispose: vi.fn() };
+
+    await expect(waitForDeadline(Promise.resolve("late"), value)).rejects.toBe(reason);
+    expect(value.check).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps only abort-shaped pipeline failures to the deadline reason", () => {
+    const controller = new AbortController();
+    const reason = new Error("extract timed out");
+    controller.abort(reason);
+    const value = { signal: controller.signal, check: vi.fn(), dispose: vi.fn() };
+    const abort = Object.assign(new Error("other text"), { name: "AbortError" });
+    const nodeAbort = new Error("The operation was aborted");
+    const ordinary = new Error("corrupt archive");
+
+    expect(createPipelineTimeoutError(abort, value)).toBe(reason);
+    expect(createPipelineTimeoutError(nodeAbort, value)).toBe(reason);
+    expect(createPipelineTimeoutError(ordinary, value)).toBe(ordinary);
+  });
+});
+
+describe("archive input staging failures", () => {
+  it("rejects non-files and inputs already over the archive limit", async () => {
+    const root = await tempRoot("fs-safe-stage-input-");
+    const directory = path.join(root, "directory");
+    const oversized = path.join(root, "oversized");
+    await fs.mkdir(directory);
+    await fs.writeFile(oversized, "1234");
+    const limits = resolveExtractLimits({ maxArchiveBytes: 3 });
+
+    await expect(stageArchiveFileForExtraction({ archivePath: directory, limits, deadline: deadline() }))
+      .rejects.toThrow("archive is not a regular file");
+    await expect(stageArchiveFileForExtraction({ archivePath: oversized, limits, deadline: deadline() }))
+      .rejects.toMatchObject({ code: "archive-size-exceeds-limit" });
+  });
+
+  itPosix("rejects symlink archive inputs", async () => {
+    const root = await tempRoot("fs-safe-stage-link-");
+    const target = path.join(root, "target");
+    const link = path.join(root, "link");
+    await fs.writeFile(target, "data");
+    await fs.symlink(target, link);
+
+    await expect(stageArchiveFileForExtraction({
+      archivePath: link,
+      limits: resolveExtractLimits(),
+      deadline: deadline(),
+    })).rejects.toThrow("archive is not a regular file");
+  });
+
+  it("rejects an archive whose identity changes after open", async () => {
+    const root = await tempRoot("fs-safe-stage-race-");
+    const archivePath = path.join(root, "archive");
+    const other = path.join(root, "other");
+    await fs.writeFile(archivePath, "archive");
+    await fs.writeFile(other, "other");
+    const realLstat = fs.lstat.bind(fs);
+    let archiveLstats = 0;
+    vi.spyOn(fs, "lstat").mockImplementation(async (candidate) => {
+      if (String(candidate) === archivePath && ++archiveLstats === 2) return await realLstat(other);
+      return await realLstat(candidate);
+    });
+
+    await expect(stageArchiveFileForExtraction({
+      archivePath,
+      limits: resolveExtractLimits(),
+      deadline: deadline(),
+    })).rejects.toThrow("archive changed during validation");
+  });
+
+  it("enforces the byte limit if a pinned input grows after its initial stat", async () => {
+    const root = await tempRoot("fs-safe-stage-growth-");
+    const archivePath = path.join(root, "archive");
+    await fs.writeFile(archivePath, "123");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      if (String(args[0]) !== archivePath) return handle;
+      let read = false;
+      return new Proxy(handle, {
+        get(target, property) {
+          if (property === "read") {
+            return async (buffer: Buffer) => {
+              if (read) return { bytesRead: 0, buffer };
+              read = true;
+              buffer.write("1234");
+              return { bytesRead: 4, buffer };
+            };
+          }
+          const value = Reflect.get(target, property);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      }) as FileHandle;
+    });
+
+    await expect(stageArchiveFileForExtraction({
+      archivePath,
+      limits: resolveExtractLimits({ maxArchiveBytes: 3 }),
+      deadline: deadline(),
+    })).rejects.toMatchObject({ code: "archive-size-exceeds-limit" });
+  });
+
+  it("writes short chunks fully and rejects a writer that makes no progress", async () => {
+    const checks = vi.fn();
+    let writes = 0;
+    const shortWriter = {
+      async write() {
+        writes += 1;
+        return { bytesWritten: 1 };
+      },
+    } as unknown as FileHandle;
+    await writeFileHandleFully({
+      handle: shortWriter,
+      buffer: Buffer.from("abc"),
+      bytes: 3,
+      deadline: { ...deadline(), check: checks },
+    });
+    expect(writes).toBe(3);
+    expect(checks).toHaveBeenCalledTimes(3);
+
+    const stalled = { async write() { return { bytesWritten: 0 }; } } as unknown as FileHandle;
+    await expect(writeFileHandleFully({
+      handle: stalled,
+      buffer: Buffer.from("x"),
+      bytes: 1,
+      deadline: deadline(),
+    })).rejects.toThrow("archive staging write made no progress");
+  });
+});
+
+describe("malformed ZIP central directories", () => {
+  it("parses ZIP64 counts and clamps integers beyond JavaScript's safe range", () => {
+    expect(readZipCentralDirectoryEntryCount(zip64Fixture(0n))).toBe(0);
+    expect(readZipCentralDirectoryEntryCount(
+      zip64Fixture(BigInt(Number.MAX_SAFE_INTEGER) + 1n),
+    )).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("falls back to the declared count for truncated and malformed directory records", () => {
+    expect(readZipCentralDirectoryEntryCount(malformedCentralDirectory({ bytes: 10 }))).toBe(1);
+    expect(readZipCentralDirectoryEntryCount(malformedCentralDirectory({
+      bytes: 46,
+      signature: 0x01020304,
+    }))).toBe(1);
+    expect(readZipCentralDirectoryEntryCount(malformedCentralDirectory({
+      bytes: 46,
+      signature: 0x02014b50,
+      nameLength: 1,
+    }))).toBe(1);
+  });
+
+  it("classifies uncommon TAR types and preserve-mode defaults", () => {
+    expect(archiveEntryKindFromTarType("GNUDumpDir")).toBe("directory");
+    expect(archiveEntryKindFromTarType("CharacterDevice")).toBe("other");
+    expect(resolveArchiveEntryMode({ kind: "directory", policy: "preserve" })).toBe(0o755);
+    expect(resolveArchiveEntryMode({ kind: "file", policy: "preserve" })).toBe(0o644);
+  });
+});

--- a/test/archive-adjacent-errors.test.ts
+++ b/test/archive-adjacent-errors.test.ts
@@ -9,7 +9,7 @@ import {
   withExtractionDeadline,
   type ExtractionDeadline,
 } from "../src/archive-deadline.js";
-import { writeFileHandleFully } from "../src/archive-file-io.js";
+import { writeFileHandleFully } from "../src/archive-input.js";
 import { stageArchiveFileForExtraction } from "../src/archive-input.js";
 import { resolveExtractLimits } from "../src/archive-limits.js";
 import { archiveEntryKindFromTarType, resolveArchiveEntryMode } from "../src/archive-policy.js";

--- a/test/archive-read-boundaries.test.ts
+++ b/test/archive-read-boundaries.test.ts
@@ -1,0 +1,363 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import JSZip from "jszip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
+import {
+  ARCHIVE_LIMIT_ERROR_CODE,
+  ArchiveFormatError,
+  ArchiveLimitError,
+  readArchiveEntry,
+} from "../src/archive.js";
+import { preflightTarMetadata } from "../src/archive-tar-meta.js";
+import {
+  __resetFsSafeNativeConfigForTest,
+  configureFsSafeNative,
+} from "../src/native-config.js";
+import {
+  __resetNativeLoaderForTest,
+  __setNativeLoaderForTest,
+  type NativeBinding,
+} from "../src/native.js";
+
+const { tempRoot } = useTempDirs();
+
+type TarEntry = {
+  path: string;
+  body?: Buffer | string;
+  type?: string;
+  mutateHeader?: (header: Buffer) => void;
+};
+
+function writeString(block: Buffer, offset: number, length: number, value: string): void {
+  block.write(value, offset, Math.min(length, Buffer.byteLength(value)), "utf8");
+}
+
+function writeOctal(block: Buffer, offset: number, length: number, value: number): void {
+  writeString(block, offset, length, `${value.toString(8).padStart(length - 1, "0")}\0`);
+}
+
+function tarFixture(entries: TarEntry[], endBlocks = true): Buffer {
+  const blocks: Buffer[] = [];
+  for (const entry of entries) {
+    const body = Buffer.isBuffer(entry.body) ? entry.body : Buffer.from(entry.body ?? "");
+    const header = Buffer.alloc(512);
+    writeString(header, 0, 100, entry.path);
+    writeOctal(header, 100, 8, 0o644);
+    writeOctal(header, 108, 8, 0);
+    writeOctal(header, 116, 8, 0);
+    writeOctal(header, 124, 12, body.length);
+    writeOctal(header, 136, 12, 0);
+    header.fill(0x20, 148, 156);
+    writeString(header, 156, 1, entry.type ?? "0");
+    writeString(header, 257, 6, "ustar\0");
+    writeString(header, 263, 2, "00");
+    entry.mutateHeader?.(header);
+    const checksum = header.reduce((sum, byte) => sum + byte, 0);
+    writeString(header, 148, 8, `${checksum.toString(8).padStart(6, "0")}\0 `);
+    blocks.push(header, body, Buffer.alloc((512 - (body.length % 512)) % 512));
+  }
+  if (endBlocks) blocks.push(Buffer.alloc(1024));
+  return Buffer.concat(blocks);
+}
+
+function rawHeader(type = "0", size = 0): Buffer {
+  return tarFixture([{ path: "entry", type, body: Buffer.alloc(size) }], false).subarray(0, 512);
+}
+
+beforeEach(() => {
+  configureFsSafeNative({ mode: "off" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+describe("TAR metadata preflight boundaries", () => {
+  it("accepts metadata at the byte limit and rejects one byte past it", async () => {
+    const root = await tempRoot("fs-safe-tar-meta-limit-");
+    const atLimit = path.join(root, "at-limit.tar");
+    const pastLimit = path.join(root, "past-limit.tar");
+    await fs.writeFile(atLimit, tarFixture([{ path: "long-name", type: "L", body: "x".repeat(16) }]));
+    await fs.writeFile(pastLimit, tarFixture([{ path: "long-name", type: "L", body: "x".repeat(17) }]));
+
+    await expect(preflightTarMetadata({ archivePath: atLimit, maxMetaEntryBytes: 16 }))
+      .resolves.toBeUndefined();
+    await expect(preflightTarMetadata({ archivePath: pastLimit, maxMetaEntryBytes: 16 }))
+      .rejects.toMatchObject({
+        code: ARCHIVE_LIMIT_ERROR_CODE.META_ENTRY_SIZE_EXCEEDS_LIMIT,
+      });
+  });
+
+  it("rejects truncated headers and entry bodies distinctly", async () => {
+    const root = await tempRoot("fs-safe-tar-truncated-");
+    const headerPath = path.join(root, "header.tar");
+    const entryPath = path.join(root, "entry.tar");
+    await fs.writeFile(headerPath, Buffer.alloc(511));
+    await fs.writeFile(entryPath, tarFixture([{ path: "value", body: "payload" }], false).subarray(0, 513));
+
+    await expect(preflightTarMetadata({ archivePath: headerPath, maxMetaEntryBytes: 1024 }))
+      .rejects.toThrow("truncated TAR header");
+    await expect(preflightTarMetadata({ archivePath: entryPath, maxMetaEntryBytes: 1024 }))
+      .rejects.toThrow("truncated TAR entry");
+  });
+
+  it("rejects malformed octal and unsafe base-256 sizes", async () => {
+    const root = await tempRoot("fs-safe-tar-size-");
+    const malformedPath = path.join(root, "malformed.tar");
+    const highBitsPath = path.join(root, "high-bits.tar");
+    const paddingPath = path.join(root, "padding.tar");
+    const malformed = rawHeader();
+    malformed.fill(0x20, 124, 136);
+    malformed.write("00000000008\0", 124, "ascii");
+    const highBits = rawHeader();
+    highBits.fill(0, 124, 136);
+    highBits[124] = 0x80;
+    highBits[125] = 1;
+    const padding = rawHeader();
+    padding.fill(0, 124, 136);
+    padding[124] = 0x80;
+    padding.writeBigUInt64BE(BigInt(Number.MAX_SAFE_INTEGER), 128);
+    const negative = rawHeader();
+    negative.fill(0xff, 124, 136);
+    await fs.writeFile(malformedPath, malformed);
+    await fs.writeFile(highBitsPath, highBits);
+    await fs.writeFile(paddingPath, padding);
+
+    await expect(preflightTarMetadata({ archivePath: malformedPath, maxMetaEntryBytes: 1024 }))
+      .rejects.toThrow("size is not valid octal");
+    await expect(preflightTarMetadata({ archivePath: highBitsPath, maxMetaEntryBytes: 1024 }))
+      .rejects.toThrow("base-256 size exceeds the safe integer range");
+    await expect(preflightTarMetadata({ archivePath: paddingPath, maxMetaEntryBytes: 1024 }))
+      .rejects.toThrow("entry padding exceeds the safe integer range");
+    await fs.writeFile(paddingPath, negative);
+    await expect(preflightTarMetadata({ archivePath: paddingPath, maxMetaEntryBytes: 1024 }))
+      .rejects.toThrow("base-256 size is negative or malformed");
+  });
+
+  it("rejects PAX and malformed GNU sparse metadata before a parser can buffer it", async () => {
+    const root = await tempRoot("fs-safe-tar-meta-malformed-");
+    const paxPath = path.join(root, "pax.tar");
+    const sparseFlagPath = path.join(root, "sparse-flag.tar");
+    const sparseExtensionPath = path.join(root, "sparse-extension.tar");
+    const sparseLimitPath = path.join(root, "sparse-limit.tar");
+    const sparseUnsupportedPath = path.join(root, "sparse-unsupported.tar");
+    await fs.writeFile(paxPath, tarFixture([{ path: "pax", type: "x", body: "9 path=a\n" }]));
+    const sparseFlag = rawHeader("S");
+    sparseFlag[482] = 2;
+    await fs.writeFile(sparseFlagPath, sparseFlag);
+    const sparseExtension = rawHeader("S");
+    sparseExtension[482] = 1;
+    const invalidExtension = Buffer.alloc(512);
+    invalidExtension[504] = 2;
+    await fs.writeFile(sparseExtensionPath, Buffer.concat([sparseExtension, invalidExtension]));
+    const repeatedExtension = Buffer.alloc(512);
+    repeatedExtension[504] = 1;
+    await fs.writeFile(sparseLimitPath, Buffer.concat([sparseExtension, repeatedExtension]));
+    const finalExtension = Buffer.alloc(512);
+    await fs.writeFile(
+      sparseUnsupportedPath,
+      Buffer.concat([sparseExtension, repeatedExtension, finalExtension]),
+    );
+
+    await expect(preflightTarMetadata({ archivePath: paxPath, maxMetaEntryBytes: 1024 }))
+      .rejects.toThrow("PAX metadata is unmeterable");
+    await expect(preflightTarMetadata({ archivePath: sparseFlagPath, maxMetaEntryBytes: 1024 }))
+      .rejects.toThrow("GNU sparse extension flag is not 0 or 1");
+    await expect(preflightTarMetadata({ archivePath: sparseExtensionPath, maxMetaEntryBytes: 1024 }))
+      .rejects.toThrow("GNU sparse extension flag is not 0 or 1");
+    await expect(preflightTarMetadata({ archivePath: sparseLimitPath, maxMetaEntryBytes: 511 }))
+      .rejects.toMatchObject({
+        code: ARCHIVE_LIMIT_ERROR_CODE.META_ENTRY_SIZE_EXCEEDS_LIMIT,
+      });
+    await expect(preflightTarMetadata({ archivePath: sparseUnsupportedPath, maxMetaEntryBytes: 1024 }))
+      .rejects.toThrow("GNU sparse entries are not supported");
+  });
+
+  it("accepts an octal size field that occupies all twelve bytes", async () => {
+    const root = await tempRoot("fs-safe-tar-full-octal-");
+    const archivePath = path.join(root, "full-octal.tar");
+    const header = rawHeader();
+    header.write("000000000001", 124, "ascii");
+    await fs.writeFile(archivePath, Buffer.concat([header, Buffer.alloc(512)]));
+
+    await expect(preflightTarMetadata({ archivePath, maxMetaEntryBytes: 1024 }))
+      .resolves.toBeUndefined();
+  });
+
+  it("meters gzip-compressed TAR input and honors an already-aborted signal", async () => {
+    const root = await tempRoot("fs-safe-tar-gzip-");
+    const archivePath = path.join(root, "fixture.tar.gz");
+    await fs.writeFile(archivePath, gzipSync(tarFixture([{ path: "value", body: "ok" }])));
+    await expect(preflightTarMetadata({ archivePath, maxMetaEntryBytes: 1024 }))
+      .resolves.toBeUndefined();
+    const controller = new AbortController();
+    controller.abort(new Error("deadline elapsed"));
+    await expect(preflightTarMetadata({
+      archivePath,
+      maxMetaEntryBytes: 1024,
+      signal: controller.signal,
+    })).rejects.toMatchObject({ code: "ABORT_ERR" });
+  });
+});
+
+describe("bounded archive reads", () => {
+  it("rejects invalid requests before opening an archive", async () => {
+    await expect(readArchiveEntry("missing.zip", "value", { maxBytes: -1 }))
+      .rejects.toBeInstanceOf(RangeError);
+    await expect(readArchiveEntry("missing.zip", "value", { maxBytes: Number.MAX_SAFE_INTEGER + 1 }))
+      .rejects.toBeInstanceOf(RangeError);
+    await expect(readArchiveEntry("missing.unknown", "value", { maxBytes: 1 }))
+      .rejects.toThrow("unsupported archive");
+    await expect(readArchiveEntry("missing.zip", "", { maxBytes: 1 }))
+      .rejects.toThrow("archive entry is not a file");
+    await expect(readArchiveEntry("missing.zip", "dir/", { maxBytes: 1 }))
+      .rejects.toThrow("archive entry is not a file");
+  });
+
+  it("rejects non-file archive inputs", async () => {
+    const root = await tempRoot("fs-safe-read-input-");
+    const directory = path.join(root, "directory.zip");
+    const target = path.join(root, "target.zip");
+    const link = path.join(root, "link.zip");
+    await fs.mkdir(directory);
+    await fs.writeFile(target, "not a zip");
+    await fs.symlink(target, link);
+
+    await expect(readArchiveEntry(directory, "value", { maxBytes: 1 }))
+      .rejects.toThrow("archive is not a regular file");
+    await expect(readArchiveEntry(link, "value", { maxBytes: 1 }))
+      .rejects.toThrow("archive is not a regular file");
+  });
+
+  it("reads ZIP entries at the limit and rejects missing, directory, link, and oversized entries", async () => {
+    const root = await tempRoot("fs-safe-read-zip-");
+    const archivePath = path.join(root, "fixture.zip");
+    const zip = new JSZip();
+    zip.file("value.txt", "value");
+    zip.folder("directory");
+    zip.file("link", "target", { unixPermissions: 0o120777 });
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer", platform: "UNIX" }));
+
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
+      .resolves.toEqual(Buffer.from("value"));
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 4 }))
+      .rejects.toMatchObject({
+        code: ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT,
+      });
+    await expect(readArchiveEntry(archivePath, "missing", { maxBytes: 5 }))
+      .rejects.toThrow("archive entry not found");
+    await expect(readArchiveEntry(archivePath, "directory", { maxBytes: 5 }))
+      .rejects.toThrow("archive entry not found");
+    await expect(readArchiveEntry(archivePath, "link", { maxBytes: 16 }))
+      .rejects.toThrow("archive entry is a link");
+  });
+
+  it("uses the ZIP buffer fallback when a library entry has no node stream", async () => {
+    const root = await tempRoot("fs-safe-read-zip-buffer-");
+    const archivePath = path.join(root, "fixture.zip");
+    const zip = new JSZip();
+    zip.file("value.txt", "value");
+    const bytes = await zip.generateAsync({ type: "nodebuffer" });
+    await fs.writeFile(archivePath, bytes);
+    const loaded = await JSZip.loadAsync(bytes);
+    const entry = loaded.file("value.txt");
+    const prototype = Object.getPrototypeOf(entry) as object;
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, "nodeStream");
+    expect(descriptor).toBeDefined();
+    Object.defineProperty(prototype, "nodeStream", { ...descriptor, value: undefined });
+    try {
+      await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
+        .resolves.toEqual(Buffer.from("value"));
+    } finally {
+      Object.defineProperty(prototype, "nodeStream", descriptor!);
+    }
+  });
+
+  it("rejects missing, non-file, and oversized TAR entries without hanging the parser", async () => {
+    const root = await tempRoot("fs-safe-read-tar-");
+    const archivePath = path.join(root, "fixture.tar");
+    await fs.writeFile(archivePath, tarFixture([
+      { path: "directory", type: "5" },
+      { path: "value.txt", body: "value" },
+    ]));
+
+    await expect(readArchiveEntry(archivePath, "missing", { maxBytes: 5 }))
+      .rejects.toThrow("archive entry not found");
+    await expect(readArchiveEntry(archivePath, "directory", { maxBytes: 5 }))
+      .rejects.toThrow("archive entry is not a file");
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 4 }))
+      .rejects.toMatchObject({
+        code: ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT,
+      });
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
+      .resolves.toEqual(Buffer.from("value"));
+  });
+
+  it("maps native manifest and reader failures to the public archive errors", async () => {
+    const root = await tempRoot("fs-safe-read-native-");
+    const archivePath = path.join(root, "fixture.zip");
+    await fs.writeFile(archivePath, await new JSZip().file("value.txt", "value").generateAsync({
+      type: "nodebuffer",
+    }));
+    let manifest: Array<{ index: number; path: string; kind: string; size: number; mode: number }> = [];
+    let readError: Error | undefined;
+    const inspectArchiveNative = vi.fn(async () => manifest);
+    const readArchiveEntryNative = vi.fn(async () => {
+      if (readError) throw readError;
+      return Buffer.from("value");
+    });
+    __setNativeLoaderForTest(() => ({
+      inspectArchiveNative,
+      readArchiveEntryNative,
+    }) as unknown as NativeBinding);
+    configureFsSafeNative({ mode: "require" });
+    const regular = { index: 0, path: "value.txt", kind: "file", size: 5, mode: 0o644 };
+
+    manifest = [regular, { ...regular, index: 1 }];
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
+      .rejects.toMatchObject({ name: "ArchiveSecurityError", code: "entry-path" });
+    manifest = [{ ...regular, kind: "directory" }];
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
+      .rejects.toThrow("archive entry is not a file");
+    manifest = [{ ...regular, path: "other.txt" }];
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
+      .rejects.toThrow("archive entry not found");
+    manifest = [{ ...regular, path: "../escape" }];
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
+      .rejects.toMatchObject({ name: "ArchiveSecurityError", code: "entry-path" });
+    manifest = [{ ...regular, path: "./value.txt" }];
+    readError = new Error(ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT);
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
+      .rejects.toBeInstanceOf(ArchiveLimitError);
+    readError = new Error("archive-header-invalid: truncated ZIP central directory");
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
+      .rejects.toBeInstanceOf(ArchiveFormatError);
+    readError = undefined;
+    await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
+      .resolves.toEqual(Buffer.from("value"));
+    expect(readArchiveEntryNative).toHaveBeenLastCalledWith(
+      expect.any(String),
+      "zip",
+      "./value.txt",
+      5,
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("requires native support for explicitly selected zstd and bzip2 TAR reads", async () => {
+    const root = await tempRoot("fs-safe-read-compressed-");
+    const archivePath = path.join(root, "fixture.bin");
+    await fs.writeFile(archivePath, "not compressed");
+
+    await expect(readArchiveEntry(archivePath, "value", { maxBytes: 5, kind: "tar-zstd" }))
+      .rejects.toMatchObject({ code: "helper-unavailable" });
+    await expect(readArchiveEntry(archivePath, "value", { maxBytes: 5, kind: "tar-bzip2" }))
+      .rejects.toMatchObject({ code: "helper-unavailable" });
+  });
+});

--- a/test/copy-fallback-cleanup.test.ts
+++ b/test/copy-fallback-cleanup.test.ts
@@ -1,0 +1,119 @@
+import fsSync from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
+import {
+  copyFallbackReplace,
+  copyFallbackReplaceSync,
+} from "../src/replace-file-copy-fallback.js";
+
+const { tempRoot } = useTempDirs();
+
+function bindHandle(handle: FileHandle, overrides: Partial<FileHandle>): FileHandle {
+  return new Proxy(handle, {
+    get(target, property) {
+      if (property in overrides) return overrides[property as keyof FileHandle];
+      const value = Reflect.get(target, property);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+describe("copy fallback cleanup failures", () => {
+  it("does not let best-effort close and source cleanup failures overturn a successful copy", async () => {
+    const root = await tempRoot("fs-safe-copy-cleanup-");
+    const asyncSource = path.join(root, "async-source");
+    const asyncDest = path.join(root, "async-dest");
+    await fs.writeFile(asyncSource, "async");
+    const asyncFs = {
+      ...fs,
+      async open(...args: Parameters<typeof fs.open>) {
+        const handle = await fs.open(...args);
+        return bindHandle(handle, {
+          async close() {
+            await handle.close();
+            throw new Error("close receipt lost");
+          },
+        });
+      },
+      async unlink(candidate: fs.PathLike) {
+        await fs.unlink(candidate);
+        throw new Error("unlink receipt lost");
+      },
+    };
+    await expect(copyFallbackReplace({
+      fsModule: asyncFs,
+      src: asyncSource,
+      dest: asyncDest,
+      restore: "none",
+      sync: true,
+    })).resolves.toBeUndefined();
+    await expect(fs.readFile(asyncDest, "utf8")).resolves.toBe("async");
+
+    const syncSource = path.join(root, "sync-source");
+    const syncDest = path.join(root, "sync-dest");
+    await fs.writeFile(syncSource, "sync");
+    const syncModule = {
+      ...fsSync,
+      closeSync(fd: number) {
+        fsSync.closeSync(fd);
+        throw new Error("close receipt lost");
+      },
+      unlinkSync(candidate: fsSync.PathLike) {
+        fsSync.unlinkSync(candidate);
+        throw new Error("unlink receipt lost");
+      },
+    };
+    expect(copyFallbackReplaceSync({
+      fsModule: syncModule,
+      src: syncSource,
+      dest: syncDest,
+      restore: "none",
+      sync: true,
+    })).toBeUndefined();
+    expect(fsSync.readFileSync(syncDest, "utf8")).toBe("sync");
+  });
+
+  it("propagates unexpected destination inspection failures and preserves the source", async () => {
+    const root = await tempRoot("fs-safe-copy-dest-error-");
+    const asyncSource = path.join(root, "async-source");
+    const syncSource = path.join(root, "sync-source");
+    const dest = path.join(root, "dest");
+    await fs.writeFile(asyncSource, "async");
+    await fs.writeFile(syncSource, "sync");
+    const denied = Object.assign(new Error("inspection denied"), { code: "EACCES" });
+    const asyncFs = {
+      ...fs,
+      async lstat(candidate: fs.PathLike) {
+        if (String(candidate) === dest) throw denied;
+        return await fs.lstat(candidate);
+      },
+    };
+    await expect(copyFallbackReplace({
+      fsModule: asyncFs,
+      src: asyncSource,
+      dest,
+      restore: "none",
+      sync: false,
+    })).rejects.toBe(denied);
+    await expect(fs.readFile(asyncSource, "utf8")).resolves.toBe("async");
+
+    const syncModule = {
+      ...fsSync,
+      lstatSync(candidate: fsSync.PathLike) {
+        if (String(candidate) === dest) throw denied;
+        return fsSync.lstatSync(candidate);
+      },
+    };
+    expect(() => copyFallbackReplaceSync({
+      fsModule: syncModule,
+      src: syncSource,
+      dest,
+      restore: "none",
+      sync: false,
+    })).toThrow(denied);
+    await expect(fs.readFile(syncSource, "utf8")).resolves.toBe("sync");
+  });
+});

--- a/test/copy-fallback-failures.test.ts
+++ b/test/copy-fallback-failures.test.ts
@@ -1,0 +1,461 @@
+import fsSync from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import {
+  assertDestinationHardlinkPolicy,
+  assertDestinationHardlinkPolicySync,
+  copyFallbackReplace,
+  copyFallbackReplaceSync,
+} from "../src/replace-file-copy-fallback.js";
+
+const { tempRoot } = useTempDirs();
+
+function bindHandle(handle: FileHandle, overrides: Partial<FileHandle>): FileHandle {
+  return new Proxy(handle, {
+    get(target, property) {
+      if (property in overrides) return overrides[property as keyof FileHandle];
+      const value = Reflect.get(target, property);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+describe("copy fallback source and destination guards", () => {
+  it("rejects async and sync non-file sources before opening them", async () => {
+    const root = await tempRoot("fs-safe-copy-source-");
+    const directory = path.join(root, "source");
+    const dest = path.join(root, "dest");
+    await fs.mkdir(directory);
+
+    await expect(copyFallbackReplace({
+      fsModule: fs,
+      src: directory,
+      dest,
+      restore: "none",
+      sync: false,
+    })).rejects.toThrow("non-file source");
+    expect(() => copyFallbackReplaceSync({
+      fsModule: fsSync,
+      src: directory,
+      dest,
+      restore: "none",
+      sync: false,
+    })).toThrow("non-file source");
+  });
+
+  itPosix("rejects symlink sources and destinations without changing their targets", async () => {
+    const root = await tempRoot("fs-safe-copy-symlink-");
+    const sourceTarget = path.join(root, "source-target");
+    const sourceLink = path.join(root, "source-link");
+    const destTarget = path.join(root, "dest-target");
+    const destLink = path.join(root, "dest-link");
+    await fs.writeFile(sourceTarget, "source");
+    await fs.writeFile(destTarget, "dest");
+    await fs.symlink(sourceTarget, sourceLink);
+    await fs.symlink(destTarget, destLink);
+
+    await expect(copyFallbackReplace({
+      fsModule: fs,
+      src: sourceLink,
+      dest: path.join(root, "unused"),
+      restore: "none",
+      sync: false,
+    })).rejects.toThrow("non-file source");
+    expect(() => copyFallbackReplaceSync({
+      fsModule: fsSync,
+      src: sourceLink,
+      dest: path.join(root, "unused-sync"),
+      restore: "none",
+      sync: false,
+    })).toThrow("non-file source");
+
+    const asyncSource = path.join(root, "async-source");
+    const syncSource = path.join(root, "sync-source");
+    await fs.writeFile(asyncSource, "replacement");
+    await fs.writeFile(syncSource, "replacement");
+    await expect(copyFallbackReplace({
+      fsModule: fs,
+      src: asyncSource,
+      dest: destLink,
+      restore: "none",
+      sync: false,
+    })).rejects.toMatchObject({ code: "symlink" });
+    expect(() => copyFallbackReplaceSync({
+      fsModule: fsSync,
+      src: syncSource,
+      dest: destLink,
+      restore: "none",
+      sync: false,
+    })).toThrow(expect.objectContaining({ code: "symlink" }));
+    await expect(fs.readFile(destTarget, "utf8")).resolves.toBe("dest");
+  });
+
+  it("rejects source identity changes after open in both implementations", async () => {
+    const root = await tempRoot("fs-safe-copy-source-race-");
+    const source = path.join(root, "source");
+    const other = path.join(root, "other");
+    await fs.writeFile(source, "source");
+    await fs.writeFile(other, "other");
+    let sourceLstats = 0;
+    const asyncFs = {
+      ...fs,
+      async lstat(candidate: fs.PathLike) {
+        if (String(candidate) === source && ++sourceLstats === 2) return await fs.lstat(other);
+        return await fs.lstat(candidate);
+      },
+    };
+    await expectFsSafeError(copyFallbackReplace({
+      fsModule: asyncFs,
+      src: source,
+      dest: path.join(root, "dest"),
+      restore: "none",
+      sync: false,
+    }), "path-mismatch");
+
+    sourceLstats = 0;
+    const syncModule = {
+      ...fsSync,
+      lstatSync(candidate: fsSync.PathLike) {
+        if (String(candidate) === source && ++sourceLstats === 2) return fsSync.lstatSync(other);
+        return fsSync.lstatSync(candidate);
+      },
+    };
+    expect(() => copyFallbackReplaceSync({
+      fsModule: syncModule,
+      src: source,
+      dest: path.join(root, "dest-sync"),
+      restore: "none",
+      sync: false,
+    })).toThrow(expect.objectContaining({ code: "path-mismatch" }));
+  });
+
+  it("rejects a destination whose identity changes while it is pinned", async () => {
+    const root = await tempRoot("fs-safe-copy-dest-race-");
+    const source = path.join(root, "source");
+    const dest = path.join(root, "dest");
+    const other = path.join(root, "other");
+    await fs.writeFile(source, "replacement");
+    await fs.writeFile(dest, "original");
+    await fs.writeFile(other, "other");
+    const asyncFs = {
+      ...fs,
+      async open(candidate: fs.PathLike, flags: string | number, mode?: number) {
+        return await fs.open(String(candidate) === dest ? other : candidate, flags, mode);
+      },
+    };
+
+    await expectFsSafeError(copyFallbackReplace({
+      fsModule: asyncFs,
+      src: source,
+      dest,
+      restore: "restore-original",
+      maxRestoreBytes: 32,
+      sync: false,
+    }), "path-mismatch");
+    await expect(fs.readFile(dest, "utf8")).resolves.toBe("original");
+
+    const syncModule = {
+      ...fsSync,
+      openSync(candidate: fsSync.PathLike, flags: fsSync.OpenMode, mode?: fsSync.Mode) {
+        return fsSync.openSync(String(candidate) === dest ? other : candidate, flags, mode);
+      },
+    };
+    expect(() => copyFallbackReplaceSync({
+      fsModule: syncModule,
+      src: source,
+      dest,
+      restore: "restore-original",
+      maxRestoreBytes: 32,
+      sync: false,
+    })).toThrow(expect.objectContaining({ code: "path-mismatch" }));
+  });
+
+  itPosix("enforces destination hardlink policy before remove or pinned replacement", async () => {
+    const root = await tempRoot("fs-safe-copy-hardlink-");
+    const original = path.join(root, "original");
+    const alias = path.join(root, "alias");
+    const asyncSource = path.join(root, "async-source");
+    const syncSource = path.join(root, "sync-source");
+    await fs.writeFile(original, "original");
+    await fs.link(original, alias);
+    await fs.writeFile(asyncSource, "replacement");
+    await fs.writeFile(syncSource, "replacement");
+
+    await expectFsSafeError(assertDestinationHardlinkPolicy(fs, alias, "reject"), "hardlink");
+    expect(() => assertDestinationHardlinkPolicySync(fsSync, alias, "reject"))
+      .toThrow(expect.objectContaining({ code: "hardlink" }));
+    await expectFsSafeError(copyFallbackReplace({
+      fsModule: fs,
+      src: asyncSource,
+      dest: alias,
+      destinationHardlinks: "reject",
+      restore: "restore-original",
+      maxRestoreBytes: 32,
+      sync: false,
+    }), "hardlink");
+    expect(() => copyFallbackReplaceSync({
+      fsModule: fsSync,
+      src: syncSource,
+      dest: alias,
+      destinationHardlinks: "reject",
+      restore: "restore-original",
+      maxRestoreBytes: 32,
+      sync: false,
+    })).toThrow(expect.objectContaining({ code: "hardlink" }));
+    await expect(fs.readFile(original, "utf8")).resolves.toBe("original");
+  });
+
+  it("treats missing and non-file destinations as no hardlink-policy decision", async () => {
+    const root = await tempRoot("fs-safe-copy-policy-noop-");
+    const missing = path.join(root, "missing");
+    const directory = path.join(root, "directory");
+    await fs.mkdir(directory);
+
+    await expect(assertDestinationHardlinkPolicy(fs, missing, "reject")).resolves.toBeUndefined();
+    await expect(assertDestinationHardlinkPolicy(fs, directory, "reject")).resolves.toBeUndefined();
+    await expect(assertDestinationHardlinkPolicy(fs, directory)).resolves.toBeUndefined();
+    expect(assertDestinationHardlinkPolicySync(fsSync, missing, "reject")).toBeUndefined();
+    expect(assertDestinationHardlinkPolicySync(fsSync, directory, "reject")).toBeUndefined();
+    expect(assertDestinationHardlinkPolicySync(fsSync, directory)).toBeUndefined();
+  });
+
+  itPosix("rejects a destination that becomes a symlink or non-file after open", async () => {
+    const root = await tempRoot("fs-safe-copy-dest-recheck-");
+    const source = path.join(root, "source");
+    const dest = path.join(root, "dest");
+    const linkTarget = path.join(root, "link-target");
+    const link = path.join(root, "link");
+    const directory = path.join(root, "directory");
+    await fs.writeFile(source, "replacement");
+    await fs.writeFile(dest, "original");
+    await fs.writeFile(linkTarget, "outside");
+    await fs.symlink(linkTarget, link);
+    await fs.mkdir(directory);
+    let destLstats = 0;
+    const symlinkAfterOpen = {
+      ...fs,
+      async lstat(candidate: fs.PathLike) {
+        if (String(candidate) === dest && ++destLstats === 2) return await fs.lstat(link);
+        return await fs.lstat(candidate);
+      },
+    };
+    await expectFsSafeError(copyFallbackReplace({
+      fsModule: symlinkAfterOpen,
+      src: source,
+      dest,
+      restore: "restore-original",
+      maxRestoreBytes: 32,
+      sync: false,
+    }), "symlink");
+
+    const directoryStat = await fs.stat(directory);
+    const nonFileAfterOpen = {
+      ...fs,
+      async open(candidate: fs.PathLike, flags: string | number, mode?: number) {
+        const handle = await fs.open(candidate, flags, mode);
+        if (String(candidate) !== dest) return handle;
+        return bindHandle(handle, {
+          stat: (async () => directoryStat) as FileHandle["stat"],
+          async close() {
+            await handle.close();
+            throw new Error("close receipt lost");
+          },
+        });
+      },
+    };
+    await expectFsSafeError(copyFallbackReplace({
+      fsModule: nonFileAfterOpen,
+      src: source,
+      dest,
+      restore: "restore-original",
+      maxRestoreBytes: 32,
+      sync: false,
+    }), "not-file");
+    await expect(fs.readFile(dest, "utf8")).resolves.toBe("original");
+  });
+
+  it("closes hardlink-policy handles when identity validation fails", async () => {
+    const root = await tempRoot("fs-safe-copy-policy-race-");
+    const dest = path.join(root, "dest");
+    const other = path.join(root, "other");
+    await fs.writeFile(dest, "dest");
+    await fs.writeFile(other, "other");
+    const asyncFs = {
+      ...fs,
+      async open() {
+        const handle = await fs.open(other, "r");
+        return bindHandle(handle, {
+          async close() {
+            await handle.close();
+            throw new Error("close receipt lost");
+          },
+        });
+      },
+    };
+    await expectFsSafeError(assertDestinationHardlinkPolicy(asyncFs, dest, "reject"), "path-mismatch");
+
+    const syncModule = {
+      ...fsSync,
+      openSync() {
+        return fsSync.openSync(other, "r");
+      },
+    };
+    expect(() => assertDestinationHardlinkPolicySync(syncModule, dest, "reject"))
+      .toThrow(expect.objectContaining({ code: "path-mismatch" }));
+  });
+});
+
+describe("copy fallback failure and restoration", () => {
+  it("restores original bytes when an async write makes no progress", async () => {
+    const root = await tempRoot("fs-safe-copy-zero-write-");
+    const source = path.join(root, "source");
+    const dest = path.join(root, "dest");
+    await fs.writeFile(source, "replacement");
+    await fs.writeFile(dest, "original");
+    let writes = 0;
+    const asyncFs = {
+      ...fs,
+      async open(candidate: fs.PathLike, flags: string | number, mode?: number) {
+        const handle = await fs.open(candidate, flags, mode);
+        if (String(candidate) !== dest) return handle;
+        return bindHandle(handle, {
+          write: (async (...args: Parameters<FileHandle["write"]>) => {
+            writes += 1;
+            if (writes === 1) return { bytesWritten: 0, buffer: args[0] };
+            return await handle.write(...args);
+          }) as FileHandle["write"],
+        });
+      },
+    };
+
+    await expect(copyFallbackReplace({
+      fsModule: asyncFs,
+      src: source,
+      dest,
+      restore: "restore-original",
+      maxRestoreBytes: 8,
+      sync: true,
+    })).rejects.toMatchObject({
+      code: "helper-failed",
+      details: { cleanup: "restored" },
+    });
+    await expect(fs.readFile(dest, "utf8")).resolves.toBe("original");
+    await expect(fs.readFile(source, "utf8")).resolves.toBe("replacement");
+  });
+
+  it("reports a synchronous double fault when neither write makes progress", async () => {
+    const root = await tempRoot("fs-safe-copy-zero-write-sync-");
+    const source = path.join(root, "source");
+    const dest = path.join(root, "dest");
+    await fs.writeFile(source, "replacement");
+    await fs.writeFile(dest, "original");
+    let destFd: number | undefined;
+    const syncModule = {
+      ...fsSync,
+      openSync(candidate: fsSync.PathLike, flags: fsSync.OpenMode, mode?: fsSync.Mode) {
+        const fd = fsSync.openSync(candidate, flags, mode);
+        if (String(candidate) === dest && typeof flags === "number" && (flags & fsSync.constants.O_RDWR)) {
+          destFd = fd;
+        }
+        return fd;
+      },
+      writeSync(fd: number, buffer: Uint8Array, offset: number, length: number, position: number) {
+        if (fd === destFd) return 0;
+        return fsSync.writeSync(fd, buffer, offset, length, position);
+      },
+    };
+
+    expect(() => copyFallbackReplaceSync({
+      fsModule: syncModule,
+      src: source,
+      dest,
+      restore: "restore-original",
+      maxRestoreBytes: 8,
+      sync: true,
+    })).toThrow(expect.objectContaining({
+      code: "helper-failed",
+      details: { cleanup: "restore-failed" },
+      cause: expect.any(AggregateError),
+    }));
+    await expect(fs.readFile(source, "utf8")).resolves.toBe("replacement");
+  });
+
+  it("accepts an exact restore budget and rejects one byte less before mutation", async () => {
+    const root = await tempRoot("fs-safe-copy-restore-limit-");
+    const exactSource = path.join(root, "exact-source");
+    const exactDest = path.join(root, "exact-dest");
+    await fs.writeFile(exactSource, "new");
+    await fs.writeFile(exactDest, "12345");
+    copyFallbackReplaceSync({
+      fsModule: fsSync,
+      src: exactSource,
+      dest: exactDest,
+      restore: "restore-original",
+      maxRestoreBytes: 5,
+      sync: true,
+    });
+    expect(fsSync.readFileSync(exactDest, "utf8")).toBe("new");
+
+    const pastSource = path.join(root, "past-source");
+    const pastDest = path.join(root, "past-dest");
+    await fs.writeFile(pastSource, "new");
+    await fs.writeFile(pastDest, "12345");
+    expect(() => copyFallbackReplaceSync({
+      fsModule: fsSync,
+      src: pastSource,
+      dest: pastDest,
+      restore: "restore-original",
+      maxRestoreBytes: 4,
+      sync: false,
+    })).toThrow(expect.objectContaining({ code: "too-large" }));
+    expect(fsSync.readFileSync(pastDest, "utf8")).toBe("12345");
+  });
+
+  it("successfully replaces both missing and existing destinations through each fallback mode", async () => {
+    const root = await tempRoot("fs-safe-copy-success-paths-");
+    const missingSource = path.join(root, "missing-source");
+    const missingDest = path.join(root, "missing-dest");
+    await fs.writeFile(missingSource, "created");
+    await copyFallbackReplace({
+      fsModule: fs,
+      src: missingSource,
+      dest: missingDest,
+      restore: "restore-original",
+      maxRestoreBytes: 16,
+      sync: false,
+    });
+    await expect(fs.readFile(missingDest, "utf8")).resolves.toBe("created");
+
+    const pinnedSource = path.join(root, "pinned-source");
+    const pinnedDest = path.join(root, "pinned-dest");
+    await fs.writeFile(pinnedSource, "new");
+    await fs.writeFile(pinnedDest, "old");
+    await copyFallbackReplace({
+      fsModule: fs,
+      src: pinnedSource,
+      dest: pinnedDest,
+      restore: "restore-original",
+      maxRestoreBytes: 3,
+      sync: true,
+    });
+    await expect(fs.readFile(pinnedDest, "utf8")).resolves.toBe("new");
+
+    const syncSource = path.join(root, "sync-source");
+    const syncDest = path.join(root, "sync-dest");
+    await fs.writeFile(syncSource, "sync-new");
+    await fs.writeFile(syncDest, "sync-old");
+    copyFallbackReplaceSync({
+      fsModule: fsSync,
+      src: syncSource,
+      dest: syncDest,
+      restore: "none",
+      sync: true,
+    });
+    expect(fsSync.readFileSync(syncDest, "utf8")).toBe("sync-new");
+  });
+
+});

--- a/test/native-loader-detectors.test.ts
+++ b/test/native-loader-detectors.test.ts
@@ -1,0 +1,211 @@
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeErrorSync } from "./helpers/security.js";
+import {
+  __nativeLoaderDetectorsForTest,
+  __resetNativeLoaderForTest,
+  __setNativeLoaderForTest,
+  requireNativeBinding,
+} from "../src/native.js";
+import {
+  __resetFsSafeNativeConfigForTest,
+  configureFsSafeNative,
+} from "../src/native-config.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  syncBuiltinESMExports();
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+function installElfReads(parts: Map<number, Buffer>, closeError?: Error): void {
+  vi.spyOn(fs, "openSync").mockReturnValue(91);
+  vi.spyOn(fs, "readSync").mockImplementation((
+    _fd,
+    buffer,
+    offset,
+    length,
+    position,
+  ) => {
+    const source = parts.get(Number(position));
+    if (!source) return 0;
+    const bytes = Math.min(length, source.length);
+    source.copy(buffer as Buffer, offset, 0, bytes);
+    return bytes;
+  });
+  vi.spyOn(fs, "closeSync").mockImplementation(() => {
+    if (closeError) throw closeError;
+  });
+  syncBuiltinESMExports();
+}
+
+function elf64(params: {
+  interpreter?: string;
+  type?: number;
+  entrySize?: number;
+  entryCount?: number;
+  interpreterSize?: number;
+  tableOffset?: bigint;
+} = {}): Map<number, Buffer> {
+  const tableOffset = params.tableOffset ?? 64n;
+  const entrySize = params.entrySize ?? 56;
+  const interpreterOffset = 128n;
+  const interpreter = Buffer.from(params.interpreter ?? "/lib64/ld-linux-x86-64.so.2\0");
+  const header = Buffer.alloc(64);
+  header.set([0x7f, 0x45, 0x4c, 0x46, 2, 1]);
+  header.writeBigUInt64LE(tableOffset, 32);
+  header.writeUInt16LE(entrySize, 54);
+  header.writeUInt16LE(params.entryCount ?? 1, 56);
+  const programHeader = Buffer.alloc(entrySize);
+  if (entrySize >= 4) programHeader.writeUInt32LE(params.type ?? 3, 0);
+  if (entrySize >= 40) {
+    programHeader.writeBigUInt64LE(interpreterOffset, 8);
+    programHeader.writeBigUInt64LE(BigInt(params.interpreterSize ?? interpreter.length), 32);
+  }
+  return new Map([
+    [0, header],
+    [Number(tableOffset), programHeader],
+    [Number(interpreterOffset), interpreter],
+  ]);
+}
+
+function elf32BigEndian(interpreter: string): Map<number, Buffer> {
+  const header = Buffer.alloc(64);
+  header.set([0x7f, 0x45, 0x4c, 0x46, 1, 2]);
+  header.writeUInt32BE(64, 28);
+  header.writeUInt16BE(32, 42);
+  header.writeUInt16BE(1, 44);
+  const programHeader = Buffer.alloc(32);
+  programHeader.writeUInt32BE(3, 0);
+  programHeader.writeUInt32BE(96, 4);
+  const encoded = Buffer.from(`${interpreter}\0`);
+  programHeader.writeUInt32BE(encoded.length, 16);
+  return new Map([
+    [0, header],
+    [64, programHeader],
+    [96, encoded],
+  ]);
+}
+
+describe("native libc detector failures", () => {
+  it("handles glibc, musl, inconclusive, and failed process reports", () => {
+    const getReport = vi.spyOn(process.report, "getReport");
+    getReport.mockReturnValue({ header: { glibcVersionRuntime: "2.39" } } as never);
+    expect(__nativeLoaderDetectorsForTest().report).toBe(false);
+    getReport.mockReturnValue({ sharedObjects: ["/lib/ld-musl-x86_64.so.1"] } as never);
+    expect(__nativeLoaderDetectorsForTest().report).toBe(true);
+    getReport.mockReturnValue({ header: {}, sharedObjects: [] } as never);
+    expect(__nativeLoaderDetectorsForTest().report).toBeUndefined();
+    getReport.mockImplementation(() => {
+      throw new Error("report disabled");
+    });
+    expect(__nativeLoaderDetectorsForTest().report).toBeUndefined();
+  });
+
+  it("continues past unreadable conventional directories and recognizes musl filenames", () => {
+    vi.spyOn(fs, "readdirSync").mockImplementation((directory) => {
+      if (String(directory) === "/lib") throw Object.assign(new Error("denied"), { code: "EACCES" });
+      return ["ld-musl-aarch64.so.1"] as never;
+    });
+    syncBuiltinESMExports();
+    expect(__nativeLoaderDetectorsForTest().filesystem).toBe(true);
+
+    vi.mocked(fs.readdirSync).mockReturnValue([] as never);
+    syncBuiltinESMExports();
+    expect(__nativeLoaderDetectorsForTest().filesystem).toBeUndefined();
+  });
+
+  it("parses little-endian 64-bit and big-endian 32-bit ELF interpreters", () => {
+    installElfReads(elf64({ interpreter: "/lib/ld-musl-x86_64.so.1" }));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBe(true);
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    installElfReads(elf32BigEndian("/lib/ld-linux.so.2"));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBe(false);
+  });
+
+  it("treats truncated, non-ELF, and invalid-class executables as inconclusive", () => {
+    installElfReads(new Map([[0, Buffer.alloc(51)]]));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    installElfReads(new Map([[0, Buffer.alloc(64)]]));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    const invalid = Buffer.alloc(64);
+    invalid.set([0x7f, 0x45, 0x4c, 0x46, 3, 3]);
+    installElfReads(new Map([[0, invalid]]));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+  });
+
+  it("rejects unsafe tables and malformed interpreter records", () => {
+    installElfReads(elf64({ entrySize: 32 }));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    installElfReads(elf64({ entryCount: 1025 }));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    installElfReads(elf64({ tableOffset: BigInt(Number.MAX_SAFE_INTEGER) + 1n }));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    installElfReads(elf64({ interpreterSize: 0 }));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    installElfReads(elf64({ interpreterSize: 4097 }));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+  });
+
+  it("handles missing interpreter headers, short reads, open errors, and close errors", () => {
+    installElfReads(elf64({ type: 1 }));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    const shortProgramHeader = elf64();
+    shortProgramHeader.set(64, Buffer.alloc(8));
+    installElfReads(shortProgramHeader);
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    const shortInterpreter = elf64();
+    shortInterpreter.set(128, Buffer.from("short"));
+    installElfReads(shortInterpreter);
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    vi.spyOn(fs, "openSync").mockImplementation(() => {
+      throw Object.assign(new Error("denied"), { code: "EACCES" });
+    });
+    syncBuiltinESMExports();
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBeUndefined();
+
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    installElfReads(elf64(), new Error("close failed"));
+    expect(__nativeLoaderDetectorsForTest().elfInterpreter).toBe(false);
+  });
+
+  it("fails closed when callers explicitly require an unavailable binding", () => {
+    __setNativeLoaderForTest(() => {
+      throw new Error("binding missing");
+    });
+    configureFsSafeNative({ mode: "auto" });
+    expectFsSafeErrorSync(() => requireNativeBinding(), "helper-unavailable");
+  });
+});

--- a/test/permissions-failures.test.ts
+++ b/test/permissions-failures.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
+import {
+  formatPermissionDetail,
+  formatPermissionRemediation,
+  inspectPathPermissions,
+  inspectWindowsAcl,
+  parseIcaclsOutput,
+  type PermissionCheck,
+} from "../src/permissions.js";
+import {
+  __resetFsSafeNativeConfigForTest,
+  configureFsSafeNative,
+} from "../src/native-config.js";
+import {
+  __resetNativeLoaderForTest,
+  __setNativeLoaderForTest,
+  type NativeBinding,
+} from "../src/native.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+describe("permission inspection failure modes", () => {
+  it("uses verified native Windows owner and DACL facts without shell fallback", async () => {
+    const root = await tempRoot("fs-safe-permission-native-");
+    const target = path.join(root, "secret");
+    await fs.writeFile(target, "secret", { mode: 0o600 });
+    const readOwnerAndDacl = vi.fn(() => ({
+      ownerSid: "S-1-5-21-42",
+      currentUserSid: "S-1-5-21-42",
+      ownerClass: "current-user",
+      worldWritable: false,
+      groupWritable: false,
+      worldReadable: false,
+      groupReadable: true,
+      fallbackRequired: false,
+      daclPresent: true,
+      isLocal: true,
+      aceListComplete: true,
+      unsupportedAceTypes: [],
+      aces: [],
+    }));
+    __setNativeLoaderForTest(() => ({ readOwnerAndDacl }) as unknown as NativeBinding);
+    configureFsSafeNative({ mode: "require" });
+    const exec = vi.fn();
+
+    await expect(inspectPathPermissions(target, { platform: "win32", exec }))
+      .resolves.toMatchObject({
+        source: "windows-acl",
+        ownerSid: "S-1-5-21-42",
+        ownerTrusted: true,
+        groupReadable: true,
+      });
+    expect(readOwnerAndDacl).toHaveBeenCalledWith(target);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("formats verified ACLs and unknown modes without inventing details", () => {
+    const acl = {
+      source: "windows-acl",
+      aclSummary: undefined,
+    } as PermissionCheck;
+    expect(formatPermissionDetail("C:\\secret", acl)).toBe("C:\\secret acl=unknown");
+    expect(formatPermissionRemediation({
+      targetPath: "C:\\secret",
+      perms: acl,
+      isDir: false,
+      posixMode: 0o600,
+      env: { SystemRoot: "C:\\Windows", USERNAME: "me" },
+    })).toContain("icacls.exe");
+    expect(formatPermissionDetail("/secret", {
+      ...acl,
+      source: "unknown",
+      bits: null,
+    })).toBe("/secret mode=unknown");
+  });
+
+  it("ignores malformed and deny ACE lines while retaining a valid grant", () => {
+    expect(parseIcaclsOutput([
+      "no access tuple",
+      "missing-colon(R)",
+      "Denied:(DENY)(F)",
+      "Inherited:(I)(OI)",
+      "Everyone:(R)",
+    ].join("\n"), "C:\\secret")).toMatchObject([
+      { principal: "Everyone", rights: ["R"], canRead: true, canWrite: false },
+    ]);
+  });
+
+  it("fails closed when a parsed ACL entry has no principal to translate", async () => {
+    const exec = vi.fn(async () => ({ stdout: ":(R)\n", stderr: "" }));
+    const result = await inspectWindowsAcl("C:\\secret", {
+      exec,
+      env: { SystemRoot: "C:\\Windows" },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("principal SID could not be verified"),
+    });
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- reject negative, malformed, and oversized base-256 TAR sizes using the full encoded field
- add focused malformed/truncated archive, native-loader, copy-fallback restore, and permission-inspection regression coverage
- cover adjacent deadline, staging-input, and ZIP64 boundary behavior

## Coverage

Native-built whole-project coverage moved from 86.05 / 78.03 / 87.24 / 87.72 to 87.95 / 81.23 / 88.23 / 89.28 for statements / branches / functions / lines.

Key branch coverage moved from 40.54% to 94.59% in `native.ts`, 67.05% to 90.58% in `archive-read.ts`, 64.70% to 94.28% in `archive-tar-meta.ts`, 70.99% to 93.12% in `replace-file-copy-fallback.ts`, and 82.38% to 88.67% in `permissions.ts`.

## Verification

- `pnpm check`
- `pnpm test:security`
- `pnpm native:build && pnpm test:coverage`
- `git diff --check`
- Codex autoreview: clean
- source-blind built-API validation for valid, oversized, and negative base-256 TAR sizes
