### PR TITLE
release: 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.5.2 - 2026-08-02
 
 ### Security and Correctness
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "fs-safe-native"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bzip2",
  "flate2",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fs-safe-native"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/openclaw/fs-safe"

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-native-build",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Private build workspace for the native bindings bundled by @openclaw/fs-safe.",
   "private": true,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Capability-style filesystem roots for Node.js apps that handle untrusted relative paths.",
   "keywords": [
     "filesystem",


### PR DESCRIPTION
## Release 0.5.2

- close the accumulated Unreleased security, correctness, compatibility, feature, and tooling notes as 0.5.2 dated 2026-08-02
- synchronize the root package, private native workspace, Cargo manifest, and Cargo lock versions

## Verification

- `pnpm install --frozen-lockfile`
- `node scripts/release-notes.mjs 0.5.2`
- `cargo fmt --check`
- `cargo clippy --workspace --locked -- -D warnings`
- `cargo test --workspace --locked`: 16/16 passed
- `pnpm check`: 99 files, 1,062 tests; 1,003 passed and 59 platform/optional cases skipped
- `pnpm native:build`
- native mode smoke: `auto`, `require`, and `off` passed
- `pnpm package:smoke`: packed `openclaw-fs-safe-0.5.2.tgz` and host binding/fallback behavior passed
- release-freeze Codex autoreview: clean, no accepted/actionable findings

After this lands, the annotated `v0.5.2` tag will trigger the repository-owned trusted publishing workflow.
