### PR TITLE
fix(path): preserve directory creation error diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Preserve filesystem failures from `ensureDirectoryWithinRoot()` and `pathScope().ensureDir()` in an optional operational `FsSafeError` diagnostic with the original cause and bounded, escaped display text, instead of misreporting them as containment violations; keep nonthrowing string results and directory safety checks.
 - Accept bounded local PAX paths, sizes, and descriptive metadata, including inert binary macOS provenance xattrs, consistently in JavaScript and native TAR extraction/reads; reject ambiguous records, extension chains, and sparse semantics while retaining byte/count limits and guarded staging. Return TAR read traversal failures through the public promise instead of escaping the parser callback.
 - Fail closed when synchronous sidecar compromise checks hit I/O errors and invoke `onCompromised` once instead of throwing from the interval. Thanks @SebTardif.
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -26,12 +26,21 @@ The exports group into a handful of themes. Each documented helper has its own p
 | Export | Page | Notes |
 |---|---|---|
 | `pathScope`, `PathScope`, `PathScopeOptions`, `PathScopeResolveOptions` | [path-scope.md](path-scope.md) | Absolute-path boundary helper with `Result`-shaped returns. |
-| `ensureDirectoryWithinRoot` | – | Create a directory while enforcing the root boundary. |
+| `ensureDirectoryWithinRoot` | [path-scope.md](path-scope.md#ensuredir-rel-options) | Create a directory while enforcing the root boundary; same result contract as `pathScope().ensureDir()`. |
 | `resolvePathWithinRoot`, `resolvePathsWithinRoot` | – | Resolve one or many relative paths against a trusted root. |
 | `resolveExistingPathsWithinRoot`, `resolveStrictExistingPathsWithinRoot` | – | Same, but require the targets to exist. |
 | `resolveWritablePathWithinRoot` | – | Resolve a write target inside a root. |
 | `resolveRootPath`, `resolveRootPathSync`, `ResolvedRootPath`, `ROOT_PATH_ALIAS_POLICIES`, `RootPathAliasPolicy` | – | Resolve a root directory honoring alias policy. |
 | `resolvePathViaExistingAncestorSync` | – | Walk to an existing ancestor for paths whose tail does not yet exist. |
+
+`ensureDirectoryWithinRoot({ rootDir, requestedPath, scopeLabel, defaultDirName?, mode? })`
+returns `{ ok: true, path }` or `{ ok: false, error: string, diagnostic?: FsSafeError }`.
+It does not throw filesystem failures: operational failures carry a
+`helper-failed` diagnostic with the original `cause` and a bounded, escaped
+message naming the native code/syscall when available. Policy failures omit
+`diagnostic`. Missing parents already created before a failure remain in place.
+The diagnostic contract is specific to directory preparation, not the other
+root-path result helpers.
 
 ### Absolute path helpers
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -2,6 +2,15 @@
 
 Every failure that's the library's job to surface lands as an `FsSafeError` with a closed `code` union you can branch on. Catch by code, not by message text — messages may change, codes will not.
 
+Result-based APIs are an exception to throwing: [`pathScope().ensureDir()`](path-scope.md#ensuredir-rel-options)
+and `ensureDirectoryWithinRoot()` return operational failures as
+`{ ok: false, error: string, diagnostic: FsSafeError }`. The diagnostic uses
+`helper-failed` / `operational`, retains the exact native error in `cause`, and
+has the same message as `error`. Its display text names the native code/syscall
+when available but omits raw paths and native messages. Policy failures keep
+the string-only result without `diagnostic`; other `pathScope` methods do not
+gain this field. Directory preparation can partially complete before failing.
+
 Path and archive-entry details embedded in diagnostics escape control characters
 as `\\uXXXX` sequences. This keeps attacker-controlled names on one log line;
 the escaped message is for diagnosis, not for reconstructing the original path.

--- a/docs/path-scope.md
+++ b/docs/path-scope.md
@@ -24,6 +24,8 @@ await sharp(photo.path).resize(800).toFile(/* … */);
 ## Signature
 
 ```ts
+import type { FsSafeError } from "@openclaw/fs-safe/errors";
+
 function pathScope(rootDir: string, options: PathScopeOptions): PathScope;
 
 type PathScopeOptions = {
@@ -36,6 +38,10 @@ type PathScopeResolveOptions = {
 
 type PathResult = { ok: true; path: string } | { ok: false; error: string };
 type PathsResult = { ok: true; paths: string[] } | { ok: false; error: string };
+// Illustrative result alias, not a named package export.
+type DirectoryResult =
+  | { ok: true; path: string }
+  | { ok: false; error: string; diagnostic?: FsSafeError };
 
 type PathScope = {
   rootDir: string;
@@ -45,7 +51,7 @@ type PathScope = {
   existing(requestedPaths: string[]): Promise<PathsResult>;
   files(requestedPaths: string[]): Promise<PathsResult>;
   writable(requestedPath: string, options?: PathScopeResolveOptions): Promise<PathResult>;
-  ensureDir(requestedPath: string, options?: PathScopeResolveOptions & { mode?: number }): Promise<PathResult>;
+  ensureDir(requestedPath: string, options?: PathScopeResolveOptions & { mode?: number }): Promise<DirectoryResult>;
 };
 ```
 
@@ -92,9 +98,29 @@ await fs.writeFile(t.path, body);
 
 Async. `mkdir -p` inside the scope. Walks each segment, refuses any symlink in the path, creates missing directories. Optional `mode` sets the directory mode.
 
+Failures remain nonthrowing results with `error: string`. Policy rejections
+(including traversal, NUL input, symlinks and non-directory segments) omit
+`diagnostic`. Operational failures from `lstat`, `realpath` or `mkdir` include
+an `FsSafeError` with `code: "helper-failed"`, `category: "operational"`, and
+the exact original error in `cause`, including its native `code`, `errno` and
+`syscall` when available. Only `ensureDir()` adds this diagnostic; other scope
+methods retain their existing result shapes.
+
+`error` equals `diagnostic.message` for operational failures, for example
+`"Could not prepare uploads directory: ENAMETOOLONG during lstat"`. Display
+text bounds and escapes the label and native code/syscall, without copying
+the requested path or native error message. Treat the raw cause as sensitive
+local diagnostic data, not as text to return to an untrusted caller. A failure
+can leave already-created parent directories; it does not roll them back or
+retry through an unchecked filesystem path.
+
 ```ts
 const dir = await uploads.ensureDir("inbox", { mode: 0o755 });
-if (!dir.ok) return reply(500, dir.error);
+if (!dir.ok) {
+  // Pass the cause only to an appropriately restricted local diagnostic sink.
+  if (dir.diagnostic) recordLocalFailure(dir.diagnostic.cause);
+  return reply(dir.diagnostic ? 500 : 400, dir.error);
+}
 ```
 
 ## Result type vs throwing

--- a/src/root-paths.ts
+++ b/src/root-paths.ts
@@ -1,10 +1,21 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { formatErrorDetail } from "./error-detail.js";
 import { FsSafeError } from "./errors.js";
-import { isNotFoundPathError, isPathInside, isPathRelativeEscape } from "./path.js";
+import {
+  assertNoNulPathInput,
+  hasNodeErrorCode,
+  isNodeError,
+  isNotFoundPathError,
+  isPathInside,
+  isPathRelativeEscape,
+} from "./path.js";
 import { root as openRoot } from "./root.js";
 
 type InvalidPathResult = { ok: false; error: string };
+type DirectoryResult =
+  | { ok: true; path: string }
+  | { ok: false; error: string; diagnostic?: FsSafeError };
 type ResolvePathsWithinRootParams = {
   rootDir: string;
   requestedPaths: string[];
@@ -34,7 +45,7 @@ export type PathScope = {
   ensureDir(
     requestedPath: string,
     options?: PathScopeResolveOptions & { mode?: number },
-  ): Promise<{ ok: true; path: string } | { ok: false; error: string }>;
+  ): Promise<DirectoryResult>;
 };
 
 function invalidPath(scopeLabel: string): InvalidPathResult {
@@ -186,7 +197,7 @@ async function assertNoSymlinkSegments(params: {
 }): Promise<void> {
   const relative = path.relative(params.rootDir, params.targetPath);
   if (isPathRelativeEscape(relative)) {
-    throw new Error(`Invalid path: must stay within ${params.scopeLabel}`);
+    throw new FsSafeError("outside-workspace", `Invalid path: must stay within ${params.scopeLabel}`);
   }
   let current = params.rootDir;
   for (const segment of relative.split(path.sep).filter(Boolean)) {
@@ -194,10 +205,13 @@ async function assertNoSymlinkSegments(params: {
     try {
       const stat = await fs.lstat(current);
       if (stat.isSymbolicLink()) {
-        throw new Error(`Invalid path: must not traverse symlinks within ${params.scopeLabel}`);
+        throw new FsSafeError(
+          "symlink", `Invalid path: must not traverse symlinks within ${params.scopeLabel}`,
+        );
       }
       if (!stat.isDirectory()) {
-        throw new Error(
+        throw new FsSafeError(
+          "not-file",
           `Invalid path: existing segment must be a directory within ${params.scopeLabel}`,
         );
       }
@@ -216,30 +230,28 @@ export async function ensureDirectoryWithinRoot(params: {
   scopeLabel: string;
   defaultDirName?: string;
   mode?: number;
-}): Promise<{ ok: true; path: string } | { ok: false; error: string }> {
-  const lexical = resolvePathWithinRoot({
-    rootDir: params.rootDir,
-    requestedPath: params.requestedPath,
-    scopeLabel: params.scopeLabel,
-    defaultFileName: params.defaultDirName,
-  });
-  if (!lexical.ok) {
-    return lexical;
-  }
-
-  const rootDir = path.resolve(params.rootDir);
-  const targetPath = path.resolve(lexical.path);
+}): Promise<DirectoryResult> {
+  const scopeLabel = formatErrorDetail(params.scopeLabel.slice(0, 80));
   try {
+    assertNoNulPathInput(params.rootDir);
+    assertNoNulPathInput(params.requestedPath);
+    if (!params.requestedPath.trim()) assertNoNulPathInput(params.defaultDirName ?? "");
+    const lexical = resolvePathWithinRoot({
+      ...params, scopeLabel, defaultFileName: params.defaultDirName,
+    });
+    if (!lexical.ok) return lexical;
+    const rootDir = path.resolve(params.rootDir);
+    const targetPath = lexical.path;
     const rootStat = await fs.lstat(rootDir);
     if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
-      return invalidPath(params.scopeLabel);
+      return invalidPath(scopeLabel);
     }
-    await assertNoSymlinkSegments({ rootDir, targetPath, scopeLabel: params.scopeLabel });
+    await assertNoSymlinkSegments({ rootDir, targetPath, scopeLabel });
     const rootReal = await fs.realpath(rootDir);
     const nearestExistingPath = await resolveNearestExistingPath(targetPath);
     const nearestExistingReal = await fs.realpath(nearestExistingPath);
     if (!isPathInside(rootReal, nearestExistingReal)) {
-      return invalidPath(params.scopeLabel);
+      return invalidPath(scopeLabel);
     }
     const relative = path.relative(rootDir, targetPath);
     let current = rootDir;
@@ -249,7 +261,7 @@ export async function ensureDirectoryWithinRoot(params: {
         try {
           const stat = await fs.lstat(current);
           if (stat.isSymbolicLink() || !stat.isDirectory()) {
-            return invalidPath(params.scopeLabel);
+            return invalidPath(scopeLabel);
           }
           break;
         } catch (err) {
@@ -259,10 +271,7 @@ export async function ensureDirectoryWithinRoot(params: {
           try {
             await fs.mkdir(current, { mode: params.mode });
           } catch (mkdirErr) {
-            if (isNotFoundPathError(mkdirErr)) {
-              throw mkdirErr;
-            }
-            if ((mkdirErr as NodeJS.ErrnoException).code === "EEXIST") {
+            if (hasNodeErrorCode(mkdirErr, "EEXIST")) {
               continue;
             }
             throw mkdirErr;
@@ -271,16 +280,30 @@ export async function ensureDirectoryWithinRoot(params: {
       }
       const currentReal = await fs.realpath(current);
       if (!isPathInside(rootReal, currentReal)) {
-        return invalidPath(params.scopeLabel);
+        return invalidPath(scopeLabel);
       }
     }
     const targetReal = await fs.realpath(targetPath);
     if (!isPathInside(rootReal, targetReal)) {
-      return invalidPath(params.scopeLabel);
+      return invalidPath(scopeLabel);
     }
     return { ok: true, path: targetPath };
-  } catch {
-    return invalidPath(params.scopeLabel);
+  } catch (cause) {
+    if (
+      (cause instanceof FsSafeError && cause.category === "policy") ||
+      hasNodeErrorCode(cause, "ENOTDIR")
+    ) {
+      return invalidPath(scopeLabel);
+    }
+    // Native messages include unbounded paths; display only bounded errno metadata.
+    const code = isNodeError(cause) && typeof cause.code === "string"
+      ? formatErrorDetail(cause.code.slice(0, 40)) : "filesystem operation failed";
+    const syscall = isNodeError(cause) && typeof cause.syscall === "string"
+      ? ` during ${formatErrorDetail(cause.syscall.slice(0, 40))}` : "";
+    const diagnostic = new FsSafeError(
+      "helper-failed", `Could not prepare ${scopeLabel}: ${code}${syscall}`, { cause },
+    );
+    return { ok: false, error: diagnostic.message, diagnostic };
   }
 }
 

--- a/test/root-directory-errors.test.ts
+++ b/test/root-directory-errors.test.ts
@@ -1,0 +1,289 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FsSafeError } from "../src/errors.js";
+import { ensureDirectoryWithinRoot, pathScope } from "../src/advanced.js";
+import { itDarwin, itPosix, useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempDirs, tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+type DirectoryResult = Awaited<ReturnType<typeof ensureDirectoryWithinRoot>>;
+
+function expectOperational(result: DirectoryResult, cause: unknown, code: string, syscall: string) {
+  expect(result.ok).toBe(false);
+  if (result.ok) throw new Error("expected directory failure");
+  expect(result.diagnostic).toBeInstanceOf(FsSafeError);
+  expect(result.diagnostic).toMatchObject({ code: "helper-failed", category: "operational" });
+  expect(result.diagnostic?.cause).toBe(cause);
+  expect(result.error).toBe(result.diagnostic?.message);
+  expect(result.error).toContain(`${code} during ${syscall}`);
+  expect(result.error).not.toContain("must stay within");
+}
+
+describe("root directory operational diagnostics", () => {
+  it.each([
+    ["lstat", "EACCES"],
+    ["mkdir", "ENOSPC"],
+    ["realpath", "EIO"],
+  ] as const)("preserves %s %s through both public entry points", async (syscall, code) => {
+    const rootDir = await tempRoot("fs-safe-dir-error-");
+    const cause = Object.assign(new Error("native failure with private path"), {
+      code, errno: -1, syscall, path: path.join(rootDir, "child"),
+    });
+    for (const entry of ["helper", "scope"] as const) {
+      const spy = vi.spyOn(fs, syscall).mockRejectedValueOnce(cause);
+      const result = entry === "helper"
+        ? await ensureDirectoryWithinRoot({ rootDir, requestedPath: "child", scopeLabel: "uploads" })
+        : await pathScope(rootDir, { label: "uploads" }).ensureDir("child");
+      expectOperational(result, cause, code, syscall);
+      expect(result).toMatchObject({ diagnostic: { cause: { code, errno: -1, syscall } } });
+      spy.mockRestore();
+      expect(await fs.readdir(rootDir)).toEqual([]);
+    }
+  });
+
+  it.each([
+    ["root lstat", "lstat", "root", 1],
+    ["symlink walk", "lstat", "child", 1],
+    ["nearest ancestor", "lstat", "child", 2],
+    ["creation lookup", "lstat", "child", 3],
+    ["created directory reinspection", "lstat", "child", 4],
+    ["root realpath", "realpath", "root", 1],
+    ["ancestor realpath", "realpath", "root", 2],
+    ["segment realpath", "realpath", "child", 1],
+    ["final realpath", "realpath", "child", 2],
+  ] as const)("retains I/O failure at %s", async (_stage, syscall, location, occurrence) => {
+    const rootDir = await tempRoot("fs-safe-dir-stage-");
+    const target = location === "root" ? rootDir : path.join(rootDir, "child");
+    const cause = Object.assign(new Error("I/O failure"), { code: "EIO", errno: -5, syscall });
+    const original = fs[syscall].bind(fs);
+    let calls = 0;
+    const spy = vi.spyOn(fs, syscall).mockImplementation(async (...args) => {
+      if (String(args[0]) === target && ++calls === occurrence) throw cause;
+      return await original(...args);
+    });
+    const result = await pathScope(rootDir, { label: "uploads" }).ensureDir("child");
+    expectOperational(result, cause, "EIO", syscall);
+    expect(calls).toBe(occurrence);
+    spy.mockRestore();
+    expect(await fs.readdir(rootDir)).toEqual(
+      ["created directory reinspection", "segment realpath", "final realpath"].includes(_stage)
+        ? ["child"] : [],
+    );
+  });
+
+  it("bounds and escapes display fields without dumping paths or native messages", async () => {
+    const rootDir = await tempRoot("fs-safe-dir-display-");
+    const cause = Object.assign(new Error(`private-path/${"secret".repeat(1000)}\nforged log`), {
+      code: `EIO\n${"x".repeat(1000)}`,
+      syscall: `lstat\r${"y".repeat(1000)}`,
+      path: path.join(rootDir, "secret"),
+    });
+    vi.spyOn(fs, "lstat").mockRejectedValueOnce(cause);
+    const result = await pathScope(rootDir, { label: `uploads\n${"z".repeat(1000)}` })
+      .ensureDir("requested-secret");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected directory failure");
+    expect(result.diagnostic?.cause).toBe(cause);
+    expect(result.error).toContain("uploads\\u000a");
+    expect(result.error).toContain("EIO\\u000a");
+    expect(result.error).toContain("lstat\\u000d");
+    expect(result.error.length).toBeLessThan(1100);
+    expect(result.error).not.toMatch(/[\r\n]|secret|private-path/u);
+    expect(result.error).not.toContain(rootDir);
+  });
+
+  it.each([new Error("private failure"), null, { code: 123, syscall: 456 }])(
+    "retains unexpected non-errno failures without rejecting",
+    async (cause) => {
+      const rootDir = await tempRoot("fs-safe-dir-unexpected-");
+      vi.spyOn(fs, "lstat").mockRejectedValueOnce(cause);
+      const result = await pathScope(rootDir, { label: "uploads" }).ensureDir("child");
+      expect(result).toMatchObject({ ok: false, diagnostic: { category: "operational" } });
+      if (result.ok) throw new Error("expected directory failure");
+      expect(result.diagnostic?.cause).toBe(cause);
+      expect(result.error).toContain("Could not prepare uploads");
+      expect(result.error).not.toContain("private failure");
+    },
+  );
+
+  itPosix("reports a 256-byte component before and after creating its missing parents", async () => {
+    const rootDir = await tempRoot("fs-safe-dir-name-");
+    const scope = pathScope(rootDir, { label: "uploads" });
+    const valid = path.join("valid", "date", "a".repeat(255));
+    await expect(scope.ensureDir(valid)).resolves.toEqual({ ok: true, path: path.join(rootDir, valid) });
+    const requestedPath = path.join("missing", "date", "a".repeat(256));
+    const target = path.join(rootDir, requestedPath);
+    await expect(fs.lstat(target)).rejects.toMatchObject({ code: "ENOENT" });
+    const realLstat = fs.lstat.bind(fs);
+    const causes: unknown[] = [];
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      try {
+        return await realLstat(...args);
+      } catch (cause) {
+        if ((cause as NodeJS.ErrnoException).code === "ENAMETOOLONG") causes.push(cause);
+        throw cause;
+      }
+    });
+    for (const [attempt, entry] of (["helper", "helper", "scope"] as const).entries()) {
+      const result = entry === "helper"
+        ? await ensureDirectoryWithinRoot({ rootDir, requestedPath, scopeLabel: "uploads" })
+        : await scope.ensureDir(requestedPath);
+      expect(causes).toHaveLength(attempt + 1);
+      expectOperational(result, causes.at(-1), "ENAMETOOLONG", "lstat");
+      expect(await fs.readdir(path.dirname(target))).toEqual([]);
+    }
+  });
+
+  itPosix("returns a real permission-denied mkdir without throwing", async (context) => {
+    const rootDir = await tempRoot("fs-safe-dir-permission-");
+    const parent = path.join(rootDir, "locked");
+    await fs.mkdir(parent, { mode: 0o500 });
+    try {
+      const probe = path.join(parent, "probe");
+      const denied = await fs.mkdir(probe).then(() => undefined, (cause: unknown) => cause);
+      if (denied === undefined) {
+        await fs.rmdir(probe);
+        context.skip("host permits mkdir in a mode 0500 directory");
+        return;
+      }
+      expect(denied).toMatchObject({ code: "EACCES", syscall: "mkdir" });
+      const realMkdir = fs.mkdir.bind(fs);
+      let nativeCause: unknown;
+      vi.spyOn(fs, "mkdir").mockImplementation(async (...args) => {
+        try {
+          return await realMkdir(...args);
+        } catch (cause) {
+          nativeCause = cause;
+          throw cause;
+        }
+      });
+      const result = await pathScope(rootDir, { label: "uploads" }).ensureDir("locked/child");
+      expectOperational(result, nativeCause, "EACCES", "mkdir");
+      expect(await fs.readdir(parent)).toEqual([]);
+    } finally {
+      await fs.chmod(parent, 0o700);
+    }
+  });
+});
+
+describe("root directory policy results", () => {
+  const policyFailure = { ok: false, error: "Invalid path: must stay within uploads" };
+
+  it("rejects traversal, root aliases, escaping defaults and NUL before I/O", async () => {
+    const rootDir = await tempRoot("fs-safe-dir-input-");
+    const lstat = vi.spyOn(fs, "lstat");
+    const mkdir = vi.spyOn(fs, "mkdir");
+    for (const params of [
+      { requestedPath: "../outside" },
+      { requestedPath: path.join(rootDir, "..", "outside") },
+      { requestedPath: "." },
+      { requestedPath: " ", defaultDirName: "../outside" },
+      { requestedPath: " ", defaultDirName: path.dirname(rootDir) },
+      { requestedPath: "parent/child\0" },
+      { requestedPath: "invalid\0/../child" },
+      { requestedPath: " ", defaultDirName: "child\0" },
+      { requestedPath: "child", rootDir: `${rootDir}\0` },
+    ]) {
+      await expect(ensureDirectoryWithinRoot({ rootDir, scopeLabel: "uploads", ...params }))
+        .resolves.toEqual(policyFailure);
+    }
+    expect(lstat).not.toHaveBeenCalled();
+    expect(mkdir).not.toHaveBeenCalled();
+    await expect(pathScope(rootDir, { label: "uploads" }).ensureDir(" "))
+      .resolves.toEqual({ ok: false, error: "path is required" });
+  });
+
+  it("keeps non-directories as policy failures", async () => {
+    const rootDir = await tempRoot("fs-safe-dir-file-");
+    const file = path.join(rootDir, "file");
+    await fs.writeFile(file, "unchanged");
+    const mkdir = vi.spyOn(fs, "mkdir");
+    for (const [root, requestedPath] of [[rootDir, "file/child"], [file, "child"]] as const) {
+      await expect(pathScope(root, { label: "uploads" }).ensureDir(requestedPath))
+        .resolves.toEqual(policyFailure);
+    }
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(await fs.readFile(file, "utf8")).toBe("unchanged");
+  });
+
+  itPosix("keeps a native ENOTDIR root lookup as a policy failure", async () => {
+    const rootDir = await tempRoot("fs-safe-dir-notdir-");
+    await fs.writeFile(path.join(rootDir, "file"), "unchanged");
+    const root = path.join(rootDir, "file", "sub");
+    await expect(fs.lstat(root)).rejects.toMatchObject({ code: "ENOTDIR" });
+    const mkdir = vi.spyOn(fs, "mkdir");
+    await expect(pathScope(root, { label: "uploads" }).ensureDir("child"))
+      .resolves.toEqual(policyFailure);
+    expect(mkdir).not.toHaveBeenCalled();
+  });
+
+  itPosix("rejects root, in-root and outside symlinks without writes", async () => {
+    const container = await tempRoot("fs-safe-dir-link-");
+    const rootDir = path.join(container, "root");
+    const outside = path.join(container, "outside");
+    const inside = path.join(rootDir, "inside");
+    await fs.mkdir(inside, { recursive: true });
+    await fs.mkdir(outside);
+    const rootAlias = path.join(container, "alias");
+    await fs.symlink(rootDir, rootAlias, "dir");
+    await fs.symlink(inside, path.join(rootDir, "inside-link"), "dir");
+    await fs.symlink(outside, path.join(rootDir, "outside-link"), "dir");
+    const mkdir = vi.spyOn(fs, "mkdir");
+    for (const [root, requestedPath] of [
+      [rootAlias, "child"], [rootDir, "inside-link/child"], [rootDir, "outside-link/child"],
+    ] as const) {
+      await expect(pathScope(root, { label: "uploads" }).ensureDir(requestedPath))
+        .resolves.toEqual(policyFailure);
+    }
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(await fs.readdir(inside)).toEqual([]);
+    expect(await fs.readdir(outside)).toEqual([]);
+  });
+
+  itDarwin("still accepts a real root beneath the macOS /tmp ancestor alias", async () => {
+    const rootDir = await fs.mkdtemp("/tmp/fs-safe-dir-alias-");
+    tempDirs.push(rootDir);
+    await expect(pathScope(rootDir, { label: "uploads" }).ensureDir("child"))
+      .resolves.toEqual({ ok: true, path: path.join(rootDir, "child") });
+  });
+
+  itPosix.each(["file", "symlink"] as const)("rejects an EEXIST race won by a %s", async (kind) => {
+    const rootDir = await tempRoot("fs-safe-dir-race-");
+    const outside = await tempRoot("fs-safe-dir-race-outside-");
+    const target = path.join(rootDir, "raced");
+    const realMkdir = fs.mkdir.bind(fs);
+    const mkdir = vi.spyOn(fs, "mkdir").mockImplementation(async (candidate, options) => {
+      if (String(candidate) !== target) return await realMkdir(candidate, options);
+      if (kind === "file") await fs.writeFile(target, "racer");
+      else await fs.symlink(outside, target, "dir");
+      throw Object.assign(new Error("exists"), { code: "EEXIST" });
+    });
+    await expect(pathScope(rootDir, { label: "uploads" }).ensureDir("raced/child"))
+      .resolves.toEqual(policyFailure);
+    expect(mkdir).toHaveBeenCalledTimes(1);
+    expect(await fs.readdir(outside)).toEqual([]);
+  });
+
+  it.each([
+    ["nearest ancestor", "root", 2, false],
+    ["segment", "child", 1, true],
+    ["final", "child", 2, true],
+  ] as const)("rejects an outside canonical path at the %s check", async (_stage, location, occurrence, created) => {
+    const rootDir = await tempRoot("fs-safe-dir-canonical-");
+    const outside = await tempRoot("fs-safe-dir-canonical-outside-");
+    const candidatePath = location === "root" ? rootDir : path.join(rootDir, "child");
+    const realRealpath = fs.realpath.bind(fs);
+    let calls = 0;
+    vi.spyOn(fs, "realpath").mockImplementation(async (candidate, options) => {
+      if (String(candidate) === candidatePath && ++calls === occurrence) return outside;
+      return await realRealpath(candidate, options);
+    });
+    await expect(pathScope(rootDir, { label: "uploads" }).ensureDir("child"))
+      .resolves.toEqual(policyFailure);
+    expect(calls).toBe(occurrence);
+    expect(await fs.readdir(rootDir)).toEqual(created ? ["child"] : []);
+    expect(await fs.readdir(outside)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers preparing directories with `ensureDirectoryWithinRoot()` or `pathScope().ensureDir()` would receive a misleading containment violation when the filesystem actually rejected an operation, for example `ENAMETOOLONG`, `EACCES`, `ENOSPC`, or `EIO`. That discarded the native failure needed to diagnose the problem, including on retries after some missing parents had already been created.

## Why This Change Was Made

Operational failures now add an optional `diagnostic?: FsSafeError` to the existing nonthrowing `{ ok: false, error: string }` result, using the existing `helper-failed` code and `operational` category while preserving the exact native error as `cause`. The display string equals the diagnostic message and includes bounded, escaped label/code/syscall fields without copying raw paths or native messages; containment, symlink rejection, EEXIST reinspection, canonical-path checks, and string-only policy rejections remain intact.

## User Impact

Callers can distinguish operational failures from policy rejections without changing their existing string-result handling. The additive diagnostic applies only to directory preparation; there is no new named export, error code, dependency, or quality baseline. The raw native cause can contain sensitive local data and must go only to a suitably restricted diagnostic sink, not an untrusted caller. Already-created missing parents still remain after failure; there is no rollback or unchecked fallback.

This PR changes upstream error legibility only. It does not publish a package, and OpenClaw dependency adoption remains separate.

## Evidence

Exact-head hosted validation passed for `1c7a1e78af4560bc7c9efd0d75eecad2c652a0b8`: [CI](https://github.com/openclaw/fs-safe/actions/runs/33137032759) passed all 15 jobs, including the six Node 22/24 full-check combinations on Linux/macOS/Windows, native checks (including musl), package smoke checks, and Cargo quality; [coverage](https://github.com/openclaw/fs-safe/actions/runs/33137032761) passed on all three platforms and merged successfully; [benchmarks](https://github.com/openclaw/fs-safe/actions/runs/33137032747) passed. The local failure history below is retained rather than presented as a green local run.

The reviewed patch was rebased onto exact main `8850a243f4b75f4ea0e394aef5b8dd219360a766`. Only the changelog conflicted, and both entries were preserved. The five source/test/docs files are byte-for-byte unchanged from the reviewed commit; main's bounded PAX archive changes are inherited, not part of this PR's six-file diff. [CI for that exact main commit passed](https://github.com/openclaw/fs-safe/actions/runs/33135122797).

- Regression red-to-green: before the fix, three regression/existing suites had 18 failures and 29 passes. After the fix, all four focused suites passed 66 tests on Node 24.20.0 and 26.7.0. The rebased candidate again passed all 66 on Node 24.20.0.
- Independent real-filesystem acceptance: published 0.5.6 passed 8 and failed 4 checks; the built candidate passed 12/12 on both Node 24 and 26. This covered real 255/256-byte components, fresh calls and retries, real EACCES mkdir failures, policy rejections, and no outside writes. This acceptance run preceded the mechanically equivalent rebase.
- Baseline attribution on unmodified exact main: the single-worker archive suite failed 3 tests, passed 14, and skipped 2. Failures were the 15-second malformed-TAR classification timeout and the 30-second TAR/ZIP Windows-name portability timeouts.
- Before rebase, the default full check failed 12 timeout/cleanup cases; a two-worker run narrowed that to 2 archive fuzz timeouts with 1091 passes and 61 skips. Both of those two cases reproduced on exact main. The other earlier failures were not individually attributed to baseline.
- Rebased `VITEST_MAX_WORKERS=2 pnpm check` failed: 24 failed, 1141 passed, 135 skipped tests across 13 failed, 93 passed, and 3 skipped files (670.24 seconds). Build, boundary/file-size checks, and docs examples passed before the test phase. The same three baseline archive timeout cases recur, but the remaining failures are not baseline-attributed: TAR entry-size limits; write-boundary races; adversarial paths; archive/PAX policy, extraction, and staging; store/JSON concurrency; move, permission, and identity tests. These include additional timeouts and ENOTEMPTY cleanup errors, plus `json.test.ts` resolving `{ v: 0 }` instead of the expected `JsonFileReadError` rejection. This was not a green local full gate. The host was subsequently measured at a load average near 120 on 32 logical CPUs. Not every local failure was individually baseline-attributed; exact-head hosted full suites now pass across all six platform/runtime combinations. No timeouts, fuzz counts, assertions, or baselines were changed.
- Rebased `pnpm pack:check`, `pnpm docs:site`, and `git diff --check` passed. Package validation was run separately because the full check stopped at test failures.
- Mandatory Codex autoreview was clean, with no accepted/actionable findings. It was retained without another review after the mechanical rebase.
- Scope: six files; production +53/-30 (net +23), tests +289, docs/changelog +48/-3 (net +45). Total +390/-33. No generated output is committed.

Commands used for the focused suites, unmodified-main baseline, and rebased validation:

```sh
pnpm test test/root-directory-errors.test.ts test/root-paths.test.ts test/root-path-store-coverage.test.ts test/absolute-directory.test.ts --reporter=verbose
pnpm test test/archive-property-fuzz.test.ts --maxWorkers 1
VITEST_MAX_WORKERS=2 pnpm check
pnpm docs:site
pnpm pack:check
git diff --check
```

The parent independently reran the real-filesystem acceptance probe against the rebased built head: 12/12 on both Node 24.20.0 and 26.7.0. The two unchanged JSON race tests were rerun together in their original order (`pnpm test test/json.test.ts -t 'recovers readJson|surfaces JsonFileReadError' --maxWorkers 1`): both passed. The reviewed production diff has no call path into the unrelated archive/store/JSON stress operations.

Ready for landing based on the clean independent review, focused and real-filesystem regression proof, and green exact-head hosted full/coverage/native/package validation. Local full-suite failures remain recorded above; they were not hidden or bypassed by changing tests. The net 23 production lines provide the additive cause-preserving diagnostic contract and bounded safe formatting; the redundant mkdir error branch was removed.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
