### PR TITLE
fix(tooling): support npm 12 pack JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fail closed when synchronous sidecar compromise checks hit I/O errors and invoke `onCompromised` once instead of throwing from the interval. Thanks @SebTardif.
 
+### Docs and Tooling
+
+- Accept npm 11 array and npm 12 package-name-keyed pack results while validating the intended package and its file metadata.
+
 ## 0.5.6 - 2026-08-14
 
 ### Security and Correctness

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
+import { normalizePackResult } from "./npm-pack-result.mjs";
 import {
   assertPublicApi,
   inspectPublicApi,
@@ -75,9 +76,7 @@ try {
     cwd: process.cwd(),
     encoding: "utf8",
   });
-  /** @type {Array<{ filename: string; files: Array<{ path: string }> }>} */
-  const pack = JSON.parse(output);
-  const [{ filename, files }] = pack;
+  const { filename, files } = normalizePackResult(JSON.parse(output), pkg.name);
   const paths = new Set(files.map((file) => file.path));
   const expected = new Set([
     "CHANGELOG.md",

--- a/scripts/npm-pack-result.mjs
+++ b/scripts/npm-pack-result.mjs
@@ -1,0 +1,44 @@
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} packageName
+ * @returns {{ filename: string; files: Array<{ path: string }> }}
+ */
+export function normalizePackResult(value, packageName) {
+  let entry;
+  if (Array.isArray(value)) {
+    if (value.length !== 1) {
+      throw new Error(`npm pack result must contain exactly one package: ${packageName}`);
+    }
+    entry = value[0];
+  } else if (isRecord(value)) {
+    if (Object.keys(value).length !== 1 || !Object.hasOwn(value, packageName)) {
+      throw new Error(`npm pack result must contain only the package key: ${packageName}`);
+    }
+    entry = value[packageName];
+  } else {
+    throw new Error("npm pack result must be an array or a package-name-keyed object");
+  }
+
+  if (!isRecord(entry) || entry.name !== packageName) {
+    throw new Error(`npm pack result must describe package: ${packageName}`);
+  }
+  const { filename, files } = entry;
+  if (typeof filename !== "string" || filename.length === 0) {
+    throw new Error(`npm pack result for ${packageName} must have a non-empty filename`);
+  }
+  if (
+    !Array.isArray(files) ||
+    !files.every((file) => isRecord(file) && typeof file.path === "string" && file.path.length > 0)
+  ) {
+    throw new Error(`npm pack result for ${packageName} must have a files array of non-empty paths`);
+  }
+  return { filename, files };
+}

--- a/test/npm-pack-result.test.ts
+++ b/test/npm-pack-result.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { normalizePackResult } from "../scripts/npm-pack-result.mjs";
+
+const packageName = "@openclaw/fs-safe";
+const packEntry = {
+  id: "@openclaw/fs-safe@0.5.6",
+  name: packageName,
+  version: "0.5.6",
+  filename: "openclaw-fs-safe-0.5.6.tgz",
+  files: [
+    { path: "README.md", size: 100, mode: 420 },
+    { path: "dist/index.js", size: 200, mode: 420 },
+    { path: "package.json", size: 300, mode: 420 },
+  ],
+};
+
+describe("npm pack result normalization", () => {
+  it.each([
+    { label: "npm 11 array", value: [packEntry] },
+    { label: "npm 12 package-name-keyed object", value: { [packageName]: packEntry } },
+  ])("retains the filename and complete files list from the $label", ({ value }) => {
+    const result = normalizePackResult(value, packageName);
+
+    expect(result).toEqual({ filename: packEntry.filename, files: packEntry.files });
+    expect(result.files).toBe(packEntry.files);
+  });
+
+  it.each([
+    { label: "null", value: null, error: "must be an array or a package-name-keyed object" },
+    { label: "empty array", value: [], error: "must contain exactly one package" },
+    { label: "empty object", value: {}, error: "must contain only the package key" },
+    { label: "bare entry", value: packEntry, error: "must contain only the package key" },
+    { label: "multiple array entries", value: [packEntry, packEntry], error: "must contain exactly one package" },
+    {
+      label: "multiple package keys",
+      value: { other: { ...packEntry, name: "other" }, [packageName]: packEntry },
+      error: "must contain only the package key",
+    },
+    { label: "wrong package key", value: { other: packEntry }, error: "must contain only the package key" },
+    { label: "wrong array package", value: [{ ...packEntry, name: "other" }], error: "must describe package" },
+    {
+      label: "key and entry name mismatch",
+      value: { [packageName]: { ...packEntry, name: "other" } },
+      error: "must describe package",
+    },
+  ])("rejects $label", ({ value, error }) => {
+    expect(() => normalizePackResult(value, packageName)).toThrow(error);
+  });
+
+  it.each([
+    { label: "null entry", entry: null, error: "must describe package" },
+    { label: "missing name", entry: { ...packEntry, name: undefined }, error: "must describe package" },
+    { label: "empty filename", entry: { ...packEntry, filename: "" }, error: "non-empty filename" },
+    { label: "non-string filename", entry: { ...packEntry, filename: 42 }, error: "non-empty filename" },
+    { label: "missing files", entry: { ...packEntry, files: undefined }, error: "files array" },
+    { label: "non-array files", entry: { ...packEntry, files: {} }, error: "files array" },
+    { label: "null file", entry: { ...packEntry, files: [null] }, error: "non-empty paths" },
+    { label: "empty path", entry: { ...packEntry, files: [{ path: "" }] }, error: "non-empty paths" },
+    { label: "non-string path", entry: { ...packEntry, files: [{ path: 42 }] }, error: "non-empty paths" },
+  ])("rejects metadata with $label in both npm formats", ({ entry, error }) => {
+    for (const value of [[entry], { [packageName]: entry }]) {
+      expect(() => normalizePackResult(value, packageName)).toThrow(error);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

npm 12 returns `npm pack --json` as an object keyed by package name, while npm 11 returns an array. The package checker destructured the result as an array and failed with `TypeError: pack is not iterable` before reaching its contents and installation checks.

Normalize both public output shapes at the parsing boundary, require exactly the intended package, and reject malformed filename/file-list metadata. Keep all existing package contents, install/import, public API verification, and temporary-directory cleanup unchanged.

Add 20 focused regression tests for both formats and invalid metadata, plus an Unreleased changelog entry. This PR does not change runtime requirements, dependencies, the public API, or PAX handling.

## Verification

- Reproduced the original failure on Node 26.7.0 / npm 12.0.2.
- `pnpm test test/npm-pack-result.test.ts`: 20 tests passed.
- Full `pnpm check` passed on Node 26.7.0 / npm 12.0.2 and Node 24.20.0 / npm 11.19.0. Each run had 1,065 passing tests and 61 skipped tests, followed by successful real pack/install/import/public API validation.
- `git diff --check` passed.
