### PR TITLE
fix: treat zero win32 inodes as unknown file identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security and Correctness
+
+- Prevent nondeterministic Windows read failures with `path-mismatch` when path-based stat reports zero file identity through libuv's FindFirstFile fallback under antivirus or indexer contention; zero Windows inodes are now treated as unknown identity like zero device serials.
+
 ## 0.5.4 - 2026-08-10
 
 **Highlight:** two security fixes in the publication path. If you run fs-safe on

--- a/src/file-identity.ts
+++ b/src/file-identity.ts
@@ -13,6 +13,18 @@ function sameStatValue(left: number | bigint, right: number | bigint): boolean {
   return typeof left === typeof right ? left === right : BigInt(left) === BigInt(right);
 }
 
+function isStatValueProvablyDifferent(
+  left: number | bigint,
+  right: number | bigint,
+  platform: NodeJS.Platform,
+): boolean {
+  if (sameStatValue(left, right)) {
+    return false;
+  }
+
+  return platform !== "win32" || (!isZero(left) && !isZero(right));
+}
+
 export function sha256Hex(data: string | Buffer, encoding?: BufferEncoding): string {
   const buffer = typeof data === "string" ? Buffer.from(data, encoding ?? "utf8") : data;
   return createHash("sha256").update(buffer).digest("hex");
@@ -23,14 +35,11 @@ export function sameFileIdentity(
   right: FileIdentityStat,
   platform: NodeJS.Platform = process.platform,
 ): boolean {
-  if (!sameStatValue(left.ino, right.ino)) {
-    return false;
-  }
-
-  // On Windows, path-based stat calls can report dev=0 while fd-based stat
-  // reports a real volume serial; treat either-side dev=0 as "unknown device".
-  if (sameStatValue(left.dev, right.dev)) {
-    return true;
-  }
-  return platform === "win32" && (isZero(left.dev) || isZero(right.dev));
+  // When Windows cannot open a path for stat, libuv's FindFirstFile fallback reports dev=0 and
+  // ino=0. Treating either unknown value as a mismatch caused nondeterministic path-mismatch
+  // failures on legitimate reads under antivirus or indexer contention.
+  return (
+    !isStatValueProvablyDifferent(left.dev, right.dev, platform) &&
+    !isStatValueProvablyDifferent(left.ino, right.ino, platform)
+  );
 }

--- a/test/archive-adjacent-errors.test.ts
+++ b/test/archive-adjacent-errors.test.ts
@@ -140,7 +140,9 @@ describe("archive input staging failures", () => {
     const changedStat = new Proxy(originalStat, {
       get(target, property) {
         if (property === "ino") {
-          return typeof target.ino === "bigint" ? target.ino + 1n : target.ino === 0 ? 1 : 0;
+          // Keep the swapped identity nonzero: zero win32 inodes are "unknown identity" by
+          // design, and float precision makes `+ 1` a no-op for indexes above 2^53.
+          return typeof target.ino === "bigint" ? target.ino + 1n : target.ino === 12345 ? 54321 : 12345;
         }
         const value = Reflect.get(target, property, target);
         return typeof value === "function" ? value.bind(target) : value;

--- a/test/coverage-more.test.ts
+++ b/test/coverage-more.test.ts
@@ -127,13 +127,25 @@ describe("secure temp root fallback coverage", () => {
 });
 
 describe("small identity and lock wrappers", () => {
-  it("compares file identities across POSIX and Windows zero-device stats", async () => {
-    expect(sameFileIdentity({ dev: 1, ino: 2 }, { dev: 1, ino: 2 }, "linux")).toBe(true);
-    expect(sameFileIdentity({ dev: 1, ino: 2 }, { dev: 1n, ino: 2n }, "linux")).toBe(true);
-    expect(sameFileIdentity({ dev: 1, ino: 2 }, { dev: 1, ino: 3 }, "linux")).toBe(false);
-    expect(sameFileIdentity({ dev: 0, ino: 2 }, { dev: 99, ino: 2 }, "win32")).toBe(true);
-    expect(sameFileIdentity({ dev: 0, ino: 2 }, { dev: 99n, ino: 2n }, "win32")).toBe(true);
-    expect(sameFileIdentity({ dev: 0n, ino: 2n }, { dev: 99n, ino: 2n }, "linux")).toBe(false);
+  it("compares file identities across POSIX and Windows zero identity stats", async () => {
+    const cases = [
+      ["linux", { dev: 1, ino: 2 }, { dev: 1, ino: 2 }, true],
+      ["linux", { dev: 1, ino: 2 }, { dev: 1n, ino: 2n }, true],
+      ["linux", { dev: 1, ino: 2 }, { dev: 1, ino: 3 }, false],
+      ["win32", { dev: 0, ino: 2 }, { dev: 99, ino: 2 }, true],
+      ["win32", { dev: 0, ino: 2 }, { dev: 99n, ino: 2n }, true],
+      ["linux", { dev: 0n, ino: 2n }, { dev: 99n, ino: 2n }, false],
+      ["win32", { dev: 1, ino: 0 }, { dev: 1, ino: 5 }, true],
+      ["win32", { dev: 1, ino: 5 }, { dev: 1, ino: 0n }, true],
+      ["win32", { dev: 0, ino: 0 }, { dev: 2, ino: 5 }, true],
+      ["win32", { dev: 1, ino: 0 }, { dev: 2, ino: 5 }, false],
+      ["win32", { dev: 1, ino: 4 }, { dev: 1, ino: 5 }, false],
+      ["linux", { dev: 1, ino: 0 }, { dev: 1, ino: 5 }, false],
+    ] as const;
+
+    for (const [platform, left, right, expected] of cases) {
+      expect(sameFileIdentity(left, right, platform)).toBe(expected);
+    }
 
     const root = await tempRoot("fs-safe-file-lock-wrapper-");
     const targetPath = path.join(root, "state.json");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows consumers performing legitimate reads could nondeterministically receive `FsSafeError("path-mismatch", "File changed during read")` when antivirus or indexer contention prevented libuv from opening the path for stat.

This was observed in `openclaw/openclaw` Windows CI after the 0.5.4 bump at commit `5295f2578e1be1`: `checks-windows-node-test` intermittently failed in `src/media/local-media-path.windows.test.ts` with `ManagedImageAttachmentError` after `verifyStableReadTarget` rejected an unchanged file.

## Why This Change Was Made

On Windows, libuv falls back to `FindFirstFile` data when `GetFileInformationByHandle` cannot open the file. That fallback reports both `dev=0` and `ino=0`. `sameFileIdentity` already treated either-side zero device identity as unknown on Win32, but compared inode identity strictly, so a path stat with `ino=0` mismatched an fd stat containing the real nonzero inode.

The comparison now uses one symmetric per-field rule: a field differs only when both values are known and unequal. Win32 zero device serials and inodes are unknown; non-Windows comparisons remain strict.

| Platform | Left `(dev, ino)` | Right `(dev, ino)` | Same identity |
| --- | --- | --- | --- |
| win32 | `(1, 0)` | `(1, 5)` | yes |
| win32 | `(1, 5)` | `(1, 0n)` | yes |
| win32 | `(0, 0)` | `(2, 5)` | yes |
| win32 | `(1, 0)` | `(2, 5)` | no |
| win32 | `(1, 4)` | `(1, 5)` | no |
| linux | `(1, 0)` | `(1, 5)` | no |

## User Impact

Windows reads no longer fail spuriously with `path-mismatch` when a transient libuv path-stat fallback cannot provide file identity. Known unequal device or inode values still fail closed, and every non-Windows comparison retains the existing strict behavior.

## Evidence

- `pnpm test test/coverage-more.test.ts test/regular-file-failure.test.ts test/rename-identity-policy.test.ts`
  - 3 test files passed
  - 39 tests passed
- `pnpm check`
  - file-size and filesystem-boundary lint passed
  - TypeScript build passed
  - documentation examples matched the built package
  - 101 test files passed, 2 skipped
  - 1,039 tests passed, 61 skipped
  - package validation passed
- `git diff --check` passed
- Structured autoreview reported no accepted or actionable findings.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
