### PR TITLE
fix(trash): preserve dangling symlinks across filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Security and Correctness
 
 - Reject synchronous secret reads when the path is retargeted after the preview check, matching the asynchronous reader's `path-mismatch` contract instead of returning bytes from the replacement file.
+- Preserve dangling symlinks when trash moves cross filesystems instead of failing while following their missing targets.
 
 ## 0.5.2 - 2026-08-02
 

--- a/src/trash.ts
+++ b/src/trash.ts
@@ -146,6 +146,16 @@ function reserveTrashDestination(trashDir: string, base: string, timestamp: numb
   return resolveContainedPath(container, base);
 }
 
+function copyTrashTargetSync(target: TrashTargetGuard, dest: string): void {
+  if (target.stat.isSymbolicLink()) {
+    const linkTarget = fs.readlinkSync(target.path);
+    assertTrashTargetGuard(target);
+    fs.symlinkSync(linkTarget, dest);
+    return;
+  }
+  fs.cpSync(target.path, dest, { recursive: true, force: false, errorOnExist: true });
+}
+
 function movePathToDestination(target: TrashTargetGuard, dest: string): boolean {
   getFsSafeTestHooks()?.beforeTrashMove?.(target.path, dest);
   assertTrashTargetGuard(target);
@@ -163,7 +173,7 @@ function movePathToDestination(target: TrashTargetGuard, dest: string): boolean 
 
   try {
     assertTrashTargetGuard(target);
-    fs.cpSync(target.path, dest, { recursive: true, force: false, errorOnExist: true });
+    copyTrashTargetSync(target, dest);
     assertTrashTargetGuard(target);
     guardedRmSync({ target: target.path, recursive: true, force: false, verifyAfter: false });
     return true;

--- a/test/clawpatch-regression.test.ts
+++ b/test/clawpatch-regression.test.ts
@@ -325,9 +325,10 @@ describe("clawpatch regression coverage", () => {
     await fs.mkdir(path.join(outsideDir, "queue"), { mode: 0o755, recursive: true });
     await fs.mkdir(failedDir);
     await fs.symlink(outsideDir, queueParent, "dir");
+    const originalMode = (await fs.stat(path.join(outsideDir, "queue"))).mode & 0o777;
 
     await expect(ensureJsonDurableQueueDirs({ queueDir, failedDir })).rejects.toBeTruthy();
-    expect((await fs.stat(path.join(outsideDir, "queue"))).mode & 0o777).toBe(0o755);
+    expect((await fs.stat(path.join(outsideDir, "queue"))).mode & 0o777).toBe(originalMode);
   });
 
   itPosix("rejects shared existing durable queue dirs under symlinked parents", async () => {
@@ -339,10 +340,12 @@ describe("clawpatch regression coverage", () => {
     await fs.mkdir(path.join(outsideDir, "state", "queue"), { mode: 0o755, recursive: true });
     await fs.mkdir(path.join(outsideDir, "state", "failed"), { mode: 0o755, recursive: true });
     await fs.symlink(outsideDir, queueParent, "dir");
+    const originalQueueMode = (await fs.stat(path.join(outsideDir, "state", "queue"))).mode & 0o777;
+    const originalFailedMode = (await fs.stat(path.join(outsideDir, "state", "failed"))).mode & 0o777;
 
     await expect(ensureJsonDurableQueueDirs({ queueDir, failedDir })).rejects.toBeTruthy();
-    expect((await fs.stat(path.join(outsideDir, "state", "queue"))).mode & 0o777).toBe(0o755);
-    expect((await fs.stat(path.join(outsideDir, "state", "failed"))).mode & 0o777).toBe(0o755);
+    expect((await fs.stat(path.join(outsideDir, "state", "queue"))).mode & 0o777).toBe(originalQueueMode);
+    expect((await fs.stat(path.join(outsideDir, "state", "failed"))).mode & 0o777).toBe(originalFailedMode);
   });
 
   itPosix("rejects symlinked durable queue failed directories during moves", async () => {

--- a/test/edge-coverage.test.ts
+++ b/test/edge-coverage.test.ts
@@ -283,11 +283,18 @@ describe("trash edge paths", () => {
     const linkPath = path.join(root, "broken-link");
     const missingTarget = path.join(root, "missing-target");
     await fs.symlink(missingTarget, linkPath);
+    const realRename = fsSync.renameSync.bind(fsSync);
+    vi.spyOn(fsSync, "renameSync").mockImplementation((from, to) => {
+      if (from === linkPath) {
+        throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+      }
+      return realRename(from, to);
+    });
 
     const dest = await movePathToTrash(linkPath, { allowedRoots: [root] });
     try {
-      // Broken links cannot be realpathed; the guard keeps lstat identity and
-      // renames the link itself instead of requiring the target to exist.
+      // Broken links cannot be realpathed; the copy fallback keeps lstat
+      // identity and recreates the link without requiring its target to exist.
       await expect(fs.readlink(dest)).resolves.toBe(missingTarget);
       await expect(fs.lstat(linkPath)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {

--- a/test/findings-regression.test.ts
+++ b/test/findings-regression.test.ts
@@ -355,18 +355,22 @@ describe("security finding regressions", () => {
   });
 
   itPosix("preserves default directory modes for zip staging parents", async () => {
-    const expectedDirectoryMode = 0o777 & ~process.umask();
-    const base = await tempRoot("fs-safe-zip-dir-mode-");
-    const archivePath = path.join(base, "pkg.zip");
-    const destDir = path.join(base, "dest");
-    await fsp.mkdir(destDir);
-    const zip = new JSZip();
-    zip.file("assets/app.js", "console.log('ok');");
-    await fsp.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+    const previousUmask = process.umask(0o022);
+    try {
+      const base = await tempRoot("fs-safe-zip-dir-mode-");
+      const archivePath = path.join(base, "pkg.zip");
+      const destDir = path.join(base, "dest");
+      await fsp.mkdir(destDir);
+      const zip = new JSZip();
+      zip.file("assets/app.js", "console.log('ok');");
+      await fsp.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
 
-    await extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 });
+      await extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 });
 
-    expect((await fsp.stat(path.join(destDir, "assets"))).mode & 0o777).toBe(expectedDirectoryMode);
+      expect((await fsp.stat(path.join(destDir, "assets"))).mode & 0o777).toBe(0o755);
+    } finally {
+      process.umask(previousUmask);
+    }
   });
 
   it("rejects durable queue ids that are not safe path segments", async () => {


### PR DESCRIPTION
## Summary

- recreate symbolic links explicitly during cross-filesystem trash fallback so dangling targets are not dereferenced
- force the dangling-symlink regression through the `EXDEV` copy path
- remove ambient-umask assumptions from the affected archive and symlink-parent mode assertions

## Linux reproduction

Tested unmodified `origin/main` in an unprivileged Debian 12 arm64 container with Node 22.23.2, pnpm 10.34.5, and a locally built native binding.

- `TMPDIR=/dev/shm pnpm test test/edge-coverage.test.ts -t "moves broken symlinks to trash"` failed with `ENOENT` at `src/trash.ts:166` because `/dev/shm` and the home trash are different filesystems.
- `umask 0027; pnpm test` exposed three ambient-mode assertions: the ZIP staging assertion and two symlink-parent fixture-mode assertions.
- The ordinary Linux suite under umask `0022` passed on the unmodified baseline, confirming why these cases stay hidden in common environments.

After the fix, the full suite passed with both conditions active: `TMPDIR=/dev/shm`, umask `0027`, 1,061 tests passed and 26 platform tests skipped.

## Verification

- `pnpm check`
- `pnpm test:security` (70 passed)
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings

The Linux proof used OrbStack's local arm64 container backend. It did not cover x86_64 Linux or a remote crabbox host.
