### PR TITLE
fix(temp): use exact identities for cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Security and Correctness
 
-- Preserve replaced temporary paths during Windows cleanup when libuv reports a zero device or inode, treating unknown identity as fail-closed instead of authorizing recursive deletion.
+- Preserve replaced temporary paths during Windows cleanup when libuv reports a zero device or inode or a file index exceeds JavaScript's safe integer range, treating unknown or rounded identity as fail-closed instead of authorizing deletion.
 
 ## 0.5.5 - 2026-08-12
 

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -399,7 +399,7 @@ export async function movePathWithCopyFallback(
       sourceHardlinks: options.sourceHardlinks ?? "allow",
       ...(rejectHardlinks ? { budget: { discovered: 1 } } : {}),
     });
-    unregisterStaged.setIdentity(await fs.lstat(staged));
+    unregisterStaged.setIdentity(await fs.lstat(staged, { bigint: true }));
     await assertCopyDestinationOutsideSource(sourcePath, targetPath);
     await guardedRename({ from: staged, to: targetPath });
     stagedCommitted = true;
@@ -411,7 +411,7 @@ export async function movePathWithCopyFallback(
   } finally {
     if (!stagedCommitted) {
       try {
-        const stagedIdentity = await fs.lstat(staged);
+        const stagedIdentity = await fs.lstat(staged, { bigint: true });
         if (!stagedIdentity.isSymbolicLink()) unregisterStaged.setIdentity(stagedIdentity);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") {

--- a/src/output-sibling.ts
+++ b/src/output-sibling.ts
@@ -112,7 +112,7 @@ export async function writeExternalFileViaSibling<T>(params: {
     const result = await params.write(tempPath);
     const pinned = await openPinnedStagedFile(tempPath, params.maxBytes);
     stagedIdentity = pinned.identity;
-    unregisterTempPath.setIdentity(stagedIdentity);
+    unregisterTempPath.setIdentity(await pinned.handle.stat({ bigint: true }));
     try {
       if (params.mode !== undefined) {
         await pinned.handle.chmod(params.mode);

--- a/src/private-temp-workspace.ts
+++ b/src/private-temp-workspace.ts
@@ -145,7 +145,7 @@ async function cleanupWorkspace(
 ): Promise<TempWorkspaceCleanupResult> {
   let current;
   try {
-    current = await fs.lstat(dir);
+    current = await fs.lstat(dir, { bigint: true });
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "identity-mismatch";
   }
@@ -162,7 +162,7 @@ function cleanupWorkspaceSync(
 ): TempWorkspaceCleanupResult {
   let current;
   try {
-    current = fsSync.lstatSync(dir);
+    current = fsSync.lstatSync(dir, { bigint: true });
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "identity-mismatch";
   }
@@ -183,12 +183,16 @@ async function createTempWorkspace(
   await ensurePrivateDirectory(root, dirMode);
   const dir = await fs.mkdtemp(path.join(root, sanitizeTempPrefix(options.prefix)));
   await fs.chmod(dir, dirMode).catch(() => undefined);
-  const stat = await fs.lstat(dir);
+  const stat = await fs.lstat(dir, { bigint: true });
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw new Error(`Temp workspace must be a directory: ${dir}`);
   }
-  const identity = { dev: stat.dev, ino: stat.ino };
-  const unregisterTempDir = registerTempPathForExit(dir, { recursive: true, identity });
+  const identity = { dev: Number(stat.dev), ino: Number(stat.ino) };
+  const cleanupIdentity = { dev: stat.dev, ino: stat.ino };
+  const unregisterTempDir = registerTempPathForExit(dir, {
+    recursive: true,
+    identity: cleanupIdentity,
+  });
   const store = fileStore({ rootDir: dir, private: true, dirMode, mode });
 
   return {
@@ -216,14 +220,14 @@ async function createTempWorkspace(
     },
     cleanup: async () => {
       try {
-        return await cleanupWorkspace(dir, identity);
+        return await cleanupWorkspace(dir, cleanupIdentity);
       } finally {
         unregisterTempDir();
       }
     },
     [Symbol.asyncDispose]: async () => {
       try {
-        await cleanupWorkspace(dir, identity);
+        await cleanupWorkspace(dir, cleanupIdentity);
       } finally {
         unregisterTempDir();
       }
@@ -271,12 +275,16 @@ export function tempWorkspaceSync(
   } catch {
     // Best-effort on platforms that do not enforce POSIX modes.
   }
-  const stat = fsSync.lstatSync(dir);
+  const stat = fsSync.lstatSync(dir, { bigint: true });
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw new Error(`Temp workspace must be a directory: ${dir}`);
   }
-  const identity = { dev: stat.dev, ino: stat.ino };
-  const unregisterTempDir = registerTempPathForExit(dir, { recursive: true, identity });
+  const identity = { dev: Number(stat.dev), ino: Number(stat.ino) };
+  const cleanupIdentity = { dev: stat.dev, ino: stat.ino };
+  const unregisterTempDir = registerTempPathForExit(dir, {
+    recursive: true,
+    identity: cleanupIdentity,
+  });
   const store = fileStoreSync({ rootDir: dir, private: true, dirMode, mode });
 
   return {
@@ -315,14 +323,14 @@ export function tempWorkspaceSync(
     },
     cleanup: () => {
       try {
-        return cleanupWorkspaceSync(dir, identity);
+        return cleanupWorkspaceSync(dir, cleanupIdentity);
       } finally {
         unregisterTempDir();
       }
     },
     [Symbol.dispose]: () => {
       try {
-        cleanupWorkspaceSync(dir, identity);
+        cleanupWorkspaceSync(dir, cleanupIdentity);
       } finally {
         unregisterTempDir();
       }

--- a/src/replace-file-descriptor.ts
+++ b/src/replace-file-descriptor.ts
@@ -1,4 +1,4 @@
-import syncFs, { type Stats } from "node:fs";
+import syncFs, { type BigIntStats, type Stats } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
@@ -86,7 +86,7 @@ export async function writeTempFile(params: {
   content: string | Uint8Array;
   mode: number;
   sync: boolean;
-}): Promise<Stats> {
+}): Promise<BigIntStats> {
   const handle = await params.fsModule.open(params.tempPath, "wx", params.mode);
   try {
     await params.fsModule.writeFile(handle, params.content);
@@ -100,7 +100,7 @@ export async function writeTempFile(params: {
         }
       }
     }
-    return await handle.stat();
+    return await handle.stat({ bigint: true });
   } finally {
     await handle.close();
   }
@@ -113,7 +113,7 @@ export function writeTempFileSync(params: {
   mode: number;
   fchmodSync?: SyncFchmod;
   sync: boolean;
-}): Stats {
+}): BigIntStats {
   const fd = params.fsModule.openSync(params.tempPath, "wx", params.mode);
   try {
     params.fsModule.writeFileSync(fd, params.content);
@@ -127,7 +127,7 @@ export function writeTempFileSync(params: {
         }
       }
     }
-    return params.fsModule.fstatSync(fd);
+    return params.fsModule.fstatSync(fd, { bigint: true });
   } finally {
     params.fsModule.closeSync(fd);
   }

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { Stats } from "node:fs";
+import type { BigIntStats, Stats } from "node:fs";
 import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
@@ -800,7 +800,7 @@ async function writeTempFileForAtomicReplace(params: {
   data: string | Buffer;
   encoding?: BufferEncoding;
   mode: number;
-}): Promise<Stats> {
+}): Promise<{ identity: Stats; cleanupIdentity: BigIntStats }> {
   const tempHandle = await fs.open(params.tempPath, OPEN_WRITE_CREATE_FLAGS, params.mode);
   try {
     if (typeof params.data === "string") {
@@ -808,7 +808,10 @@ async function writeTempFileForAtomicReplace(params: {
     } else {
       await tempHandle.writeFile(params.data);
     }
-    return await tempHandle.stat();
+    return {
+      identity: await tempHandle.stat(),
+      cleanupIdentity: await tempHandle.stat({ bigint: true }),
+    };
   } finally {
     await tempHandle.close().catch(() => {});
   }
@@ -1612,13 +1615,13 @@ async function writeFileFallback(
   try {
     tempPath = buildAtomicWriteTempPath(destinationPath);
     unregisterTempPath = registerTempPathForExit(tempPath);
-    const writtenStat = await writeTempFileForAtomicReplace({
+    const written = await writeTempFileForAtomicReplace({
       tempPath,
       data: params.data,
       encoding: params.encoding,
       mode: mode || 0o600,
     });
-    unregisterTempPath.setIdentity(writtenStat);
+    unregisterTempPath.setIdentity(written.cleanupIdentity);
     const commitTempPath = tempPath;
     await withAsyncDirectoryGuards([destinationGuard], async () => {
       await fs.rename(commitTempPath, destinationPath);
@@ -1630,7 +1633,7 @@ async function writeFileFallback(
       await verifyAtomicWriteResult({
         root,
         targetPath: destinationPath,
-        expectedIdentity: writtenStat,
+        expectedIdentity: written.identity,
       });
     } catch (err) {
       emitWriteBoundaryWarning(`post-write verification failed: ${String(err)}`);

--- a/src/sibling-temp.ts
+++ b/src/sibling-temp.ts
@@ -72,7 +72,7 @@ export async function writeSiblingTempFile<T>(
   try {
     tempExists = true;
     const result = await options.writeTemp(tempPath);
-    unregisterTempPath.setIdentity(await fs.lstat(tempPath));
+    unregisterTempPath.setIdentity(await fs.lstat(tempPath, { bigint: true }));
     if (options.mode !== undefined) {
       await fs.chmod(tempPath, options.mode).catch(() => undefined);
     }

--- a/src/temp-cleanup.ts
+++ b/src/temp-cleanup.ts
@@ -58,7 +58,7 @@ export function registerTempPathForExit(
   };
   if (!entry.identity) {
     try {
-      entry.identity = fsSync.lstatSync(tempPath);
+      entry.identity = fsSync.lstatSync(tempPath, { bigint: true });
     } catch {
       // Callers that register before creation set the identity after opening.
     }

--- a/src/temp-cleanup.ts
+++ b/src/temp-cleanup.ts
@@ -21,7 +21,10 @@ function pathStillMatchesReceipt(entry: TempCleanupEntry): boolean {
     return false;
   }
   try {
-    return sameFileIdentityForCleanup(fsSync.lstatSync(entry.path), entry.identity);
+    return sameFileIdentityForCleanup(
+      fsSync.lstatSync(entry.path, { bigint: true }),
+      entry.identity,
+    );
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === "ENOENT";
   }

--- a/src/temp-target.ts
+++ b/src/temp-target.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { lstat, mkdtemp, rm } from "node:fs/promises";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { sameFileIdentityForCleanup, type FileIdentityStat } from "./file-identity.js";
 import { assertSafePathSegment, sanitizeSafePathSegment } from "./safe-path-segment.js";
@@ -128,7 +128,7 @@ async function cleanupTempDir(
   onCleanupError?: (error: unknown) => void,
 ) {
   try {
-    const current = await lstat(dir, { bigint: true }).catch((error: unknown) => {
+    const current = await fs.lstat(dir, { bigint: true }).catch((error: unknown) => {
       if (isNodeErrorWithCode(error, "ENOENT")) {
         return undefined;
       }
@@ -137,7 +137,7 @@ async function cleanupTempDir(
     if (!current || !sameFileIdentityForCleanup(current, identity)) {
       return;
     }
-    await rm(dir, { recursive: true, force: true });
+    await fs.rm(dir, { recursive: true, force: true });
   } catch (err) {
     if (!isNodeErrorWithCode(err, "ENOENT")) {
       onCleanupError?.(err);
@@ -157,10 +157,10 @@ export async function tempFile(params: {
 }): Promise<TempFile> {
   const rootDir = resolveTempRoot(params.rootDir);
   const prefix = `${sanitizePrefix(params.prefix)}-`;
-  const dir = await mkdtemp(path.join(rootDir, prefix));
+  const dir = await fs.mkdtemp(path.join(rootDir, prefix));
   // Windows file indexes can exceed Number.MAX_SAFE_INTEGER. Cleanup receipts
   // must retain the exact identity or adjacent directories can compare equal.
-  const identity = await lstat(dir, { bigint: true });
+  const identity = await fs.lstat(dir, { bigint: true });
   const unregisterTempDir = registerTempPathForExit(dir, { recursive: true, identity });
   const file = (fileName?: string) =>
     path.join(dir, sanitizeTempFileName(fileName ?? params.fileName ?? "download.bin"));

--- a/src/temp-target.ts
+++ b/src/temp-target.ts
@@ -128,7 +128,7 @@ async function cleanupTempDir(
   onCleanupError?: (error: unknown) => void,
 ) {
   try {
-    const current = await lstat(dir).catch((error: unknown) => {
+    const current = await lstat(dir, { bigint: true }).catch((error: unknown) => {
       if (isNodeErrorWithCode(error, "ENOENT")) {
         return undefined;
       }
@@ -158,7 +158,9 @@ export async function tempFile(params: {
   const rootDir = resolveTempRoot(params.rootDir);
   const prefix = `${sanitizePrefix(params.prefix)}-`;
   const dir = await mkdtemp(path.join(rootDir, prefix));
-  const identity = await lstat(dir);
+  // Windows file indexes can exceed Number.MAX_SAFE_INTEGER. Cleanup receipts
+  // must retain the exact identity or adjacent directories can compare equal.
+  const identity = await lstat(dir, { bigint: true });
   const unregisterTempDir = registerTempPathForExit(dir, { recursive: true, identity });
   const file = (fileName?: string) =>
     path.join(dir, sanitizeTempFileName(fileName ?? params.fileName ?? "download.bin"));

--- a/test/additional-boundary-bypass.test.ts
+++ b/test/additional-boundary-bypass.test.ts
@@ -90,6 +90,17 @@ describe("additional helper boundary bypass attempts", () => {
       .resolves.toBe("keep");
   });
 
+  it("captures exact directory identities for temp file cleanup", async () => {
+    const layout = await makeTempLayout("fs-safe-temp-exact-identity", tempDirs);
+    const lstat = vi.spyOn(fsp, "lstat");
+    const target = await tempFile({ rootDir: layout.root, prefix: "download" });
+    expect(lstat).toHaveBeenCalledWith(target.dir, { bigint: true });
+
+    lstat.mockClear();
+    await target.cleanup();
+    expect(lstat).toHaveBeenCalledWith(target.dir, { bigint: true });
+  });
+
   it("rejects remote or encoded-separator file URLs while accepting local file URLs", () => {
     const local = pathToFileURL(path.join(os.tmpdir(), "safe.txt")).toString();
     expect(safeFileURLToPath(local)).toBe(path.join(os.tmpdir(), "safe.txt"));

--- a/test/atomic-publication-stress.test.ts
+++ b/test/atomic-publication-stress.test.ts
@@ -1,5 +1,5 @@
 import fsSync from "node:fs";
-import fs from "node:fs/promises";
+import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -174,6 +174,9 @@ describe("atomic publication stress regressions", () => {
 
   it("keeps a failed sibling output temp registered when immediate cleanup fails", async () => {
     const root = await tempRoot("fs-safe-output-cleanup-");
+    const probeHandle = await fs.open(path.join(root, "stat-probe"), "w");
+    const stat = vi.spyOn(Object.getPrototypeOf(probeHandle) as FileHandle, "stat");
+    await probeHandle.close();
     let tempPath = "";
     let cleanupAttempts = 0;
     const realRename = fs.rename.bind(fs);
@@ -200,6 +203,7 @@ describe("atomic publication stress regressions", () => {
         await fs.writeFile(candidate, "partial");
       },
     })).rejects.toMatchObject({ code: "EACCES" });
+    expect(stat).toHaveBeenCalledWith({ bigint: true });
     await expect(fs.stat(tempPath)).resolves.toBeTruthy();
 
     __cleanupRegisteredTempPathsForTest();

--- a/test/atomic.test.ts
+++ b/test/atomic.test.ts
@@ -84,7 +84,9 @@ describe("atomic helpers", () => {
     const root = await tempRoot("fs-safe-temp-cleanup-");
     const tempPath = path.join(root, "leftover.tmp");
     await fs.writeFile(tempPath, "temp", "utf8");
+    const lstat = vi.spyOn(fsSync, "lstatSync");
     const unregister = registerTempPathForExit(tempPath);
+    expect(lstat).toHaveBeenCalledWith(tempPath, { bigint: true });
 
     __cleanupRegisteredTempPathForTest(tempPath);
 

--- a/test/atomic.test.ts
+++ b/test/atomic.test.ts
@@ -1,7 +1,7 @@
 import fsSync from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { expectFsSafeError, expectFsSafeErrorSync } from "./helpers/security.js";
 import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import {
@@ -90,6 +90,21 @@ describe("atomic helpers", () => {
 
     await expect(fs.access(tempPath)).rejects.toMatchObject({ code: "ENOENT" });
     unregister();
+  });
+
+  it("compares exact identities during exit cleanup", async () => {
+    const root = await tempRoot("fs-safe-temp-cleanup-exact-");
+    const tempPath = path.join(root, "leftover.tmp");
+    await fs.writeFile(tempPath, "temp", "utf8");
+    const identity = await fs.lstat(tempPath, { bigint: true });
+    registerTempPathForExit(tempPath, { identity });
+    const lstat = vi.spyOn(fsSync, "lstatSync");
+    try {
+      __cleanupRegisteredTempPathForTest(tempPath);
+      expect(lstat).toHaveBeenCalledWith(tempPath, { bigint: true });
+    } finally {
+      lstat.mockRestore();
+    }
   });
 
   it("cleans registered temp directories and ignores missing entries", async () => {

--- a/test/coverage-more.test.ts
+++ b/test/coverage-more.test.ts
@@ -153,6 +153,14 @@ describe("small identity and lock wrappers", () => {
       .toBe(false);
     expect(sameFileIdentityForCleanup({ dev: 0, ino: 2 }, { dev: 1, ino: 2 }, "win32"))
       .toBe(false);
+    const roundedOriginal = Number(9_007_199_254_740_992n);
+    const roundedReplacement = Number(9_007_199_254_740_993n);
+    expect(roundedReplacement).toBe(roundedOriginal);
+    expect(sameFileIdentityForCleanup(
+      { dev: 1n, ino: 9_007_199_254_740_992n },
+      { dev: 1n, ino: 9_007_199_254_740_993n },
+      "win32",
+    )).toBe(false);
 
     const root = await tempRoot("fs-safe-file-lock-wrapper-");
     const targetPath = path.join(root, "state.json");


### PR DESCRIPTION
## Summary

- retain exact bigint filesystem identities for explicit and process-exit temp cleanup
- apply the same ownership fence to stable async and sync temp workspaces while preserving their public numeric identity receipt
- add deterministic regression checks for bigint stat acquisition, cover unsafe integer rounding, and document the strengthened Windows cleanup guarantee

## Root cause

The zero-identity guard from #132 closed one fail-open case, but temp cleanup still captured Node's default numeric Windows file identity. File indexes above JavaScript's safe integer range can round two distinct directories to the same numeric inode. After the created directory was renamed and replaced, cleanup could therefore mistake the replacement for the original and recursively delete it.

This change captures and compares bigint identities end to end for cleanup decisions. Unknown identities still fail closed, and the stable temp-workspace API continues returning numeric `dev` and `ino` fields for compatibility.

## Verification

- `pnpm check` — 101 test files passed, 1,042 tests passed
- `pnpm test:security` — 5 test files passed, 71 tests passed
- focused exact-identity regression run — 4 test files passed, 60 tests passed
- native Windows focused run — 3 test files passed, 40 tests passed, 2 platform skips
- native Windows compiled-package scenario — replacement survived cleanup with `compiled-temp-cleanup=keep`
- source-blind packed-artifact validation — explicit and exit cleanup removed owned paths, preserved distinct replacement sentinels, returned `identity-mismatch` for a replaced workspace, and retained numeric public receipt fields
- autoreview — clean twice, no accepted or actionable findings
