### PR TITLE
fix(ci): set up Node before pnpm in Crabbox

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -43,14 +43,14 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
+      # Crabbox images may not expose Node or npm until setup-node runs.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
 
       - name: Prepare pnpm workspace
         shell: bash
@@ -59,7 +59,6 @@ jobs:
           git fetch --no-tags --depth=50 origin "+refs/heads/main:refs/remotes/origin/main"
           pnpm install --frozen-lockfile
           node --version
-          pnpm --version
           pnpm --version
 
       - name: Mark Crabbox ready

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Preserve replaced temporary paths during Windows cleanup when libuv reports a zero device or inode or a file index exceeds JavaScript's safe integer range, treating unknown or rounded identity as fail-closed instead of authorizing deletion.
 
+### Docs and Tooling
+
+- Set up Node before pnpm when hydrating Crabbox runners so minimal images without a preinstalled npm can prepare the workspace.
+
 ## 0.5.5 - 2026-08-12
 
 ### Security and Correctness

--- a/test/crabbox-hydrate-workflow.test.ts
+++ b/test/crabbox-hydrate-workflow.test.ts
@@ -1,0 +1,14 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("Crabbox hydrate workflow", () => {
+  it("sets up Node before pnpm without requesting an unavailable pnpm cache", async () => {
+    const workflow = await readFile(".github/workflows/crabbox-hydrate.yml", "utf8");
+    const setupNode = workflow.indexOf("uses: actions/setup-node@");
+    const setupPnpm = workflow.indexOf("uses: pnpm/action-setup@");
+
+    expect(setupNode).toBeGreaterThan(-1);
+    expect(setupPnpm).toBeGreaterThan(setupNode);
+    expect(workflow.slice(setupNode, setupPnpm)).not.toContain("cache: pnpm");
+  });
+});


### PR DESCRIPTION
## Summary

- install Node before `pnpm/action-setup` in the Crabbox hydration workflow
- avoid requesting the pnpm cache before pnpm exists on minimal self-hosted images
- add a regression test for the action ordering and remove a duplicate version probe

## Root cause

Crabbox hydrate run 31786819954 reached `pnpm/action-setup` before `actions/setup-node`. The self-hosted image did not expose `npm`, so pnpm's self-installer exited before Node setup could run.

## Proof

- `actionlint .github/workflows/crabbox-hydrate.yml`
- `pnpm test test/crabbox-hydrate-workflow.test.ts`
- `pnpm check` under Node 22.13.0: 1,043 tests passed, 61 skipped, package check passed
- autoreview: clean, no accepted/actionable findings

The scheduled coverage failure is separate: setup completed successfully, then a platform test failed. Current-main coverage is green across Linux, macOS, and Windows on #135.
