### PR TITLE
chore(deps): refresh native build tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 
 ### Docs and Tooling
 
+- Refresh the native package build CLI to `@napi-rs/cli` 3.8.2.
 - Include the README banner in the npm tarball and require it during pack checks so the published README does not reference a missing package asset; sanitize pnpm-only npm configuration from package-smoke subprocesses so the documented release check stays warning-free on newer npm versions.
 - Audit every public export and documented default against generated declarations and real filesystem behavior, add executable documentation-contract coverage, and correct stale examples and security guarantees across root writes, local roots, shared types, paths, temp roots, archives, errors, and filename portability.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 ### Docs and Tooling
 
 - Refresh the native package build CLI to `@napi-rs/cli` 3.8.2.
+- Give parallel native archive tests collision-free temporary paths so one fixture cannot remove another test's file on coarse-resolution clocks.
 - Include the README banner in the npm tarball and require it during pack checks so the published README does not reference a missing package asset; sanitize pnpm-only npm configuration from package-smoke subprocesses so the documented release check stays warning-free on newer npm versions.
 - Audit every public export and documented default against generated declarations and real filesystem behavior, add executable documentation-contract coverage, and correct stale examples and security guarantees across root writes, local roots, shared types, paths, temp roots, archives, errors, and filename portability.
 

--- a/native/src/archive.rs
+++ b/native/src/archive.rs
@@ -862,6 +862,8 @@ mod tests {
 
     use super::*;
 
+    static TEMP_PATH_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
     fn fixture_tar() -> Vec<u8> {
         let mut bytes = Vec::new();
         {
@@ -886,8 +888,9 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
+        let sequence = TEMP_PATH_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         std::env::temp_dir().join(format!(
-            "fs-safe-archive-{}-{nonce}.{suffix}",
+            "fs-safe-archive-{}-{nonce}-{sequence}.{suffix}",
             std::process::id()
         ))
     }

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "tar": "7.5.22"
   },
   "devDependencies": {
-    "@napi-rs/cli": "3.8.1",
+    "@napi-rs/cli": "3.8.2",
     "@types/node": "^26.1.2",
     "@vitest/coverage-v8": "4.1.10",
     "sigstore": "5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@napi-rs/cli':
-        specifier: 3.8.1
-        version: 3.8.1(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)
+        specifier: 3.8.2
+        version: 3.8.2(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2
@@ -397,8 +397,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@napi-rs/cli@3.8.1':
-    resolution: {integrity: sha512-XDtwn0o6XGLxzMoL7FrTDA7jz7t6UUAI+QreICK5QgDOqeZJODmLv0p77kzQNyfKbXVomAw1u2SC5Zzsr07gig==}
+  '@napi-rs/cli@3.8.2':
+    resolution: {integrity: sha512-iFmp3Lo/ipXoJI1I/6V/xU4hQV42bXS3A7j8C+Wt3LOtYY7HFCilkhyUkN1igLJFXWMICq95kNxhNcwzNRd+Kw==}
     engines: {node: ^20.17.0 || ^22.13.0 || >= 23.5.0}
     hasBin: true
     peerDependencies:
@@ -1999,7 +1999,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@napi-rs/cli@3.8.1(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)':
+  '@napi-rs/cli@3.8.2(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@26.1.2)
       '@napi-rs/cross-toolchain': 1.0.3


### PR DESCRIPTION
## Summary

- update `@napi-rs/cli` from 3.8.1 to 3.8.2 and refresh the lockfile
- make parallel native archive fixtures collision-free after the full gate reproduced a PID/timestamp path collision
- document both maintenance changes under Unreleased

## Verification

- `pnpm outdated --format json`: `{}` after the update
- `cargo update --workspace --dry-run --verbose`: zero compatible lockfile updates
- all stable direct Rust dependencies match their latest crates.io releases; only prerelease `zip` 9 and `libc` 1 versions are newer
- `cargo fmt --check`
- `cargo clippy --workspace --locked -- -D warnings`
- `cargo test --workspace --locked`: 16/16 passed, plus 25 full-suite repetitions passed for the fixture-collision regression
- `pnpm check`: 99 files, 1,062 tests; 1,003 passed and 59 platform/optional cases skipped
- `pnpm native:build`
- native mode smoke: `auto`, `require`, and `off` all passed
- `pnpm package:smoke`: packed tarball and host binding/fallback behavior passed
- final Codex autoreview: clean, no accepted/actionable findings
