### PR TITLE
fix(ci): stabilize Windows race regressions

### DIFF
--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -219,12 +219,14 @@ async function openVerifiedLocalFile(
     if (!preOpenStat.isFile() && !preOpenStat.isSymbolicLink()) {
       throw new FsSafeError("not-file", "not a file");
     }
-    await fsSafeTestHooks?.afterPreOpenLstat?.(filePath);
   } catch (err) {
     if (err instanceof FsSafeError) {
       throw err;
     }
     // ENOENT and other lstat errors: fall through and let fs.open handle.
+  }
+  if (preOpenStat) {
+    await fsSafeTestHooks?.afterPreOpenLstat?.(filePath);
   }
 
   let handle: FileHandle;

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { createAsyncLock } from "../src/async-lock.js";
 import { writeTextAtomic } from "../src/atomic.js";
+import { FsSafeError } from "../src/errors.js";
 import {
   JsonFileReadError,
   readRootJsonObjectSync,
@@ -314,17 +315,18 @@ describe("json file helpers", () => {
     const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
       if (args[0] === filePath) {
         racesInjected += 1;
-        await writeTextAtomic(filePath, `{"v":${racesInjected}}`);
+        throw new FsSafeError("path-mismatch", "injected read race");
       }
-      return originalOpen(...args);
+      return await originalOpen(...args);
     });
 
     try {
       await expect(readJson(filePath)).rejects.toMatchObject({
         name: "JsonFileReadError",
         reason: "read",
+        cause: expect.objectContaining({ code: "path-mismatch" }),
       } satisfies Partial<JsonFileReadError>);
-      expect(racesInjected).toBeGreaterThanOrEqual(5);
+      expect(racesInjected).toBe(5);
     } finally {
       openSpy.mockRestore();
     }

--- a/test/path-stress-regression.test.ts
+++ b/test/path-stress-regression.test.ts
@@ -11,6 +11,23 @@ import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 
 const { tempRoot } = useTempDirs();
 
+async function renameForRace(from: string, to: string): Promise<void> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await fs.rename(from, to);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      const transientWindowsDenial =
+        process.platform === "win32" &&
+        (code === "EACCES" || code === "EBUSY" || code === "EPERM");
+      if (!transientWindowsDenial || attempt === 9) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10 * (attempt + 1)));
+    }
+  }
+}
 
 async function createFifo(filePath: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
@@ -112,8 +129,8 @@ describe("path stress regressions", () => {
           return;
         }
         swapped = true;
-        await fs.rename(targetDir, displacedDir);
-        await fs.rename(replacementDir, targetDir);
+        await renameForRace(targetDir, displacedDir);
+        await renameForRace(replacementDir, targetDir);
       },
     });
 
@@ -121,6 +138,23 @@ describe("path stress regressions", () => {
     await expect(fs.readFile(path.join(displacedDir, "value.txt"), "utf8")).resolves.toBe(
       "trusted",
     );
+  });
+
+  it("propagates a race-hook failure after the pre-open inspection", async () => {
+    const rootDir = await tempRoot("fs-safe-parent-swap-hook-");
+    await fs.writeFile(path.join(rootDir, "value.txt"), "trusted");
+    const scoped = await openRoot(rootDir);
+    const targetFile = path.join(scoped.rootReal, "value.txt");
+    const failure = new Error("race setup failed");
+    __setFsSafeTestHooksForTest({
+      afterPreOpenLstat(filePath) {
+        if (filePath === targetFile) {
+          throw failure;
+        }
+      },
+    });
+
+    await expect(scoped.readText("value.txt")).rejects.toBe(failure);
   });
 
   itPosix("rejects advisory access after the root pathname is replaced", async () => {


### PR DESCRIPTION
## Summary

- inject the retryable `path-mismatch` failure directly when testing JSON retry exhaustion, preserving the exact five-attempt budget without depending on Windows rename identity timing
- retry only transient Windows directory-rename denials while arranging the real parent-swap regression
- propagate post-`lstat` test-hook failures so a failed race setup cannot be silently treated as an ordinary path inspection error

## Proof

- `pnpm test test/json.test.ts test/path-stress-regression.test.ts` (10 repeated runs)
- `pnpm check` (100 files passed, 1,035 tests passed, 61 skipped)
- `git diff --check`
- Codex autoreview: clean, no accepted/actionable findings

Fixes the Windows failures in coverage run 30976077742.
