### PR TITLE
fix(permissions): preserve Windows ACL verification diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Preserve underlying command diagnostics (command, timing, timeout flag, exit code/signal, and sanitized stderr) and cause on Windows ACL `permission-unverified` errors without changing verification semantics.
 - Preserve filesystem failures from `ensureDirectoryWithinRoot()` and `pathScope().ensureDir()` in an optional operational `FsSafeError` diagnostic with the original cause and bounded, escaped display text, instead of misreporting them as containment violations; keep nonthrowing string results and directory safety checks.
 - Accept bounded local PAX paths, sizes, and descriptive metadata, including inert binary macOS provenance xattrs, consistently in JavaScript and native TAR extraction/reads; reject ambiguous records, extension chains, and sparse semantics while retaining byte/count limits and guarded staging. Return TAR read traversal failures through the public promise instead of escaping the parser callback.
 - Fail closed when synchronous sidecar compromise checks hit I/O errors and invoke `onCompromised` once instead of throwing from the interval. Thanks @SebTardif.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -75,6 +75,17 @@ Built-in PowerShell, `icacls.exe`, and `whoami.exe` invocations have a fixed
 30-second per-process deadline. A command failure or timeout returns an
 unverified result (`source: "unknown"`) so callers fail closed. Advanced callers
 that inject a custom `exec` implementation own that executor's deadline.
+Failed owner and ACL inspections retain `error` text and an optional
+`errorDetail: PermissionCommandFailure` with `command`, integer `durationMs`,
+`timedOut`, `exitCode`, `signal`, and `stderr`. The type is exported from both
+`@openclaw/fs-safe/permissions` and `@openclaw/fs-safe/advanced`. Built-in
+execution measures elapsed time; injected execFile-shaped failures receive
+best-effort command diagnostics. Plain errors have no `errorDetail`.
+Display reasons and stderr escape control characters and are limited to 400
+characters, including a trailing `…` when truncated. Diagnostics do not copy
+stdout or read target file contents. The separate `errorCause` retains the
+original exception for restricted local diagnosis; do not serialize or expose
+it as display text.
 The parser is on the advanced surface so tests and CLIs can process captured
 `icacls` output without spawning a process.
 

