### PR TITLE
fix(lock): treat sync compromise-check I/O as a lost lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Security and Correctness
+
+- Treat synchronous sidecar compromise-check I/O failures as a lost lock and invoke `onCompromised` once, instead of throwing from the interval and never notifying the holder.
+
 ## 0.5.6 - 2026-08-14
 
 ### Security and Correctness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Security and Correctness
 
-- Treat synchronous sidecar compromise-check I/O failures as a lost lock and invoke `onCompromised` once, instead of throwing from the interval and never notifying the holder.
+- Fail closed when synchronous sidecar compromise checks hit I/O errors and invoke `onCompromised` once instead of throwing from the interval. Thanks @SebTardif.
 
 ## 0.5.6 - 2026-08-14
 

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -176,7 +176,10 @@ detection, not revocation of work already in progress.
 retry, payload parsing, stale policy, owner-scoped reentrancy, guarded
 identity-conditioned reclaim, verification, and compromise monitoring. They do
 not use the async manager queue or support async callbacks. Retry waits block
-the calling thread; use the async API in request-serving code.
+the calling thread; use the async API in request-serving code. The sync
+compromise interval treats a thrown verification I/O error as a lost lock and
+invokes `onCompromised` once, matching the asynchronous `.catch(() => false)`
+contract. An explicit `verifyStillHeld()` call still propagates that I/O error.
 
 Always release in a `finally`:
 

--- a/src/file-lock-sync.ts
+++ b/src/file-lock-sync.ts
@@ -265,8 +265,14 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
       const returnedHandle = createSyncHeldLockHandle(createdHeld);
       if (options.onCompromised && (options.compromiseCheckIntervalMs ?? 0) > 0) {
         createdHeld.timer = setInterval(() => {
-          if (!returnedHandle.verifyStillHeld()) {
-            if (createdHeld.timer) clearInterval(createdHeld.timer);
+          let stillHeld: boolean;
+          try {
+            stillHeld = returnedHandle.verifyStillHeld();
+          } catch {
+            stillHeld = false;
+          }
+          if (!stillHeld && createdHeld.timer) {
+            clearInterval(createdHeld.timer);
             createdHeld.timer = undefined;
             options.onCompromised?.({ lockPath, normalizedTargetPath });
           }

--- a/test/file-lock-sync-failure.test.ts
+++ b/test/file-lock-sync-failure.test.ts
@@ -156,6 +156,50 @@ describe("synchronous file-lock failure handling", () => {
     await expect(fs.readFile(lock.lockPath, "utf8")).resolves.toBe("replacement");
   });
 
+  it("treats a thrown compromise check as a lost lock instead of an uncaught exception", async () => {
+    const root = await tempRoot("fs-safe-sync-lock-timer-throw-");
+    const targetPath = path.join(root, "state.json");
+    const compromised = vi.fn();
+    const exceptions: unknown[] = [];
+    const onUncaught = (error: unknown) => {
+      exceptions.push(error);
+    };
+    process.on("uncaughtException", onUncaught);
+    let lock: ReturnType<typeof acquireFileLockSync> | undefined;
+    try {
+      lock = acquireFileLockSync(targetPath, {
+        ...lockOptions(),
+        compromiseCheckIntervalMs: 10,
+        onCompromised: compromised,
+      });
+      const failure = Object.assign(new Error("lock snapshot failed"), { code: "EIO" });
+      const realLstat = fsSync.lstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "lstatSync").mockImplementation((filePath, options) => {
+        if (String(filePath) === lock.lockPath) {
+          throw failure;
+        }
+        return realLstat(filePath, options as never);
+      });
+      await vi.waitFor(() => {
+        expect(compromised).toHaveBeenCalledTimes(1);
+      });
+      expect(compromised).toHaveBeenCalledWith({
+        lockPath: lock.lockPath,
+        normalizedTargetPath: lock.normalizedTargetPath,
+      });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 40);
+      });
+      expect(compromised).toHaveBeenCalledTimes(1);
+      expect(exceptions).toEqual([]);
+      expect(() => lock.verifyStillHeld()).toThrow(failure);
+    } finally {
+      process.off("uncaughtException", onUncaught);
+      vi.restoreAllMocks();
+      lock?.release();
+    }
+  });
+
   it("falls back to the resolved target when parent realpath lookup fails", async () => {
     const root = await tempRoot("fs-safe-sync-lock-realpath-failure-");
     const targetPath = path.join(root, "state.json");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers using `acquireFileLockSync()` with `onCompromised` would never be told the sidecar became unreadable. The periodic check threw from `setInterval` on I/O such as `EIO` or `EACCES`, so the holder kept working as if it still owned the lock.

## Why This Change Was Made

[#134](https://github.com/openclaw/fs-safe/pull/134) already maps asynchronous compromise-check I/O to a lost lock via `.catch(() => false)`. The synchronous timer introduced in [#59](https://github.com/openclaw/fs-safe/pull/59) / [#64](https://github.com/openclaw/fs-safe/pull/64) still called `verifyStillHeld()` unguarded. This PR applies the same fail-closed detector on the sync path and leaves explicit `verifyStillHeld()` throwing so callers that inspect on demand still see the I/O error.

## User Impact

A sync lock with `compromiseCheckIntervalMs` now fires `onCompromised` once when a verification read fails, then stops the timer. Direct `verifyStillHeld()` calls are unchanged.

## Evidence

terminal output from the patched package at `/tmp/fs-safe-sync-compromise`. After acquire, `lstatSync` on the sidecar was forced to `EIO`:

```console
$ node /tmp/proof-fs-safe-sync-compromise.mjs
elapsed_ms=17
onCompromised_count=1
lockPath=.../fs-safe-sync-proof-Bk8Ycz/state.json.lock
explicit_verify_throws=true
result=PASS
```

`pnpm check` passed: 1045 tests, 61 skipped, docs examples match, pack check clean.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included

## Real behavior proof

- **Behavior or issue addressed:** Sync compromise monitoring threw from the interval on snapshot I/O and never invoked `onCompromised`.
- **Real environment tested:** macOS 15, Node v22, patched worktree at `/tmp/fs-safe-sync-compromise` built with `pnpm build`.
- **Exact steps or command run after this patch:** Acquired `acquireFileLockSync` with a 15ms compromise interval, then forced `lstatSync` on the sidecar to throw `EIO`.
- **Evidence after fix:** terminal output above. `onCompromised` fired once at 17ms. A later explicit `verifyStillHeld()` still threw `EIO`.
- **Observed result after fix:** The sync interval matches the async lost-lock contract from #134. Holders are notified once. On-demand verification still surfaces the I/O error.
- **What was not tested:** A live disk `EIO` from a failing volume (the injected `EIO` is the same Node error object the runtime uses).

## Related

- Follows [openclaw/fs-safe#134](https://github.com/openclaw/fs-safe/pull/134) (async interval).
- Sync timer introduced in [openclaw/fs-safe#59](https://github.com/openclaw/fs-safe/pull/59) and [openclaw/fs-safe#64](https://github.com/openclaw/fs-safe/pull/64) (2026-07-26 / 2026-07-27).
