### PR TITLE
fix(lock): treat compromise-check I/O failure as a lost lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Treat asynchronous sidecar compromise-check I/O failures as a lost lock and invoke `onCompromised` once, instead of leaking an unhandled rejection from the interval.
 - Preserve replaced temporary paths during Windows cleanup when libuv reports a zero device or inode or a file index exceeds JavaScript's safe integer range, treating unknown or rounded identity as fail-closed instead of authorizing deletion.
 
 ## 0.5.5 - 2026-08-12

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -167,8 +167,8 @@ type FileLockHandle = {
 `verifyStillHeld()` compares the current sidecar with the ownership snapshot
 captured at acquisition. Set `compromiseCheckIntervalMs` together with
 `onCompromised` for a cheap periodic check; the callback fires once after the
-sidecar no longer matches. This is detection, not revocation of work already in
-progress.
+sidecar no longer matches or after a verification I/O failure. This is
+detection, not revocation of work already in progress.
 
 ## Synchronous locks
 

--- a/src/sidecar-lock-acquire.ts
+++ b/src/sidecar-lock-acquire.ts
@@ -184,13 +184,16 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
         const interval = options.compromiseCheckIntervalMs;
         if (options.onCompromised && interval !== undefined && interval > 0) {
           createdHeld.compromiseTimer = setInterval(() => {
-            void returnedHandle.verifyStillHeld().then((stillHeld) => {
-              if (!stillHeld && createdHeld.compromiseTimer) {
-                clearInterval(createdHeld.compromiseTimer);
-                createdHeld.compromiseTimer = undefined;
-                options.onCompromised?.({ lockPath, normalizedTargetPath });
-              }
-            });
+            void returnedHandle
+              .verifyStillHeld()
+              .catch(() => false)
+              .then((stillHeld) => {
+                if (!stillHeld && createdHeld.compromiseTimer) {
+                  clearInterval(createdHeld.compromiseTimer);
+                  createdHeld.compromiseTimer = undefined;
+                  options.onCompromised?.({ lockPath, normalizedTargetPath });
+                }
+              });
           }, interval);
           createdHeld.compromiseTimer.unref();
         }

--- a/test/sidecar-lock-acquire-failure.test.ts
+++ b/test/sidecar-lock-acquire-failure.test.ts
@@ -5,11 +5,13 @@ import { useTempDirs } from "./helpers/vitest.js";
 import { configureFsSafeNative } from "../src/native-config.js";
 import { root } from "../src/root.js";
 import { createSidecarLockManager, withSidecarLock } from "../src/sidecar-lock.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 
 const { tempRoot } = useTempDirs();
 
 afterEach(() => {
   configureFsSafeNative({ mode: "auto" });
+  __setFsSafeTestHooksForTest(undefined);
   vi.restoreAllMocks();
 });
 
@@ -216,6 +218,48 @@ describe("asynchronous sidecar lock acquisition failures", () => {
     });
     await lock.release();
     expect(compromised).not.toHaveBeenCalled();
+  });
+
+  it("treats a rejected compromise check as a lost lock instead of an unhandled rejection", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-sidecar-timer-reject-");
+    const manager = createSidecarLockManager(`timer-reject-${Date.now()}-${Math.random()}`);
+    const compromised = vi.fn();
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const lock = await manager.acquire({
+        targetPath: path.join(directory, "state.json"),
+        payload: async () => ({}),
+        compromiseCheckIntervalMs: 10,
+        onCompromised: compromised,
+      });
+      const failure = Object.assign(new Error("lock snapshot failed"), { code: "EIO" });
+      __setFsSafeTestHooksForTest({
+        beforeSidecarLockSnapshotOpen: async () => {
+          throw failure;
+        },
+      });
+      await vi.waitFor(() => {
+        expect(compromised).toHaveBeenCalledTimes(1);
+      });
+      expect(compromised).toHaveBeenCalledWith({
+        lockPath: lock.lockPath,
+        normalizedTargetPath: lock.normalizedTargetPath,
+      });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 40);
+      });
+      expect(compromised).toHaveBeenCalledTimes(1);
+      expect(rejections).toEqual([]);
+      __setFsSafeTestHooksForTest(undefined);
+      await lock.release();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
   });
 
   it("reset fails closed across malformed held-lock snapshots and reclaim guards", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers using `acquireFileLock` / `createSidecarLockManager` with `compromiseCheckIntervalMs` and `onCompromised` would never learn that the lock could no longer be verified when the sidecar snapshot read failed with a filesystem I/O error (for example `EIO`). The interval promise had no rejection handler, so Node emitted an unhandled rejection on every tick and the compromise callback never ran.

This is the async sidecar lock surface (periodic ownership check), not path confinement or archive extraction.

## Why This Change Was Made

The interval now maps `verifyStillHeld()` rejection to "not held" and fires `onCompromised` once, then stops the timer. That matches the existing fail-closed identity policy: if the library cannot confirm the sidecar still matches the acquisition snapshot, treat the lock as lost. Public `verifyStillHeld()` still rejects so callers who check it themselves see the I/O error. No API shape change.

## User Impact

Holders that already register `onCompromised` now get that callback when a periodic snapshot read fails, instead of an unhandled rejection storm and a silent detector. Transient disk errors can produce a false-positive compromise signal; that is detection only, not automatic revocation of in-flight work. The callback still fires at most once.

## Evidence

Live `node` against built `dist/file-lock.js` on origin/main vs this branch. Same script: acquire a lock with a 20ms compromise interval, then make `verifyStillHeld()` reject with `EIO`.

Before (origin/main `f748844`):

```console
$ node /tmp/proof-fs-safe-f001.mjs /tmp/fs-safe-main-proof
{
  "packageRoot": "/tmp/fs-safe-main-proof",
  "fired": false,
  "unhandledRejections": [
    "Error: EIO during sidecar snapshot",
    "Error: EIO during sidecar snapshot"
  ],
  "waitMs": 1005
}
```

`onCompromised` never ran. The interval kept throwing (dozens of unhandled rejections in one second).

After (this branch):

```console
$ node /tmp/proof-fs-safe-f001.mjs /tmp/fs-safe-f001
onCompromised {"lockPath":".../state.json.lock","normalizedTargetPath":".../state.json"}
{
  "packageRoot": "/tmp/fs-safe-f001",
  "fired": true,
  "unhandledRejections": [],
  "waitMs": 21
}
```

Callback fired once in 21ms. Zero unhandled rejections.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included

## Real behavior proof

- **Behavior or issue addressed:** Periodic sidecar compromise check dropped I/O failures as unhandled rejections and never called `onCompromised`.
- **Real environment tested:** macOS, Node v22, package built from this branch and from origin/main `f748844` under `/tmp/fs-safe-f001` and `/tmp/fs-safe-main-proof`.
- **Exact steps or command run after this patch:**

  ```bash
  node /tmp/proof-fs-safe-f001.mjs /tmp/fs-safe-main-proof
  node /tmp/proof-fs-safe-f001.mjs /tmp/fs-safe-f001
  ```

- **Evidence after fix:** terminal output from the patched build:

  ```console
  onCompromised {"lockPath":".../state.json.lock","normalizedTargetPath":".../state.json"}
  {
    "packageRoot": "/tmp/fs-safe-f001",
    "fired": true,
    "unhandledRejections": [],
    "waitMs": 21
  }
  ```

- **Observed result after fix:** The interval treats a rejected snapshot as a lost lock, fires `onCompromised` once, and does not emit unhandled rejections.
- **What was not tested:** Synchronous `acquireFileLockSync` interval (separate throw-in-timer path). Live antivirus-induced `EIO` on a production volume.

## Origin

The interval was added in [`b1132f91`](https://github.com/openclaw/fs-safe/commit/b1132f91) via [#92](https://github.com/openclaw/fs-safe/pull/92) (2026-08-02). The `.then` had no rejection handler from the start.
