### PR TITLE
fix(path): reject raced FIFOs without blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Open pinned and standalone regular-file reads nonblocking on POSIX before descriptor type validation, so a raced FIFO or device cannot stall the worker; share the same read-open flags with root reads, hashing, and move-copy fallbacks.
 - Compare exact bigint filesystem identities during exclusive publication and rollback cleanup, so rounded Windows file indexes cannot hide replaced source or target paths or authorize deletion of an attacker replacement.
 
 ## 0.5.3 - 2026-08-08

--- a/src/file-hash.ts
+++ b/src/file-hash.ts
@@ -1,10 +1,10 @@
 import { createHash } from "node:crypto";
-import fsSync from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { getNativeBinding, type NativeBinding } from "./native.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 
 export type Sha256FileInput = string | FileHandle;
 
@@ -12,18 +12,6 @@ export type Sha256FileResult = {
   bytes: number;
   digest: string;
 };
-
-function readFlags(): number {
-  return (
-    fsSync.constants.O_RDONLY |
-    (process.platform !== "win32" && typeof fsSync.constants.O_NOFOLLOW === "number"
-      ? fsSync.constants.O_NOFOLLOW
-      : 0) |
-    (process.platform !== "win32" && typeof fsSync.constants.O_NONBLOCK === "number"
-      ? fsSync.constants.O_NONBLOCK
-      : 0)
-  );
-}
 
 export async function hashFileHandle(
   handle: FileHandle,
@@ -61,7 +49,7 @@ async function hashPath(filePath: string): Promise<Sha256FileResult> {
 
   let handle: FileHandle;
   try {
-    handle = await fs.open(filePath, readFlags());
+    handle = await fs.open(filePath, resolveReadOpenFlags());
   } catch (error) {
     if ((error as NodeJS.ErrnoException | null)?.code === "ELOOP") {
       throw new FsSafeError("symlink", "SHA-256 path must not be a symbolic link", {

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { guardedRename } from "./guarded-mutation.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { registerTempPathForExit } from "./temp-cleanup.js";
 
 export type MovePathWithCopyFallbackOptions = {
@@ -158,18 +159,6 @@ async function assertSourceStillMatches(
   }
 }
 
-function regularReadFlags(): number {
-  return (
-    fsConstants.O_RDONLY |
-    (typeof fsConstants.O_NOFOLLOW === "number" && process.platform !== "win32"
-      ? fsConstants.O_NOFOLLOW
-      : 0) |
-    (typeof fsConstants.O_NONBLOCK === "number" && process.platform !== "win32"
-      ? fsConstants.O_NONBLOCK
-      : 0)
-  );
-}
-
 async function chmodDirectoryPinned(directoryPath: string, mode: number): Promise<void> {
   if (process.platform === "win32") {
     // Node cannot portably open a Windows directory for descriptor-bound
@@ -206,7 +195,7 @@ async function copyRegularFilePinned(params: {
   let destinationCreated = false;
   let sourceHandle: FileHandle;
   try {
-    sourceHandle = await fs.open(params.from, regularReadFlags());
+    sourceHandle = await fs.open(params.from, resolveReadOpenFlags());
   } catch (error) {
     const code = (error as NodeJS.ErrnoException | null)?.code;
     if (code === "ELOOP" || code === "ENOENT" || code === "ENOTDIR") {

--- a/src/pinned-open.ts
+++ b/src/pinned-open.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { isUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity as hasSameFileIdentity } from "./file-identity.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 
 export type PinnedOpenSyncFailureReason = "path" | "validation" | "io";
 
@@ -37,9 +38,7 @@ export function openPinnedFileSync(params: {
 }): PinnedOpenSyncResult {
   const ioFs = params.ioFs ?? fs;
   const allowedType = params.allowedType ?? "file";
-  const openReadFlags =
-    ioFs.constants.O_RDONLY |
-    (typeof ioFs.constants.O_NOFOLLOW === "number" ? ioFs.constants.O_NOFOLLOW : 0);
+  const openReadFlags = resolveReadOpenFlags({ constants: ioFs.constants });
   let fd: number | null = null;
   try {
     if (isUnsafeDeviceReadPath(params.filePath)) {

--- a/src/read-open-flags.ts
+++ b/src/read-open-flags.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+
+type ReadOpenFlagConstants = Pick<typeof fs.constants, "O_RDONLY"> &
+  Partial<Pick<typeof fs.constants, "O_NOFOLLOW" | "O_NONBLOCK">>;
+
+export function resolveReadOpenFlags(options?: {
+  constants?: ReadOpenFlagConstants;
+  followSymlinks?: boolean;
+}): number {
+  const constants = options?.constants ?? fs.constants;
+  const noFollow =
+    process.platform !== "win32" &&
+    options?.followSymlinks !== true &&
+    typeof constants.O_NOFOLLOW === "number"
+      ? constants.O_NOFOLLOW
+      : 0;
+  const nonBlocking =
+    process.platform !== "win32" && typeof constants.O_NONBLOCK === "number"
+      ? constants.O_NONBLOCK
+      : 0;
+  return constants.O_RDONLY | noFollow | nonBlocking;
+}

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -8,6 +8,7 @@ import { assertNoUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { isNotFoundPathError } from "./path.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { assertNoSymlinkParents, assertNoSymlinkParentsSync } from "./symlink-parents.js";
 
 export type RegularFileStatResult = { missing: true } | { missing: false; stat: Stats };
@@ -36,15 +37,6 @@ export function resolveRegularFileAppendFlags(
     constants.O_APPEND |
     constants.O_WRONLY |
     (typeof noFollow === "number" ? noFollow : 0)
-  );
-}
-
-function resolveRegularFileReadFlags(): number {
-  return (
-    fsSync.constants.O_RDONLY |
-    (typeof fsSync.constants.O_NOFOLLOW === "number" && process.platform !== "win32"
-      ? fsSync.constants.O_NOFOLLOW
-      : 0)
   );
 }
 
@@ -106,7 +98,7 @@ export async function readRegularFile(params: {
 
   let handle: FileHandle;
   try {
-    handle = await fs.open(params.filePath, resolveRegularFileReadFlags());
+    handle = await fs.open(params.filePath, resolveReadOpenFlags());
   } catch (err) {
     if (isNotFoundPathError(err)) {
       throw new FsSafeError("path-mismatch", `File changed during read: ${params.filePath}`);
@@ -227,7 +219,7 @@ export function readRegularFileSync(params: { filePath: string; maxBytes?: numbe
 
   let fd: number;
   try {
-    fd = fsSync.openSync(params.filePath, resolveRegularFileReadFlags());
+    fd = fsSync.openSync(params.filePath, resolveReadOpenFlags());
   } catch (error) {
     if (isNotFoundPathError(error)) {
       throw new FsSafeError("path-mismatch", `File changed during read: ${params.filePath}`);

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -34,6 +34,7 @@ import {
   isSymlinkOpenError,
 } from "./path.js";
 import { readOpenedFileSafely, type ReadResult } from "./read-opened-file.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { resolveRootPath } from "./root-path.js";
 import {
   assertRootIdentityCurrent,
@@ -143,13 +144,8 @@ function logWarn(message: string): void {
 }
 
 const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsConstants;
-const NONBLOCK_OPEN_FLAG =
-  process.platform !== "win32" && "O_NONBLOCK" in fsConstants ? fsConstants.O_NONBLOCK : 0;
-const OPEN_READ_FLAGS =
-  fsConstants.O_RDONLY |
-  (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0) |
-  NONBLOCK_OPEN_FLAG;
-const OPEN_READ_FOLLOW_FLAGS = fsConstants.O_RDONLY | NONBLOCK_OPEN_FLAG;
+const OPEN_READ_FLAGS = resolveReadOpenFlags();
+const OPEN_READ_FOLLOW_FLAGS = resolveReadOpenFlags({ followSymlinks: true });
 const OPEN_WRITE_EXISTING_FLAGS =
   fsConstants.O_WRONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 const OPEN_WRITE_CREATE_FLAGS =

--- a/test/pinned-open.test.ts
+++ b/test/pinned-open.test.ts
@@ -1,9 +1,11 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { openPinnedFileSync } from "../src/pinned-open.js";
+import { itPosix } from "./helpers/vitest.js";
 
 type PinnedOpenSyncFs = NonNullable<Parameters<typeof openPinnedFileSync>[0]["ioFs"]>;
 type PinnedOpenSyncLstatSync = PinnedOpenSyncFs["lstatSync"];
@@ -190,5 +192,34 @@ describe("openPinnedFileSync", () => {
       ioFs,
     });
     expectOpenReason(opened, "io");
+  });
+
+  itPosix("rejects a raced FIFO without blocking the descriptor open", async () => {
+    await withTempDir("fs-safe-open-fifo-", async (root) => {
+      const filePath = path.join(root, "value");
+      const displacedPath = path.join(root, "value.displaced");
+      await fsp.writeFile(filePath, "regular");
+      let swapped = false;
+      const ioFs: PinnedOpenSyncFs = {
+        constants: fs.constants,
+        lstatSync: fs.lstatSync,
+        realpathSync: fs.realpathSync,
+        openSync: (candidate, flags, mode) => {
+          expect(typeof flags).toBe("number");
+          expect((flags as number) & fs.constants.O_NONBLOCK).toBe(fs.constants.O_NONBLOCK);
+          fs.renameSync(filePath, displacedPath);
+          expect(spawnSync("mkfifo", [filePath]).status).toBe(0);
+          swapped = true;
+          return fs.openSync(candidate, flags, mode);
+        },
+        fstatSync: fs.fstatSync,
+        closeSync: fs.closeSync,
+      };
+
+      const opened = openPinnedFileSync({ filePath, ioFs });
+
+      expectOpenReason(opened, "validation");
+      expect(swapped).toBe(true);
+    });
   });
 });

--- a/test/regular-file-failure.test.ts
+++ b/test/regular-file-failure.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -50,6 +51,41 @@ describe("regular file refusal and race handling", () => {
     await expect(readRegularFile({ filePath: missing })).rejects.toMatchObject({ code: "ENOENT" });
     expect(() => readRegularFileSync({ filePath: missing })).toThrow(
       expect.objectContaining({ code: "ENOENT" }),
+    );
+  });
+
+  itPosix("rejects FIFO swaps without blocking async or sync reads", async () => {
+    const root = await tempRoot("fs-safe-regular-fifo-");
+    const asyncPath = path.join(root, "async");
+    const asyncDisplaced = path.join(root, "async.displaced");
+    await fs.writeFile(asyncPath, "regular");
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+      expect(typeof flags).toBe("number");
+      expect((flags as number) & fsSync.constants.O_NONBLOCK).toBe(fsSync.constants.O_NONBLOCK);
+      await fs.rename(asyncPath, asyncDisplaced);
+      expect(spawnSync("mkfifo", [asyncPath]).status).toBe(0);
+      return await realOpen(candidate, flags, mode);
+    });
+
+    await expect(readRegularFile({ filePath: asyncPath })).rejects.toThrow(
+      "File is not a regular file",
+    );
+
+    const syncPath = path.join(root, "sync");
+    const syncDisplaced = path.join(root, "sync.displaced");
+    await fs.writeFile(syncPath, "regular");
+    const realOpenSync = fsSync.openSync.bind(fsSync);
+    vi.spyOn(fsSync, "openSync").mockImplementationOnce((candidate, flags, mode) => {
+      expect(typeof flags).toBe("number");
+      expect((flags as number) & fsSync.constants.O_NONBLOCK).toBe(fsSync.constants.O_NONBLOCK);
+      fsSync.renameSync(syncPath, syncDisplaced);
+      expect(spawnSync("mkfifo", [syncPath]).status).toBe(0);
+      return realOpenSync(candidate, flags, mode);
+    });
+
+    expect(() => readRegularFileSync({ filePath: syncPath })).toThrow(
+      "File is not a regular file",
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where pinned and standalone regular-file reads could block indefinitely when a regular path was replaced by a FIFO or device between inspection and descriptor open.

## Why This Change Was Made

All affected readers now use one internal POSIX nonblocking, no-follow flag resolver before descriptor type and identity validation. Root reads, hashing, and move-copy fallbacks share the same policy. No public interface or error shape changes.

## User Impact

Raced special files are rejected promptly instead of pinning a worker. Ordinary regular-file reads retain their existing behavior.

## Evidence

- Before: the new pinned, async, and sync FIFO-swap regressions failed because descriptor flags contained `0` instead of `O_NONBLOCK` (`2048`).
- After: `pnpm check` passes: build, docs, 1,035 tests, package validation, and filesystem-boundary lint.
- Autoreview: clean; no accepted or actionable findings.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
