### PR TITLE
fix(archive): support bounded local PAX metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
         run: node scripts/native-mode-smoke.mjs off
 
       - name: Test native security and path equivalence
-        run: pnpm test test/native-integration.test.ts test/native-write-containment.test.ts test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts test/private-directory.test.ts
+        env:
+          FS_SAFE_PAX_REQUIRE_NATIVE: "1"
+        run: pnpm test test/native-integration.test.ts test/native-write-containment.test.ts test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts test/private-directory.test.ts test/archive-pax.test.ts test/archive-pax-security.test.ts test/archive-pax-compressed.test.ts
 
   native-musl:
     name: Native check (linux-x64-musl)
@@ -133,7 +135,7 @@ jobs:
             node scripts/native-mode-smoke.mjs auto
             node scripts/native-mode-smoke.mjs require
             node scripts/native-mode-smoke.mjs off
-            pnpm test test/native-write-containment.test.ts test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts
+            FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm test test/native-write-containment.test.ts test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts test/archive-pax.test.ts test/archive-pax-security.test.ts test/archive-pax-compressed.test.ts
           '
 
   cargo-quality:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Accept bounded local PAX paths, sizes, and descriptive metadata, including inert binary macOS provenance xattrs, consistently in JavaScript and native TAR extraction/reads; reject ambiguous records, extension chains, and sparse semantics while retaining byte/count limits and guarded staging. Return TAR read traversal failures through the public promise instead of escaping the parser callback.
 - Fail closed when synchronous sidecar compromise checks hit I/O errors and invoke `onCompromised` once instead of throwing from the interval. Thanks @SebTardif.
 
 ## 0.5.6 - 2026-08-14

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -155,16 +155,51 @@ codes remain `"destination-not-directory"`, `"destination-symlink"`, and
 - **Zip bombs:** `maxExtractedBytes` and `maxEntryBytes` apply to *post-decompression* bytes, so highly-compressed payloads hit the cap before they exhaust disk.
 - **Corrupt ZIP payloads:** streamed output must match both the central-directory CRC and declared uncompressed size before it can leave private staging.
 - **Slow-loris archives:** `timeoutMs` is a hard wall-clock budget. Extraction is aborted on overrun.
-- **Metadata bombs:** a fixed-header pass-through reader rejects oversized PAX, GNU long-name, and GNU long-link bodies before either TAR implementation buffers them. It understands octal and base-256 size fields without interpreting metadata content.
+- **Metadata bombs:** a streaming pass-through reader rejects oversized PAX, GNU long-name, and GNU long-link bodies before either TAR implementation buffers them. It understands octal and base-256 fixed sizes and validates bounded local PAX bodies before using their size overrides for member framing. Original archive bytes remain unchanged.
 
-PAX headers can override the next entry's size from inside their content. The
-fixed-header meter deliberately never interprets that content, so PAX and GNU
-sparse entries are rejected with
-`ArchiveFormatError("archive-header-invalid")` rather than guessing. GNU sparse
-extension blocks are still metered in 512-byte units before rejection, ensuring
-malformed or excessive chains cannot bypass the metadata ceiling. GNU long-name
-and long-link entries remain supported because their fixed header size fully
-determines their layout.
+### Bounded local PAX support
+
+Extraction and single-entry reads accept one nonempty local POSIX `x` header
+(USTAR or GNU header format) immediately before one regular/contiguous file,
+directory, symlink, or hardlink. `path`, `linkpath`, and `size` override that
+member only. Effective paths still pass traversal validation before stripping,
+then depth, collision, filter, and link policy checks. PAX never permits link
+creation. Effective sizes drive framing, filters, and the existing output-byte
+budgets; `maxEntries` still counts members, not their metadata headers.
+
+Records must have exact byte lengths, ASCII keys, a final newline, and no
+duplicate keys, embedded newlines, or unconsumed bytes. Structural `path` and
+`linkpath` values and ownership names must be nonempty printable ASCII. A PAX
+member's raw name, USTAR prefix, and raw link target must also be printable
+ASCII; raw link targets must be present only on links, even when overridden.
+Unicode
+PAX structural text is deliberately unsupported because the underlying parsers
+do not agree when UTF-8 is split across input chunks. `size`, `uid`, and `gid`
+must be canonical unsigned decimal safe integers (zero is valid; signs, leading
+zeros, fractions, and exponents are not). Padded member sizes must also fit the
+safe integer range. Raw and effective directory/link sizes must both be zero;
+non-directory paths ending with a separator and `linkpath` on non-links are
+rejected rather than allowing parser-specific type or framing changes.
+
+The descriptive allowlist is `mtime`, `atime`, `ctime` (signed decimal seconds
+with optional fractional digits, within JavaScript's Date range), `uid`, `gid`,
+`uname`, and `gname`. These attributes are accepted but not restored to the
+destination. `LIBARCHIVE.xattr.*` and `SCHILY.xattr.*` with nonempty ASCII
+alphanumeric/dot/underscore/hyphen suffixes are also accepted as inert metadata,
+never restored as extended attributes. Their values are byte-counted and may
+contain NUL or non-UTF8 bytes, including macOS provenance metadata; embedded
+newlines are rejected because they can disrupt downstream record parsing.
+
+Global `g`, old `X`, old GNU `N`, empty/dangling/repeated local headers, mixed
+PAX/GNU extension chains, unknown keys, charset declarations, ACL extensions,
+and all sparse extensions (including `GNU.sparse.*`, `SCHILY.filetype`,
+`SCHILY.realsize`, and `SCHILY.size`) fail closed with
+`ArchiveFormatError("archive-header-invalid")`. Standalone GNU long-name `L`
+and long-link `K` support is unchanged. GNU sparse extension blocks are still
+metered in 512-byte units before rejection, preserving metadata-limit errors
+for excessive chains. The per-body `maxMetaEntryBytes` limit bounds PAX storage
+and duplicate-key state; one local header per member prevents local metadata
+chains without introducing a new limit or changing defaults.
 
 ## `resolveArchiveKind`
 

--- a/native/src/archive.rs
+++ b/native/src/archive.rs
@@ -64,10 +64,8 @@ struct CancellationReader<R> {
 impl<R: Read> Read for CancellationReader<R> {
     fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
         if self.cancelled.load(Ordering::Relaxed) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Interrupted,
-                "archive operation aborted",
-            ));
+            // Cancellation is terminal; read_to_end retries Interrupted forever.
+            return Err(std::io::Error::other("archive operation aborted"));
         }
         self.inner.read(buffer)
     }
@@ -159,6 +157,15 @@ fn checked_path(path: std::borrow::Cow<'_, std::path::Path>) -> Result<String> {
         .map_err(|_| Error::new(Status::InvalidArg, "archive entry path is not valid UTF-8"))
 }
 
+fn drain_tar_metadata(reader: &mut impl Read) -> std::io::Result<()> {
+    let mut buffer = [0_u8; 8 * 1024];
+    loop {
+        if reader.read(&mut buffer)? == 0 {
+            return Ok(());
+        }
+    }
+}
+
 fn inspect_tar(
     path: &str,
     format: ArchiveFormat,
@@ -197,6 +204,10 @@ fn inspect_tar(
             mode: header.mode().unwrap_or(0),
         });
     }
+    // tar stops at its end marker; finish the same full-input metadata check
+    // as JS preflight before accepting a manifest for extraction or reading.
+    drain_tar_metadata(&mut archive.into_inner())
+        .map_err(|error| io_error("finish tar metadata", error))?;
     Ok(result)
 }
 
@@ -968,8 +979,63 @@ mod tests {
         };
         assert_eq!(
             reader.read(&mut [0_u8; 8]).unwrap_err().kind(),
-            std::io::ErrorKind::Interrupted
+            std::io::ErrorKind::Other
         );
+    }
+
+    #[test]
+    fn metadata_reads_propagate_cancellation_without_retrying() {
+        struct CancelAfterRead {
+            inner: CancellationReader<Cursor<Vec<u8>>>,
+            reads: usize,
+        }
+
+        impl Read for CancelAfterRead {
+            fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+                self.reads += 1;
+                assert!(self.reads <= 2, "metadata drain retried cancellation");
+                let result = self.inner.read(buffer);
+                self.inner.cancelled.store(true, Ordering::Relaxed);
+                result
+            }
+        }
+
+        for buffered in [false, true] {
+            let mut reader = CancelAfterRead {
+                inner: CancellationReader {
+                    inner: Cursor::new(vec![0_u8; 16 * 1024]),
+                    cancelled: Arc::new(AtomicBool::new(false)),
+                },
+                reads: 0,
+            };
+            let result = if buffered {
+                // tar buffers PAX bodies through read_to_end, unlike our drain.
+                reader.read_to_end(&mut Vec::new()).map(|_| ())
+            } else {
+                drain_tar_metadata(&mut reader)
+            };
+            let error = result.unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::Other);
+            assert_eq!(error.to_string(), "archive operation aborted");
+            assert_eq!(reader.reads, 2);
+        }
+    }
+
+    #[test]
+    fn metadata_drain_reaches_eof_and_preserves_trailer_validation() {
+        for extra_byte in [false, true] {
+            let length = 16 * 1024 + usize::from(extra_byte);
+            let mut input = Cursor::new(vec![0_u8; length]);
+            let result = drain_tar_metadata(&mut TarMetadataMeter::new(&mut input, 1024));
+            assert_eq!(input.position(), length as u64);
+            if extra_byte {
+                let error = result.unwrap_err();
+                assert!(error.to_string().contains("archive-header-invalid"));
+                assert!(error.to_string().contains("truncated TAR header"));
+            } else {
+                result.unwrap();
+            }
+        }
     }
 
     #[test]

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -6,6 +6,7 @@ use napi_derive::napi;
 mod archive;
 mod fast_file;
 mod tar_meter;
