### PR TITLE
fix: synchronize ClawSweeper dispatch identity

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -83,6 +83,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           TARGET_REPO: ${{ github.repository }}
+          TARGET_BRANCH: ${{ github.event.repository.default_branch }}
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           ITEM_KIND: ${{ github.event_name == 'pull_request_target' && 'pull_request' || 'issue' }}
           SOURCE_EVENT: ${{ github.event_name }}
@@ -92,14 +93,52 @@ jobs:
             echo "::notice::Skipping ClawSweeper dispatch because no dispatch credential is configured."
             exit 0
           fi
+          ingress_fingerprint="$(node <<'NODE'
+          const crypto = require("node:crypto");
+          const fs = require("node:fs");
+          const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+          const pullRequest = event.pull_request && typeof event.pull_request === "object"
+            ? event.pull_request
+            : {};
+          const headSha = String(pullRequest.head?.sha || "").trim().toLowerCase();
+          const updatedAt = String(pullRequest.updated_at || "").trim();
+          if (
+            process.env.ITEM_KIND !== "pull_request" ||
+            !/^[0-9a-f]{40}$/.test(headSha) ||
+            !updatedAt
+          ) {
+            process.stdout.write("");
+          } else {
+            process.stdout.write(
+              crypto
+                .createHash("sha256")
+                .update(
+                  JSON.stringify({
+                    version: 1,
+                    target_repo: String(process.env.TARGET_REPO || "").toLowerCase(),
+                    item_number: Number(process.env.ITEM_NUMBER),
+                    action: String(process.env.SOURCE_ACTION || ""),
+                    head_sha: headSha,
+                    updated_at: updatedAt,
+                    body: typeof pullRequest.body === "string" ? pullRequest.body : "",
+                    label: String(event.label?.name || ""),
+                  }),
+                )
+                .digest("hex"),
+            );
+          }
+          NODE
+          )"
           payload="$(jq -nc \
             --arg target_repo "$TARGET_REPO" \
+            --arg target_branch "$TARGET_BRANCH" \
             --argjson item_number "$ITEM_NUMBER" \
             --arg item_kind "$ITEM_KIND" \
             --arg source_event "$SOURCE_EVENT" \
             --arg source_action "$SOURCE_ACTION" \
+            --arg ingress_fingerprint "$ingress_fingerprint" \
             --argjson supersedes_in_progress "$SUPERSEDES_IN_PROGRESS" \
-            '{event_type:"clawsweeper_item",client_payload:{target_repo:$target_repo,item_number:$item_number,item_kind:$item_kind,source_event:$source_event,source_action:$source_action,supersedes_in_progress:$supersedes_in_progress}}')"
+            '{event_type:"clawsweeper_item",client_payload:({target_repo:$target_repo,target_branch:$target_branch,item_number:$item_number,item_kind:$item_kind,source_event:$source_event,source_action:$source_action,supersedes_in_progress:$supersedes_in_progress} + (if $ingress_fingerprint != "" then {ingress_route:"target_dispatcher",ingress_fingerprint:$ingress_fingerprint} else {} end))}')"
           gh api repos/openclaw/clawsweeper/dispatches \
             --method POST \
             --input - <<< "$payload"

