### PR TITLE
chore(release): prepare 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.5.3 - 2026-08-08
 
 ### Security and Correctness
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "fs-safe-native"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bzip2",
  "flate2",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fs-safe-native"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/openclaw/fs-safe"

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-native-build",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Private build workspace for the native bindings bundled by @openclaw/fs-safe.",
   "private": true,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Capability-style filesystem roots for Node.js apps that handle untrusted relative paths.",
   "keywords": [
     "filesystem",


### PR DESCRIPTION
## Summary

- synchronize root npm, native workspace, Cargo manifest, and Cargo lock versions at 0.5.3
- date the existing unreleased changelog section for the patch release

## Verification

- `pnpm check` — 1,035 tests plus docs/build/package and boundary checks passed
- `cargo test --workspace --locked` — 18 tests passed
- `node scripts/release-notes.mjs 0.5.3` produced non-empty notes
- Codex autoreview — clean, no accepted/actionable findings

After this preparation lands and exact-head CI is green, the protected annotated v0.5.3 tag will trigger the repository release workflow.
