### PR TITLE
fix(tests): use native smoke result descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Docs and Tooling
 
+- Fix the standalone native smoke script to use the numeric descriptor returned by `openBeneath()` for identity checks and cleanup.
 - Accept npm 11 array and npm 12 package-name-keyed pack results while validating the intended package and its file metadata.
 
 ### Dependencies and maintenance

--- a/scripts/native-smoke.mjs
+++ b/scripts/native-smoke.mjs
@@ -18,7 +18,7 @@ try {
   console.log("native smoke: write fixture");
   fs.writeFileSync(path.join(root, "nested", "source"), "source");
   console.log("native smoke: open");
-  const fd = native.openBeneath(rootFd, "nested/source", fs.constants.O_RDONLY);
+  const { fd } = native.openBeneath(rootFd, "nested/source", fs.constants.O_RDONLY);
   try {
     console.log("native smoke: fstat");
     const identity = native.fstatIdentity(fd);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where running the standalone native filesystem diagnostic failed during descriptor identity checking and cleanup. `openBeneath()` returns `{ fd, containment }`, but this script still treated the entire result as a numeric descriptor. Its `closeSync()` error also masked the original identity-check failure.

This is a stale standalone script contract, not a broken CI path: current CI uses `scripts/native-mode-smoke.mjs`.

## Why This Change Was Made

Destructure the numeric `fd` at the call site and retain the existing `try/finally` ownership. Keep the tiny diagnostic available without changing the binding, containment semantics, Windows lossless identities, or retained-directory staging. The return-contract migration in #65 missed this caller; current documentation already describes the object result.

## User Impact

Tooling only. The standalone diagnostic can complete its mkdir, open, identity, hardlink, rename, and collision checks again. No public API, package behavior, security policy, or compatibility change.

## Evidence

Actual darwin-arm64 addon, built with `pnpm build` and `pnpm native:build`:

- Before: `node scripts/native-smoke.mjs` exited 1 with `ERR_INVALID_ARG_TYPE`: the fd argument received an Object.
- After: the same command exited 0 with `native smoke: PASS`, including the later hardlink and rename/collision checks.
- Existing native descriptor/containment integration regression passed against the built addon.
- `pnpm check`: lint, build, and documentation checks passed; tests hit 68 timeouts plus cleanup errors on a heavily loaded host.
- Full suite retried with `pnpm test --maxWorkers=2`: 1,282 passed, 112 skipped, three archive-fuzz tests timed out. Test timeouts and repository configuration are unchanged. PR CI remains the full-suite landing gate.
- `git diff --check` passed. Independent Codex autoreview reported no actionable findings.

- [x] Existing regression test and actual native before/after smoke exercised
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated for the tooling correction
- [x] No credentials, private paths, private hosts, or sensitive contents included
