### PR TITLE
fix(temp): preserve replacements with unknown identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security and Correctness
+
+- Preserve replaced temporary paths during Windows cleanup when libuv reports a zero device or inode, treating unknown identity as fail-closed instead of authorizing recursive deletion.
+
 ## 0.5.5 - 2026-08-12
 
 ### Security and Correctness

--- a/src/file-identity.ts
+++ b/src/file-identity.ts
@@ -43,3 +43,20 @@ export function sameFileIdentity(
     !isStatValueProvablyDifferent(left.ino, right.ino, platform)
   );
 }
+
+export function sameFileIdentityForCleanup(
+  left: FileIdentityStat,
+  right: FileIdentityStat,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  // A zero Windows device or inode is unknown, not proof that a pathname still
+  // names the object we created. Cleanup must fail closed rather than delete a
+  // replacement that happens to share the known half of the identity.
+  if (
+    platform === "win32" &&
+    (isZero(left.dev) || isZero(left.ino) || isZero(right.dev) || isZero(right.ino))
+  ) {
+    return false;
+  }
+  return sameStatValue(left.dev, right.dev) && sameStatValue(left.ino, right.ino);
+}

--- a/src/native-operations.ts
+++ b/src/native-operations.ts
@@ -2,7 +2,7 @@ import fsSync, { type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { ContainmentGuarantee } from "./containment.js";
-import { sameFileIdentity } from "./file-identity.js";
+import { sameFileIdentityForCleanup } from "./file-identity.js";
 import { getNativeBinding, type NativeBinding } from "./native.js";
 
 export type NativeFileHandle = {
@@ -73,7 +73,7 @@ export function removeNativeCreatedFileIfStillPinned(params: {
       parentPathStat.dev === parentFdStat.dev &&
       parentPathStat.ino === parentFdStat.ino &&
       !target.isSymbolicLink() &&
-      sameFileIdentity(target, params.created)
+      sameFileIdentityForCleanup(target, params.created)
     ) {
       fsSync.rmSync(targetPath);
     }

--- a/src/output-sibling.ts
+++ b/src/output-sibling.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { createAsyncDirectoryGuard } from "./directory-guard.js";
 import { syncDirectoryBestEffort } from "./directory-durability.js";
 import { FsSafeError } from "./errors.js";
-import { sameFileIdentity } from "./file-identity.js";
+import { sameFileIdentity, sameFileIdentityForCleanup } from "./file-identity.js";
 import { withAsyncDirectoryGuards } from "./guarded-mutation.js";
 import { sanitizeUntrustedFileName } from "./filename.js";
 import { registerTempPathForExit } from "./temp-cleanup.js";
@@ -84,7 +84,7 @@ async function cleanupTempPath(
 ): Promise<boolean> {
   try {
     const current = await fs.lstat(tempPath);
-    if (!identity || (!current.isSymbolicLink() && sameFileIdentity(current, identity))) {
+    if (!identity || (!current.isSymbolicLink() && sameFileIdentityForCleanup(current, identity))) {
       await fs.rm(tempPath, { force: true });
     }
     return true;

--- a/src/private-temp-workspace.ts
+++ b/src/private-temp-workspace.ts
@@ -9,7 +9,7 @@ import {
   type FileStoreSync,
 } from "./file-store.js";
 import { FsSafeError } from "./errors.js";
-import { sameFileIdentity } from "./file-identity.js";
+import { sameFileIdentityForCleanup } from "./file-identity.js";
 import { isNotFoundPathError } from "./path.js";
 import { throwFsSafeReadError } from "./read-error.js";
 import {
@@ -149,7 +149,7 @@ async function cleanupWorkspace(
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "identity-mismatch";
   }
-  if (!sameFileIdentity(current, identity)) {
+  if (!sameFileIdentityForCleanup(current, identity)) {
     return "identity-mismatch";
   }
   await fs.rm(dir, { recursive: true, force: true });
@@ -166,7 +166,7 @@ function cleanupWorkspaceSync(
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "identity-mismatch";
   }
-  if (!sameFileIdentity(current, identity)) {
+  if (!sameFileIdentityForCleanup(current, identity)) {
     return "identity-mismatch";
   }
   fsSync.rmSync(dir, { recursive: true, force: true });

--- a/src/publish-file.ts
+++ b/src/publish-file.ts
@@ -10,7 +10,11 @@ import {
 } from "./directory-durability.js";
 import { FsSafeError } from "./errors.js";
 import { hashFileHandle } from "./file-hash.js";
-import { sameFileIdentity, type FileIdentityStat } from "./file-identity.js";
+import {
+  sameFileIdentity,
+  sameFileIdentityForCleanup,
+  type FileIdentityStat,
+} from "./file-identity.js";
 import { syncNativeFileBestEffort } from "./native-operations.js";
 import { getNativeBinding, requireNativeBinding, type NativeBinding } from "./native.js";
 import {
@@ -247,7 +251,7 @@ async function removeCreatedTargetIfUnchanged(
   }
   try {
     const current = await fs.lstat(targetPath, { bigint: true });
-    if (!current.isSymbolicLink() && sameFileIdentity(current, identity)) {
+    if (!current.isSymbolicLink() && sameFileIdentityForCleanup(current, identity)) {
       await fs.rm(targetPath);
       return "removed";
     }

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -8,7 +8,11 @@ import type { ContainmentGuarantee } from "./containment.js";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard, createNearestExistingDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { syncDirectoryBestEffort } from "./fsync.js";
-import { sameFileIdentity, type FileIdentityStat } from "./file-identity.js";
+import {
+  sameFileIdentity,
+  sameFileIdentityForCleanup,
+  type FileIdentityStat,
+} from "./file-identity.js";
 import { mkdirPathComponentsWithGuards } from "./guarded-mkdir.js";
 import { withAsyncDirectoryGuards } from "./guarded-mutation.js";
 import {
@@ -1236,7 +1240,7 @@ async function removePathIfIdentityUnchanged(
 ): Promise<void> {
   const parentGuard = await createAsyncDirectoryGuard(path.dirname(targetPath));
   const current = await fs.lstat(targetPath);
-  if (current.isSymbolicLink() || !sameFileIdentity(current, identity)) {
+  if (current.isSymbolicLink() || !sameFileIdentityForCleanup(current, identity)) {
     return;
   }
   await withAsyncDirectoryGuards([parentGuard], async () => {

--- a/src/temp-cleanup.ts
+++ b/src/temp-cleanup.ts
@@ -1,5 +1,5 @@
 import fsSync from "node:fs";
-import { sameFileIdentity, type FileIdentityStat } from "./file-identity.js";
+import { sameFileIdentityForCleanup, type FileIdentityStat } from "./file-identity.js";
 
 export type TempPathIdentityReceipt = FileIdentityStat;
 
@@ -21,7 +21,7 @@ function pathStillMatchesReceipt(entry: TempCleanupEntry): boolean {
     return false;
   }
   try {
-    return sameFileIdentity(fsSync.lstatSync(entry.path), entry.identity);
+    return sameFileIdentityForCleanup(fsSync.lstatSync(entry.path), entry.identity);
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === "ENOENT";
   }

--- a/src/temp-target.ts
+++ b/src/temp-target.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { lstat, mkdtemp, rm } from "node:fs/promises";
 import path from "node:path";
-import { sameFileIdentity, type FileIdentityStat } from "./file-identity.js";
+import { sameFileIdentityForCleanup, type FileIdentityStat } from "./file-identity.js";
 import { assertSafePathSegment, sanitizeSafePathSegment } from "./safe-path-segment.js";
 import { resolveSecureTempRoot } from "./secure-temp-dir.js";
 import { registerTempPathForExit } from "./temp-cleanup.js";
@@ -134,7 +134,7 @@ async function cleanupTempDir(
       }
       throw error;
     });
-    if (!current || !sameFileIdentity(current, identity)) {
+    if (!current || !sameFileIdentityForCleanup(current, identity)) {
       return;
     }
     await rm(dir, { recursive: true, force: true });

--- a/test/atomic.test.ts
+++ b/test/atomic.test.ts
@@ -105,6 +105,25 @@ describe("atomic helpers", () => {
     await expect(fs.access(tempDir)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("preserves registered temp paths when Windows identity is unknown", async () => {
+    const root = await tempRoot("fs-safe-temp-cleanup-unknown-");
+    const tempPath = path.join(root, "leftover.tmp");
+    await fs.writeFile(tempPath, "replacement", "utf8");
+    const identity = await fs.lstat(tempPath);
+    registerTempPathForExit(tempPath, {
+      identity: { dev: identity.dev, ino: 0 },
+    });
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { ...platformDescriptor, value: "win32" });
+    try {
+      __cleanupRegisteredTempPathForTest(tempPath);
+    } finally {
+      Object.defineProperty(process, "platform", platformDescriptor!);
+    }
+
+    await expect(fs.readFile(tempPath, "utf8")).resolves.toBe("replacement");
+  });
+
   it("uses the permission-error copy fallback when requested", async () => {
     const root = await tempRoot("fs-safe-atomic-");
     const filePath = path.join(root, "state.txt");

--- a/test/coverage-more.test.ts
+++ b/test/coverage-more.test.ts
@@ -15,7 +15,7 @@ import {
   createSyncDirectoryGuard,
 } from "../src/directory-guard.js";
 import { drainFileLockManagerForTest, resetFileLockManagerForTest } from "../src/file-lock.js";
-import { sameFileIdentity } from "../src/file-identity.js";
+import { sameFileIdentity, sameFileIdentityForCleanup } from "../src/file-identity.js";
 import { readLocalFileFromRoots, resolveLocalPathFromRootsSync } from "../src/local-roots.js";
 import { resolveSecureTempRoot, type ResolveSecureTempRootOptions } from "../src/secure-temp-dir.js";
 import { writeSiblingTempFile, writeViaSiblingTempPath } from "../src/sibling-temp.js";
@@ -146,6 +146,13 @@ describe("small identity and lock wrappers", () => {
     for (const [platform, left, right, expected] of cases) {
       expect(sameFileIdentity(left, right, platform)).toBe(expected);
     }
+
+    expect(sameFileIdentityForCleanup({ dev: 1, ino: 2 }, { dev: 1, ino: 2 }, "win32"))
+      .toBe(true);
+    expect(sameFileIdentityForCleanup({ dev: 1, ino: 0 }, { dev: 1, ino: 2 }, "win32"))
+      .toBe(false);
+    expect(sameFileIdentityForCleanup({ dev: 0, ino: 2 }, { dev: 1, ino: 2 }, "win32"))
+      .toBe(false);
 
     const root = await tempRoot("fs-safe-file-lock-wrapper-");
     const targetPath = path.join(root, "state.json");


### PR DESCRIPTION
## Summary

- separate permissive Windows identity compatibility checks from the exact identity proof required before cleanup deletes a path
- apply the fail-closed cleanup predicate to temp directories, exit cleanup, failed publication cleanup, and other identity-gated removal paths
- add a portable zero-identity regression and document the security/correctness fix

## Root cause

Windows path-based stats can report a zero device or inode when libuv falls back to `FindFirstFile`. The general identity comparison intentionally treats those fields as unknown so legitimate reads do not fail nondeterministically. Cleanup reused that permissive comparison as deletion authorization, allowing a replacement directory with an unknown inode to compare equal to the original and be recursively removed.

Cleanup now requires exact, nonzero Windows device and inode values. Non-destructive verification keeps the existing unknown-identity behavior.

## Validation

- `pnpm check`
- `git diff --check`
- native Windows, Node 24: `pnpm test test/additional-boundary-bypass.test.ts test/atomic.test.ts test/coverage-more.test.ts` (37 passed, 4 platform-skipped)
- native Windows compiled-library scenario: replaced a `tempFile()` directory, called `cleanup()`, and verified `replacement.txt` still contained `keep`
- autoreview: clean, no accepted/actionable findings