--- a/test/clawsweeper-dispatch-workflow.test.ts
+++ b/test/clawsweeper-dispatch-workflow.test.ts
@@ -1,0 +1,190 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const behaviorIt = process.platform === "win32" ? it.skip : it;
+
+function exactReviewBlock(workflow: string) {
+  const start = workflow.indexOf("      - name: Dispatch exact ClawSweeper review");
+  const end = workflow.indexOf("      - name: Acknowledge and dispatch ClawSweeper comment");
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return workflow.slice(start, end);
+}
+
+function exactReviewRun(workflow: string) {
+  const match = exactReviewBlock(workflow).match(/\n        run: \|\r?\n([\s\S]*)$/u);
+  expect(match).not.toBeNull();
+  return (match?.[1] ?? "")
+    .split(/\r?\n/u)
+    .map((line) => (line.startsWith("          ") ? line.slice(10) : line))
+    .join("\n")
+    .trimEnd();
+}
+
+function executeExactReview(run: string, event: object, environment: Record<string, string>) {
+  const directory = mkdtempSync(join(tmpdir(), "fs-safe-clawsweeper-dispatch-"));
+  const eventPath = join(directory, "event.json");
+  const capturePath = join(directory, "dispatch.json");
+  const scriptPath = join(directory, "dispatch.sh");
+  const ghPath = join(directory, "gh");
+
+  try {
+    writeFileSync(eventPath, JSON.stringify(event), "utf8");
+    writeFileSync(scriptPath, `#!/usr/bin/env bash\nset -euo pipefail\n${run}\n`, "utf8");
+    writeFileSync(
+      ghPath,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'test "$#" -eq 6',
+        'test "$1" = "api"',
+        'test "$2" = "repos/openclaw/clawsweeper/dispatches"',
+        'test "$3" = "--method"',
+        'test "$4" = "POST"',
+        'test "$5" = "--input"',
+        'test "$6" = "-"',
+        'cat > "$GH_CAPTURE"',
+      ].join("\n"),
+      "utf8",
+    );
+    chmodSync(scriptPath, 0o755);
+    chmodSync(ghPath, 0o755);
+
+    const result = spawnSync("bash", [scriptPath], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...environment,
+        GH_CAPTURE: capturePath,
+        GH_TOKEN: "proof-token",
+        GITHUB_EVENT_PATH: eventPath,
+        PATH: `${directory}:${process.env.PATH ?? ""}`,
+        SUPERSEDES_IN_PROGRESS: "false",
+      },
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    return JSON.parse(readFileSync(capturePath, "utf8")) as {
+      event_type: string;
+      client_payload: Record<string, unknown>;
+    };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+describe("ClawSweeper dispatch workflow", () => {
+  it("carries trusted branch authority and canonical PR ingress identity", async () => {
+    const workflow = await readFile(".github/workflows/clawsweeper-dispatch.yml", "utf8");
+    const exactReview = exactReviewBlock(workflow);
+
+    expect(exactReview).toContain(
+      "if: ${{ steps.trust.outputs.allowed == 'true' && github.event_name != 'issue_comment' }}",
+    );
+    expect(exactReview).toContain(
+      "TARGET_BRANCH: ${{ github.event.repository.default_branch }}",
+    );
+    expect(exactReview).toContain('--arg target_branch "$TARGET_BRANCH"');
+    expect(exactReview).toContain("target_branch:$target_branch");
+    expect(exactReview).toContain('process.env.ITEM_KIND !== "pull_request"');
+    expect(exactReview).toContain('/^[0-9a-f]{40}$/.test(headSha)');
+    expect(exactReview).toContain("version: 1");
+    expect(exactReview).toContain(
+      'target_repo: String(process.env.TARGET_REPO || "").toLowerCase()',
+    );
+    expect(exactReview).toContain("item_number: Number(process.env.ITEM_NUMBER)");
+    expect(exactReview).toContain('action: String(process.env.SOURCE_ACTION || "")');
+    expect(exactReview).toContain("head_sha: headSha");
+    expect(exactReview).toContain("updated_at: updatedAt");
+    expect(exactReview).toContain(
+      'body: typeof pullRequest.body === "string" ? pullRequest.body : ""',
+    );
+    expect(exactReview).toContain('label: String(event.label?.name || "")');
+    expect(exactReview).toContain('ingress_route:"target_dispatcher"');
+    expect(exactReview).toContain("ingress_fingerprint:$ingress_fingerprint");
+    expect(exactReview).not.toContain('target_branch || "main"');
+  });
+
+  behaviorIt("serializes PR identity and leaves issue dispatches unpaired", async () => {
+    const workflow = await readFile(".github/workflows/clawsweeper-dispatch.yml", "utf8");
+    const run = exactReviewRun(workflow);
+    const pullRequest = {
+      head: { sha: "B".repeat(40) },
+      updated_at: "2026-08-10T22:00:00Z",
+      body: "proof body",
+    };
+    const prPayload = executeExactReview(
+      run,
+      { pull_request: pullRequest, label: { name: "proof: sufficient" } },
+      {
+        TARGET_REPO: "openclaw/fs-safe",
+        TARGET_BRANCH: "stable",
+        ITEM_NUMBER: "445",
+        ITEM_KIND: "pull_request",
+        SOURCE_EVENT: "pull_request_target",
+        SOURCE_ACTION: "synchronize",
+      },
+    );
+    const fingerprint = createHash("sha256")
+      .update(
+        JSON.stringify({
+          version: 1,
+          target_repo: "openclaw/fs-safe",
+          item_number: 445,
+          action: "synchronize",
+          head_sha: "b".repeat(40),
+          updated_at: pullRequest.updated_at,
+          body: pullRequest.body,
+          label: "proof: sufficient",
+        }),
+      )
+      .digest("hex");
+    expect(prPayload).toEqual({
+      event_type: "clawsweeper_item",
+      client_payload: {
+        target_repo: "openclaw/fs-safe",
+        target_branch: "stable",
+        item_number: 445,
+        item_kind: "pull_request",
+        source_event: "pull_request_target",
+        source_action: "synchronize",
+        supersedes_in_progress: false,
+        ingress_route: "target_dispatcher",
+        ingress_fingerprint: fingerprint,
+      },
+    });
+
+    const issuePayload = executeExactReview(
+      run,
+      { issue: { number: 446 } },
+      {
+        TARGET_REPO: "openclaw/fs-safe",
+        TARGET_BRANCH: "stable",
+        ITEM_NUMBER: "446",
+        ITEM_KIND: "issue",
+        SOURCE_EVENT: "issues",
+        SOURCE_ACTION: "opened",
+      },
+    );
+    expect(issuePayload.client_payload).toEqual({
+      target_repo: "openclaw/fs-safe",
+      target_branch: "stable",
+      item_number: 446,
+      item_kind: "issue",
+      source_event: "issues",
+      source_action: "opened",
+      supersedes_in_progress: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- carry fs-safe's authenticated event-repository default branch in exact-review dispatches
- add the canonical PR-only `target_dispatcher` fingerprint used by ClawSweeper's direct webhook route
- guard both the trusted-command workflow condition and serialized PR/issue payloads

## Problem

fs-safe's trusted dispatcher still emitted the legacy exact-review payload without `target_branch` or cross-route identity. A missing branch forces legacy intake to resolve repository metadata through GitHub, and a missing canonical fingerprint prevents ClawSweeper from synchronizing the dispatcher delivery with the corresponding direct webhook admission.

This is the fs-safe producer-side equivalent of the receiver work in [openclaw/clawsweeper#1105](https://github.com/openclaw/clawsweeper/pull/1105) and the OpenClaw producer update in [openclaw/openclaw#121674](https://github.com/openclaw/openclaw/pull/121674).

## Implementation

- source `target_branch` from `${{ github.event.repository.default_branch }}`, which is trusted base-repository event metadata
- for valid pull-request events, compute the receiver's canonical v1 SHA-256 identity from repository, item number, action, head SHA, update timestamp, body, and label
- attach `ingress_route: target_dispatcher` and `ingress_fingerprint` only when that PR identity is complete
- preserve the existing trusted-command gate; keep issue dispatches branch-aware but unpaired; leave the comment route, triggers, permissions, and credentials unchanged

## Validation

- `pnpm exec vitest run test/clawsweeper-dispatch-workflow.test.ts` — pass on Windows (static contract; Bash behavior case skipped on native Windows)
- `pnpm build` and `pnpm docs:check` — pass as part of `pnpm check`
- `node scripts/check-pack.mjs` — pass
- `git diff --check` — pass
- mechanical comparison of the fingerprint heredoc with the landed OpenClaw producer — byte-identical after indentation normalization; SHA-256 `0EBC06B190B0DD8F0A3F13CECA78037D5B0CE1227B19B690ACA017809EDFBB48`
- full `pnpm check` reached the full test suite: 779 passed, 291 skipped, and 29 failed because this Windows process lacks symlink privilege (`EPERM`); the workflow/test diff does not touch filesystem runtime code

## Real Behavior Proof

**Claim:** the exact committed workflow serializes a trusted non-`main` branch and the same PR identity as the direct webhook, while issue dispatches contain no ingress pairing fields.

**Exact head:** `91d4399b4fe974150ac3d8c2a559f49025e977a4`

**Exercised surface:** the `run:` block is dynamically extracted from `.github/workflows/clawsweeper-dispatch.yml` and executed unchanged. The only substituted boundary is a local `gh` executable that validates all six expected CLI arguments and captures stdin instead of contacting GitHub.

**Fixture:** PR #445 on branch `stable`, uppercase 40-hex head SHA, update timestamp, body, action, and label; followed by issue #446.

**Command/environment:**

```text
Git Bash 5.2.37 / Node 24.13.0 / checksum-verified jq 1.8.2
Git Bash external-CSW-117-dispatch-proof-harness openclaw/fs-safe stable 445
```

**Observed result:**

```json
{"ok":true,"target_repo":"openclaw/fs-safe","target_branch":"stable","pr_fingerprint":"0a15d1fc4464a61b648cfde44fc07aa5b4a15064f7d566efba08c2e8d8dd9da3","issue_ingress_fields":false}
```

**Authenticated equivalence proof (read-only):** the merged OpenClaw producer from [openclaw/openclaw#121674](https://github.com/openclaw/openclaw/pull/121674) contains the same 33-line fingerprint program byte-for-byte after indentation normalization, plus the same `target_branch` and conditional `target_dispatcher` serialization. [OpenClaw run 31442689798](https://github.com/openclaw/openclaw/actions/runs/31442689798) executed that landed producer in GitHub Actions with an authenticated ClawSweeper App token, logged `TARGET_BRANCH: main`, constructed the fingerprint-bearing payload, and ended with `Dispatched ClawSweeper review.` [ClawSweeper receiver run 31442699197](https://github.com/openclaw/clawsweeper/actions/runs/31442699197) then received item `openclaw/openclaw#121738` with `target_branch: main`, `ingress_route: target_dispatcher`, and fingerprint `3a67694d83f13fa111dc13be3befecd65b7ef52f675215b3f233fc6e08d62983`; its durable-control-plane enqueue completed successfully. The exact-head harness above supplies the repository-specific `openclaw/fs-safe` / `stable` inputs and issue fallback.

**Artifact:** retained CSW-117 fs-safe proof note and shared external dispatch-proof harness, plus the linked authenticated producer and receiver runs.

**Limits:** no new workflow, queue, gate, or production mutation was initiated for this proof. A pull-request candidate cannot make its own `pull_request_target` check execute the candidate workflow because GitHub deliberately loads that workflow from the base branch; this PR's initial dispatch check therefore exercised the legacy base workflow. The authenticated proof uses the already-landed byte-identical OpenClaw producer, while the exact-head harness proves fs-safe's repository-specific serialization. Resolved Crabbox provider `aws` was attempted: `run_6ca6896f4d04` obtained lease `cbx_3ef75fb28817` but rsync closed before transferring bytes; the final bounded recovery `run_446e534f7cd5` timed out after 30 minutes waiting for capacity. The late-lease hint named `cbx_6a57a750d4d6`; `crabbox list --provider aws` confirmed no active lease.

## Review

The repository autoreview path ran TruffleHog plus Codex review on the dirty patch and committed range. One accepted test finding required the `gh` stub to validate `--method POST --input -`; that was fixed in both repository variants and the focused proof was rerun. Final committed-range review: no accepted/actionable findings; patch correct (0.94 confidence).

ClawSweeper's P3 suggestion to edit `CHANGELOG.md` is deliberately not accepted. The enclosing CSW workspace policy makes changelogs release-owned and explicitly excludes them from normal ClawSweeper PRs; this task is also constrained to the minimal producer workflow/guard contract. Operational release-note context is recorded in this PR body instead.

## Risks and rollout

This changes a GitHub workflow, so it requires normal maintainer workflow-file review. The payload remains backward-compatible: it adds branch authority to all exact-review items and optional ingress metadata to valid PRs. No workflow permissions, triggers, admission limits, queues, deployments, package behavior, or credentials change. Rollback is the two-file revert.