--- a/docs/secure-file.md
+++ b/docs/secure-file.md
@@ -75,6 +75,18 @@ type SecureFileReadOptions = {
 | `too-large` | File size or bytes read exceeded `maxBytes`. |
 | `timeout` | `timeoutMs` elapsed while reading. |
 
+Windows inspection failures remain operational `permission-unverified` errors
+and still refuse the read. Their message includes the underlying reason when
+available. `details` includes `ownerError` for owner-query failures and, when
+command diagnostics are available, `command`, `durationMs`, `timedOut`,
+`exitCode`, `signal`, and `stderr`. Reasons and stderr are control-character
+escaped and limited to 400 characters each (including a truncation marker).
+No stdout or target file contents are copied into these display diagnostics.
+The original inspection exception is retained as `cause`; built-in command
+errors also retain their original execFile exception in the cause chain.
+Treat causes as restricted local diagnostic data. No retries are performed,
+and verification order and rejection conditions are unchanged.
+
 ## See also
 
 - [Permissions](permissions.md) — standalone POSIX mode and Windows ACL checks.

--- a/src/advanced.ts
+++ b/src/advanced.ts
@@ -139,6 +139,7 @@ export {
   resolveWindowsUserPrincipal,
   summarizeWindowsAcl,
   type IcaclsResetCommandOptions,
+  type PermissionCommandFailure,
   type PermissionExec,
   type WindowsAclEntry,
   type WindowsAclSummary,

--- a/src/permission-exec.ts
+++ b/src/permission-exec.ts
@@ -1,15 +1,97 @@
 import { execFile } from "node:child_process";
+import path from "node:path";
 import { promisify } from "node:util";
+import { formatErrorDetail } from "./error-detail.js";
 
 const execFileAsync = promisify(execFile);
 
 export const DEFAULT_PERMISSION_EXEC_TIMEOUT_MS = 30_000;
+
+export type PermissionCommandFailure = {
+  command: string;
+  durationMs: number;
+  timedOut: boolean;
+  exitCode: number | null;
+  signal: string | null;
+  stderr: string;
+};
+
+export function formatPermissionErrorDetail(value: string): string {
+  const formatted = formatErrorDetail(value);
+  return formatted.length > 400 ? `${formatted.slice(0, 399)}…` : formatted;
+}
+
+function commandFailureFields(error: unknown) {
+  const fields = error && typeof error === "object" ? error : {};
+  return {
+    timedOut: "killed" in fields && fields.killed === true &&
+      "signal" in fields && fields.signal === "SIGKILL",
+    exitCode: "code" in fields && typeof fields.code === "number" ? fields.code : null,
+    signal: "signal" in fields && typeof fields.signal === "string" ? fields.signal : null,
+    stderr: formatPermissionErrorDetail(
+      "stderr" in fields && (typeof fields.stderr === "string" || Buffer.isBuffer(fields.stderr))
+        ? fields.stderr.toString() : "",
+    ),
+  };
+}
+
+export class PermissionCommandError extends Error implements PermissionCommandFailure {
+  readonly command: string;
+  readonly durationMs: number;
+  readonly timedOut: boolean;
+  readonly exitCode: number | null;
+  readonly signal: string | null;
+  readonly stderr: string;
+
+  constructor(
+    command: string,
+    durationMs: number,
+    cause: unknown,
+    timeoutMs = DEFAULT_PERMISSION_EXEC_TIMEOUT_MS,
+  ) {
+    const fields = commandFailureFields(cause);
+    super(fields.timedOut
+      ? `Windows permission inspection timed out after ${timeoutMs}ms`
+      : `Windows permission command ${formatPermissionErrorDetail(path.win32.basename(command))} failed (exit code ${fields.exitCode}, signal ${formatPermissionErrorDetail(fields.signal ?? "none")})`,
+    { cause });
+    this.name = "PermissionCommandError";
+    this.command = command;
+    this.durationMs = Math.round(durationMs);
+    this.timedOut = fields.timedOut;
+    this.exitCode = fields.exitCode;
+    this.signal = fields.signal;
+    this.stderr = fields.stderr;
+  }
+}
+
+export function getPermissionCommandFailure(
+  error: unknown,
+  command: string,
+  durationMs: number,
+): PermissionCommandFailure | undefined {
+  if (error instanceof PermissionCommandError) {
+    return {
+      command: error.command,
+      durationMs: error.durationMs,
+      timedOut: error.timedOut,
+      exitCode: error.exitCode,
+      signal: error.signal,
+      stderr: error.stderr,
+    };
+  }
+  if (!error || typeof error !== "object" ||
+    !("code" in error || "signal" in error || "killed" in error || "stderr" in error)) {
+    return undefined;
+  }
+  return { command, durationMs: Math.round(durationMs), ...commandFailureFields(error) };
+}
 
 export async function executePermissionCommand(
   command: string,
   args: string[],
   timeoutMs = DEFAULT_PERMISSION_EXEC_TIMEOUT_MS,
 ): Promise<{ stdout: string; stderr: string }> {
+  const startedAt = performance.now();
   try {
     return (await execFileAsync(command, args, {
       encoding: "utf8",
@@ -19,18 +101,6 @@ export async function executePermissionCommand(
       killSignal: "SIGKILL",
     })) as { stdout: string; stderr: string };
   } catch (err) {
-    if (
-      err &&
-      typeof err === "object" &&
-      "killed" in err &&
-      err.killed === true &&
-      "signal" in err &&
-      err.signal === "SIGKILL"
-    ) {
-      throw new Error(`Windows permission inspection timed out after ${timeoutMs}ms`, {
-        cause: err,
-      });
-    }
-    throw err;
+    throw new PermissionCommandError(command, performance.now() - startedAt, err, timeoutMs);
   }
 }

--- a/src/permissions-public.ts
+++ b/src/permissions-public.ts
@@ -11,6 +11,7 @@ export {
   safeStat,
   type PermissionCheck,
   type PermissionCheckOptions,
+  type PermissionCommandFailure,
   type SafeStatResult,
 } from "./permissions.js";
 export {

--- a/src/permissions-windows.ts
+++ b/src/permissions-windows.ts
@@ -1,6 +1,11 @@
 import os from "node:os";
 import { getNativeBinding } from "./native.js";
-import { executePermissionCommand } from "./permission-exec.js";
+import {
+  executePermissionCommand,
+  formatPermissionErrorDetail,
+  getPermissionCommandFailure,
+  type PermissionCommandFailure,
+} from "./permission-exec.js";
 import type { PermissionCheck, PermissionCheckOptions, SafeStatResult } from "./permissions.js";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.js";
 import { resolveWindowsSystemCommand } from "./windows-command.js";
@@ -32,6 +37,8 @@ export type WindowsAclSummary = {
   untrustedGroup: WindowsAclEntry[];
   trusted: WindowsAclEntry[];
   error?: string;
+  errorDetail?: PermissionCommandFailure;
+  errorCause?: unknown;
 };
 
 export type WindowsUserInfoProvider = () => { username?: string | null };
@@ -142,7 +149,7 @@ export async function inspectWindowsPermissions(params: {
   });
   if (owner.error) {
     const error = `Windows owner inspection failed: ${owner.error}`;
-    return { ...unverified, ownerError: owner.error, error };
+    return { ...unverified, ownerError: owner.error, error, errorDetail: owner.errorDetail, errorCause: owner.errorCause };
   }
   const acl = await inspectWindowsAcl(params.targetPath, {
     env: params.opts?.env,
@@ -156,7 +163,7 @@ export async function inspectWindowsPermissions(params: {
     ...(owner.trusted !== undefined ? { ownerTrusted: owner.trusted } : {}),
     ...(owner.error ? { ownerError: owner.error } : {}),
   };
-  if (!acl.ok) return { ...unverified, ...ownerFields, error: acl.error };
+  if (!acl.ok) return { ...unverified, ...ownerFields, error: acl.error, errorDetail: acl.errorDetail, errorCause: acl.errorCause };
   return {
     ok: true,
     isSymlink: params.stat.isSymlink,
@@ -276,7 +283,13 @@ export function summarizeWindowsAcl(entries: WindowsAclEntry[], env?: NodeJS.Pro
 }
 
 export async function inspectWindowsAcl(targetPath: string, opts?: { env?: NodeJS.ProcessEnv; exec?: PermissionExec; currentUserSid?: string; principalSids?: Record<string, string>; principalTranslationFailed?: boolean }): Promise<WindowsAclSummary> {
-  const exec = opts?.exec ?? defaultPermissionExec;
+  let command = "";
+  let startedAt = performance.now();
+  const exec: PermissionExec = async (file, args) => {
+    command = file;
+    startedAt = performance.now();
+    return await (opts?.exec ?? defaultPermissionExec)(file, args);
+  };
   try {
     if (opts?.principalTranslationFailed) throw new Error("Windows ACL principal SID translation failed");
     const { stdout, stderr } = await exec(resolveWindowsSystemCommand("icacls.exe", opts?.env), [targetPath]);
@@ -301,7 +314,12 @@ export async function inspectWindowsAcl(targetPath: string, opts?: { env?: NodeJ
     }
     return { ok: true, entries, trusted, untrustedWorld, untrustedGroup };
   } catch (err) {
-    return { ok: false, entries: [], trusted: [], untrustedWorld: [], untrustedGroup: [], error: String(err) };
+    return {
+      ok: false, entries: [], trusted: [], untrustedWorld: [], untrustedGroup: [],
+      error: formatPermissionErrorDetail(String(err)),
+      errorDetail: getPermissionCommandFailure(err, command, performance.now() - startedAt),
+      errorCause: err,
+    };
   }
 }
 

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs/promises";
+import type { PermissionCommandFailure } from "./permission-exec.js";
 import {
   formatIcaclsResetCommand,
   inspectWindowsPermissions,
   type PermissionExec,
 } from "./permissions-windows.js";
+export type { PermissionCommandFailure } from "./permission-exec.js";
 export {
   createIcaclsResetCommand,
   formatIcaclsResetCommand,
@@ -40,6 +42,9 @@ export type PermissionCheck = {
   ownerError?: string;
   aclSummary?: string;
   error?: string;
+  errorDetail?: PermissionCommandFailure;
+  /** Original inspection failure, retained separately from serializable diagnostics. */
+  errorCause?: unknown;
 };
 
 export type PermissionCheckOptions = {

--- a/src/secure-file.ts
+++ b/src/secure-file.ts
@@ -10,6 +10,7 @@ import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { isWindowsDriveLetterPath, isWindowsNetworkPath } from "./local-file-access.js";
 import { isPathInside, isSymlinkOpenError } from "./path.js";
+import { formatPermissionErrorDetail } from "./permission-exec.js";
 import {
   inspectPathPermissions,
   isGroupReadable,
@@ -177,13 +178,24 @@ async function assertSecurePermissions(
   const permissions = platform === "win32"
     ? await inspectPathPermissions(realPath, options.inject)
     : inspectOpenedPermissions(stat, platform);
+  const reason = permissions.error ? `: ${formatPermissionErrorDetail(permissions.error)}` : "";
+  const diagnostics = {
+    ...(permissions.errorCause !== undefined ? { cause: permissions.errorCause } : {}),
+    ...(permissions.ownerError || permissions.errorDetail ? {
+      details: {
+        ...(permissions.ownerError ? { ownerError: formatPermissionErrorDetail(permissions.ownerError) } : {}),
+        ...permissions.errorDetail,
+      },
+    } : {}),
+  };
   if (!permissions.ok) {
-    throw new FsSafeError("permission-unverified", `${label(options)} permissions could not be verified: ${realPath}`);
+    throw new FsSafeError("permission-unverified", `${label(options)} permissions could not be verified: ${realPath}${reason}`, diagnostics);
   }
   if (platform === "win32" && permissions.source === "unknown") {
     throw new FsSafeError(
       "permission-unverified",
-      `${label(options)} ACL verification unavailable on Windows for ${realPath}.`,
+      `${label(options)} ACL verification unavailable on Windows for ${realPath}${reason || "."}`,
+      diagnostics,
     );
   }
   if (platform === "win32" && permissions.ownerTrusted !== true) {

--- a/src/windows-owner.ts
+++ b/src/windows-owner.ts
@@ -1,3 +1,8 @@
+import {
+  formatPermissionErrorDetail,
+  getPermissionCommandFailure,
+  type PermissionCommandFailure,
+} from "./permission-exec.js";
 import { resolveWindowsSystemCommand } from "./windows-command.js";
 
 export type WindowsOwnerExec = (
@@ -13,6 +18,8 @@ export type WindowsOwnerSummary = {
   remote?: boolean;
   trusted?: boolean;
   error?: string;
+  errorDetail?: PermissionCommandFailure;
+  errorCause?: unknown;
 };
 
 const SID_RE = /^\*?s-\d+-\d+(-\d+)+$/i;
@@ -126,11 +133,14 @@ export async function inspectWindowsOwner(params: {
   env?: NodeJS.ProcessEnv;
   exec: WindowsOwnerExec;
 }): Promise<WindowsOwnerSummary> {
+  let command = "";
+  let startedAt = performance.now();
   try {
-    const command = resolveWindowsSystemCommand(
+    command = resolveWindowsSystemCommand(
       String.raw`WindowsPowerShell\v1.0\powershell.exe`,
       params.env,
     );
+    startedAt = performance.now();
     const { stdout } = await params.exec(command, [
       "-NoLogo",
       "-NoProfile",
@@ -166,6 +176,10 @@ export async function inspectWindowsOwner(params: {
       trusted: !remote && (ownerSid === currentUserSid || TRUSTED_OWNER_SIDS.has(ownerSid)),
     };
   } catch (err) {
-    return { error: String(err) };
+    return {
+      error: formatPermissionErrorDetail(String(err)),
+      errorDetail: getPermissionCommandFailure(err, command, performance.now() - startedAt),
+      errorCause: err,
+    };
   }
 }

--- a/test/permissions-exec.test.ts
+++ b/test/permissions-exec.test.ts
@@ -6,7 +6,10 @@ import { expectFsSafeError } from "./helpers/security.js";
 import {
   DEFAULT_PERMISSION_EXEC_TIMEOUT_MS,
   executePermissionCommand,
+  getPermissionCommandFailure,
+  PermissionCommandError,
 } from "../src/permission-exec.js";
+import { FsSafeError } from "../src/errors.js";
 import {
   __resetFsSafeNativeConfigForTest,
   configureFsSafeNative,
@@ -30,12 +33,165 @@ describe("Windows permission command execution", () => {
     const timeoutMs = 100;
     const startedAt = performance.now();
 
-    await expect(
-      executePermissionCommand(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], timeoutMs),
-    ).rejects.toThrow(`Windows permission inspection timed out after ${timeoutMs}ms`);
+    const execution = executePermissionCommand(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], timeoutMs);
+    await expect(execution).rejects.toThrow(`Windows permission inspection timed out after ${timeoutMs}ms`);
+    await expect(execution).rejects.toBeInstanceOf(PermissionCommandError);
+    await expect(execution).rejects.toMatchObject({
+      command: process.execPath,
+      durationMs: expect.any(Number),
+      timedOut: true,
+      exitCode: null,
+      signal: "SIGKILL",
+      cause: expect.objectContaining({ killed: true, signal: "SIGKILL" }),
+    });
+    await execution.catch((error: PermissionCommandError) => {
+      expect(error.durationMs).toBeGreaterThanOrEqual(timeoutMs);
+      expect(Number.isInteger(error.durationMs)).toBe(true);
+    });
 
     expect(performance.now() - startedAt).toBeLessThan(3_000);
     expect(DEFAULT_PERMISSION_EXEC_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it("preserves non-timeout child failures without copying stdout into diagnostics", async () => {
+    const execution = executePermissionCommand(process.execPath, [
+      "-e",
+      'process.stdout.write("PRIVATE_CHILD_STDOUT"); process.stderr.write("ACL access denied"); process.exitCode = 23;',
+    ]);
+    await expect(execution).rejects.toBeInstanceOf(PermissionCommandError);
+    await expect(execution).rejects.toMatchObject({
+      command: process.execPath,
+      timedOut: false,
+      exitCode: 23,
+      signal: null,
+      stderr: "ACL access denied",
+      message: expect.stringContaining(`${path.basename(process.execPath)} failed (exit code 23`),
+      cause: expect.objectContaining({ code: 23 }),
+    });
+    await execution.catch((error: PermissionCommandError) => {
+      expect(error.durationMs).toBeGreaterThanOrEqual(0);
+      expect(Number.isInteger(error.durationMs)).toBe(true);
+      const detail = getPermissionCommandFailure(error, "ignored", 0);
+      expect(Object.keys(detail!).sort()).toEqual([
+        "command", "durationMs", "exitCode", "signal", "stderr", "timedOut",
+      ]);
+      expect(`${error.message}${JSON.stringify(detail)}`).not.toContain("PRIVATE_CHILD_STDOUT");
+    });
+  });
+
+  it("escapes control characters in stderr and bounds the excerpt including its marker", async () => {
+    const stderr = `\u001b[31mdenied\n${"x".repeat(500)}`;
+    const escapedPrefix = "\\u001b[31mdenied\\u000a";
+    await expect(executePermissionCommand(process.execPath, [
+      "-e", `process.stderr.write(${JSON.stringify(stderr)}); process.exitCode = 1;`,
+    ])).rejects.toMatchObject({
+      stderr: `${escapedPrefix}${"x".repeat(399 - escapedPrefix.length)}…`,
+      timedOut: false,
+    });
+  });
+
+  it("wraps spawn errors and leaves plain errors without invented command details", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-permission-spawn-"));
+    tempDirs.push(dir);
+    const command = path.join(dir, "missing-command");
+    await expect(executePermissionCommand(command, [])).rejects.toMatchObject({
+      name: "PermissionCommandError", command, timedOut: false,
+      exitCode: null, signal: null, stderr: "",
+      cause: expect.objectContaining({ code: "ENOENT" }),
+    });
+    expect(getPermissionCommandFailure(new Error("plain"), command, 10)).toBeUndefined();
+    expect(getPermissionCommandFailure(null, command, 10)).toBeUndefined();
+  });
+
+  it.each(["structured", "raw"])("preserves a %s owner timeout through a failed secure read", async (kind) => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-permission-owner-detail-"));
+    tempDirs.push(dir);
+    const target = path.join(dir, "secret.json");
+    const secret = "SECRET_FILE_CONTENT_MUST_NOT_APPEAR";
+    await fs.writeFile(target, secret, { mode: 0o600 });
+    const original = Object.assign(new Error("owner query timed out"), {
+      killed: true, signal: "SIGKILL", code: null, stderr: "owner inspection stalled\n",
+    });
+    let commandError: unknown;
+    const exec = vi.fn(async (command: string) => {
+      commandError = kind === "structured"
+        ? new PermissionCommandError(command, 30_125, original)
+        : original;
+      throw commandError;
+    });
+    const failure = await readSecureFile({
+      filePath: target,
+      inject: { platform: "win32", env: { SystemRoot: "C:\\Windows" }, exec },
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(FsSafeError);
+    expect(failure).toMatchObject({
+      code: "permission-unverified",
+      category: "operational",
+      message: expect.stringContaining(kind === "structured"
+        ? "Windows permission inspection timed out after 30000ms" : "owner query timed out"),
+      details: {
+        command: expect.stringContaining("powershell.exe"),
+        durationMs: kind === "structured" ? 30_125 : expect.any(Number),
+        timedOut: true, exitCode: null, signal: "SIGKILL",
+        stderr: "owner inspection stalled\\u000a",
+        ownerError: expect.stringContaining("timed out"),
+      },
+    });
+    const error = failure as FsSafeError;
+    expect(error.cause).toBe(commandError);
+    if (kind === "structured") expect((error.cause as Error).cause).toBe(original);
+    expect(`${error.message}${JSON.stringify(error.details)}`).not.toContain(secret);
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves icacls stderr and exit status after a successful owner query", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-permission-acl-detail-"));
+    tempDirs.push(dir);
+    const target = path.join(dir, "secret.json");
+    const secret = "SECRET_FILE_CONTENT_MUST_NOT_APPEAR";
+    await fs.writeFile(target, secret, { mode: 0o600 });
+    const original = Object.assign(new Error(`ACL query denied\n${"x".repeat(500)}`), {
+      code: 5, signal: null, killed: false,
+      stderr: `\u001b[31mACL access denied\n${"x".repeat(500)}`,
+      stdout: "PRIVATE_CHILD_STDOUT",
+    });
+    const exec = vi.fn(async (command: string) => {
+      if (command.endsWith("powershell.exe")) {
+        return { stdout: JSON.stringify({
+          ownerSid: "S-1-5-21-42", currentUserSid: "S-1-5-21-42", remote: false,
+        }), stderr: "" };
+      }
+      throw original;
+    });
+    const failure = await readSecureFile({
+      filePath: target,
+      inject: { platform: "win32", env: { SystemRoot: "C:\\Windows" }, exec },
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(FsSafeError);
+    expect(failure).toMatchObject({
+      code: "permission-unverified", category: "operational",
+      message: expect.stringContaining("Error: ACL query denied\\u000a"),
+      details: {
+        command: "C:\\Windows\\System32\\icacls.exe",
+        durationMs: expect.any(Number), timedOut: false, exitCode: 5, signal: null,
+        stderr: expect.stringContaining("\\u001b[31mACL access denied\\u000a"),
+      },
+    });
+    const error = failure as FsSafeError;
+    expect(error.cause).toBe(original);
+    expect(error.details?.stderr).toHaveLength(400);
+    expect(String(error.details?.stderr)).toMatch(/…$/u);
+    const reason = error.message.split(": Error: ")[1]!;
+    expect(`Error: ${reason}`).toHaveLength(400);
+    const diagnostic = `${error.message}${JSON.stringify(error.details)}`;
+    expect(diagnostic).not.toContain(secret);
+    expect(diagnostic).not.toContain("PRIVATE_CHILD_STDOUT");
+    expect(diagnostic).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/u);
+    expect(exec.mock.calls.map(([command]) => path.win32.basename(command))).toEqual([
+      "powershell.exe", "icacls.exe",
+    ]);
   });
 
   it("allows a slow command to finish within its deadline", async () => {

--- a/test/permissions-failures.test.ts
+++ b/test/permissions-failures.test.ts
@@ -108,4 +108,31 @@ describe("permission inspection failure modes", () => {
     });
     expect(exec).toHaveBeenCalledTimes(1);
   });
+
+  it("attributes an injected principal translation failure to PowerShell, not icacls", async () => {
+    const original = Object.assign(new Error("translation denied"), {
+      code: 9, signal: null, stderr: "SID translation failed\n",
+    });
+    const exec = vi.fn(async (command: string) => {
+      if (command.endsWith("icacls.exe")) return { stdout: "DOMAIN\\user:(R)\n", stderr: "" };
+      throw original;
+    });
+    const result = await inspectWindowsAcl("C:\\secret", {
+      exec, env: { SystemRoot: "C:\\Windows" },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "Error: translation denied",
+      errorDetail: {
+        command: expect.stringContaining("powershell.exe"),
+        durationMs: expect.any(Number), timedOut: false, exitCode: 9, signal: null,
+        stderr: "SID translation failed\\u000a",
+      },
+    });
+    expect(result.errorCause).toBe(original);
+    expect(exec.mock.calls.map(([command]) => path.win32.basename(command))).toEqual([
+      "icacls.exe", "powershell.exe",
+    ]);
+  });
 });

--- a/test/public-api.json
+++ b/test/public-api.json
@@ -286,6 +286,7 @@
         "PathScope",
         "PathScopeOptions",
         "PathScopeResolveOptions",
+        "PermissionCommandFailure",
         "PermissionExec",
         "ReadLocalFileFromRootsOptions",
         "RegularFileStatResult",
@@ -402,6 +403,7 @@
         "OwnerAndDaclResult",
         "PermissionCheck",
         "PermissionCheckOptions",
+        "PermissionCommandFailure",
         "SafeStatResult",
         "WindowsAccessControlEntry",
         "WindowsAceFlags"

--- a/test/secure-file-failure.test.ts
+++ b/test/secure-file-failure.test.ts
@@ -80,7 +80,11 @@ describe("secure file inspection failures", () => {
     });
     await expect(
       readSecureFile({ filePath, inject: { platform: "win32" } }),
-    ).rejects.toMatchObject({ code: "permission-unverified" });
+    ).rejects.toMatchObject({
+      code: "permission-unverified",
+      category: "operational",
+      message: expect.stringContaining("Error: permission inspection denied"),
+    });
   });
 
   it("times out a stalled read and closes its pinned handle", async () => {


### PR DESCRIPTION
## Problem

Windows ACL verification flattened an underlying command failure into a generic `permission-unverified` error, discarding the stderr, exit status, and timing needed to diagnose it. The [flaky first-run CI job from PR #149](https://github.com/openclaw/fs-safe/actions/runs/33139324912/job/98746388827) illustrates the diagnostic gap on contended Windows runners.

[PR #99](https://github.com/openclaw/fs-safe/pull/99) raised the built-in deadline to 30 seconds per subprocess. This change preserves evidence when a command still fails, making those failures diagnosable and giving any future retry condition real diagnostics to inspect.

## Change

- Add a typed `PermissionCommandError` with command timing in `permission-exec`; propagate a structured `PermissionCommandFailure` containing `command`, `durationMs`, `timedOut`, `exitCode`, `signal`, and sanitized, bounded stderr.
- Thread `errorDetail` and `errorCause` through `inspectWindowsOwner`, `inspectWindowsAcl`, and `PermissionCheck`.
- Attach the diagnostics to `FsSafeError` details and cause, and enrich its message in `secure-file`.
- Sanitize diagnostics with `formatErrorDetail` and a 400-character cap. Capture stderr only, never stdout or file contents.
- Preserve command attribution so failures distinguish `powershell.exe` from `icacls.exe`, including failures reached through `whoami`.
- Export `PermissionCommandFailure` through the `/permissions` and `/advanced` package subpaths.
- Update the permission and secure-file documentation and changelog.

## Unchanged

Security assertion semantics, error codes, throw conditions, and fail-closed behavior remain unchanged. No retries are added.

## Proof

Completed verification for the prepared change:

- Focused Vitest run covering six permission, secure-file, API, and documentation test files: 125 passed.
- TypeScript (`tsc`), file-size and filesystem-boundary lints, documentation checks, and package/public-API checks: all green.
- Full local `pnpm test` has pre-existing native PAX failures caused by a stale prebuilt native binary. These are unrelated to this change and fail identically on clean `main`.

Refs #99.
