### PR TITLE
fix: reject retargeted synchronous secret reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security and Correctness
+
+- Reject synchronous secret reads when the path is retargeted after the preview check, matching the asynchronous reader's `path-mismatch` contract instead of returning bytes from the replacement file.
+
 ## 0.5.2 - 2026-08-02
 
 ### Security and Correctness

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -123,8 +123,16 @@ function readSecretFileOutcomeSync(
       message: `Failed to read ${label} file at ${resolvedPath}: ${String(error)}`,
     };
   }
-
   try {
+    if (!sameFileIdentity(previewStat, opened.stat)) {
+      const error = new FsSafeError("path-mismatch", "security validation failed");
+      return {
+        ok: false,
+        code: "path-mismatch",
+        error,
+        message: `Failed to read ${label} file at ${resolvedPath}: ${String(error)}`,
+      };
+    }
     const raw = readFileDescriptorBoundedSync(opened.fd, maxBytes).toString("utf8");
     const secret = raw.trim();
     if (!secret) {

--- a/test/secret-file-failure.test.ts
+++ b/test/secret-file-failure.test.ts
@@ -2,12 +2,14 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { expectFsSafeError, expectFsSafeErrorSync } from "./helpers/security.js";
 import { itPosix, itWin32, useTempDirs } from "./helpers/vitest.js";
 import {
   readSecretFileSync,
   tryReadSecretFileSync,
   writeSecretFileAtomic,
 } from "../src/secret-file.js";
+import { readSecretFile } from "../src/secret-read-async.js";
 
 const { tempRoot } = useTempDirs();
 
@@ -124,6 +126,34 @@ describe("secret file refusal paths", () => {
     expect(() => readSecretFileSync(filePath, "token")).toThrow(
       expect.objectContaining({ code: "not-found" }),
     );
+  });
+
+  itPosix("rejects a secret path retargeted after the preview in sync and async readers", async () => {
+    const root = await tempRoot("fs-safe-secret-preview-retarget-");
+    const originalPath = path.join(root, "original");
+    const replacementPath = path.join(root, "replacement");
+    const syncLink = path.join(root, "sync-token");
+    const asyncLink = path.join(root, "async-token");
+    await fs.writeFile(originalPath, "original");
+    await fs.writeFile(replacementPath, "replacement");
+    await fs.symlink(originalPath, syncLink);
+    await fs.symlink(originalPath, asyncLink);
+
+    const realpathSync = fsSync.realpathSync.bind(fsSync);
+    vi.spyOn(fsSync, "realpathSync").mockImplementationOnce((candidate, options) => {
+      fsSync.unlinkSync(syncLink);
+      fsSync.symlinkSync(replacementPath, syncLink);
+      return realpathSync(candidate, options as never);
+    });
+    expectFsSafeErrorSync(() => readSecretFileSync(syncLink, "sync token"), "path-mismatch");
+
+    const realpath = fs.realpath.bind(fs);
+    vi.spyOn(fs, "realpath").mockImplementationOnce(async (candidate, options) => {
+      await fs.unlink(asyncLink);
+      await fs.symlink(replacementPath, asyncLink);
+      return await realpath(candidate, options as never);
+    });
+    await expectFsSafeError(readSecretFile(asyncLink, "async token"), "path-mismatch");
   });
 
   it("rejects a different descriptor identity during post-write verification", async () => {


### PR DESCRIPTION
## Summary

This audits every explicit platform branch, Windows path conditional, native/fallback selection, and hand-maintained sync/async pair in `src/` against the documented and exported contracts.

One deterministic security divergence had a clear contract and is fixed: `readSecretFileSync()` previewed one file, then trusted the identity selected by a later `realpathSync()` call. If the path was retargeted between those steps, the sync reader returned replacement bytes while `readSecretFile()` rejected the same race with `path-mismatch`. The sync reader now compares the preview identity with the pinned descriptor before reading.

The other confirmed divergences below need public error-code or portability decisions, so this PR deliberately leaves them unchanged.

## Bug and repro

- `src/secret-file.ts:127`: retarget a secret symlink from file A to file B inside the `realpathSync` seam; before the fix, `readSecretFileSync(link)` returned B while `readSecretFile(link)` threw `path-mismatch`. The new regression failed on unmodified `origin/main` with “expected function to throw an error, but it didn't.”

## Inventory

| Seam examined | Files / public operations | Verdict | Notes |
|---|---|---|---|
| Windows/POSIX containment and normalization | `path.ts`, `root-path.ts`, `root-path-existing.ts`, `root-path-symlink.ts`; `isPathInside`, `resolveRootPath`, `resolveRootPathSync` | agreed | Sync/async traversal, overlong input, separators, drive-relative input, whitespace, and symlink hops agree in host proofs and shared logic. |
| Case-sensitive Windows directories | `path.ts`, `root-path.ts`, `deny-mutations.ts`; Root containment and deny policies | unverifiable-from-here | Windows comparison lowercases paths. A per-directory case-sensitive Windows volume could make differently cased siblings distinct while lexical containment treats them as equal. Needs a real Windows case-sensitive-directory proof before changing public comparison behavior. |
| Unsafe devices, reserved names, file URLs, and filename sanitation | `device-path.ts`, `local-file-access.ts`, `filename.ts`, `safe-path-segment.ts`; all read/open entry points | agreed | Platform-injected tests cover POSIX devices/fd namespaces, Windows devices, UNC/extended paths, drive-relative segments, trailing dot/space aliases, and sanitized output. |
| Portable archive entry names | `archive-entry.ts`; `validateArchiveEntryPath`, extraction/read paths | divergent-and-escalated | `NUL`, `dir/CON.txt`, `payload.txt:stream`, trailing-dot/space names, and Windows-invalid characters are accepted on POSIX but alias, fail, or address ADS/device semantics on Windows. Recommend a portable segment policy, but rejecting currently accepted POSIX archives is a compatibility decision. |
| Archive native/JavaScript policy and modes | `archive.ts`, `archive-native.ts`, `archive-read.ts`, `archive-input.ts`, `archive-staging.ts`, `archive-kind.ts` | agreed | Shared TypeScript policy owns paths, filters, collision checks, limits, and clamped modes; targeted native/JS equivalence passed. Windows intentionally does not claim POSIX mode enforcement. |
| Root read/open surface | `root-impl.ts`, `root-context.ts`, `opened-realpath.ts`; `open`, `read*`, `stat`, `list`, `exists`, `walk` | agreed | Error normalization, device checks, symlink/hardlink policy, and writable-directory `not-file` behavior align. Windows opened-handle path discovery remains best-effort as documented. |
| Root mutation surface | `root-impl.ts`, `root-errors.ts`; `write`, `create`, `copyIn`, `append`, `openWritable`, `mkdir`, `remove`, `move` | agreed | Native/guarded selection, fallback error normalization, deny policies, missing parents, overwrite, directory targets, and cleanup ownership were traced for every verb. |
| Native pinned writes versus guarded fallback | `pinned-write.ts`, `native-pinned-write.ts`, `native-operations.ts` | agreed | Create-only collision timing, stream limits, modes, identity fences, cleanup, and rename policies agree in native-backed tests. |
| Remaining native OS error mappings | `native/src/windows.rs`, `native/src/unix.rs`, `native-operations.ts` | unverifiable-from-here | The known public cases (`EPERM`, `ENOENT`, `EEXIST`, `ENAMETOOLONG`, directory targets) are aligned. Unmapped Windows/NT and POSIX errors collapse to `EIO`; a live cross-OS fault matrix is needed to prove less common codes. |
| Native loader/config target selection | `native.ts`, `native-config.ts` | agreed | Seven published target selections, musl detection, auto/off/require behavior, and helper-unavailable paths are covered by deterministic loader injection. |
| Directory durability | `directory-durability.ts`, `fsync.ts`; async/sync strict and best-effort APIs | agreed | Windows unsupported open/sync families are explicit, access errors remain strict, and sync/async identity revalidation matches. |
| Atomic replace and copy fallback | `replace-file.ts`, `replace-file-descriptor.ts`, `replace-file-copy-fallback.ts`; async/sync twins | agreed | Descriptor modes, Windows no-mode boundary, hardlinks, symlinks, retry/copy policy, restoration, and sync ordering agree. |
| Cross-device/Windows move fallback | `move-path.ts`; `movePathWithCopyFallback` | agreed | Only `EXDEV` and Windows `EPERM` enter copy fallback; source identity, hardlinks, modes, and cleanup are fenced consistently. |
| Permission and ownership semantics | `secure-file.ts`, `permissions.ts`, `permissions-windows.ts`, `windows-owner.ts`, `owner-dacl.ts`, `private-directory.ts` | unverifiable-from-here | Injected native/fallback ACL facts agree and POSIX mode ownership is clear. Live Windows ACL inheritance, remote-volume locality, and owner-command behavior cannot be fully verified on macOS. |
| Secret read path identity | `secret-file.ts`, `secret-read-async.ts`; strict/optional sync and async readers | divergent-and-fixed | Sync now compares the preview identity with the opened descriptor, matching async `path-mismatch` behavior. |
| Secret read I/O error selection | `secret-file.ts:147`, `secret-read-async.ts:82` | divergent-and-escalated | A post-validation read `EIO` becomes `invalid-path` in sync and `path-mismatch` in async. Recommend preserving the underlying I/O error or defining one common operational code; neither current code accurately describes it, so this PR does not choose. |
| Secret writes and modes | `secret-file.ts`; `writeSecretFileAtomic`, `createSecretFileAtomic` | agreed | POSIX enforces exact descriptor modes; Windows explicitly skips POSIX mode enforcement while retaining identity and type checks. |
| Regular-file sync/async twins | `regular-file.ts`; stat/read/append pairs | agreed | Missing, type, hardlink, symlink, bounded-growth, identity, encoding, and mode behavior match. |
| JSON sync/async families | `json.ts`; strict/lenient reads and writes | agreed | Differences in retry and legacy sync-write options are documented; strict/lenient read result contracts and bounded errors align. |
| FileStore sync/async validation errors | `file-store.ts:132`, `file-store.ts:339`, `file-store.ts:444` | divergent-and-escalated | One-line repro: read a stable directory key. Async returns `not-file`; sync returns `path-mismatch`. Stable hardlinks similarly become `hardlink` async versus `path-mismatch` sync. Recommend semantic codes in sync, but that is a public code change. |
| Temp workspace sync/async reads | `private-temp-workspace.ts:256` | divergent-and-escalated | One-line repro: create a directory at a workspace leaf and call `read`. Async returns `not-file`; sync fabricates raw `ENOENT`. Recommend matching the async Root codes, pending compatibility approval. |
| Directory guards and symlink-parent sync/async twins | `directory-guard.ts`, `guarded-mutation.ts`, `symlink-parents.ts` | divergent-and-escalated | With default `allowMissing`, an existing file ancestor plus `/child` returns success async because `ENOTDIR` is treated as missing, while sync throws raw `ENOTDIR`. Recommend defining whether this helper is a pure symlink predicate or also validates usable ancestry before changing either side. |
| Standalone and Root walking | `walk.ts`, `root-walk.ts` | agreed | Budgets, depth, filtering, failed-directory reporting, symlink policies, and cycle detection match between sync/async standalone walkers and the documented Root variant. |
| Sidecar/file-lock sync/async paths | `sidecar-lock*.ts`, `file-lock.ts`, `file-lock-sync.ts` | agreed | Ownership tokens, bounded snapshots, reclaim, reentrancy, and cleanup match. The Windows transient `EPERM` retry is intentionally async-only and documented as such. |
| Hash native/fallback | `file-hash.ts`, `native/src/fast_file.rs`; `sha256File` | agreed | Results, offsets, file type, and path identity agree; native acceleration preserves the caller-owned handle contract. |
| Exclusive publication native/fallback | `publish-file.ts`, `publish-file-failure.ts` | agreed | Hardlink/copy/rename selection, collision behavior, hashes, cleanup receipts, and directory sync agree in targeted equivalence tests. |
| Local roots, home paths, and secure temp roots | `local-roots.ts`, `home-dir.ts`, `secure-temp-dir.ts`, `temp-target.ts` | agreed | URL/platform adapters, canonical roots, missing paths, Windows fallback joining, UID/mode availability, and sync/async temp semantics are explicit and covered. |
| JSON durable queue platform branches | `json-durable-queue.ts` | agreed | Darwin system aliases, Windows root comparison, no-follow availability, mode best-effort behavior, and entry identity checks are internally consistent. |
| Repeated no-follow/platform fallbacks | `output-sibling.ts`, `sidecar-lock-reclaim.ts`, `file-lock-sync.ts`, `file-store-boundary.ts`, `archive-read.ts`, `archive-input.ts`, `archive-staging.ts`, `sidecar-lock.ts` | agreed | Each omits unavailable Windows POSIX flags but retains lstat/fstat/identity checks or an explicitly best-effort mode boundary. |

## Verification

- Confirmed the new regression fails on unmodified source: sync returned replacement bytes instead of throwing.
- `pnpm install --frozen-lockfile`
- `pnpm native:build`
- Targeted native integration/publication/archive/secret suites: 74 passed, 5 platform skips
- `pnpm native:test`: 16 passed
- `pnpm test:coverage`: 1,004 passed, 59 platform skips; 90.05% line coverage
- `pnpm check`: 1,004 passed, 59 platform skips
- `pnpm test:security`: 70 passed
- `git diff --check`
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings

Generated `coverage/`, `dist/`, native binary, and Cargo target artifacts were removed before commit.