+mod tar_pax;
 #[cfg(unix)]
 mod unix;
 #[cfg(windows)]

--- a/native/src/tar_meter.rs
+++ b/native/src/tar_meter.rs
@@ -1,3 +1,4 @@
+use crate::tar_pax::{LocalPax, parse_local_pax};
 use std::io::{self, Read};
 
 pub const INVALID_HEADER: &str = "archive-header-invalid";
@@ -7,6 +8,11 @@ enum MeterState {
     Header,
     Data {
         remaining: u64,
+    },
+    Pax {
+        body: Vec<u8>,
+        used: usize,
+        padding: u64,
     },
     SparseHeader {
         data_remaining: u64,
@@ -20,6 +26,8 @@ pub struct TarMetadataMeter<R> {
     state: MeterState,
     block: [u8; 512],
     block_len: usize,
+    pending_pax: Option<LocalPax>,
+    pending_gnu: bool,
 }
 
 impl<R> TarMetadataMeter<R> {
@@ -30,6 +38,8 @@ impl<R> TarMetadataMeter<R> {
             state: MeterState::Header,
             block: [0; 512],
             block_len: 0,
+            pending_pax: None,
+            pending_gnu: false,
         }
     }
 
@@ -79,6 +89,10 @@ impl<R> TarMetadataMeter<R> {
 
     fn finish_header(&mut self) -> io::Result<()> {
         if self.block.iter().all(|byte| *byte == 0) {
+            if self.pending_pax.is_some() {
+                return Err(Self::invalid("dangling PAX metadata"));
+            }
+            self.pending_gnu = false;
             self.state = MeterState::Header;
             self.block_len = 0;
             return Ok(());
@@ -95,19 +109,51 @@ impl<R> TarMetadataMeter<R> {
                 "non-directory entry path ends with a separator",
             ));
         }
-        let size = Self::parse_size(self.block[124..136].try_into().unwrap())?;
-        let padded = Self::padded_size(size)?;
+        let mut size = Self::parse_size(self.block[124..136].try_into().unwrap())?;
         let entry_type = self.block[156];
-        if matches!(entry_type, b'x' | b'g' | b'L' | b'K' | b'X')
+        if matches!(entry_type, b'x' | b'g' | b'L' | b'K' | b'X' | b'N')
             && size > self.max_meta_entry_bytes
         {
             return Err(Self::meta_limit());
         }
-        if matches!(entry_type, b'x' | b'g' | b'X') {
+        if matches!(entry_type, b'g' | b'X' | b'N') {
             return Err(Self::invalid(
-                "PAX metadata is unmeterable without interpreting content",
+                "global/old PAX and old GNU metadata are not supported",
             ));
         }
+        if entry_type == b'x' {
+            if self.pending_pax.is_some() || self.pending_gnu || size == 0 {
+                return Err(Self::invalid("empty, repeated or mixed PAX metadata"));
+            }
+            let magic = &self.block[257..265];
+            if magic != b"ustar\x0000" && magic != b"ustar  \0" {
+                return Err(Self::invalid("unrecognized PAX header format"));
+            }
+            let padded = Self::padded_size(size)?;
+            let length = usize::try_from(size).map_err(|_| Self::meta_limit())?;
+            let mut body = Vec::new();
+            body.try_reserve_exact(length)
+                .map_err(|_| Self::meta_limit())?;
+            body.resize(length, 0);
+            self.state = MeterState::Pax {
+                body,
+                used: 0,
+                padding: padded - size,
+            };
+            self.block_len = 0;
+            return Ok(());
+        }
+        // Preserve sparse extension metering before reporting unsupported PAX.
+        if entry_type != b'S'
+            && let Some(pax) = self.pending_pax.take()
+        {
+            size = pax.member_size(entry_type, size, &self.block)?;
+            if Self::padded_size(size)? > 9_007_199_254_740_991 {
+                return Err(Self::invalid("entry padding exceeds the safe integer range"));
+            }
+        }
+        self.pending_gnu = matches!(entry_type, b'L' | b'K');
+        let padded = Self::padded_size(size)?;
         self.state = if entry_type == b'S' {
             match self.block[482] {
                 0 => return Err(Self::invalid("GNU sparse entries are not supported")),
@@ -148,6 +194,24 @@ impl<R> TarMetadataMeter<R> {
         let mut offset = 0;
         while offset < bytes.len() {
             match self.state {
+                MeterState::Pax {
+                    ref mut body,
+                    ref mut used,
+                    padding,
+                } => {
+                    let take = (body.len() - *used).min(bytes.len() - offset);
+                    body[*used..*used + take].copy_from_slice(&bytes[offset..offset + take]);
+                    *used += take;
+                    offset += take;
+                    if *used == body.len() {
+                        self.pending_pax = Some(parse_local_pax(body)?);
+                        self.state = if padding == 0 {
+                            MeterState::Header
+                        } else {
+                            MeterState::Data { remaining: padding }
+                        };
+                    }
+                }
                 MeterState::Header => {
                     let take = (512 - self.block_len).min(bytes.len() - offset);
                     self.block[self.block_len..self.block_len + take]
@@ -187,10 +251,14 @@ impl<R> TarMetadataMeter<R> {
     }
 
     fn check_eof(&self) -> io::Result<()> {
+        if self.pending_pax.is_some() {
+            return Err(Self::invalid("dangling PAX metadata"));
+        }
         match self.state {
             MeterState::Header if self.block_len == 0 => Ok(()),
             MeterState::Header => Err(Self::invalid("truncated TAR header")),
             MeterState::Data { .. } => Err(Self::invalid("truncated TAR entry data")),
+            MeterState::Pax { .. } => Err(Self::invalid("truncated PAX metadata")),
             MeterState::SparseHeader { .. } => Err(Self::invalid("truncated GNU sparse header")),
         }
     }
@@ -209,6 +277,10 @@ impl<R: Read> Read for TarMetadataMeter<R> {
 }
 
 #[cfg(test)]
+#[path = "tar_meter_tests.rs"]
+mod pax_tests;
+
+#[cfg(test)]
 mod tests {
     use std::io::{Cursor, Read};
 
@@ -218,6 +290,7 @@ mod tests {
         let mut header = [0_u8; 512];
         header[0] = b'x';
         header[156] = entry_type;
+        header[257..265].copy_from_slice(b"ustar\x0000");
         if base_256 {
             header[124] = 0x80;
             header[128..136].copy_from_slice(&size.to_be_bytes());
@@ -244,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_in_limit_pax_without_interpreting_size_overrides() {
+    fn rejects_malformed_in_limit_pax() {
         let bytes = [header(b'x', 8, false).as_slice(), &vec![0; 512]].concat();
         let error = consume(bytes, 1024).unwrap_err();
         assert!(error.to_string().contains(INVALID_HEADER));

--- a/native/src/tar_meter_tests.rs
+++ b/native/src/tar_meter_tests.rs
@@ -1,0 +1,118 @@
+use super::*;
+use std::io::Cursor;
+
+struct Chunked {
+    inner: Cursor<Vec<u8>>,
+    chunk: usize,
+}
+
+impl Read for Chunked {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        let size = output.len().min(self.chunk);
+        self.inner.read(&mut output[..size])
+    }
+}
+
+fn record(key: &str, value: &[u8]) -> Vec<u8> {
+    let payload = [format!(" {key}=").as_bytes(), value, b"\n"].concat();
+    let mut length = payload.len() + 1;
+    while length != length.to_string().len() + payload.len() {
+        length = length.to_string().len() + payload.len();
+    }
+    [length.to_string().as_bytes(), &payload].concat()
+}
+
+fn member(name: &str, kind: u8, raw_size: u64, body: &[u8]) -> Vec<u8> {
+    let mut header = tar::Header::new_ustar();
+    header.set_path(name).unwrap();
+    header.set_entry_type(tar::EntryType::new(kind));
+    header.set_mode(0o644);
+    header.set_size(raw_size);
+    header.set_cksum();
+    [header.as_bytes().as_slice(), body, &vec![0; (512 - body.len() % 512) % 512]].concat()
+}
+
+fn pax(body: &[u8]) -> Vec<u8> {
+    member("PaxHeader", b'x', body.len() as u64, body)
+}
+
+fn reader(bytes: Vec<u8>, chunk: usize, limit: u64) -> TarMetadataMeter<Chunked> {
+    TarMetadataMeter::new(Chunked { inner: Cursor::new(bytes), chunk }, limit)
+}
+
+#[test]
+fn pax_framing_matches_tar_across_chunk_boundaries_and_size_directions() {
+    for (raw, size) in [(1, 700), (700, 1), (700, 0)] {
+        let metadata = [
+            record("mtime", b"1787334189.823045922"),
+            record("LIBARCHIVE.xattr.com.apple.provenance", b"AQIAcwhBclAufnY"),
+            record("SCHILY.xattr.com.apple.provenance", b"\x01\x02\0s\x08ArP.~v"),
+            record("SCHILY.xattr.user.binary", b"\0\xff\xfe\xc3"),
+            record("path", b"package/value"),
+            record("size", size.to_string().as_bytes()),
+        ].concat();
+        let body = vec![b'a'; size];
+        let bytes = [pax(&metadata), member("raw", b'0', raw, &body), member("sentinel", b'0', 3, b"end"), vec![0; 1024]].concat();
+        for chunk in [1, 2, 3, 7, 511, 512, 513, 1023, 4096] {
+            let mut output = Vec::new();
+            reader(bytes.clone(), chunk, metadata.len() as u64).read_to_end(&mut output).unwrap();
+            assert_eq!(output, bytes, "meter must retain original bytes");
+            let mut archive = tar::Archive::new(reader(bytes.clone(), chunk, metadata.len() as u64));
+            let mut entries = archive.entries().unwrap();
+            let mut first = entries.next().unwrap().unwrap();
+            assert_eq!(first.path_bytes().as_ref(), b"package/value");
+            assert_eq!(first.size(), size as u64);
+            let mut actual = Vec::new();
+            first.read_to_end(&mut actual).unwrap();
+            assert_eq!(actual, body);
+            let mut sentinel = entries.next().unwrap().unwrap();
+            assert_eq!(sentinel.path_bytes().as_ref(), b"sentinel");
+            actual.clear();
+            sentinel.read_to_end(&mut actual).unwrap();
+            assert_eq!(actual, b"end");
+            assert!(entries.next().is_none());
+        }
+    }
+}
+
+#[test]
+fn pax_state_rejects_truncation_duplicates_mixed_and_dangling_metadata() {
+    let metadata = record("path", b"safe");
+    let extension = pax(&metadata);
+    let file = member("raw", b'0', 0, b"");
+    let gnu = member("LongName", b'L', 5, b"long\0");
+    let invalid = [
+        extension[..513].to_vec(), extension.clone(),
+        [extension.clone(), vec![0; 1024]].concat(),
+        [extension.clone(), extension.clone(), file.clone()].concat(),
+        [extension.clone(), gnu.clone(), file.clone()].concat(),
+        [gnu, extension, file.clone()].concat(),
+        [pax(&[metadata.clone(), metadata].concat()), file.clone()].concat(),
+        [pax(&record("SCHILY.xattr.user.binary", b"a\nb")), file.clone()].concat(),
+        [pax(&record("size", b"01")), file.clone()].concat(),
+        [pax(&record("GNU.sparse.major", b"1")), file.clone()].concat(),
+        [pax(&record("path", "caf\u{e9}".as_bytes())), file.clone()].concat(),
+        [pax(&record("size", b"9007199254740991")), file].concat(),
+    ];
+    for bytes in invalid {
+        for chunk in [1, 7, 511, 512, 513, 4096] {
+            let error = reader(bytes.clone(), chunk, 1024).read_to_end(&mut Vec::new()).unwrap_err();
+            assert!(error.to_string().contains(INVALID_HEADER), "{error}");
+        }
+    }
+}
+
+#[test]
+fn metadata_limit_precedes_body_allocation_and_sparse_rejection() {
+    for kind in [b'x', b'g', b'X', b'N', b'L', b'K'] {
+        let bytes = member("metadata", kind, 513, b"");
+        let error = reader(bytes, 1, 512).read_to_end(&mut Vec::new()).unwrap_err();
+        assert!(error.to_string().contains(META_LIMIT));
+    }
+    let metadata = record("path", b"safe");
+    let mut sparse = member("sparse", b'S', 0, b"");
+    sparse[482] = 1;
+    let bytes = [pax(&metadata), sparse, vec![0; 512]].concat();
+    let error = reader(bytes, 7, 511).read_to_end(&mut Vec::new()).unwrap_err();
+    assert!(error.to_string().contains(META_LIMIT));
+}

--- a/native/src/tar_pax.rs
+++ b/native/src/tar_pax.rs
@@ -1,0 +1,172 @@
+use std::collections::HashSet;
+use std::io;
+
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+#[derive(Default)]
+pub struct LocalPax {
+    size: Option<u64>,
+    path_trailing_separator: bool,
+    linkpath: bool,
+}
+
+fn invalid() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "archive-header-invalid: unsupported or malformed PAX metadata",
+    )
+}
+
+fn decimal(bytes: &[u8]) -> io::Result<u64> {
+    if bytes.is_empty() || (bytes.len() > 1 && bytes[0] == b'0') {
+        return Err(invalid());
+    }
+    let mut value = 0_u64;
+    for byte in bytes {
+        if !byte.is_ascii_digit() {
+            return Err(invalid());
+        }
+        value = value
+            .checked_mul(10)
+            .and_then(|n| n.checked_add((byte - b'0') as u64))
+            .filter(|n| *n <= MAX_SAFE_INTEGER)
+            .ok_or_else(invalid)?;
+    }
+    Ok(value)
+}
+
+fn ascii(bytes: &[u8]) -> io::Result<&str> {
+    if bytes.is_empty() || bytes.iter().any(|byte| !(0x20..=0x7e).contains(byte)) {
+        return Err(invalid());
+    }
+    std::str::from_utf8(bytes).map_err(|_| invalid())
+}
+
+fn timestamp(bytes: &[u8]) -> io::Result<()> {
+    let text = ascii(bytes)?;
+    let unsigned = text.strip_prefix('-').unwrap_or(text);
+    let (integer, fraction) = unsigned.split_once('.').unwrap_or((unsigned, "0"));
+    decimal(integer.as_bytes())?;
+    if fraction.is_empty() || !fraction.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(invalid());
+    }
+    let value: f64 = text.parse().map_err(|_| invalid())?;
+    if value.abs() > 8_640_000_000_000.0 {
+        return Err(invalid());
+    }
+    Ok(())
+}
+
+// Keep this byte grammar aligned with src/archive-tar-pax.ts. In particular,
+// Rust takes the first duplicate and JS takes the last, so neither is allowed.
+pub fn parse_local_pax(body: &[u8]) -> io::Result<LocalPax> {
+    if body.is_empty() {
+        return Err(invalid());
+    }
+    let mut result = LocalPax::default();
+    let mut keys = HashSet::new();
+    let mut offset = 0;
+    while offset < body.len() {
+        let space = body[offset..]
+            .iter()
+            .position(|b| *b == b' ')
+            .ok_or_else(invalid)?;
+        let length = decimal(&body[offset..offset + space])?;
+        let length = usize::try_from(length).map_err(|_| invalid())?;
+        if length > body.len() - offset || length <= space + 3 {
+            return Err(invalid());
+        }
+        let end = offset + length;
+        if body[end - 1] != b'\n' {
+            return Err(invalid());
+        }
+        let record = &body[offset + space + 1..end - 1];
+        if record.contains(&b'\n') {
+            return Err(invalid());
+        }
+        let equals = record
+            .iter()
+            .position(|b| *b == b'=')
+            .ok_or_else(invalid)?;
+        let key = ascii(&record[..equals])?;
+        if !key.bytes().all(|b| b.is_ascii_alphanumeric() || b"_.-".contains(&b))
+            || !keys.insert(key)
+        {
+            return Err(invalid());
+        }
+        let value = &record[equals + 1..];
+        match key {
+            "path" => {
+                ascii(value)?;
+                result.path_trailing_separator = matches!(value.last(), Some(b'/' | b'\\'));
+            }
+            "linkpath" => {
+                ascii(value)?;
+                result.linkpath = true;
+            }
+            "size" => result.size = Some(decimal(value)?),
+            "uid" | "gid" => {
+                decimal(value)?;
+            }
+            "uname" | "gname" => {
+                ascii(value)?;
+            }
+            "mtime" | "atime" | "ctime" => timestamp(value)?,
+            _ if ["LIBARCHIVE.xattr.", "SCHILY.xattr."]
+                .iter()
+                .any(|prefix| key.starts_with(prefix) && key.len() > prefix.len()) =>
+            {
+                // Ignored binary values may contain NUL/non-UTF8, but not LF:
+                // tar's numeric lookup stops at any malformed preceding line.
+            }
+            _ => return Err(invalid()),
+        }
+        offset = end;
+    }
+    Ok(result)
+}
+
+impl LocalPax {
+    pub fn member_size(
+        &self,
+        entry_type: u8,
+        raw_size: u64,
+        header: &[u8; 512],
+    ) -> io::Result<u64> {
+        if !matches!(entry_type, 0 | b'0' | b'1' | b'2' | b'5' | b'7') {
+            return Err(invalid());
+        }
+        let raw_name = raw_text(&header[..100])?;
+        let raw_link = raw_text(&header[157..257])?;
+        if &header[257..265] == b"ustar\x0000" {
+            raw_text(&header[345..500])?;
+        }
+        let is_link = matches!(entry_type, b'1' | b'2');
+        if is_link != !raw_link.is_empty() {
+            return Err(invalid());
+        }
+        let size = self.size.unwrap_or(raw_size);
+        if raw_size > MAX_SAFE_INTEGER
+            || size > MAX_SAFE_INTEGER
+            || (matches!(entry_type, b'1' | b'2' | b'5') && (raw_size != 0 || size != 0))
+        {
+            return Err(invalid());
+        }
+        if entry_type != b'5' && (self.path_trailing_separator || raw_name.ends_with('\\')) {
+            return Err(invalid());
+        }
+        if self.linkpath && !is_link {
+            return Err(invalid());
+        }
+        Ok(size)
+    }
+}
+
+fn raw_text(field: &[u8]) -> io::Result<&str> {
+    let end = field.iter().position(|byte| *byte == 0).unwrap_or(field.len());
+    if end == 0 {
+        Ok("")
+    } else {
+        ascii(&field[..end])
+    }
+}

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -165,7 +165,14 @@ async function readTarEntry(archivePath: string, entryPath: string, maxBytes: nu
       maxMetaEntrySize: DEFAULT_MAX_META_ENTRY_BYTES,
       onReadEntry(entry) {
         const info = readTarEntryInfo(entry);
-        validateArchiveEntryPath(info.path, { escapeLabel: "archive root" });
+        try {
+          validateArchiveEntryPath(info.path, { escapeLabel: "archive root" });
+        } catch (error) {
+          // Throws escaping node-tar's callback do not reject its promise.
+          entryError ??= error instanceof Error ? error : new Error(String(error));
+          entry.resume();
+          return;
+        }
         const normalized = normalizeArchiveEntryPath(info.path).replace(/^\.\//, "");
         if (seenPaths.has(normalized)) {
           entryError ??= new ArchiveSecurityError(
@@ -270,13 +277,10 @@ export async function readArchiveEntry(
           signal,
         );
       } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message.includes(ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT)
-        ) {
-          throw new ArchiveLimitError(
-            ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT,
-          );
+        if (error instanceof Error) {
+          for (const code of Object.values(ARCHIVE_LIMIT_ERROR_CODE)) {
+            if (error.message.includes(code)) throw new ArchiveLimitError(code);
+          }
         }
         if (error instanceof Error && isArchiveFormatErrorMessage(error.message)) {
           throw new ArchiveFormatError(error.message, { cause: error });

--- a/src/archive-tar-meta.ts
+++ b/src/archive-tar-meta.ts
@@ -4,16 +4,20 @@ import { pipeline } from "node:stream/promises";
 import { createGunzip } from "node:zlib";
 import { ArchiveFormatError } from "./archive-errors.js";
 import { ARCHIVE_LIMIT_ERROR_CODE, ArchiveLimitError } from "./archive-limits.js";
+import { parseLocalPax, paxMemberSize, type LocalPax } from "./archive-tar-pax.js";
 
 type MeterState =
   | { kind: "header" }
   | { kind: "data"; remaining: number }
+  | { kind: "pax"; body: Buffer; used: number; padding: number }
   | { kind: "sparse"; dataRemaining: number; metaBytes: number };
 
 class TarMetadataMeter extends Transform {
   private readonly block = Buffer.alloc(512);
   private blockLength = 0;
   private state: MeterState = { kind: "header" };
+  private pendingPax: LocalPax | undefined;
+  private pendingGnu = false;
 
   constructor(private readonly maxMetaEntryBytes: number) {
     super();
@@ -39,7 +43,9 @@ class TarMetadataMeter extends Transform {
       return Number(value);
     }
     const zero = field.indexOf(0);
-    const text = field.subarray(0, zero < 0 ? field.length : zero).toString("ascii").trim();
+    const bytes = field.subarray(0, zero < 0 ? field.length : zero);
+    if (bytes.some((byte) => byte > 0x7f)) throw this.invalid("size is not ASCII octal");
+    const text = bytes.toString("ascii").trim();
     if (!text || !/^[0-7]+$/.test(text)) throw this.invalid("size is not valid octal");
     const value = Number.parseInt(text, 8);
     if (!Number.isSafeInteger(value)) throw this.invalid("octal size exceeds the safe integer range");
@@ -48,6 +54,8 @@ class TarMetadataMeter extends Transform {
 
   private finishHeader(): void {
     if (this.block.every((byte) => byte === 0)) {
+      if (this.pendingPax) throw this.invalid("dangling PAX metadata");
+      this.pendingGnu = false;
       this.blockLength = 0;
       this.state = { kind: "header" };
       return;
@@ -60,13 +68,33 @@ class TarMetadataMeter extends Transform {
     if (this.block[156] !== 0x35 && name.at(-1) === 0x2f) {
       throw this.invalid("non-directory entry path ends with a separator");
     }
-    const size = this.parseSize();
-    const type = this.block[156];
-    if ([0x78, 0x67, 0x4c, 0x4b, 0x58].includes(type ?? -1) && size > this.maxMetaEntryBytes) {
+    let size = this.parseSize();
+    const type = this.block[156]!;
+    if ([0x78, 0x67, 0x4c, 0x4b, 0x58, 0x4e].includes(type) && size > this.maxMetaEntryBytes) {
       throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.META_ENTRY_SIZE_EXCEEDS_LIMIT);
     }
-    if (type === 0x78 || type === 0x67 || type === 0x58) {
-      throw this.invalid("PAX metadata is unmeterable without interpreting content");
+    if (type === 0x67 || type === 0x58 || type === 0x4e) {
+      throw this.invalid("global/old PAX and old GNU metadata are not supported");
+    }
+    if (type === 0x78) {
+      if (this.pendingPax || this.pendingGnu || size === 0) throw this.invalid("empty, repeated or mixed PAX metadata");
+      const magic = this.block.subarray(257, 265).toString("latin1");
+      if (magic !== "ustar\0" + "00" && magic !== "ustar  \0") throw this.invalid("unrecognized PAX header format");
+      const padded = Math.ceil(size / 512) * 512;
+      if (!Number.isSafeInteger(padded)) throw this.invalid("entry padding exceeds the safe integer range");
+      this.state = { kind: "pax", body: Buffer.alloc(size), used: 0, padding: padded - size };
+      this.blockLength = 0;
+      return;
+    }
+    // Sparse headers retain their metadata-limit-before-format-error ordering.
+    if (this.pendingPax && type !== 0x53) {
+      size = paxMemberSize(this.pendingPax, type, size, this.block);
+      this.pendingPax = undefined;
+    }
+    if (type === 0x4c || type === 0x4b) {
+      this.pendingGnu = true;
+    } else {
+      this.pendingGnu = false;
     }
     const padded = Math.ceil(size / 512) * 512;
     if (!Number.isSafeInteger(padded)) throw this.invalid("entry padding exceeds the safe integer range");
@@ -103,6 +131,18 @@ class TarMetadataMeter extends Transform {
   private meter(chunk: Buffer): void {
     let offset = 0;
     while (offset < chunk.length) {
+      if (this.state.kind === "pax") {
+        const state = this.state;
+        const take = Math.min(state.body.length - state.used, chunk.length - offset);
+        chunk.copy(state.body, state.used, offset, offset + take);
+        state.used += take;
+        offset += take;
+        if (state.used === state.body.length) {
+          this.pendingPax = parseLocalPax(state.body);
+          this.state = state.padding === 0 ? { kind: "header" } : { kind: "data", remaining: state.padding };
+        }
+        continue;
+      }
       if (this.state.kind === "data") {
         const take = Math.min(this.state.remaining, chunk.length - offset);
         offset += take;
@@ -131,7 +171,8 @@ class TarMetadataMeter extends Transform {
   }
 
   override _flush(callback: (error?: Error | null) => void): void {
-    if (this.state.kind === "header" && this.blockLength === 0) callback();
+    if (this.pendingPax) callback(this.invalid("dangling PAX metadata"));
+    else if (this.state.kind === "header" && this.blockLength === 0) callback();
     else callback(this.invalid(this.state.kind === "header" ? "truncated TAR header" : "truncated TAR entry"));
   }
 }

--- a/src/archive-tar-pax.ts
+++ b/src/archive-tar-pax.ts
@@ -1,0 +1,86 @@
+import { ArchiveFormatError } from "./archive-errors.js";
+
+export type LocalPax = { path?: string; linkpath?: string; size?: number };
+
+function invalid(): never {
+  throw new ArchiveFormatError("invalid TAR header: unsupported or malformed PAX metadata");
+}
+
+function decimal(bytes: Buffer): number {
+  const text = bytes.toString("latin1");
+  if (!/^(0|[1-9][0-9]*)$/.test(text)) invalid();
+  const value = Number(text);
+  if (!Number.isSafeInteger(value)) invalid();
+  return value;
+}
+
+function ascii(bytes: Buffer): string {
+  if (bytes.length === 0 || bytes.some((byte) => byte < 0x20 || byte > 0x7e)) invalid();
+  return bytes.toString("ascii");
+}
+
+// Keep this grammar aligned with native/src/tar_pax.rs. Downstream parsers
+// disagree on duplicates, coercions and UTF-8 chunk boundaries.
+export function parseLocalPax(body: Buffer): LocalPax {
+  if (body.length === 0) invalid();
+  const result: LocalPax = {};
+  const keys = new Set<string>();
+  let offset = 0;
+  while (offset < body.length) {
+    const space = body.indexOf(0x20, offset);
+    if (space < 0) invalid();
+    const length = decimal(body.subarray(offset, space));
+    if (length > body.length - offset || length <= space - offset + 3) invalid();
+    const end = offset + length;
+    if (body[end - 1] !== 0x0a) invalid();
+    const record = body.subarray(space + 1, end - 1);
+    if (record.includes(0x0a)) invalid();
+    const equals = record.indexOf(0x3d);
+    if (equals <= 0) invalid();
+    const key = ascii(record.subarray(0, equals));
+    if (!/^[A-Za-z0-9_.-]+$/.test(key) || keys.has(key)) invalid();
+    keys.add(key);
+    const value = record.subarray(equals + 1);
+    if (/^(LIBARCHIVE|SCHILY)\.xattr\..+$/.test(key)) {
+      // Inert bytes, never restored. Newlines would corrupt Rust's subsequent
+      // record lookup; NUL and non-UTF8 bytes in these values are harmless.
+    } else if (key === "path" || key === "linkpath") {
+      result[key] = ascii(value);
+    } else if (key === "size") {
+      result.size = decimal(value);
+    } else if (key === "uid" || key === "gid") {
+      decimal(value);
+    } else if (key === "uname" || key === "gname") {
+      ascii(value);
+    } else if (key === "mtime" || key === "atime" || key === "ctime") {
+      const text = ascii(value);
+      if (!/^-?(0|[1-9][0-9]*)(\.[0-9]+)?$/.test(text) || Math.abs(Number(text)) > 8_640_000_000_000) invalid();
+    } else {
+      invalid();
+    }
+    offset = end;
+  }
+  return result;
+}
+
+function rawText(field: Buffer): string {
+  const zero = field.indexOf(0);
+  const value = field.subarray(0, zero < 0 ? field.length : zero);
+  return value.length === 0 ? "" : ascii(value);
+}
+
+export function paxMemberSize(pax: LocalPax, type: number, rawSize: number, header: Buffer): number {
+  if (![0, 0x30, 0x31, 0x32, 0x35, 0x37].includes(type)) invalid();
+  const rawName = rawText(header.subarray(0, 100));
+  const rawLink = rawText(header.subarray(157, 257));
+  if (header.subarray(257, 265).equals(Buffer.from("ustar\0" + "00"))) {
+    rawText(header.subarray(345, 500));
+  }
+  const isLink = type === 0x31 || type === 0x32;
+  if (isLink !== (rawLink.length > 0)) invalid();
+  const size = pax.size ?? rawSize;
+  if ([0x31, 0x32, 0x35].includes(type) && (rawSize !== 0 || size !== 0)) invalid();
+  if (type !== 0x35 && (pax.path?.endsWith("/") || pax.path?.endsWith("\\") || rawName.endsWith("\\"))) invalid();
+  if (pax.linkpath !== undefined && !isLink) invalid();
+  return size;
+}

--- a/src/archive-tar-runtime.ts
+++ b/src/archive-tar-runtime.ts
@@ -26,6 +26,7 @@ export type TarModule = {
     preservePaths: false;
     noChmod: true;
     preserveOwner: false;
+    noMtime: true;
     strict: true;
     maxMetaEntrySize: number;
     filter?(this: TarParser, entryPath: string, entry: unknown): boolean;

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -387,6 +387,7 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
               preservePaths: false,
               noChmod: true,
               preserveOwner: false,
+              noMtime: true,
               strict: true,
               maxMetaEntrySize: limits.maxMetaEntryBytes,
               filter(this: { abort(error: Error): void }, _entryPath, entry) {

--- a/test/archive-pax-compressed.test.ts
+++ b/test/archive-pax-compressed.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extractArchive, readArchiveEntry } from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __resetNativeLoaderForTest, __setNativeLoaderForTest } from "../src/native.js";
+import { paxNative } from "./helpers/archive-pax-native.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+// Synthetic USTAR: the 136-byte public provenance shape, path=renamed,
+// size=700 over raw size=1, 700 'a' bytes, then sentinel='end'. No executable.
+const fixtures = {
+  "tar-bzip2": "QlpoOTFBWSZTWaPpgLYAAJZfiP3QQAF/4jpkeeJvZ9/RABAICDAA+bMGpTxMU0wQDTQAA9Roe1TQ0aaCtAKG0ag002pk00NGjCNMIaBhJJNGin6psmFP1Q0yAAAAA3qTZ7+bvz9zond5VIsZhIKcsoqSuFRKjFQVaC9kjTg8F9tb/eF1Zq4ocNNL/kxPYs6OzjIrlYAlFOSVrJB1qqOAAlKAZwiEwpnYdPKTH/RmVkEJhBgYbTZ0EIoqwOuOJAVvWdjy5QPNls7YWoU5xdRORENT+6EglKBSs5g4aPANgUbIKjVSCJrDLGJgkQ+9KKelZ76FwdhbIq73uwExwbhMnhpnBUDPaBcVVlRIqcokvrpgan2XrOrJSiUEJrZkPwi68xZ1qQx/i7kinChIUfTAWwA=",
+  "tar-zstd": "KLUv/QRYzQcAwowrJDCHqg6gYBt7erELv4rtgRpeZX+V9VEVgMWTbbwCEBHVdliDBFHteIRKNnWVbm2L79iRmcD/wbb9lGkEyXIRtqgprm2ZxeXKJbA5El7CNgEWAygoEI9zKHDLbIp60GgmyLB4QM0z0DANVa7tYNjq9VRV/CgG9Oy9fD0Bg8c5EDSGB+Eo0mJckHkZlbcocEpJFQqZpqRLucufWb5W43IMzoTG/58z+X9mO+J2Lk4EGgCg5T84/jWNMaAS6G7A7AQE0/EBBQJQwIWrLhhQDehmgIwDIAKDaDikAFrCRRUQKya4OSoAwBAHq5hpQ2Xwc8MAx8plbgJIpiLRgA==",
+} as const;
+
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+describe.skipIf(!paxNative)("PAX compressed native mode=require", () => {
+  beforeEach(() => {
+    configureFsSafeNative({ mode: "require" });
+    __setNativeLoaderForTest(() => paxNative!);
+  });
+
+  it.each(["tar-bzip2", "tar-zstd"] as const)("extracts and reads %s with effective budgets", async (kind) => {
+    const root = await tempRoot("fs-safe-pax-compressed-");
+    const archivePath = path.join(root, "fixture.bin");
+    const destDir = path.join(root, "out");
+    await fs.mkdir(destDir);
+    await fs.writeFile(archivePath, Buffer.from(fixtures[kind], "base64"));
+    await extractArchive({ archivePath, destDir, kind, timeoutMs: 10_000, limits: { maxMetaEntryBytes: 164, maxEntries: 2, maxEntryBytes: 700, maxExtractedBytes: 703 } });
+    expect(await fs.readFile(path.join(destDir, "renamed"))).toEqual(Buffer.alloc(700, 0x61));
+    expect(await fs.readFile(path.join(destDir, "sentinel"), "utf8")).toBe("end");
+    expect(await readArchiveEntry(archivePath, "renamed", { kind, maxBytes: 700 })).toEqual(Buffer.alloc(700, 0x61));
+    expect(await readArchiveEntry(archivePath, "sentinel", { kind, maxBytes: 3 })).toEqual(Buffer.from("end"));
+    await expect(readArchiveEntry(archivePath, "renamed", { kind, maxBytes: 699 })).rejects.toMatchObject({ code: "archive-entry-extracted-size-exceeds-limit" });
+    for (const [limits, code] of [
+      [{ maxMetaEntryBytes: 163 }, "archive-meta-entry-size-exceeds-limit"],
+      [{ maxEntryBytes: 699 }, "archive-entry-extracted-size-exceeds-limit"],
+    ] as const) {
+      const rejectedDir = await fs.mkdtemp(path.join(root, "rejected-"));
+      await expect(extractArchive({ archivePath, destDir: rejectedDir, kind, timeoutMs: 10_000, limits })).rejects.toMatchObject({ code });
+      expect(await fs.readdir(rejectedDir)).toEqual([]);
+    }
+  });
+});

--- a/test/archive-pax-security.test.ts
+++ b/test/archive-pax-security.test.ts
@@ -1,0 +1,212 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extractArchive, readArchiveEntry, type ExtractArchiveOptions } from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __resetNativeLoaderForTest, __setNativeLoaderForTest } from "../src/native.js";
+import { tarFixture, type TarFixtureEntry } from "./helpers/archive-fuzz.js";
+import { paxArchive, paxHeader, paxRecord, publicMetadata } from "./helpers/archive-pax.js";
+import { paxNative } from "./helpers/archive-pax-native.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const invalid = "archive-header-invalid";
+const member = { path: "raw", body: "payload" };
+
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+for (const mode of ["off", "require"] as const) {
+  describe.skipIf(mode === "require" && !paxNative)(`PAX security mode=${mode}`, () => {
+    beforeEach(() => {
+      configureFsSafeNative({ mode });
+      if (mode === "require") __setNativeLoaderForTest(() => paxNative!);
+    });
+
+    async function setup(bytes: Buffer) {
+      const root = await tempRoot("fs-safe-pax-security-");
+      const archivePath = path.join(root, "fixture.tar");
+      const destDir = path.join(root, "out");
+      await fs.writeFile(archivePath, bytes);
+      await fs.mkdir(destDir);
+      return { archivePath, destDir, timeoutMs: 10_000 };
+    }
+
+    async function reject(bytes: Buffer, code = invalid, options: Partial<ExtractArchiveOptions> = {}, read = true) {
+      const fixture = await setup(bytes);
+      await expect(extractArchive({ ...fixture, ...options })).rejects.toMatchObject({ code });
+      expect(await fs.readdir(fixture.destDir)).toEqual([]);
+      if (read) await expect(readArchiveEntry(fixture.archivePath, "raw", { maxBytes: 1000 })).rejects.toMatchObject({ code });
+    }
+
+    it.each([
+      ["empty path", "path", ""], ["empty linkpath", "linkpath", ""], ["empty size", "size", ""],
+      ["negative size", "size", "-1"], ["signed size", "size", "+1"], ["fractional size", "size", "1.5"],
+      ["exponent", "size", "1e3"], ["hex", "size", "0x10"], ["leading zero", "size", "01"],
+      ["unsafe integer", "size", "9007199254740992"], ["unsafe padding", "size", "9007199254740990991"],
+      ["padding overflow", "size", "9007199254740991"], ["space", "size", " 1"],
+      ["NUL path", "path", "ok\0evil"], ["Unicode path", "path", "café"],
+      ["Unicode linkpath", "linkpath", "café"], ["Unicode owner", "uname", "café"],
+      ["non-ASCII key", "päth", "ok"], ["newline xattr", "SCHILY.xattr.user.binary", "ok\nbad"],
+      ["charset", "hdrcharset", "BINARY"], ["charset alias", "charset", "UTF-8"],
+      ["sparse map", "GNU.sparse.map", "0,1"], ["sparse name", "GNU.sparse.name", "raw"],
+      ["sparse size", "GNU.sparse.size", "1"], ["sparse 1.0", "GNU.sparse.major", "1"],
+      ["SCHILY sparse", "SCHILY.filetype", "sparse"], ["realsize", "SCHILY.realsize", "1"],
+      ["SCHILY size", "SCHILY.size", "1"], ["ACL", "SCHILY.acl.access", "user::rwx"],
+      ["unknown", "vendor.unknown", "value"], ["type override", "type", "5"],
+      ["negative uid", "uid", "-1"], ["invalid time", "mtime", "Infinity"],
+      ["out of range time", "mtime", "8640000000001"], ["empty owner", "uname", ""],
+      ["empty namespace suffix", "SCHILY.xattr.", "value"],
+    ])("rejects %s", async (_label, key, value) => {
+      await reject(paxArchive([[key!, value!]]));
+    });
+
+    it.each([
+      Buffer.from(""), Buffer.from("9 path=a"), Buffer.from("8 path=a\n"), Buffer.from("11 path=a\n"),
+      Buffer.from("09 path=a\n"), Buffer.from("+9 path=a\n"), Buffer.from("0 path=a\n"),
+      Buffer.from("999999999999999999999999 path=a\n"), Buffer.from("9 path=a\0"),
+      Buffer.from("9 path=a\ntrailing"), Buffer.from("9 path=a\n\n"),
+      paxRecord("path", "a\nb"), paxRecord("bad key", "value"),
+      Buffer.concat([paxRecord("path", "a"), paxRecord("path", "b")]),
+      Buffer.concat([paxRecord("size", "1"), paxRecord("size", "7")]),
+      Buffer.concat([paxRecord("SCHILY.xattr.user.binary", "a"), paxRecord("SCHILY.xattr.user.binary", "b")]),
+    ])("rejects malformed framing or duplicates %#", async (body) => {
+      await reject(tarFixture([{ path: "PaxHeader", type: "x", body }, member]));
+    });
+
+    it("rejects global, old, dangling, repeated and mixed extension chains", async () => {
+      const pax = paxHeader([["path", "renamed"]]);
+      const gnu = { path: "LongName", type: "L", body: "long-name\0" };
+      const chains: TarFixtureEntry[][] = [
+        [{ ...pax, type: "g" }, member], [{ ...pax, type: "X" }, member],
+        [{ ...pax, type: "N" }, member], [pax], [pax, pax, member],
+        [pax, gnu, member], [gnu, pax, member], [pax, { ...gnu, type: "K" }, member],
+        [pax, { path: "device", type: "3" }],
+        [{ ...pax, mutateHeader: (header) => header.fill(0, 257, 265) }, member],
+      ];
+      for (const chain of chains) await reject(tarFixture(chain));
+      await reject(tarFixture([pax], false));
+    });
+
+    it("rejects dangling metadata after TAR end blocks on the complete input", async () => {
+      await reject(Buffer.concat([tarFixture([member]), tarFixture([paxHeader([["path", "dangling"]])])]));
+    });
+
+    it("rejects raw and effective non-file sizes and separator/type coercions", async () => {
+      for (const type of ["1", "2", "5"]) {
+        for (const [rawSize, effectiveSize] of [[1, 0], [0, 1], [1, 1]]) {
+          await reject(tarFixture([paxHeader([["size", String(effectiveSize)]]), {
+            path: "raw", type, linkPath: "target",
+            mutateHeader: (header) => header.write(`${rawSize!.toString(8).padStart(11, "0")}\0`, 124, "ascii"),
+          }]));
+        }
+      }
+      for (const type of ["0", "7", "1", "2"]) {
+        await reject(tarFixture([paxHeader([["path", "dir/"]]), { ...member, type }]));
+        await reject(tarFixture([paxHeader([["path", "safe"]]), { path: "raw/", type }]));
+      }
+      await reject(paxArchive([["linkpath", "target"]]));
+      await reject(paxArchive([["path", "dir\\"]]));
+    });
+
+    it("rejects ambiguous raw text, raw numbers and link fields even when overridden", async () => {
+      for (const entry of [
+        { ...member, path: "café" },
+        { ...member, linkPath: "not-a-link" },
+        { path: "link", type: "2", linkPath: "" },
+        { ...member, mutateHeader: (header: Buffer) => { header[124] = 0xb0; } },
+        { ...member, mutateHeader: (header: Buffer) => { header.write("café", 345, "utf8"); } },
+      ]) await reject(tarFixture([paxHeader([["path", "safe"], ["size", "0"]]), entry]));
+    });
+
+    it("applies exact and over metadata, member, total and entry-count limits", async () => {
+      const body = Buffer.alloc(700, 0x61);
+      const bytes = paxArchive([["path", "renamed"], ["size", "700"]], body, 1);
+      const meta = Buffer.byteLength(paxHeader([["path", "renamed"], ["size", "700"]]).body!);
+      await extractArchive({ ...await setup(bytes), limits: { maxMetaEntryBytes: meta, maxEntries: 2, maxEntryBytes: 700, maxExtractedBytes: 703 } });
+      for (const [limits, code] of [
+        [{ maxMetaEntryBytes: meta - 1 }, "archive-meta-entry-size-exceeds-limit"],
+        [{ maxMetaEntryBytes: 0 }, "archive-meta-entry-size-exceeds-limit"],
+        [{ maxEntries: 1 }, "archive-entry-count-exceeds-limit"],
+        [{ maxEntries: 0 }, "archive-entry-count-exceeds-limit"],
+        [{ maxEntryBytes: 699 }, "archive-entry-extracted-size-exceeds-limit"],
+        [{ maxExtractedBytes: 702 }, "archive-extracted-size-exceeds-limit"],
+      ] as const) await reject(bytes, code, { limits }, false);
+      const fixture = await setup(bytes);
+      await expect(readArchiveEntry(fixture.archivePath, "renamed", { maxBytes: 699 })).rejects.toMatchObject({ code: "archive-entry-extracted-size-exceeds-limit" });
+    });
+
+    it("returns the same default metadata limit error from extraction and reads", async () => {
+      await reject(paxArchive([["SCHILY.xattr.user.binary", Buffer.alloc(1024 * 1024, 0xff)]]), "archive-meta-entry-size-exceeds-limit");
+    });
+
+    it("meters forbidden old headers and sparse chains before format rejection", async () => {
+      for (const type of ["g", "X", "N"]) {
+        const bytes = tarFixture([{ path: "metadata", type, mutateHeader: (header) => header.write("00000001001\0", 124, "ascii") }]);
+        await reject(bytes, "archive-meta-entry-size-exceeds-limit", { limits: { maxMetaEntryBytes: 512 } }, false);
+      }
+      const sparse = tarFixture([{ path: "sparse", type: "S", mutateHeader: (header) => {
+        header.write("ustar  \0", 257, "ascii");
+        header[482] = 1;
+      } }], false);
+      const bytes = Buffer.concat([tarFixture([paxHeader([["path", "safe"]])], false), sparse, Buffer.alloc(512)]);
+      await reject(bytes, "archive-meta-entry-size-exceeds-limit", { limits: { maxMetaEntryBytes: 511 } }, false);
+      await reject(bytes);
+    });
+
+    it("preserves standalone GNU long-name and long-link handling", async () => {
+      const long = "directory/" + "a".repeat(120);
+      const fixture = await setup(tarFixture([{ path: "LongName", type: "L", body: long + "\0" }, member]));
+      await extractArchive(fixture);
+      expect(await fs.readFile(path.join(fixture.destDir, long), "utf8")).toBe("payload");
+      expect(await readArchiveEntry(fixture.archivePath, long, { maxBytes: 7 })).toEqual(Buffer.from("payload"));
+      await reject(tarFixture([{ path: "LongLink", type: "K", body: long + "\0" }, { path: "link", type: "2", linkPath: "raw" }]), "entry-link", {}, false);
+    });
+
+    it("keeps traversal before stripping/filtering and checks effective depth/collisions", async () => {
+      for (const badPath of ["../escape", "/absolute", "a/../../escape", "C:escape"]) {
+        await reject(paxArchive([["path", badPath]]), "entry-path", { stripComponents: 20, entryFilter: () => "skip", onFiltered: "skip-entry" });
+      }
+      await reject(paxArchive([["path", "a/b/c"]]), "archive-entry-path-components-exceeds-limit", { limits: { maxEntryPathComponents: 2 } }, false);
+      for (const alias of ["sentinel", "SENTINEL"]) await reject(paxArchive([["path", alias]]), "entry-path", {}, false);
+      await reject(tarFixture([paxHeader([["path", "a/value"]]), member, { path: "b/value" }]), "entry-path", { stripComponents: 1 }, false);
+    });
+
+    it("filters using effective path/size and preserves stripped/skipped byte budgets", async () => {
+      const bytes = paxArchive([["path", "package/renamed"], ["size", "700"]], Buffer.alloc(700), 1);
+      const seen: Array<{ path: string; size: number }> = [];
+      const fixture = await setup(bytes);
+      await extractArchive({ ...fixture, limits: { maxEntryBytes: 3, maxExtractedBytes: 3 }, onFiltered: "skip-entry", entryFilter: (entry) => {
+        seen.push(entry);
+        return entry.path === "package/renamed" ? "skip" : "extract";
+      } });
+      expect(seen).toMatchObject([{ path: "package/renamed", size: 700 }, { path: "sentinel", size: 3 }]);
+      expect(await fs.readdir(fixture.destDir)).toEqual(["sentinel"]);
+      await reject(bytes, "entry-filtered", { entryFilter: () => "skip" }, false);
+      await reject(bytes, "archive-entry-count-exceeds-limit", { limits: { maxEntries: 1 }, stripComponents: 9 }, false);
+      await extractArchive({ ...await setup(bytes), stripComponents: 9, limits: { maxEntryBytes: 0, maxExtractedBytes: 0 } });
+    });
+
+    it("accepts descriptive metadata and zero-size directories without restoring ownership", async () => {
+      const fixture = await setup(tarFixture([paxHeader([
+        ["path", "directory/"], ["size", "0"], ["uid", "123"], ["gid", "456"],
+        ["uname", "nobody"], ["gname", "nogroup"], ["mtime", "-1.25"], ["atime", "0.01"], ["ctime", "123.456"],
+      ]), { path: "raw", type: "5" }, publicMetadata(), member]));
+      await extractArchive(fixture);
+      expect((await fs.stat(path.join(fixture.destDir, "directory"))).isDirectory()).toBe(true);
+      expect(await fs.readFile(path.join(fixture.destDir, "raw"), "utf8")).toBe("payload");
+    });
+
+    it.each(["1", "2"])("never grants link permission for PAX type %s", async (type) => {
+      const bytes = tarFixture([paxHeader([["path", "link"], ["linkpath", "../outside"], ["size", "0"]]), { path: "raw", type, linkPath: "target" }]);
+      await reject(bytes, "entry-link", {}, false);
+      const fixture = await setup(bytes);
+      await expect(readArchiveEntry(fixture.archivePath, "link", { maxBytes: 10 })).rejects.toThrow("not a file");
+      await extractArchive({ ...fixture, entryFilter: () => "skip", onFiltered: "skip-entry" });
+      expect(await fs.readdir(fixture.destDir)).toEqual([]);
+      await extractArchive({ ...fixture, stripComponents: 2 });
+    });
+  });
+}

--- a/test/archive-pax.test.ts
+++ b/test/archive-pax.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extractArchive, readArchiveEntry } from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __resetNativeLoaderForTest, __setNativeLoaderForTest } from "../src/native.js";
+import { tarFixture } from "./helpers/archive-fuzz.js";
+import { paxArchive, paxRecord, publicMetadata } from "./helpers/archive-pax.js";
+import { useTempDirs } from "./helpers/vitest.js";
+import { paxNative } from "./helpers/archive-pax-native.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+for (const mode of ["off", "require"] as const) {
+  describe.skipIf(mode === "require" && !paxNative)(`bounded PAX mode=${mode}`, () => {
+    let inspectNative: ReturnType<typeof vi.fn>;
+    let extractNative: ReturnType<typeof vi.fn>;
+    let readNative: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      configureFsSafeNative({ mode });
+      if (mode === "require") {
+        // Deliberately fail if unavailable: these regressions must execute Rust.
+        const native = paxNative!;
+        inspectNative = vi.fn(native.inspectArchiveNative.bind(native));
+        extractNative = vi.fn(native.extractArchiveNative.bind(native));
+        readNative = vi.fn(native.readArchiveEntryNative.bind(native));
+        __setNativeLoaderForTest(() => ({ ...native, inspectArchiveNative: inspectNative, extractArchiveNative: extractNative, readArchiveEntryNative: readNative }));
+      }
+    });
+
+    async function check(bytes: Buffer, expected: Buffer, name: string, gzip: boolean): Promise<void> {
+      const root = await tempRoot("fs-safe-pax-");
+      const archivePath = path.join(root, gzip ? "fixture.tar.gz" : "fixture.tar");
+      const destDir = path.join(root, "out");
+      await fs.writeFile(archivePath, gzip ? gzipSync(bytes) : bytes);
+      await fs.mkdir(destDir);
+      await extractArchive({ archivePath, destDir, timeoutMs: 10_000 });
+      expect(await fs.readFile(path.join(destDir, name))).toEqual(expected);
+      expect(await fs.readFile(path.join(destDir, "sentinel"), "utf8")).toBe("end");
+      expect(await readArchiveEntry(archivePath, name, { maxBytes: expected.length })).toEqual(expected);
+      expect(await readArchiveEntry(archivePath, "sentinel", { maxBytes: 3 })).toEqual(Buffer.from("end"));
+      if (mode === "require") {
+        expect(inspectNative).toHaveBeenCalledTimes(3);
+        expect(extractNative).toHaveBeenCalledTimes(1);
+        expect(readNative).toHaveBeenCalledTimes(2);
+      }
+    }
+
+    it.each([false, true])("accepts public release binary provenance (gzip=%s)", async (gzip) => {
+      const metadata = publicMetadata();
+      expect(Buffer.byteLength(metadata.body!)).toBe(136);
+      await check(tarFixture([metadata, { path: "crabbox", body: "payload" }, { path: "sentinel", body: "end" }]), Buffer.from("payload"), "crabbox", gzip);
+    });
+
+    it.each([[1, 700], [700, 1], [700, 0]])("uses PAX size instead of raw size %i -> %i", async (raw, size) => {
+      const body = Buffer.alloc(size, 0x61);
+      await check(paxArchive([["path", "package/value"], ["size", String(size)]], body, raw), body, "package/value", false);
+    });
+
+    it("keeps structural records after binary non-UTF8 xattrs intact", async () => {
+      const body = Buffer.alloc(700, 0x62);
+      await check(paxArchive([
+        ["SCHILY.xattr.user.binary", Buffer.from([0, 0xff, 0xfe, 0xc3])],
+        ["path", "renamed"], ["size", "700"],
+      ], body, 1), body, "renamed", true);
+    });
+
+    it("accepts ignored binary metadata at the default ceiling across parser chunks", async () => {
+      const key = "SCHILY.xattr.user.binary";
+      const limit = 1024 * 1024;
+      const value = Buffer.alloc(limit - paxRecord(key, "").length - 5, 0xff);
+      // The larger decimal length prefix adds five bytes at this body size.
+      expect(paxRecord(key, value).length).toBe(limit);
+      const bytes = paxArchive([[key, value]]);
+      await check(bytes, Buffer.from("payload"), "raw", true);
+    });
+  });
+}

--- a/test/archive-read-boundaries.test.ts
+++ b/test/archive-read-boundaries.test.ts
@@ -100,7 +100,7 @@ describe("TAR metadata preflight boundaries", () => {
       .rejects.toThrow("base-256 size is negative or malformed");
   });
 
-  it("rejects PAX and malformed GNU sparse metadata before a parser can buffer it", async () => {
+  it("rejects dangling PAX and malformed GNU sparse metadata", async () => {
     const root = await tempRoot("fs-safe-tar-meta-malformed-");
     const paxPath = path.join(root, "pax.tar");
     const sparseFlagPath = path.join(root, "sparse-flag.tar");
@@ -126,7 +126,7 @@ describe("TAR metadata preflight boundaries", () => {
     );
 
     await expect(preflightTarMetadata({ archivePath: paxPath, maxMetaEntryBytes: 1024 }))
-      .rejects.toThrow("PAX metadata is unmeterable");
+      .rejects.toThrow("dangling PAX metadata");
     await expect(preflightTarMetadata({ archivePath: sparseFlagPath, maxMetaEntryBytes: 1024 }))
       .rejects.toThrow("GNU sparse extension flag is not 0 or 1");
     await expect(preflightTarMetadata({ archivePath: sparseExtensionPath, maxMetaEntryBytes: 1024 }))

--- a/test/helpers/archive-pax-native.ts
+++ b/test/helpers/archive-pax-native.ts
@@ -1,0 +1,18 @@
+import { createRequire } from "node:module";
+import { hostNativeTarget } from "../../scripts/native-targets.mjs";
+import type { NativeBinding } from "../../src/native.js";
+
+// pnpm check rebuilds dist, removing its staged binding. Load the actual host
+// build artifact here so the PAX proof still executes Rust during that check.
+function loadNative(): NativeBinding | undefined {
+  try {
+    const target = hostNativeTarget();
+    if (!target) throw new Error("no native target for PAX tests");
+    return createRequire(import.meta.url)(`../../native/${target.artifact}`) as NativeBinding;
+  } catch (error) {
+    if (process.env.FS_SAFE_PAX_REQUIRE_NATIVE === "1") throw error;
+    return undefined; // Like the existing native suite, JS-only CI can omit Rust.
+  }
+}
+
+export const paxNative = loadNative();

--- a/test/helpers/archive-pax.ts
+++ b/test/helpers/archive-pax.ts
@@ -1,0 +1,30 @@
+import { tarFixture, type TarFixtureEntry } from "./archive-fuzz.js";
+
+export function paxRecord(key: string, value: string | Buffer): Buffer {
+  const payload = Buffer.concat([Buffer.from(` ${key}=`), Buffer.from(value), Buffer.from("\n")]);
+  let length = payload.length + 1;
+  while (String(length).length + payload.length !== length) {
+    length = String(length).length + payload.length;
+  }
+  return Buffer.concat([Buffer.from(String(length)), payload]);
+}
+
+export function paxHeader(records: ReadonlyArray<readonly [string, string | Buffer]>): TarFixtureEntry {
+  return { path: "PaxHeader/member", type: "x", body: Buffer.concat(records.map(([key, value]) => paxRecord(key, value))) };
+}
+
+export function publicMetadata(): TarFixtureEntry {
+  return paxHeader([
+    ["mtime", "1787334189.823045922"],
+    ["LIBARCHIVE.xattr.com.apple.provenance", "AQIAcwhBclAufnY"],
+    ["SCHILY.xattr.com.apple.provenance", Buffer.from([1, 2, 0, 115, 8, 65, 114, 80, 46, 126, 118])],
+  ]);
+}
+
+export function paxArchive(records: ReadonlyArray<readonly [string, string | Buffer]>, body = Buffer.from("payload"), rawSize = body.length): Buffer {
+  return tarFixture([
+    paxHeader(records),
+    { path: "raw", body, mutateHeader: (header) => header.write(`${rawSize.toString(8).padStart(11, "0")}\0`, 124, "ascii") },
+    { path: "sentinel", body: "end" },
+  ]);
+}

--- a/test/native-archive-equivalence.test.ts
+++ b/test/native-archive-equivalence.test.ts
@@ -363,7 +363,7 @@ describe.each(archiveBackends)("%s archive path", (backend) => {
   });
 
   it.each([
-    ["PAX size overrides", { path: "PaxHeader", type: "x" as const, body: "10 path=a\n" }],
+    ["dangling PAX metadata", { path: "PaxHeader", type: "x" as const, body: "10 path=a\n" }],
     ["GNU sparse entries", { path: "sparse", type: "S" as const }],
   ])("rejects unmeterable %s with the same typed format error", async (_label, entry) => {
     useBackend(backend);


### PR DESCRIPTION
## Summary

Replace the blanket local-PAX rejection with bounded byte-level interpretation in both JavaScript and native TAR meters. PAX size overrides now drive framing, while effective paths and sizes continue through the existing extraction/read policy. Original archive bytes are not rewritten.

This fixes standard release archives that contain fractional timestamps and binary macOS provenance metadata. The implementation intentionally supports a narrow, documented local-PAX subset: ambiguous records, duplicate keys, global/old headers, mixed extension chains, unsupported structural text, and sparse semantics still fail closed. Xattrs and ownership metadata are accepted only as inert metadata and are not restored. Existing limits, guarded staging, link rejection, and package dependencies are unchanged.

Keep complete-input native validation and terminal cancellation alongside PAX support: the TAR reader stops at end markers and buffers PAX through a retrying read helper. Also return JS TAR-read traversal failures through the public promise. Add native-required PAX coverage to Linux, macOS, Windows, and musl CI lanes.

## Verification

- Genuine red/green: the same initial 12 positive PAX regressions failed with the original rejection, then passed in JavaScript and actual native execution.
- Fresh public-API live proof: extract and bounded-read the unchanged [official Crabbox 0.46.0 Darwin ARM64 archive](https://github.com/openclaw/crabbox/releases/download/v0.46.0/crabbox_0.46.0_darwin_arm64.tar.gz) in both `mode: "off"` and `mode: "require"`. Download verified at 30,134,912 bytes, SHA-256 `2216da0acbcc6e822ee341ec313aaab58875db951fa1daf0d13dd710ebfba9b8`. Both extracted member hashes match independent expectations; sizes are 109,941,296 and 6,871,408 bytes, with executable modes retained.
- Exact metadata/count/member/total limits pass together; reducing each relevant budget by one rejects with the expected typed error and leaves the destination empty. Bounded entry reads pass at the exact size and reject one byte less.
- Cancellation proof: a 50 ms timeout rejects and the native subprocess exits naturally in 163 ms instead of retrying indefinitely.
- `FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm check`: 1,191 passed, 61 baseline skips, including build/docs/package/public-API checks.
- Three PAX suites: 146 passed, no skips, including gzip/bzip2/zstd, byte framing, traversal, malformed records, limits, links, and sparse rejection. Wider focused native/boundary run: 229 passed, five platform-specific skips.
- `pnpm native:test`: 23 passed; native build, Clippy with warnings denied, workflow lint, and `git diff --check` passed.

No consumer overrides, cloud credentials/resources, downloaded executable execution, or dependency changes were used. This PR does not publish a package release.

## Recorded public-API runtime output

The following is the observed local runtime output from the built public exports for the exact source committed as `2fea6a51a7f6834aa07a01f6f68e1f6c5980fe1a`, not an agent transcript. The real archive is unchanged; both native and JavaScript modes are explicit.

<details>
<summary>Observed extraction and bounded reads: mode off</summary>

```json
{
  "phase": "preland",
  "mode": "off",
  "success": true,
  "files": [
    {
      "name": "crabbox",
      "size": 109941296,
      "sha256": "9a4a0b312c26e40e1f4da897b284d6f2ac3f9ac73bbb5e3fe1c957200cf06452"
    },
    {
      "name": "crabbox-apple-vm-helper",
      "size": 6871408,
      "sha256": "ba38d42445d202c843bff099476e115312555733f6d6a8a7a4de0ecbd585c45e"
    }
  ]
}
```

```json
{
  "phase": "preland",
  "mode": "off",
  "success": true,
  "checks": [
    {
      "check": "read-exact-bytes",
      "name": "crabbox",
      "success": true,
      "size": 109941296,
      "sha256": "9a4a0b312c26e40e1f4da897b284d6f2ac3f9ac73bbb5e3fe1c957200cf06452"
    },
    {
      "check": "read-exact-bytes",
      "name": "crabbox-apple-vm-helper",
      "success": true,
      "size": 6871408,
      "sha256": "ba38d42445d202c843bff099476e115312555733f6d6a8a7a4de0ecbd585c45e"
    },
    {
      "check": "read-over-limit-rejected",
      "success": true
    },
    {
      "check": "extraction-meta-limit-rejected",
      "success": true,
      "code": "archive-meta-entry-size-exceeds-limit",
      "destinationEmpty": true
    },
    {
      "check": "extraction-count-limit-rejected",
      "success": true,
      "code": "archive-entry-count-exceeds-limit",
      "destinationEmpty": true
    },
    {
      "check": "extraction-entry-limit-rejected",
      "success": true,
      "code": "archive-entry-extracted-size-exceeds-limit",
      "destinationEmpty": true
    },
    {
      "check": "extraction-total-limit-rejected",
      "success": true,
      "code": "archive-extracted-size-exceeds-limit",
      "destinationEmpty": true
    },
    {
      "check": "extraction-exact-all-limits",
      "success": true
    }
  ]
}
```

</details>

<details>
<summary>Observed extraction and bounded reads: mode require</summary>

```json
{
  "phase": "preland",
  "mode": "require",
  "success": true,
  "files": [
    {
      "name": "crabbox",
      "size": 109941296,
      "sha256": "9a4a0b312c26e40e1f4da897b284d6f2ac3f9ac73bbb5e3fe1c957200cf06452"
    },
    {
      "name": "crabbox-apple-vm-helper",
      "size": 6871408,
      "sha256": "ba38d42445d202c843bff099476e115312555733f6d6a8a7a4de0ecbd585c45e"
    }
  ]
}
```

```json
{
  "phase": "preland",
  "mode": "require",
  "success": true,
  "checks": [
    {
      "check": "read-exact-bytes",
      "name": "crabbox",
      "success": true,
      "size": 109941296,
      "sha256": "9a4a0b312c26e40e1f4da897b284d6f2ac3f9ac73bbb5e3fe1c957200cf06452"
    },
    {
      "check": "read-exact-bytes",
      "name": "crabbox-apple-vm-helper",
      "success": true,
      "size": 6871408,
      "sha256": "ba38d42445d202c843bff099476e115312555733f6d6a8a7a4de0ecbd585c45e"
    },
    {
      "check": "read-over-limit-rejected",
      "success": true
    },
    {
      "check": "extraction-meta-limit-rejected",
      "success": true,
      "code": "archive-meta-entry-size-exceeds-limit",
      "destinationEmpty": true
    },
    {
      "check": "extraction-count-limit-rejected",
      "success": true,
      "code": "archive-entry-count-exceeds-limit",
      "destinationEmpty": true
    },
    {
      "check": "extraction-entry-limit-rejected",
      "success": true,
      "code": "archive-entry-extracted-size-exceeds-limit",
      "destinationEmpty": true
    },
    {
      "check": "extraction-total-limit-rejected",
      "success": true,
      "code": "archive-extracted-size-exceeds-limit",
      "destinationEmpty": true
    },
    {
      "check": "extraction-exact-all-limits",
      "success": true
    }
  ]
}
```

</details>

The automatic review environment could not build its native binding because no Rust toolchain was configured. That is not a runtime result for this change. A working local Rust toolchain built the binding for the results above; all four GitHub native lanes also passed. Build JavaScript before staging the binding (`pnpm build`, then `pnpm native:build`), since the JavaScript build clears `dist`.
