### PR TITLE
feat(native): split bindings into platform packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Deliberately do not build a host binding here. On Windows this exercises
-      # the shipping command fallback; native-check covers the bundled binding.
+      # the shipping command fallback; native-check covers the platform binding.
       - name: Check JavaScript fallback
         run: pnpm check
 
@@ -207,12 +207,12 @@ jobs:
       - name: Build and stage host binding
         run: pnpm native:build
 
-      - name: Pack and smoke test bundled package
+      - name: Pack and smoke test root and host packages
         run: pnpm package:smoke
 
       - name: Upload behavior proof
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: bundled-package-proof-${{ runner.os }}-${{ runner.arch }}
+          name: platform-package-proof-${{ runner.os }}-${{ runner.arch }}
           path: release-artifacts/manifest.json
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,16 @@ jobs:
           if (!cargo.match(new RegExp(`^version = "${version.replaceAll(".", "\\.")}"$`, "m"))) {
             throw new Error(`native/Cargo.toml does not declare ${version}`);
           }
+          const nativePackages = require("node:fs").readdirSync("packages");
+          if (nativePackages.length !== 7) {
+            throw new Error(`expected seven native packages, found ${nativePackages.length}`);
+          }
+          for (const directory of nativePackages) {
+            const platformPkg = JSON.parse(readFileSync(`packages/${directory}/package.json`, "utf8"));
+            if (platformPkg.version !== version || pkg.optionalDependencies?.[platformPkg.name] !== version) {
+              throw new Error(`${platformPkg.name} and its root optional dependency must declare ${version}`);
+            }
+          }
           NODE
           package_version="$(node -p "require('./package.json').version")"
           [ "${RELEASE_TAG}" = "v${package_version}" ]
@@ -179,7 +189,7 @@ jobs:
           retention-days: 1
 
   collect:
-    name: Assemble and validate @openclaw/fs-safe
+    name: Assemble and validate release packages
     if: github.ref_protected
     needs: prebuild
     runs-on: ubuntu-latest
@@ -214,10 +224,10 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Assemble bundled bindings
-        run: node scripts/assemble-native-binaries.mjs --source artifacts --destination dist/native
+      - name: Assemble platform packages
+        run: node scripts/assemble-native-binaries.mjs --source artifacts
 
-      - name: Pack and smoke test the single package
+      - name: Pack and smoke test all packages
         run: node scripts/check-release-packages.mjs --output release-artifacts
 
       - name: Upload release package
@@ -265,7 +275,7 @@ jobs:
             --notes-file release-notes.md
 
   publish:
-    name: Publish @openclaw/fs-safe
+    name: Publish npm packages
     if: github.ref_protected
     needs: draft-release
     runs-on: ubuntu-latest
@@ -303,8 +313,8 @@ jobs:
           name: release-package
           path: release-artifacts
 
-      - name: Publish validated artifact or verify
-        run: node scripts/publish-or-verify.mjs --package "@openclaw/fs-safe" --artifacts release-artifacts
+      - name: Publish platform packages, then root package
+        run: node scripts/publish-release-packages.mjs release-artifacts
 
   release:
     name: Verify and promote GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,7 @@ jobs:
         run: node scripts/assemble-native-binaries.mjs --source artifacts
 
       - name: Pack and smoke test all packages
-        run: node scripts/check-release-packages.mjs --output release-artifacts
+        run: pnpm package:collect
 
       - name: Upload release package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist/
 node_modules
 target/
 native/*.node
+packages/*/*.node
 native/index.js
 native/index.d.ts
 coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+This will be released as 0.6.0. Native bindings now install through optional
+platform packages; deployments that omit optional dependencies must enable them
+before selecting native mode `require` or using native-only features.
+
 ### Security and Correctness
 
 - Preserve underlying command diagnostics (command, timing, timeout flag, exit code/signal, and sanitized stderr) and cause on Windows ACL `permission-unverified` errors without changing verification semantics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Docs and Tooling
 
+- Publish native bindings as platform-filtered optional packages and load only the matching package, avoiding installation of binaries for six unrelated targets.
 - Restore six missing documentation navigation entries, remove the dangling page, correct the lock-config link, and reject missing, nonexistent, or duplicate registrations before replacing site output. Thanks @Yigtwxx.
 - Fix the standalone native smoke script to use the numeric descriptor returned by `openBeneath()` for identity checks and cleanup.
 - Accept npm 11 array and npm 12 package-name-keyed pack results while validating the intended package and its file metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ before selecting native mode `require` or using native-only features.
 
 ### Docs and Tooling
 
-- Publish native bindings as platform-filtered optional packages and load only the matching package, avoiding installation of binaries for six unrelated targets; verify root-only npm/pnpm resolution and document omitted-optionals limits. Thanks @RomneyDa.
+- Publish native bindings as platform-filtered optional packages and load only the matching package, avoiding installation of binaries for six unrelated targets; verify root-only npm/pnpm resolution and document omitted-optionals limits and native-only recovery guidance. Thanks @RomneyDa.
 - Restore six missing documentation navigation entries, remove the dangling page, correct the lock-config link, and reject missing, nonexistent, or duplicate registrations before replacing site output. Thanks @Yigtwxx.
 - Fix the standalone native smoke script to use the numeric descriptor returned by `openBeneath()` for identity checks and cleanup.
 - Accept npm 11 array and npm 12 package-name-keyed pack results while validating the intended package and its file metadata.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "fs-safe-native"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "bzip2",
  "flate2",

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Full docs and reference at **[fs-safe.io](https://fs-safe.io)**.
 
 ## Contents
 
-[Why this exists](#why-this-exists) · [Not a sandbox](#not-a-sandbox) · [Install](#install) · [0.5 migration](docs/migrating-to-0.5.md) · [Python migration](#migrating-from-the-python-helper) · [Quick start](#quick-start) · [Reading](#reading) · [Subpaths](#subpaths) · [Failure semantics](#failure-semantics-in-the-name) · [Directory durability](#directory-durability) · [Atomic writes](#atomic-writes) · [External outputs](#external-outputs) · [Stores](#stores) · [Secure absolute reads](#secure-absolute-file-reads) · [Walking](#directory-walking) · [Archive extraction](#archive-extraction) · [Path scopes](#advanced-path-scopes) · [Errors](#errors) · [Safety model](#safety-model) · [Limitations](#limitations)
+[Why this exists](#why-this-exists) · [Not a sandbox](#not-a-sandbox) · [Install](#install) · [0.6 migration](docs/migrating-to-0.6.md) · [Python migration](#migrating-from-the-python-helper) · [Quick start](#quick-start) · [Reading](#reading) · [Subpaths](#subpaths) · [Failure semantics](#failure-semantics-in-the-name) · [Directory durability](#directory-durability) · [Atomic writes](#atomic-writes) · [External outputs](#external-outputs) · [Stores](#stores) · [Secure absolute reads](#secure-absolute-file-reads) · [Walking](#directory-walking) · [Archive extraction](#archive-extraction) · [Path scopes](#advanced-path-scopes) · [Errors](#errors) · [Safety model](#safety-model) · [Limitations](#limitations)
 
 ## Why this exists
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pnpm add @openclaw/fs-safe
 
 Node 22 or newer. Core root/path/json/temp helpers avoid framework dependencies. Archive helpers use optional `jszip` and `tar` dependencies for ZIP/TAR support; installs that omit optional dependencies can still use every non-archive subpath.
 
-The package bundles prebuilt native bindings for seven supported targets. They
+The package installs one prebuilt native binding for the current supported target. It
 supply fd-relative and atomic no-replace primitives that Node does not expose
 directly. Configure the lazy loader before first use when you need a strict
 environment policy:
@@ -80,11 +80,11 @@ replace a writable parent between its identity check and Node's pathname
 mutation can redirect that mutation outside the root before the post-check
 reports the escape. Use `require` when hostile concurrent mutation is in scope.
 
-Equivalent env var: `FS_SAFE_NATIVE_MODE=auto|off|require`. All seven binaries
-ship inside `@openclaw/fs-safe`; there are no platform packages, postinstall
-steps, downloads, or consumer Rust builds. This makes the tarball larger than
-a per-platform package, but makes installation deterministic. On a platform
-without a bundled binary, `auto` silently retains lexical and canonical root
+Equivalent env var: `FS_SAFE_NATIVE_MODE=auto|off|require`. The seven bindings
+ship as exact-version optional packages filtered by OS, CPU, and Linux libc, so
+a normal install receives only its matching binary. There are no postinstall
+steps, runtime downloads, or consumer Rust builds. On a platform without a
+published binding, or when optional dependencies are omitted, `auto` silently retains lexical and canonical root
 checks, no-follow opens, guarded temp+rename writes, and post-write identity
 verification. See the [native
 helper policy](docs/native-helper.md) for the exact boundary and deployment
@@ -97,7 +97,7 @@ and guarded JavaScript results are best-effort. See the [security model](docs/se
 
 ## Migrating from the Python helper
 
-Version 0.5 replaces the persistent Python worker with bundled prebuilt native
+Version 0.5 replaces the persistent Python worker with prebuilt native
 bindings. The modes map directly: `configureFsSafePython({ mode: "auto" })`
 becomes `configureFsSafeNative({ mode: "auto" })`, and likewise for `off` and
 `require`. Replace `FS_SAFE_PYTHON_MODE` with `FS_SAFE_NATIVE_MODE`; remove

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -1,6 +1,6 @@
 # Archive extraction
 
-`@openclaw/fs-safe/archive` extracts ZIP and TAR archives behind one API, with traversal checks, blocked-link-type rejection, and entry-count and byte budgets. When the bundled native binding is available for the current platform, Rust streams ZIP, TAR, gzip, zstd, and bzip2 while TypeScript remains the sole policy owner; every accepted output is created fd-relative in a private staging root. Extraction then merges through the same safe-open boundary used by direct writes — a symlinked entry can't trick the merge into following an out-of-tree path.
+`@openclaw/fs-safe/archive` extracts ZIP and TAR archives behind one API, with traversal checks, blocked-link-type rejection, and entry-count and byte budgets. When the native binding is available for the current platform, Rust streams ZIP, TAR, gzip, zstd, and bzip2 while TypeScript remains the sole policy owner; every accepted output is created fd-relative in a private staging root. Extraction then merges through the same safe-open boundary used by direct writes — a symlinked entry can't trick the merge into following an out-of-tree path.
 
 The guarded JavaScript fallback uses optional runtime dependencies: `jszip` for
 ZIP and `tar` for TAR/gzip. The native path does not use those packages. Installs

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -65,7 +65,11 @@ metadata/tarball endpoint is checked before installation, so a missing fixture
 cannot masquerade as successful platform filtering. These temporary fixtures
 never enter `packages/`, release artifacts, or the publish manifest. They prove
 installer filtering, not foreign native compilation or execution. Full release
-collection uses the actual seven collected native tarballs instead. Archive
+collection uses the actual seven collected native tarballs instead. Run it with
+`pnpm package:collect` after assembling all seven real bindings; missing targets
+fail collection. `pnpm package:collect --allow-host-only` exercises the same
+lifecycle boundary locally but proves only the host. Both collection commands
+require the pnpm lifecycle CLI path; direct `node` invocation is unsupported. Archive
 codecs and their dependencies are packed from the installed dependency graph.
 
 PR CI builds and executes four host targets: Linux x64 glibc, Linux x64 musl

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -79,8 +79,14 @@ Small, focused PRs land faster. The general shape:
 
 Maintainers publish from a protected `vX.Y.Z` tag on `main` through
 `.github/workflows/release.yml`. The workflow requires the package version and a
-dated `CHANGELOG.md` section to match the tag, then publishes with npm trusted
-publishing and provenance before creating the GitHub release.
+dated `CHANGELOG.md` section to match the tag. It builds and publishes all seven
+platform packages before publishing `@openclaw/fs-safe`, verifies every registry
+artifact and provenance statement, and then creates the GitHub release.
+
+Each package needs its own npm trusted-publisher configuration for
+`openclaw/fs-safe` and `release.yml`. A new platform package must be created and
+configured on npm before the first tag that references it; npm trust is
+package-specific and cannot be bootstrapped by the tag workflow itself.
 
 External contributors do not need to do anything beyond getting the pull
 request merged. Maintainers must not publish locally or add npm automation

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -114,7 +114,7 @@ type FsSafeErrorCode =
 | `device-path` | A read/open target is a known unsafe device or process-fd path. | `/dev/zero`, `/dev/random`, `/dev/stdin`, `/dev/fd/*`, `/proc/*/fd/*`, or a Windows reserved device name. |
 | `hardlink` | Read or copy with `hardlinks: "reject"` saw `nlink > 1`. | File is hardlinked — possibly an alias of an out-of-tree inode. |
 | `helper-failed` | A native mechanism or multi-step operational helper failed. | Inspect `cause` and any operation-specific `details`; retrying may be unsafe if the operation partially completed. |
-| `helper-unavailable` | Required native binding could not be loaded. | Unsupported platform, missing/incompatible bundled binary, or `FS_SAFE_NATIVE_MODE=require`. `auto` falls back where possible; `require` fails closed. |
+| `helper-unavailable` | Required native binding could not be loaded. | Unsupported platform, omitted/missing/incompatible platform package, or `FS_SAFE_NATIVE_MODE=require`. `auto` falls back where possible; `require` fails closed. |
 | `insecure-permissions` | A secure file or path permission check found a mode/ACL that allows broader access than requested. | File or directory is group/world writable/readable; Windows ACL grants broad read. |
 | `invalid-path` | Input was empty, contained NUL, was an unparseable URL, or otherwise unusable. | Caller didn't validate input; input was a network path on Windows, a drive-relative segment in a portable relative path or store key, or a leading drive-relative spelling such as `C:name` used as a Root destination. Existing-object Root lookups retain legal POSIX drive-like names. |
 | `not-empty` | `remove()` on a non-empty directory. | Use `replaceDirectoryAtomic` or remove children first. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ await fs.remove("notes/archive/today.txt");
 
 - **First time?** [Install](install.md), then walk through the [Quickstart](quickstart.md). Five minutes from `pnpm add` to a working root.
 - **Upgrading from 0.4?** Follow [Migrating to 0.5](migrating-to-0.5.md) in order, including the archive clamp-default audit.
+- **Upgrading from 0.5?** Follow [Migrating to 0.6](migrating-to-0.6.md) to adopt platform-native optional packages.
 - **Designing a workspace feature.** Read the [Security model](security-model.md) before you trust the boundary, the [native helper policy](native-helper.md) before you pick deployment defaults, and the [Errors](errors.md) reference so you know what to catch.
 - **Replacing ad-hoc atomic writes.** Jump to [Atomic writes](atomic.md) or, for keyed JSON state, [JSON files](json.md).
 - **Extracting an upload.** Start at [Archive extraction](archive.md) — handles ZIP and TAR with traversal, link, count, and byte limits.
@@ -74,6 +75,7 @@ await fs.remove("notes/archive/today.txt");
 | [`@openclaw/fs-safe/advanced`](advanced.md) | Directory of lower-level composition helpers (path scopes, regular-file I/O, install paths, sibling-temp writes, …). |
 | [`@openclaw/fs-safe/test-hooks`](test-hooks.md) | Test-only injection hooks for reproducing open/lstat races. |
 | [Migrating to 0.5](migrating-to-0.5.md) | End-to-end checklist for Python removal and 0.4 API behavior changes. |
+| [Migrating to 0.6](migrating-to-0.6.md) | Installer-policy checklist for the platform-native package split. |
 
 ## Status
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ await fs.remove("notes/archive/today.txt");
 |---|---|
 | [`root()`](root.md) | One boundary for read/write/move/remove and bounded recursive walking inside a trusted directory. |
 | [`@openclaw/fs-safe/config`](config.md) | Process-global native helper and lock-option defaults. |
-| [Native helper policy](native-helper.md) | Choose `auto`, `off`, or `require` for bundled native primitives. |
+| [Native helper policy](native-helper.md) | Choose `auto`, `off`, or `require` for platform-native primitives. |
 | [Native architecture](native.md) | Understand the thin syscall layer, beneath model, platform mechanisms, and fallback boundary. |
 | [`replaceFileAtomic`](atomic.md) | Sibling-temp + rename, fsync hooks, mode preservation, copy fallback. |
 | [`@openclaw/fs-safe/durability`](durability.md) | Pinned directory identities, durable creation, exclusive publication, streaming SHA-256, provenance receipts, and sync-failure policy. |

--- a/docs/install.md
+++ b/docs/install.md
@@ -87,17 +87,21 @@ Use the main entry for the common surface, or the focused subpaths when you want
 
 `@openclaw/fs-safe` lists `jszip` and `tar` as optional dependencies for [archive extraction](archive.md). They are loaded lazily and only required when ZIP/TAR helpers run. Installs that omit optional dependencies can still import and use every non-archive subpath; archive calls fail with a clear missing-optional-dependency message.
 
-There are no peer dependencies. The single npm package bundles all seven native binaries, so consumers do not run a native build, download platform code, or execute a postinstall step. Shipping every target increases the tarball size compared with per-platform packages, intentionally trading bandwidth for deterministic installation.
+There are no peer dependencies. Exact-version optional packages carry the seven
+native targets and npm-compatible OS, CPU, and Linux libc filters install only
+the matching binary. Consumers do not run a native build, download code at
+runtime, or execute a postinstall step. Omitting optional dependencies keeps the
+guarded JavaScript fallback but disables native-only features.
 
 Upgrading an existing consumer? Follow [Migrating to 0.5](migrating-to-0.5.md)
 before choosing a native mode or accepting the new archive clamp default.
 
 ## Native helper policy
 
-The bundled native binaries provide fd-relative open/link/mkdir primitives,
+The platform native binaries provide fd-relative open/link/mkdir primitives,
 atomic no-replace rename, and file identity checks. The default is `auto`: use
 the matching binary when it loads, otherwise silently keep the guarded
-JavaScript path. Platforms without one of the seven bundled targets therefore
+JavaScript path. Platforms without one of the seven published targets therefore
 continue through the documented fallback in `auto` mode.
 
 ```ts

--- a/docs/install.md
+++ b/docs/install.md
@@ -93,8 +93,8 @@ the matching binary. Consumers do not run a native build, download code at
 runtime, or execute a postinstall step. Omitting optional dependencies keeps the
 guarded JavaScript fallback but disables native-only features.
 
-Upgrading an existing consumer? Follow [Migrating to 0.5](migrating-to-0.5.md)
-before choosing a native mode or accepting the new archive clamp default.
+Upgrading an existing 0.5 consumer? Follow [Migrating to 0.6](migrating-to-0.6.md)
+before deploying with native mode `require` or native-only features.
 
 ## Native helper policy
 

--- a/docs/migrating-to-0.5.md
+++ b/docs/migrating-to-0.5.md
@@ -8,8 +8,8 @@ description: "Ordered checklist for moving a 0.4 consumer from the Python helper
 Use this checklist from top to bottom. Version 0.5 replaces the Python worker,
 changes the default archive mode policy, and adds explicit contracts for
 publication, walking, locks, secrets, and native-only features. Nothing in this
-guide requires a Rust toolchain: all supported native binaries are prebuilt and
-bundled in `@openclaw/fs-safe`.
+guide requires a Rust toolchain: all supported native binaries are prebuilt.
+Current releases install the matching exact-version optional platform package.
 
 ## 1. Update the package and runtime
 
@@ -17,10 +17,10 @@ bundled in `@openclaw/fs-safe`.
 - Update `@openclaw/fs-safe` and regenerate every lock or shrinkwrap file your
   deployment consumes.
 - Keep optional dependencies enabled if you want JavaScript ZIP/TAR support.
-  Native loading no longer depends on optional packages because all seven
-  binaries ship in `@openclaw/fs-safe`. An install that omits optional packages
-  can still import fs-safe, but missing JS archive decoders fail with actionable
-  errors.
+  Native loading no longer depends on Python. Keep optional dependencies enabled
+  for the matching native package and JavaScript ZIP/TAR decoders. An install
+  that omits them can still import fs-safe, but native-only features and missing
+  JS archive decoders fail with actionable errors.
 
 If you call `resolveRootPath()` or `resolveRootPathSync()` directly, upgrade to
 0.5: versions through 0.4.7 could approve an in-root symlink traversal that
@@ -42,7 +42,7 @@ configureFsSafeNative({ mode: "auto" });
 | `configureFsSafePython({ mode })` | `configureFsSafeNative({ mode })` |
 | `FS_SAFE_PYTHON_MODE` | `FS_SAFE_NATIVE_MODE` |
 | `OPENCLAW_FS_SAFE_PYTHON_MODE` | `OPENCLAW_FS_SAFE_NATIVE_MODE` |
-| `pythonPath`, `FS_SAFE_PYTHON`, pinned-Python aliases | Nothing; bundled native binaries do not use an interpreter |
+| `pythonPath`, `FS_SAFE_PYTHON`, pinned-Python aliases | Nothing; prebuilt native binaries do not use an interpreter |
 
 The old names warn once and map `auto`, `off`, or `require` so a shipped 0.4
 deployment does not silently change policy. Interpreter paths are ignored and

--- a/docs/migrating-to-0.6.md
+++ b/docs/migrating-to-0.6.md
@@ -1,0 +1,43 @@
+---
+title: Migrating to 0.6
+description: "Upgrade checklist for the platform-native package split."
+---
+
+# Migrating from 0.5 to 0.6
+
+Version 0.6 moves native bindings out of the root `@openclaw/fs-safe` tarball
+and into exact-version platform packages. This removes unrelated operating
+system and architecture binaries from each installation.
+
+## Keep optional dependencies enabled for native mode
+
+Package managers select one binding by OS, CPU, and Linux libc. A normal
+install needs no command change:
+
+```bash
+pnpm add @openclaw/fs-safe
+```
+
+If a deployment currently installs 0.5 with `--omit=optional`, `--no-optional`,
+or an equivalent lockfile policy, change that policy before upgrading when it
+uses native mode `require` or any native-only feature. Version 0.5 kept its
+binding in the root tarball; version 0.6 intentionally does not.
+
+Omitting optional dependencies remains supported for fallback-capable APIs in
+`auto` mode. It disables native-only features such as zstd/bzip2 TAR handling,
+retained-directory staging, atomic `rename-noreplace`, and Windows private
+directory creation. Native mode `require` reports `helper-unavailable` when the
+matching package is absent or incompatible.
+
+## Deployment checklist
+
+1. Remove any option or policy that omits optional dependencies when native
+   support is required.
+2. Regenerate every lockfile or shrinkwrap file consumed by deployment.
+3. Verify that the lock contains the matching `@openclaw/fs-safe-*` package.
+4. Run a native-required operation on every deployed OS/libc target.
+5. Keep an `FS_SAFE_NATIVE_MODE=off` lane when the guarded JavaScript fallback
+   is part of the application contract.
+
+No Rust toolchain, postinstall build, or runtime download is introduced. See
+[Native helper policy](native-helper.md) for the exact fallback boundary.

--- a/docs/native-helper.md
+++ b/docs/native-helper.md
@@ -98,3 +98,4 @@ consumer performs its 0.5 upgrade.
 - [File locks](sidecar-lock.md)
 - [Durability](durability.md)
 - [Migrating to 0.5](migrating-to-0.5.md)
+- [Migrating to 0.6](migrating-to-0.6.md)

--- a/docs/native-helper.md
+++ b/docs/native-helper.md
@@ -1,11 +1,15 @@
 ---
 title: Native helper policy
-description: "How fs-safe loads its bundled native filesystem primitives and how auto, require, and off affect guarded fallbacks."
+description: "How fs-safe loads its platform-specific native filesystem primitives and how auto, require, and off affect guarded fallbacks."
 ---
 
 # Native helper policy
 
-`@openclaw/fs-safe` itself contains seven prebuilt binaries for Linux x64/arm64 (glibc or musl), macOS x64/arm64, and Windows x64. The loader selects `dist/native/<target>/fs-safe-native.node` without optional platform packages, downloads, postinstall scripts, or a consumer Rust build. Carrying every target makes the npm tarball larger, but every installation receives the same complete artifact.
+`@openclaw/fs-safe` declares seven exact-version optional packages for Linux
+x64/arm64 (glibc or musl), macOS x64/arm64, and Windows x64. Package-manager
+OS, CPU, and libc filters install only the matching package. The loader requires
+that package lazily, without runtime downloads, postinstall scripts, or a
+consumer Rust build.
 
 ```ts
 import { configureFsSafeNative } from "@openclaw/fs-safe/config";
@@ -21,8 +25,8 @@ The equivalent environment variables are `FS_SAFE_NATIVE_MODE` and `OPENCLAW_FS_
 
 | Mode | Behavior |
 |---|---|
-| `auto` | Prefer native primitives when the current bundled binary loads; otherwise silently use the guarded JavaScript path. |
-| `off` | Do not load a bundled binary. Use the guarded JavaScript path deterministically. |
+| `auto` | Prefer native primitives when the current platform package loads; otherwise silently use the guarded JavaScript path. |
+| `off` | Do not load a native package. Use the guarded JavaScript path deterministically. |
 | `require` | Throw `FsSafeError("helper-unavailable")` instead of falling back when an operation needs the native binding and it cannot load. |
 
 Configure the mode once during startup. Loading is lazy and cached; changing from `auto` to `require` after a failed load changes failure policy but does not repeatedly probe the binary.
@@ -34,7 +38,7 @@ change the mode policy of existing fallback-capable APIs.
 
 ## Native boundary
 
-The bundled native layer exposes policy-free filesystem mechanisms: beneath-root
+The native layer exposes policy-free filesystem mechanisms: beneath-root
 open/mkdir/link, replace and no-replace rename, identity reads, archive decode/execution,
 clone/copy/hash workers, and Windows security descriptor calls. The TypeScript
 layer owns policy, retries, filters, budgets, modes, cleanup, error

--- a/docs/native.md
+++ b/docs/native.md
@@ -160,3 +160,4 @@ silently selects the JavaScript fallback in `auto`, throws typed
 - [Durability](durability.md)
 - [Permissions](permissions.md)
 - [Migrating to 0.5](migrating-to-0.5.md)
+- [Migrating to 0.6](migrating-to-0.6.md)

--- a/docs/native.md
+++ b/docs/native.md
@@ -1,11 +1,11 @@
 ---
 title: Native architecture
-description: "The bundled native bindings, fd-relative beneath model, platform mechanisms, loader security, and JavaScript fallback contract."
+description: "The platform-specific native bindings, fd-relative beneath model, platform mechanisms, loader security, and JavaScript fallback contract."
 ---
 
 # Native architecture
 
-`@openclaw/fs-safe` bundles native bindings that supply mechanisms Node does
+`@openclaw/fs-safe` uses native bindings that supply mechanisms Node does
 not expose directly. The Rust layer is deliberately not a second policy engine.
 TypeScript owns trusted-root selection, path validation, archive filtering,
 budgets, modes, identity fencing, cleanup decisions, and error normalization.
@@ -14,8 +14,9 @@ platform syscall sequence that can preserve the boundary.
 
 Every operation that has an equivalent safe Node implementation keeps that
 guarded JavaScript path. Native loading is lazy; installs do not compile Rust,
-run postinstall code, or fetch binaries. The npm tarball carries all seven
-supported targets, so it is larger than a per-platform package by design.
+run postinstall code, or fetch binaries at runtime. Seven exact-version optional
+packages are filtered by OS, CPU, and Linux libc, so an installation receives
+only its matching prebuilt binding.
 Native-only formats and creation-time Windows DACL guarantees fail explicitly
 instead of substituting a weaker implementation.
 
@@ -143,10 +144,10 @@ infer native loading from timing.
 Importing fs-safe never executes a child process. Linux libc selection uses
 the Node process report, conventional musl library filenames, and the ELF
 `PT_INTERP` field of `process.execPath`. If all probes are inconclusive, the
-loader conservatively attempts the bundled glibc binary and lets normal module
-loading fail into `auto` fallback. The loader requires only
-`dist/native/<target>/fs-safe-native.node`; it never probes optional packages,
-downloads code, or runs a postinstall step. A missing or incompatible binary
+loader conservatively attempts the glibc package and lets normal module loading
+fail into `auto` fallback. The loader requires only the package selected from
+the detected target; it never probes unrelated packages, downloads code, or
+runs a postinstall step. A missing or incompatible binary
 silently selects the JavaScript fallback in `auto`, throws typed
 `helper-unavailable` in `require`, and is never inspected in `off`. Tests reject
 `child_process`, `exec`, or `spawn` usage in the loader.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -89,7 +89,7 @@ it as display text.
 The parser is on the advanced surface so tests and CLIs can process captured
 `icacls` output without spawning a process.
 
-When the bundled native binding is available, `inspectPathPermissions()`
+When the native binding is available, `inspectPathPermissions()`
 reads the owner and DACL directly with Windows security APIs. It classifies the
 current user, LocalSystem, and built-in Administrators as trusted and reports
 the world/group read/write facts consumed by secure reads. Descriptor forms it
@@ -139,7 +139,7 @@ Object-specific and other ACE layouts are not guessed: they are omitted,
 `complete` becomes false, and their numeric types appear in
 `unsupportedAceTypes`, allowing a security-sensitive caller to fail closed.
 Non-Windows systems return `{ status: "unsupported-platform", platform }`.
-Windows requires the bundled native binding; if it is unavailable or forced
+Windows requires the native binding; if it is unavailable or forced
 off, the call throws `FsSafeError("helper-unavailable")`. The existing coarse
 `inspectPathPermissions()` API still owns its compatibility fallback and trust
 classification.

--- a/docs/root.md
+++ b/docs/root.md
@@ -140,7 +140,7 @@ new destination name is subject to the portable guard.
 
 ## Native helper mode
 
-Create-only writes prefer the bundled native helper for fd-relative opens and
+Create-only writes prefer the platform native helper for fd-relative opens and
 atomic no-replace rename. Operations without native wiring retain their guarded
 JavaScript implementations.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,7 +17,7 @@ The double-underscore prefix is a deliberate "hands off" signal: production code
 ## When to reach for hooks
 
 - Reproduce a TOCTOU race deterministically: simulate a symlink swap between resolve and open, or between write and rename.
-- Force guarded JavaScript behavior without removing bundled binaries from your runners.
+- Force guarded JavaScript behavior without removing platform packages from your runners.
 - Inject latency to test cancellation/timeout paths.
 
 If you don't need to inject a race, you don't need hooks — most tests should drive the library through normal calls and assert on observable behavior.

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fs-safe-native"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/openclaw/fs-safe"

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-native-build",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Private build workspace for the native bindings bundled by @openclaw/fs-safe.",
   "private": true,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Capability-style filesystem roots for Node.js apps that handle untrusted relative paths.",
   "keywords": [
     "filesystem",
@@ -148,13 +148,13 @@
     "crabbox:warmup": "crabbox warmup"
   },
   "optionalDependencies": {
-    "@openclaw/fs-safe-darwin-arm64": "0.5.6",
-    "@openclaw/fs-safe-darwin-x64": "0.5.6",
-    "@openclaw/fs-safe-linux-arm64-gnu": "0.5.6",
-    "@openclaw/fs-safe-linux-arm64-musl": "0.5.6",
-    "@openclaw/fs-safe-linux-x64-gnu": "0.5.6",
-    "@openclaw/fs-safe-linux-x64-musl": "0.5.6",
-    "@openclaw/fs-safe-win32-x64-msvc": "0.5.6",
+    "@openclaw/fs-safe-darwin-arm64": "0.6.0",
+    "@openclaw/fs-safe-darwin-x64": "0.6.0",
+    "@openclaw/fs-safe-linux-arm64-gnu": "0.6.0",
+    "@openclaw/fs-safe-linux-arm64-musl": "0.6.0",
+    "@openclaw/fs-safe-linux-x64-gnu": "0.6.0",
+    "@openclaw/fs-safe-linux-x64-musl": "0.6.0",
+    "@openclaw/fs-safe-win32-x64-msvc": "0.6.0",
     "jszip": "^3.10.1",
     "tar": "7.5.22"
   },

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "native:test": "cargo test --manifest-path native/Cargo.toml",
     "pack:check": "pnpm build && node scripts/check-pack.mjs",
     "public-api:update": "pnpm build && node scripts/check-pack.mjs --update-public-api",
+    "package:collect": "node scripts/check-release-packages.mjs --output release-artifacts",
     "package:smoke": "node scripts/check-release-packages.mjs --allow-host-only --output release-artifacts",
     "check:changed": "pnpm run check",
     "release:notes": "node scripts/release-notes.mjs",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "dist/**/*.js",
     "dist/**/*.d.ts",
     "dist/**/*.d.ts.map",
-    "dist/native/**/*.node",
     "docs/**/*.md",
     "docs/assets/readme-banner.jpg",
     "README.md",
@@ -149,6 +148,13 @@
     "crabbox:warmup": "crabbox warmup"
   },
   "optionalDependencies": {
+    "@openclaw/fs-safe-darwin-arm64": "0.5.6",
+    "@openclaw/fs-safe-darwin-x64": "0.5.6",
+    "@openclaw/fs-safe-linux-arm64-gnu": "0.5.6",
+    "@openclaw/fs-safe-linux-arm64-musl": "0.5.6",
+    "@openclaw/fs-safe-linux-x64-gnu": "0.5.6",
+    "@openclaw/fs-safe-linux-x64-musl": "0.5.6",
+    "@openclaw/fs-safe-win32-x64-msvc": "0.5.6",
     "jszip": "^3.10.1",
     "tar": "7.5.22"
   },

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-darwin-arm64",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "macOS arm64 native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@openclaw/fs-safe-darwin-arm64",
+  "version": "0.5.6",
+  "description": "macOS arm64 native binding for @openclaw/fs-safe.",
+  "license": "MIT",
+  "author": "OpenClaw Team <dev@openclaw.ai>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openclaw/fs-safe.git",
+    "directory": "packages/darwin-arm64"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "fs-safe-native.node",
+  "files": [
+    "fs-safe-native.node"
+  ],
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@openclaw/fs-safe-darwin-x64",
+  "version": "0.5.6",
+  "description": "macOS x64 native binding for @openclaw/fs-safe.",
+  "license": "MIT",
+  "author": "OpenClaw Team <dev@openclaw.ai>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openclaw/fs-safe.git",
+    "directory": "packages/darwin-x64"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "fs-safe-native.node",
+  "files": [
+    "fs-safe-native.node"
+  ],
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-darwin-x64",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "macOS x64 native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@openclaw/fs-safe-linux-arm64-gnu",
+  "version": "0.5.6",
+  "description": "Linux arm64 glibc native binding for @openclaw/fs-safe.",
+  "license": "MIT",
+  "author": "OpenClaw Team <dev@openclaw.ai>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openclaw/fs-safe.git",
+    "directory": "packages/linux-arm64-gnu"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "fs-safe-native.node",
+  "files": [
+    "fs-safe-native.node"
+  ],
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-arm64-gnu",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Linux arm64 glibc native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-musl/package.json
+++ b/packages/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-arm64-musl",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Linux arm64 musl native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-musl/package.json
+++ b/packages/linux-arm64-musl/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@openclaw/fs-safe-linux-arm64-musl",
+  "version": "0.5.6",
+  "description": "Linux arm64 musl native binding for @openclaw/fs-safe.",
+  "license": "MIT",
+  "author": "OpenClaw Team <dev@openclaw.ai>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openclaw/fs-safe.git",
+    "directory": "packages/linux-arm64-musl"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "main": "fs-safe-native.node",
+  "files": [
+    "fs-safe-native.node"
+  ],
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-x64-gnu",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Linux x64 glibc native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@openclaw/fs-safe-linux-x64-gnu",
+  "version": "0.5.6",
+  "description": "Linux x64 glibc native binding for @openclaw/fs-safe.",
+  "license": "MIT",
+  "author": "OpenClaw Team <dev@openclaw.ai>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openclaw/fs-safe.git",
+    "directory": "packages/linux-x64-gnu"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "fs-safe-native.node",
+  "files": [
+    "fs-safe-native.node"
+  ],
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/linux-x64-musl/package.json
+++ b/packages/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-x64-musl",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Linux x64 musl native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-x64-musl/package.json
+++ b/packages/linux-x64-musl/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@openclaw/fs-safe-linux-x64-musl",
+  "version": "0.5.6",
+  "description": "Linux x64 musl native binding for @openclaw/fs-safe.",
+  "license": "MIT",
+  "author": "OpenClaw Team <dev@openclaw.ai>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openclaw/fs-safe.git",
+    "directory": "packages/linux-x64-musl"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "main": "fs-safe-native.node",
+  "files": [
+    "fs-safe-native.node"
+  ],
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/win32-x64-msvc/package.json
+++ b/packages/win32-x64-msvc/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@openclaw/fs-safe-win32-x64-msvc",
+  "version": "0.5.6",
+  "description": "Windows x64 MSVC native binding for @openclaw/fs-safe.",
+  "license": "MIT",
+  "author": "OpenClaw Team <dev@openclaw.ai>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openclaw/fs-safe.git",
+    "directory": "packages/win32-x64-msvc"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "fs-safe-native.node",
+  "files": [
+    "fs-safe-native.node"
+  ],
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/win32-x64-msvc/package.json
+++ b/packages/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-win32-x64-msvc",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Windows x64 MSVC native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,27 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@types/node@26.3.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.1))
     optionalDependencies:
+      '@openclaw/fs-safe-darwin-arm64':
+        specifier: 0.5.6
+        version: link:packages/darwin-arm64
+      '@openclaw/fs-safe-darwin-x64':
+        specifier: 0.5.6
+        version: link:packages/darwin-x64
+      '@openclaw/fs-safe-linux-arm64-gnu':
+        specifier: 0.5.6
+        version: link:packages/linux-arm64-gnu
+      '@openclaw/fs-safe-linux-arm64-musl':
+        specifier: 0.5.6
+        version: link:packages/linux-arm64-musl
+      '@openclaw/fs-safe-linux-x64-gnu':
+        specifier: 0.5.6
+        version: link:packages/linux-x64-gnu
+      '@openclaw/fs-safe-linux-x64-musl':
+        specifier: 0.5.6
+        version: link:packages/linux-x64-musl
+      '@openclaw/fs-safe-win32-x64-msvc':
+        specifier: 0.5.6
+        version: link:packages/win32-x64-msvc
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -53,6 +74,20 @@ importers:
         version: 7.5.22
 
   native: {}
+
+  packages/darwin-arm64: {}
+
+  packages/darwin-x64: {}
+
+  packages/linux-arm64-gnu: {}
+
+  packages/linux-arm64-musl: {}
+
+  packages/linux-x64-gnu: {}
+
+  packages/linux-x64-musl: {}
+
+  packages/win32-x64-msvc: {}
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,25 +46,25 @@ importers:
         version: 4.1.11(@types/node@26.3.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.3.0)(esbuild@0.28.1))
     optionalDependencies:
       '@openclaw/fs-safe-darwin-arm64':
-        specifier: 0.5.6
+        specifier: 0.6.0
         version: link:packages/darwin-arm64
       '@openclaw/fs-safe-darwin-x64':
-        specifier: 0.5.6
+        specifier: 0.6.0
         version: link:packages/darwin-x64
       '@openclaw/fs-safe-linux-arm64-gnu':
-        specifier: 0.5.6
+        specifier: 0.6.0
         version: link:packages/linux-arm64-gnu
       '@openclaw/fs-safe-linux-arm64-musl':
-        specifier: 0.5.6
+        specifier: 0.6.0
         version: link:packages/linux-arm64-musl
       '@openclaw/fs-safe-linux-x64-gnu':
-        specifier: 0.5.6
+        specifier: 0.6.0
         version: link:packages/linux-x64-gnu
       '@openclaw/fs-safe-linux-x64-musl':
-        specifier: 0.5.6
+        specifier: 0.6.0
         version: link:packages/linux-x64-musl
       '@openclaw/fs-safe-win32-x64-msvc':
-        specifier: 0.5.6
+        specifier: 0.6.0
         version: link:packages/win32-x64-msvc
       jszip:
         specifier: ^3.10.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - native
+  - packages/*
 
 linkWorkspacePackages: true
 

--- a/scripts/assemble-native-binaries.mjs
+++ b/scripts/assemble-native-binaries.mjs
@@ -6,14 +6,13 @@ import {
   statSync,
 } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
-import { nativeTargets } from "./native-targets.mjs";
+import { fileURLToPath } from "node:url";
+import { nativePackageDirectory, nativeTargets } from "./native-targets.mjs";
 
 const sourceIndex = process.argv.indexOf("--source");
 const destinationIndex = process.argv.indexOf("--destination");
 const sourceRoot = resolve(sourceIndex >= 0 ? process.argv[sourceIndex + 1] : "artifacts");
-const destinationRoot = resolve(
-  destinationIndex >= 0 ? process.argv[destinationIndex + 1] : "dist/native",
-);
+const destinationRoot = destinationIndex >= 0 ? resolve(process.argv[destinationIndex + 1]) : undefined;
 
 function filesBelow(directory) {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -23,7 +22,6 @@ function filesBelow(directory) {
 }
 
 const artifacts = filesBelow(sourceRoot);
-rmSync(destinationRoot, { recursive: true, force: true });
 for (const target of nativeTargets) {
   const matches = artifacts.filter((path) => basename(path) === target.artifact);
   if (matches.length !== 1) {
@@ -33,7 +31,11 @@ for (const target of nativeTargets) {
   }
   const [source] = matches;
   if (statSync(source).size === 0) throw new Error(`${target.artifact} is empty`);
-  const destination = join(destinationRoot, target.label, "fs-safe-native.node");
+  const packageDirectory = fileURLToPath(nativePackageDirectory(target));
+  const destination = destinationRoot
+    ? join(destinationRoot, target.label, "fs-safe-native.node")
+    : join(packageDirectory, "fs-safe-native.node");
+  rmSync(destination, { force: true });
   mkdirSync(dirname(destination), { recursive: true });
   copyFileSync(source, destination);
   if (statSync(destination).size === 0) throw new Error(`${destination} is empty after copy`);

--- a/scripts/check-release-packages.mjs
+++ b/scripts/check-release-packages.mjs
@@ -14,8 +14,9 @@ import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { hostNativeTarget, nativePackageDirectory, nativeTargets } from "./native-targets.mjs";
 import { normalizePackResult } from "./npm-pack-result.mjs";
-import { consumerInstallSmoke, isolatedConsumerEnv } from "./consumer-install-smoke.mjs";
+import { consumerInstallSmoke, isolatedConsumerEnv, resolvePnpmCli } from "./consumer-install-smoke.mjs";
 
+const pnpmCli = resolvePnpmCli();
 const outputIndex = process.argv.indexOf("--output");
 const outputDir = resolve(outputIndex >= 0 ? process.argv[outputIndex + 1] : "release-artifacts");
 const allowHostOnly = process.argv.includes("--allow-host-only");
@@ -139,7 +140,7 @@ async function main() {
   if (!host || !targets.some((target) => target.label === host.label)) {
     throw new Error(`release smoke requires the host target ${host?.label ?? "unknown"}`);
   }
-  await consumerInstallSmoke({ rootPkg, manifest, outputDir, npmCli, allowHostOnly });
+  await consumerInstallSmoke({ rootPkg, manifest, outputDir, npmCli, pnpmCli, allowHostOnly });
 
   for (const artifact of manifest) {
     console.log(`${artifact.name}: ${artifact.size} bytes gzipped, ${artifact.unpackedSize} bytes unpacked`);

--- a/scripts/check-release-packages.mjs
+++ b/scripts/check-release-packages.mjs
@@ -12,7 +12,9 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
-import { hostNativeTarget, nativeTargets } from "./native-targets.mjs";
+import { fileURLToPath } from "node:url";
+import { hostNativeTarget, nativePackageDirectory, nativeTargets } from "./native-targets.mjs";
+import { normalizePackResult } from "./npm-pack-result.mjs";
 
 const outputIndex = process.argv.indexOf("--output");
 const outputDir = resolve(outputIndex >= 0 ? process.argv[outputIndex + 1] : "release-artifacts");
@@ -44,72 +46,98 @@ function resolveNpmCli() {
 }
 
 function runNpm(args, options) {
-  return execFileSync(process.execPath, [npmCli, ...args], {
-    ...options,
-    env: npmEnv,
-  });
+  return execFileSync(process.execPath, [npmCli, ...args], { ...options, env: npmEnv });
 }
 
-const pkg = JSON.parse(readFileSync("package.json", "utf8"));
-if (pkg.name !== "@openclaw/fs-safe") throw new Error(`unexpected package name ${pkg.name}`);
-if (pkg.author !== "OpenClaw Team <dev@openclaw.ai>") {
-  throw new Error("root package has unexpected author metadata");
-}
-if (pkg.publishConfig?.access !== "public" || pkg.publishConfig?.provenance !== true) {
-  throw new Error("root package must publish publicly with provenance");
-}
-if (pkg.optionalDependencies?.["@openclaw/fs-safe-native"]) {
-  throw new Error("root package must not depend on the retired native loader package");
+function readPackage(directory = ".") {
+  return JSON.parse(readFileSync(join(directory, "package.json"), "utf8"));
 }
 
-const expectedTargets = allowHostOnly ? [hostNativeTarget()].filter(Boolean) : nativeTargets;
-if (expectedTargets.length === 0) {
-  throw new Error(`no bundled native target for ${process.platform}-${process.arch}`);
-}
-for (const target of expectedTargets) {
-  const binary = join("dist", "native", target.label, "fs-safe-native.node");
-  if (!existsSync(binary) || statSync(binary).size === 0) {
-    throw new Error(`missing or empty bundled binary ${binary}`);
-  }
-}
-
-const packed = JSON.parse(
-  runNpm(
+function packPackage(directory, expectedName) {
+  const output = runNpm(
     ["pack", "--json", "--ignore-scripts", "--pack-destination", outputDir],
-    { encoding: "utf8" },
-  ),
-);
-const [artifact] = packed;
-if (!artifact?.filename || !artifact?.integrity || artifact.version !== pkg.version) {
-  throw new Error("npm pack returned incomplete root-package metadata");
-}
-const paths = new Set(artifact.files.map((file) => file.path));
-for (const expected of ["dist/index.js", "dist/index.d.ts", "package.json"]) {
-  if (!paths.has(expected)) throw new Error(`packed root package is missing ${expected}`);
-}
-for (const target of expectedTargets) {
-  const binary = `dist/native/${target.label}/fs-safe-native.node`;
-  if (!paths.has(binary)) throw new Error(`packed root package is missing ${binary}`);
-}
-if (!allowHostOnly) {
-  const packedNativePaths = [...paths].filter((path) => path.endsWith("/fs-safe-native.node"));
-  if (packedNativePaths.length !== nativeTargets.length) {
-    throw new Error(`packed root package has ${packedNativePaths.length} native binaries, expected 7`);
+    { cwd: directory, encoding: "utf8" },
+  );
+  const parsed = JSON.parse(output);
+  const normalized = normalizePackResult(parsed, expectedName);
+  const entry = Array.isArray(parsed) ? parsed[0] : parsed[expectedName];
+  const artifact = { ...entry, ...normalized };
+  if (!artifact.filename || !artifact.integrity) {
+    throw new Error(`npm pack returned incomplete metadata for ${expectedName}`);
   }
+  return artifact;
 }
 
-const manifest = [
-  {
+function manifestEntry(pkg, artifact) {
+  return {
     name: pkg.name,
     version: pkg.version,
     filename: artifact.filename,
     integrity: artifact.integrity,
     size: artifact.size,
     unpackedSize: artifact.unpackedSize,
-  },
-];
+  };
+}
+
+const rootPkg = readPackage();
+if (rootPkg.name !== "@openclaw/fs-safe") throw new Error(`unexpected package name ${rootPkg.name}`);
+if (rootPkg.author !== "OpenClaw Team <dev@openclaw.ai>") {
+  throw new Error("root package has unexpected author metadata");
+}
+if (rootPkg.publishConfig?.access !== "public" || rootPkg.publishConfig?.provenance !== true) {
+  throw new Error("root package must publish publicly with provenance");
+}
+
+const targets = allowHostOnly ? [hostNativeTarget()].filter(Boolean) : nativeTargets;
+if (targets.length === 0) throw new Error(`no native target for ${process.platform}-${process.arch}`);
+
+const manifest = [];
+for (const target of targets) {
+  const directory = fileURLToPath(nativePackageDirectory(target));
+  const pkg = readPackage(directory);
+  const binary = join(directory, "fs-safe-native.node");
+  if (!existsSync(binary) || statSync(binary).size === 0) {
+    throw new Error(`missing or empty native package binary ${binary}`);
+  }
+  if (
+    pkg.name !== target.package ||
+    pkg.version !== rootPkg.version ||
+    pkg.main !== "fs-safe-native.node" ||
+    pkg.os?.[0] !== target.os ||
+    pkg.cpu?.[0] !== target.cpu ||
+    (target.libc && pkg.libc?.[0] !== target.libc) ||
+    pkg.publishConfig?.access !== "public" ||
+    pkg.publishConfig?.provenance !== true
+  ) {
+    throw new Error(`${target.package} metadata does not match its native target`);
+  }
+  if (rootPkg.optionalDependencies?.[target.package] !== rootPkg.version) {
+    throw new Error(`root package must pin ${target.package}@${rootPkg.version}`);
+  }
+  const artifact = packPackage(directory, pkg.name);
+  const paths = new Set(artifact.files.map((file) => file.path));
+  if (!paths.has("fs-safe-native.node") || !paths.has("package.json") || paths.size !== 2) {
+    throw new Error(`${pkg.name} must contain only package.json and fs-safe-native.node`);
+  }
+  manifest.push(manifestEntry(pkg, artifact));
+}
+
+const rootArtifact = packPackage(process.cwd(), rootPkg.name);
+const rootPaths = new Set(rootArtifact.files.map((file) => file.path));
+for (const expected of ["dist/index.js", "dist/index.d.ts", "package.json"]) {
+  if (!rootPaths.has(expected)) throw new Error(`packed root package is missing ${expected}`);
+}
+if ([...rootPaths].some((path) => path.endsWith(".node"))) {
+  throw new Error("packed root package must not contain native binaries");
+}
+manifest.push(manifestEntry(rootPkg, rootArtifact));
 writeFileSync(join(outputDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
 
+const host = hostNativeTarget();
+if (!host || !targets.some((target) => target.label === host.label)) {
+  throw new Error(`release smoke requires the host target ${host?.label ?? "unknown"}`);
+}
+const hostArtifact = manifest.find((entry) => entry.name === host.package);
 const smoke = mkdtempSync(join(tmpdir(), "fs-safe-release-smoke-"));
 try {
   writeFileSync(join(smoke, "package.json"), '{"private":true,"type":"module"}\n');
@@ -120,51 +148,40 @@ try {
       "--no-audit",
       "--no-fund",
       "--no-package-lock",
-      join(outputDir, artifact.filename),
+      join(outputDir, rootArtifact.filename),
+      join(outputDir, hostArtifact.filename),
     ],
     { cwd: smoke, stdio: "pipe" },
   );
   execFileSync(
     process.execPath,
-    [
-      "--input-type=module",
-      "--eval",
-      "await import('@openclaw/fs-safe'); await import('@openclaw/fs-safe/config');",
-    ],
+    ["--input-type=module", "--eval", "await import('@openclaw/fs-safe'); await import('@openclaw/fs-safe/config');"],
     { cwd: smoke, stdio: "pipe" },
   );
 
   const fixture = join(smoke, "fixture.txt");
   writeFileSync(fixture, "abc");
+  const hashScript =
+    "import {configureFsSafeNative} from '@openclaw/fs-safe';" +
+    "import {sha256File} from '@openclaw/fs-safe/durability';" +
+    "configureFsSafeNative({mode:'require'});" +
+    `const result=await sha256File(${JSON.stringify(fixture)});` +
+    "if(result.digest!=='ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')throw new Error('native hash mismatch');" +
+    "console.log(JSON.stringify(result));";
   const nativeProof = execFileSync(
     process.execPath,
-    [
-      "--input-type=module",
-      "--eval",
-      "import {configureFsSafeNative} from '@openclaw/fs-safe';" +
-        "import {sha256File} from '@openclaw/fs-safe/durability';" +
-        "configureFsSafeNative({mode:'require'});" +
-        `const result=await sha256File(${JSON.stringify(fixture)});` +
-        "if(result.digest!=='ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')throw new Error('native hash mismatch');" +
-        "console.log(JSON.stringify(result));",
-    ],
+    ["--input-type=module", "--eval", hashScript],
     { cwd: smoke, encoding: "utf8" },
   ).trim();
 
-  const installedNative = join(smoke, "node_modules", "@openclaw", "fs-safe", "dist", "native");
-  const hiddenNative = `${installedNative}.removed`;
-  renameSync(installedNative, hiddenNative);
+  const installedBinary = join(smoke, "node_modules", ...host.package.split("/"), "fs-safe-native.node");
+  renameSync(installedBinary, `${installedBinary}.removed`);
   const fallbackProof = execFileSync(
     process.execPath,
     [
       "--input-type=module",
       "--eval",
-      "import {configureFsSafeNative} from '@openclaw/fs-safe';" +
-        "import {sha256File} from '@openclaw/fs-safe/durability';" +
-        "configureFsSafeNative({mode:'auto'});" +
-        `const result=await sha256File(${JSON.stringify(fixture)});` +
-        "if(result.digest!=='ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')throw new Error('fallback hash mismatch');" +
-        "console.log(JSON.stringify(result));",
+      hashScript.replace("mode:'require'", "mode:'auto'").replace("native hash mismatch", "fallback hash mismatch"),
     ],
     { cwd: smoke, encoding: "utf8" },
   ).trim();
@@ -182,12 +199,12 @@ try {
     { cwd: smoke, encoding: "utf8" },
   ).trim();
   console.log(`native binding: ${nativeProof}`);
-  console.log(`auto fallback without bundled directory: ${fallbackProof}`);
-  console.log(`required mode without bundled directory: ${requiredProof}`);
+  console.log(`auto fallback without platform package binary: ${fallbackProof}`);
+  console.log(`required mode without platform package binary: ${requiredProof}`);
 } finally {
   rmSync(smoke, { recursive: true, force: true });
 }
 
-console.log(`packed tarball: ${artifact.filename}`);
-console.log(`gzipped size: ${artifact.size} bytes`);
-console.log(`unpacked size: ${artifact.unpackedSize} bytes`);
+for (const artifact of manifest) {
+  console.log(`${artifact.name}: ${artifact.size} bytes gzipped, ${artifact.unpackedSize} bytes unpacked`);
+}

--- a/scripts/check-release-packages.mjs
+++ b/scripts/check-release-packages.mjs
@@ -205,6 +205,41 @@ try {
   rmSync(smoke, { recursive: true, force: true });
 }
 
+const omittedOptionalSmoke = mkdtempSync(join(tmpdir(), "fs-safe-omitted-optional-smoke-"));
+try {
+  writeFileSync(join(omittedOptionalSmoke, "package.json"), '{"private":true,"type":"module"}\n');
+  runNpm(
+    [
+      "install",
+      "--ignore-scripts",
+      "--omit=optional",
+      "--no-audit",
+      "--no-fund",
+      "--no-package-lock",
+      join(outputDir, rootArtifact.filename),
+    ],
+    { cwd: omittedOptionalSmoke, stdio: "pipe" },
+  );
+  const omittedFixture = join(omittedOptionalSmoke, "fixture.txt");
+  writeFileSync(omittedFixture, "abc");
+  const omittedProof = execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      "import {configureFsSafeNative} from '@openclaw/fs-safe';" +
+        "import {sha256File} from '@openclaw/fs-safe/durability';" +
+        "configureFsSafeNative({mode:'require'});" +
+        `try{await sha256File(${JSON.stringify(omittedFixture)});throw new Error('native binding unexpectedly loaded')}` +
+        "catch(error){if(error.code!=='helper-unavailable')throw error;console.log(error.code)}",
+    ],
+    { cwd: omittedOptionalSmoke, encoding: "utf8" },
+  ).trim();
+  console.log(`required mode with --omit=optional: ${omittedProof}`);
+} finally {
+  rmSync(omittedOptionalSmoke, { recursive: true, force: true });
+}
+
 for (const artifact of manifest) {
   console.log(`${artifact.name}: ${artifact.size} bytes gzipped, ${artifact.unpackedSize} bytes unpacked`);
 }

--- a/scripts/consumer-fixture-artifacts.mjs
+++ b/scripts/consumer-fixture-artifacts.mjs
@@ -1,12 +1,24 @@
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { create as createTar } from "tar";
 import { nativePackageDirectory, nativeTargets } from "./native-targets.mjs";
 import { normalizePackResult } from "./npm-pack-result.mjs";
 
 const readPackage = (directory) => JSON.parse(readFileSync(join(directory, "package.json"), "utf8"));
+
+export async function snapshotConsumerDependency(directory, fixtureDir) {
+  const pkg = readPackage(directory);
+  assert.ok(!pkg.bundleDependencies && !pkg.bundledDependencies, "fixture dependency bundles need explicit collection");
+  const tarball = join(fixtureDir, `${pkg.name.replaceAll("/", "-")}-${pkg.version}.tgz`);
+  // These are installed published files, not a source tree to repack through
+  // npm lifecycle/packlist rules (repacking installed tar fails on CI hosts).
+  await createTar({ cwd: directory, file: tarball, gzip: true, prefix: "package/", portable: true },
+    readdirSync(directory).filter((name) => name !== "node_modules"));
+  return { pkg, tarball };
+}
 
 function dependencyDirectory(name, directory) {
   const require = createRequire(join(directory, "package.json"));
@@ -70,7 +82,7 @@ export async function consumerFixtureArtifacts({ rootPkg, manifest, outputDir, f
     const key = `${pkg.name}@${pkg.version}`;
     if (seen.has(key)) return;
     seen.add(key);
-    await pack(directory);
+    artifacts.push(await snapshotConsumerDependency(directory, fixtureDir));
     for (const dependency of Object.keys({ ...pkg.dependencies, ...pkg.optionalDependencies })) {
       await collect(dependency, directory);
     }

--- a/scripts/consumer-fixture-artifacts.mjs
+++ b/scripts/consumer-fixture-artifacts.mjs
@@ -30,9 +30,14 @@ export async function consumerFixtureArtifacts({ rootPkg, manifest, outputDir, f
   const synthetic = [];
   async function pack(directory) {
     const pkg = readPackage(directory);
-    const parsed = JSON.parse(await runNpm([
-      "pack", "--json", "--ignore-scripts", "--pack-destination", fixtureDir,
-    ], directory));
+    let parsed;
+    try {
+      parsed = JSON.parse(await runNpm([
+        "pack", "--json", "--ignore-scripts", "--loglevel=verbose", "--pack-destination", fixtureDir,
+      ], directory));
+    } catch (cause) {
+      throw new Error(`could not pack consumer fixture ${pkg.name}@${pkg.version}`, { cause });
+    }
     const { filename } = normalizePackResult(parsed, pkg.name);
     artifacts.push({ pkg, tarball: join(fixtureDir, filename) });
   }

--- a/scripts/consumer-fixture-artifacts.mjs
+++ b/scripts/consumer-fixture-artifacts.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,11 +13,17 @@ export async function snapshotConsumerDependency(directory, fixtureDir) {
   const pkg = readPackage(directory);
   assert.ok(!pkg.bundleDependencies && !pkg.bundledDependencies, "fixture dependency bundles need explicit collection");
   const tarball = join(fixtureDir, `${pkg.name.replaceAll("/", "-")}-${pkg.version}.tgz`);
-  // These are installed published files, not a source tree to repack through
-  // npm lifecycle/packlist rules (repacking installed tar fails on CI hosts).
-  await createTar({ cwd: directory, file: tarball, gzip: true, prefix: "package/", portable: true },
-    readdirSync(directory).filter((name) => name !== "node_modules"));
-  return { pkg, tarball };
+  const staging = mkdtempSync(join(fixtureDir, "dependency-"));
+  try {
+    // Snapshot published bytes, not source packing rules or pnpm's hardlink
+    // topology. Tar packing can stall on those shared-store hardlinks.
+    const entries = readdirSync(directory).filter((name) => name !== "node_modules");
+    for (const name of entries) cpSync(join(directory, name), join(staging, name), { recursive: true });
+    await createTar({ cwd: staging, file: tarball, gzip: true, prefix: "package/", portable: true }, entries);
+    return { pkg, tarball };
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
 }
 
 function dependencyDirectory(name, directory) {

--- a/scripts/consumer-install-smoke.mjs
+++ b/scripts/consumer-install-smoke.mjs
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import { execFile, execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
 import { consumerFixtureArtifacts } from "./consumer-fixture-artifacts.mjs";
 import { startConsumerRegistry } from "./consumer-registry.mjs";
@@ -41,11 +41,11 @@ async function run(cli, args, cwd, env) {
   return stdout.trim();
 }
 
-function pnpmCli() {
-  if (process.env.npm_execpath && /pnpm\.(?:c?js|mjs)$/.test(process.env.npm_execpath)) return process.env.npm_execpath;
-  const command = process.platform === "win32" ? "where.exe" : "which";
-  const found = execFileSync(command, ["pnpm"], { encoding: "utf8", timeout: 10_000 }).trim().split(/\r?\n/)[0];
-  return realpathSync(found);
+export function resolvePnpmCli(cli = process.env.npm_execpath) {
+  const resolved = cli && isAbsolute(cli) && statSync(cli, { throwIfNoEntry: false })?.isFile()
+    ? realpathSync(cli) : undefined;
+  if (resolved && /^pnpm\.(?:c?js|mjs)$/.test(basename(resolved))) return resolved;
+  throw new Error("package collection requires a pnpm lifecycle CLI; run pnpm package:collect or pnpm package:smoke");
 }
 
 const hashScript = `
@@ -63,7 +63,7 @@ const hashScript = `
   }
 `;
 
-export async function consumerInstallSmoke({ rootPkg, manifest, outputDir, npmCli, allowHostOnly }) {
+export async function consumerInstallSmoke({ rootPkg, manifest, outputDir, npmCli, pnpmCli, allowHostOnly }) {
   const temporary = mkdtempSync(join(tmpdir(), "fs-safe-consumer-proof-"));
   let server;
   try {
@@ -95,7 +95,7 @@ export async function consumerInstallSmoke({ rootPkg, manifest, outputDir, npmCl
       root: manifest.find((artifact) => artifact.name === rootPkg.name),
       syntheticForeignPackages: synthetic, managers: [],
     };
-    for (const [manager, cli] of [["npm", npmCli], ["pnpm", pnpmCli()]]) {
+    for (const [manager, cli] of [["npm", npmCli], ["pnpm", pnpmCli]]) {
       const managerProof = { manager, cases: [] };
       for (const omitted of [false, true]) {
         const directory = join(temporary, `${manager}-${omitted ? "omitted" : "normal"}`);

--- a/scripts/docs-site-navigation.mjs
+++ b/scripts/docs-site-navigation.mjs
@@ -8,7 +8,7 @@ export const sections = [
   ["Stores", ["store.md", "json-store.md", "file-store.md", "private-file-store.md"]],
   ["Specialized", ["secret-file.md", "secure-file.md", "permissions.md", "regular-file.md", "sidecar-lock.md", "local-roots.md"]],
   ["Path & filename", ["path.md", "filename.md", "install-path.md"]],
-  ["Reference", ["errors.md", "types.md", "public-api.md", "testing.md", "timing.md", "advanced.md", "test-hooks.md", "migrating-to-0.5.md", "contributing.md"]],
+  ["Reference", ["errors.md", "types.md", "public-api.md", "testing.md", "timing.md", "advanced.md", "test-hooks.md", "migrating-to-0.5.md", "migrating-to-0.6.md", "contributing.md"]],
 ];
 
 export const buildExcludes = [];

--- a/scripts/native-targets.mjs
+++ b/scripts/native-targets.mjs
@@ -1,40 +1,69 @@
 export const nativeTargets = [
   {
     label: "linux-x64-gnu",
+    package: "@openclaw/fs-safe-linux-x64-gnu",
+    os: "linux",
+    cpu: "x64",
+    libc: "glibc",
     rust: "x86_64-unknown-linux-gnu",
     artifact: "fs-safe-native.linux-x64-gnu.node",
   },
   {
     label: "linux-x64-musl",
+    package: "@openclaw/fs-safe-linux-x64-musl",
+    os: "linux",
+    cpu: "x64",
+    libc: "musl",
     rust: "x86_64-unknown-linux-musl",
     artifact: "fs-safe-native.linux-x64-musl.node",
   },
   {
     label: "linux-arm64-gnu",
+    package: "@openclaw/fs-safe-linux-arm64-gnu",
+    os: "linux",
+    cpu: "arm64",
+    libc: "glibc",
     rust: "aarch64-unknown-linux-gnu",
     artifact: "fs-safe-native.linux-arm64-gnu.node",
   },
   {
     label: "linux-arm64-musl",
+    package: "@openclaw/fs-safe-linux-arm64-musl",
+    os: "linux",
+    cpu: "arm64",
+    libc: "musl",
     rust: "aarch64-unknown-linux-musl",
     artifact: "fs-safe-native.linux-arm64-musl.node",
   },
   {
     label: "darwin-x64",
+    package: "@openclaw/fs-safe-darwin-x64",
+    os: "darwin",
+    cpu: "x64",
     rust: "x86_64-apple-darwin",
     artifact: "fs-safe-native.darwin-x64.node",
   },
   {
     label: "darwin-arm64",
+    package: "@openclaw/fs-safe-darwin-arm64",
+    os: "darwin",
+    cpu: "arm64",
     rust: "aarch64-apple-darwin",
     artifact: "fs-safe-native.darwin-arm64.node",
   },
   {
     label: "win32-x64-msvc",
+    package: "@openclaw/fs-safe-win32-x64-msvc",
+    os: "win32",
+    cpu: "x64",
     rust: "x86_64-pc-windows-msvc",
     artifact: "fs-safe-native.win32-x64-msvc.node",
   },
 ];
+
+export function nativePackageDirectory(target) {
+  return new URL(`../packages/${target.label}/`, import.meta.url);
+}
 
 export function hostNativeTarget() {
   const platformArch = `${process.platform}-${process.arch}`;

--- a/scripts/prepack-build.mjs
+++ b/scripts/prepack-build.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
@@ -24,21 +24,9 @@ if (!tscBin || !existsSync(tscBin)) {
   throw new Error("TypeScript compiler is unavailable; run pnpm install before packing");
 }
 
-const nativeDirectory = resolve("dist/native");
-const heldNativeDirectory = resolve(".fs-safe-prepack-native");
-rmSync(heldNativeDirectory, { recursive: true, force: true });
-if (existsSync(nativeDirectory)) renameSync(nativeDirectory, heldNativeDirectory);
-
-try {
-  rmSync("dist", { recursive: true, force: true });
-  const result = spawnSync(process.execPath, [tscBin, "-p", "tsconfig.json"], {
-    stdio: "inherit",
-    env: process.env,
-  });
-  if (result.status !== 0) process.exitCode = result.status ?? 1;
-} finally {
-  if (existsSync(heldNativeDirectory)) {
-    mkdirSync("dist", { recursive: true });
-    renameSync(heldNativeDirectory, nativeDirectory);
-  }
-}
+rmSync("dist", { recursive: true, force: true });
+const result = spawnSync(process.execPath, [tscBin, "-p", "tsconfig.json"], {
+  stdio: "inherit",
+  env: process.env,
+});
+if (result.status !== 0) process.exitCode = result.status ?? 1;

--- a/scripts/publish-release-packages.mjs
+++ b/scripts/publish-release-packages.mjs
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { publishOrVerify } from "./publish-or-verify.mjs";
+
+export async function publishReleasePackages({
+  artifactsDir = "release-artifacts",
+  publish = publishOrVerify,
+} = {}) {
+  const directory = resolve(artifactsDir);
+  const manifest = JSON.parse(readFileSync(join(directory, "manifest.json"), "utf8"));
+  if (!Array.isArray(manifest) || manifest.length < 2) {
+    throw new Error("release manifest must contain platform packages and the root package");
+  }
+  const rootPackages = manifest.filter((entry) => entry?.name === "@openclaw/fs-safe");
+  if (rootPackages.length !== 1) {
+    throw new Error("release manifest must contain exactly one @openclaw/fs-safe package");
+  }
+  const platformPackages = manifest.filter((entry) => entry?.name !== "@openclaw/fs-safe");
+  for (const artifact of [...platformPackages, ...rootPackages]) {
+    await publish({ packageName: artifact.name, artifactsDir: directory });
+  }
+}
+
+const entryPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined;
+if (entryPath === import.meta.url) {
+  await publishReleasePackages({ artifactsDir: process.argv[2] });
+}

--- a/scripts/stage-host-native.mjs
+++ b/scripts/stage-host-native.mjs
@@ -1,20 +1,15 @@
 import { copyFileSync, mkdirSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import { hostNativeTarget } from "./native-targets.mjs";
+import { fileURLToPath } from "node:url";
+import { hostNativeTarget, nativePackageDirectory } from "./native-targets.mjs";
 
 const repositoryRoot = resolve(import.meta.dirname, "..");
 const target = hostNativeTarget();
-if (!target) throw new Error(`no bundled native target for ${process.platform}-${process.arch}`);
+if (!target) throw new Error(`no native target for ${process.platform}-${process.arch}`);
 
 const source = resolve(repositoryRoot, "native", target.artifact);
-const destination = resolve(
-  repositoryRoot,
-  "dist",
-  "native",
-  target.label,
-  "fs-safe-native.node",
-);
+const destination = resolve(fileURLToPath(nativePackageDirectory(target)), "fs-safe-native.node");
 if (statSync(source).size === 0) throw new Error(`${target.artifact} is empty`);
 mkdirSync(dirname(destination), { recursive: true });
 copyFileSync(source, destination);
-console.log(`staged ${target.label} binding at dist/native/${target.label}/fs-safe-native.node`);
+console.log(`staged ${target.label} binding at packages/${target.label}/fs-safe-native.node`);

--- a/src/archive-kind.ts
+++ b/src/archive-kind.ts
@@ -16,8 +16,8 @@ function requireNativeArchiveKind(kind: "tar-bzip2" | "tar-zstd"): ArchiveKind {
   if (!getNativeBinding()) {
     throw new FsSafeError(
       "helper-unavailable",
-      `${kind} archives require a supported bundled native binding; ` +
-        "use FS_SAFE_NATIVE_MODE=auto or require on a supported platform",
+      `${kind} archives require the matching optional native platform package; ` +
+        "install @openclaw/fs-safe with optional dependencies enabled on a supported platform and use FS_SAFE_NATIVE_MODE=auto or require",
     );
   }
   return kind;

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -291,7 +291,8 @@ export async function readArchiveEntry(
     if (kind === "tar-zstd" || kind === "tar-bzip2") {
       throw new FsSafeError(
         "helper-unavailable",
-        `${kind} archives require a supported bundled native binding`,
+        `${kind} archives require the matching optional native platform package; ` +
+          "install @openclaw/fs-safe with optional dependencies enabled on a supported platform and use FS_SAFE_NATIVE_MODE=auto or require",
       );
     }
     return kind === "zip"

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -342,7 +342,8 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
   if (kind === "tar-zstd" || kind === "tar-bzip2") {
     throw new FsSafeError(
       "helper-unavailable",
-      `${kind} archives require a supported bundled native binding`,
+      `${kind} archives require the matching optional native platform package; ` +
+        "install @openclaw/fs-safe with optional dependencies enabled on a supported platform and use FS_SAFE_NATIVE_MODE=auto or require",
     );
   }
   if (kind === "tar") {

--- a/src/native.ts
+++ b/src/native.ts
@@ -5,8 +5,6 @@ import {
   readdirSync,
 } from "node:fs";
 import { createRequire } from "node:module";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { FsSafeError } from "./errors.js";
 import type { NativeBinding } from "./native-binding.js";
 import { getFsSafeNativeConfig } from "./native-config.js";
@@ -14,7 +12,6 @@ import { getFsSafeNativeConfig } from "./native-config.js";
 export type { NativeBinding } from "./native-binding.js";
 
 const require = createRequire(import.meta.url);
-const bundledNativeDirectory = fileURLToPath(new URL("../dist/native/", import.meta.url));
 let binding: NativeBinding | undefined;
 let loadError: unknown;
 let attempted = false;
@@ -166,12 +163,16 @@ function bundledTarget(): string | undefined {
   return targetFor(process.platform, process.arch, isMusl());
 }
 
+function nativePackageForTarget(target: string): string {
+  return `@openclaw/fs-safe-${target}`;
+}
+
 function loadBundledBinding(): NativeBinding {
   const target = bundledTarget();
   if (!target) {
     throw new Error(`Unsupported OS or architecture: ${process.platform}-${process.arch}`);
   }
-  return require(join(bundledNativeDirectory, target, "fs-safe-native.node")) as NativeBinding;
+  return require(nativePackageForTarget(target)) as NativeBinding;
 }
 
 export function __loadBundledNativeForTest(): NativeBinding {

--- a/src/owner-dacl.ts
+++ b/src/owner-dacl.ts
@@ -44,7 +44,8 @@ export function readOwnerAndDacl(targetPath: string): OwnerAndDaclResult {
   if (!native) {
     throw new FsSafeError(
       "helper-unavailable",
-      "Windows owner and DACL facts require the bundled native binding",
+      "Windows owner and DACL facts require the matching optional native platform package; " +
+        "install @openclaw/fs-safe with optional dependencies enabled on a supported platform and use FS_SAFE_NATIVE_MODE=auto or require",
     );
   }
   const facts = native.readOwnerAndDacl(targetPath);

--- a/src/private-directory.ts
+++ b/src/private-directory.ts
@@ -13,7 +13,7 @@ export async function createPrivateDirectory(
   if (platform !== "win32") {
     throw new FsSafeError(
       "helper-unavailable",
-      "private-directory creation is available only on Windows through the bundled native binding",
+      "private-directory creation is supported only on Windows",
     );
   }
 
@@ -21,7 +21,8 @@ export async function createPrivateDirectory(
   if (!native) {
     throw new FsSafeError(
       "helper-unavailable",
-      "private Windows directory creation requires the bundled native binding",
+      "private Windows directory creation requires the matching optional native platform package; " +
+        "install @openclaw/fs-safe with optional dependencies enabled on a supported platform and use FS_SAFE_NATIVE_MODE=auto or require",
     );
   }
   native.createPrivateDirectory(targetPath);

--- a/test/consumer-dependency-snapshot.test.ts
+++ b/test/consumer-dependency-snapshot.test.ts
@@ -1,0 +1,38 @@
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { extract } from "tar";
+import { afterEach, expect, it } from "vitest";
+import { snapshotConsumerDependency } from "../scripts/consumer-fixture-artifacts.mjs";
+
+const directories: string[] = [];
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+it("snapshots installed payloads without source packing rules or dependency links", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "fs-safe-dependency-snapshot-"));
+  directories.push(directory);
+  const installed = join(directory, "installed");
+  const artifacts = join(directory, "artifacts");
+  const consumer = join(directory, "consumer");
+  await Promise.all([mkdir(installed), mkdir(artifacts), mkdir(consumer)]);
+  // A published payload can retain source-only publishing metadata. The
+  // resolver fixture needs installed bytes, not another publication build.
+  const pkg = {
+    name: "published-codec", version: "1.2.3", main: "runtime.js", files: ["source"],
+    scripts: { prepack: "exit 99" }, dependencies: { dependency: "1.0.0" },
+  };
+  const manifest = `${JSON.stringify(pkg, null, 2)}\n`;
+  await writeFile(join(installed, "package.json"), manifest);
+  await writeFile(join(installed, "runtime.js"), "module.exports = 'published bytes';\n");
+  await mkdir(join(installed, "node_modules"));
+  await writeFile(join(installed, "node_modules", "unrelated"), "must not be bundled");
+
+  const artifact = await snapshotConsumerDependency(installed, artifacts);
+  expect(artifact.pkg).toEqual(pkg);
+  await extract({ file: artifact.tarball, cwd: consumer });
+  expect((await readdir(join(consumer, "package"))).sort()).toEqual(["package.json", "runtime.js"]);
+  expect(await readFile(join(consumer, "package", "package.json"), "utf8")).toBe(manifest);
+  expect(await readFile(join(consumer, "package", "runtime.js"), "utf8")).toBe("module.exports = 'published bytes';\n");
+});

--- a/test/consumer-dependency-snapshot.test.ts
+++ b/test/consumer-dependency-snapshot.test.ts
@@ -1,13 +1,36 @@
-import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { link, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { extract } from "tar";
+import { extract, list } from "tar";
 import { afterEach, expect, it } from "vitest";
 import { snapshotConsumerDependency } from "../scripts/consumer-fixture-artifacts.mjs";
 
 const directories: string[] = [];
 afterEach(async () => {
   await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })));
+});
+
+it("materializes pnpm hardlinked files as independent registry payload entries", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "fs-safe-hardlink-snapshot-"));
+  directories.push(directory);
+  const installed = join(directory, "installed");
+  const artifacts = join(directory, "artifacts");
+  await mkdir(join(installed, "dist", "cjs"), { recursive: true });
+  await mkdir(join(installed, "dist", "esm"));
+  await mkdir(artifacts);
+  await writeFile(join(installed, "package.json"), '{"name":"hardlinked-codec","version":"1.0.0"}');
+  for (let index = 0; index < 20; index++) {
+    const source = join(installed, "dist", "cjs", `${index}.d.ts`);
+    await writeFile(source, "export {};\n");
+    await link(source, join(installed, "dist", "esm", `${index}.d.ts`));
+  }
+  const artifact = await snapshotConsumerDependency(installed, artifacts);
+  const files: string[] = [];
+  await list({ file: artifact.tarball, onReadEntry(entry) {
+    expect(entry.type).not.toBe("Link");
+    if (entry.type === "File") files.push(entry.path);
+  } });
+  expect(files).toHaveLength(41);
 });
 
 it("snapshots installed payloads without source packing rules or dependency links", async () => {

--- a/test/consumer-pnpm-lifecycle.test.ts
+++ b/test/consumer-pnpm-lifecycle.test.ts
@@ -1,0 +1,49 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { isolatedConsumerEnv, resolvePnpmCli } from "../scripts/consumer-install-smoke.mjs";
+
+const directories: string[] = [];
+function temporary() {
+  const directory = mkdtempSync(join(tmpdir(), "fs-safe-pnpm-lifecycle-"));
+  directories.push(directory);
+  return directory;
+}
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+it("uses the actual pnpm lifecycle JavaScript CLI", () => {
+  expect(resolvePnpmCli()).toBe(realpathSync(process.env.npm_execpath!));
+});
+
+it("rejects absent lifecycle paths and shell/cmd launchers instead of searching PATH", () => {
+  vi.stubEnv("npm_execpath", undefined);
+  expect(() => resolvePnpmCli()).toThrow("run pnpm package:collect or pnpm package:smoke");
+  const directory = temporary();
+  for (const name of ["pnpm", "pnpm.cmd", "npm-cli.js"]) {
+    const launcher = join(directory, name);
+    writeFileSync(launcher, "not a pnpm JavaScript CLI");
+    expect(() => resolvePnpmCli(launcher)).toThrow("pnpm lifecycle CLI");
+  }
+  expect(() => resolvePnpmCli("pnpm.mjs")).toThrow("pnpm lifecycle CLI");
+  expect(() => resolvePnpmCli(join(directory, "pnpm.mjs"))).toThrow("pnpm lifecycle CLI");
+});
+
+it("rejects direct collection before creating artifacts when the lifecycle is absent", () => {
+  const directory = temporary();
+  const output = join(directory, "artifacts");
+  try {
+    execFileSync(process.execPath, ["scripts/check-release-packages.mjs", "--output", output], {
+      env: isolatedConsumerEnv(join(directory, "config")), encoding: "utf8", timeout: 10_000, stdio: "pipe",
+    });
+    expect.fail("direct collection must reject a missing lifecycle CLI");
+  } catch (error) {
+    expect(error).toMatchObject({ status: 1 });
+    expect(String((error as { stderr: string }).stderr)).toContain("run pnpm package:collect or pnpm package:smoke");
+  }
+  expect(existsSync(output)).toBe(false);
+});

--- a/test/docs-site-navigation.test.ts
+++ b/test/docs-site-navigation.test.ts
@@ -114,7 +114,8 @@ describe("docs site navigation", () => {
       ["secure-file", "Specialized", "secret-file", "permissions"],
       ["permissions", "Specialized", "secure-file", "regular-file"],
       ["public-api", "Reference", "types", "testing"],
-      ["migrating-to-0.5", "Reference", "test-hooks", "contributing"],
+      ["migrating-to-0.5", "Reference", "test-hooks", "migrating-to-0.6"],
+      ["migrating-to-0.6", "Reference", "migrating-to-0.5", "contributing"],
     ]) {
       const html = readFileSync(path.join(output, `${page}.html`), "utf8");
       expect(html).toContain(`<a class="nav-link active" href="${page}.html">`);

--- a/test/native-loader.test.ts
+++ b/test/native-loader.test.ts
@@ -155,7 +155,7 @@ describe("native helper configuration", () => {
   });
 });
 
-describe("bundled native loader", () => {
+describe("platform native loader", () => {
   let hostBinding: NativeBinding | undefined;
   try {
     hostBinding = __loadBundledNativeForTest();
@@ -163,12 +163,12 @@ describe("bundled native loader", () => {
     // Ordinary JavaScript-only jobs intentionally run without a built binding.
   }
 
-  it.runIf(Boolean(hostBinding))("loads the bundled binary for the host target", () => {
+  it.runIf(Boolean(hostBinding))("loads the platform binary for the host target", () => {
     expect(hostBinding?.openBeneath).toBeTypeOf("function");
     expect(hostBinding?.sha256File).toBeTypeOf("function");
   });
 
-  it("maps every bundled target without probing the host", () => {
+  it("maps every platform target without probing the host", () => {
     expect(__nativeTargetForTest("linux", "x64")).toBe("linux-x64-gnu");
     expect(__nativeTargetForTest("linux", "x64", true)).toBe("linux-x64-musl");
     expect(__nativeTargetForTest("linux", "arm64")).toBe("linux-arm64-gnu");
@@ -197,7 +197,7 @@ describe("bundled native loader", () => {
     expect(loader).not.toMatch(/(?:child_process|execSync|execFileSync|spawnSync|\bspawn\s*\()/);
     expect(loader).toContain("isMuslFromElfInterpreter");
     expect(loader).toContain("Unknown Linux libc: try the glibc binary");
-    expect(loader).toContain('"fs-safe-native.node"');
-    expect(loader).not.toContain("@openclaw/fs-safe-native");
+    expect(loader).toContain("@openclaw/fs-safe-");
+    expect(loader).not.toContain("dist/native");
   });
 });

--- a/test/native-only-diagnostics.test.ts
+++ b/test/native-only-diagnostics.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { extractArchive, readArchiveEntry, resolveArchiveKind } from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __resetNativeLoaderForTest, __setNativeLoaderForTest } from "../src/native.js";
+import { readOwnerAndDacl } from "../src/owner-dacl.js";
+import { createPrivateDirectory } from "../src/private-directory.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const guidance = "install @openclaw/fs-safe with optional dependencies enabled on a supported platform " +
+  "and use FS_SAFE_NATIVE_MODE=auto or require";
+
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+for (const mode of ["off", "auto"] as const) {
+  describe(`native-only diagnostics with mode ${mode}`, () => {
+    function unavailable() {
+      configureFsSafeNative({ mode });
+      __setNativeLoaderForTest(() => { throw new Error("platform package omitted"); });
+    }
+
+    it.each(["tar-zstd", "tar-bzip2"] as const)("explains recovery for %s detection, extraction and reads", async (kind) => {
+      unavailable();
+      const root = await tempRoot("fs-safe-native-diagnostics-");
+      const archivePath = path.join(root, kind === "tar-zstd" ? "fixture.tar.zst" : "fixture.tar.bz2");
+      const destDir = path.join(root, "destination");
+      await fs.writeFile(archivePath, "not compressed");
+      const expected = {
+        code: "helper-unavailable",
+        message: `${kind} archives require the matching optional native platform package; ${guidance}`,
+      };
+      expect(() => resolveArchiveKind(archivePath)).toThrow(expect.objectContaining(expected));
+      await expect(extractArchive({ archivePath, destDir, kind })).rejects.toMatchObject(expected);
+      await expect(readArchiveEntry(archivePath, "value", { maxBytes: 5, kind })).rejects.toMatchObject(expected);
+      await expect(fs.stat(destDir)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+
+    it("explains Windows recovery without creating a directory or returning ACL facts", async () => {
+      unavailable();
+      const root = await tempRoot("fs-safe-windows-diagnostics-");
+      const target = path.join(root, "private");
+      await expect(createPrivateDirectory(target, { platform: "win32" })).rejects.toMatchObject({
+        code: "helper-unavailable",
+        message: `private Windows directory creation requires the matching optional native platform package; ${guidance}`,
+      });
+      await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+      const descriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+      Object.defineProperty(process, "platform", { ...descriptor, value: "win32" });
+      try {
+        expect(() => readOwnerAndDacl(target)).toThrow(expect.objectContaining({
+          code: "helper-unavailable",
+          message: `Windows owner and DACL facts require the matching optional native platform package; ${guidance}`,
+        }));
+      } finally {
+        Object.defineProperty(process, "platform", descriptor);
+      }
+    });
+  });
+}
+
+it("reports unsupported private-directory platforms without suggesting an install", async () => {
+  await expect(createPrivateDirectory("unused", { platform: "linux" })).rejects.toMatchObject({
+    code: "helper-unavailable",
+    message: "private-directory creation is supported only on Windows",
+  });
+});

--- a/test/publish-release-packages.test.ts
+++ b/test/publish-release-packages.test.ts
@@ -1,0 +1,37 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { publishReleasePackages } from "../scripts/publish-release-packages.mjs";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("publish-release-packages", () => {
+  it("publishes every platform package before exposing the root package", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "fs-safe-publish-release-test-"));
+    temporaryDirectories.push(directory);
+    await writeFile(
+      join(directory, "manifest.json"),
+      JSON.stringify([
+        { name: "@openclaw/fs-safe" },
+        { name: "@openclaw/fs-safe-darwin-arm64" },
+        { name: "@openclaw/fs-safe-linux-x64-gnu" },
+      ]),
+    );
+    const publish = vi.fn(async () => undefined);
+
+    await publishReleasePackages({ artifactsDir: directory, publish });
+
+    expect(publish.mock.calls.map(([options]) => options)).toEqual([
+      { packageName: "@openclaw/fs-safe-darwin-arm64", artifactsDir: resolve(directory) },
+      { packageName: "@openclaw/fs-safe-linux-x64-gnu", artifactsDir: resolve(directory) },
+      { packageName: "@openclaw/fs-safe", artifactsDir: resolve(directory) },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Move the seven native bindings into exact-version optional platform packages so a normal install receives only its OS/CPU/libc binding. The root tarball contains no native binary; loading remains lazy, with no consumer Rust build, postinstall, or runtime download.

The intentional 0.6 compatibility contract is accepted. Deployments that omit optional dependencies retain safe imports and fallback-capable operations in `auto`/`off`, but must enable optionals for `require` or native-only features. The 0.5-to-0.6 migration guide documents that deployment change.

## Integration and ownership

Current main includes the landed strict pathname-hash prerequisite #158 and Crabbox configuration fix #159. Both are integrated without rewriting contributor or preparation history. The only merge conflict was the changelog: the 0.6 migration text and native-package entry are retained alongside main's hash and Crabbox entries. Hash code, regression tests, proof workflow and Crabbox configuration remain unchanged from main.

TypeScript retains filesystem policy and strict pathname identity fencing; the optional native package supplies mechanisms. The isolated consumer smoke exercises the rebuilt pathname hashing code and the real host binding. Release collection remains `pnpm package:collect`, which requires all seven real bindings; host-only smoke does not weaken that release requirement. Mocked publisher tests verify platform-first/root-last ordering without publishing anything.

## Validation

Prepared head: `388862c0b58550d5d2d90b386638189627e2fc24`, incorporating main `0c7200656719e5923aac8be924a9376261d7e241`. [Current-head CI](https://github.com/openclaw/fs-safe/actions/runs/33254973257) passed all 15 jobs. [Coverage](https://github.com/openclaw/fs-safe/actions/runs/33254973267) passed all three OS inputs and merged coverage; [both CodeQL analyses](https://github.com/openclaw/fs-safe/actions/runs/33254973260) and [benchmarks](https://github.com/openclaw/fs-safe/actions/runs/33254973261) also passed. No hosted retry was needed. The four downloaded consumer proof artifacts were checked for both package managers, all normal/omitted cases, selected-only packages, native-required hashes and missing-binding failures.

Local Node 24.20.0 / pnpm 11.24.0 proof passed 193 focused tests, build, documentation examples/site, package validation, and diff checks. Actual `pnpm package:collect --allow-host-only` passed both root-only npm 11.19.0 and pnpm 11.24.0 consumers on Darwin arm64, including cleanup. The binding's SHA-256 matches the prior fresh source build; native inputs are unchanged. Packed hash/strict-identity JavaScript matches the newly rebuilt code. Default full collection rejected the absent real Linux binding as expected; no full seven-target release pass is claimed.

**Local full check remains not green under filesystem load.** `pnpm check` recorded 1,948 passed, 40 failed and 25 skipped tests. The one bounded serialized retry of all 16 failed suites recorded 534 passed, 19 failed and 6 skipped, finishing within its 15-minute outer bound. Remaining failures are unchanged test/extraction timeouts and subsequent cleanup errors; the two retry assertions explicitly contain five-second extraction timeouts, not divergent parser results. Original logs and process samples are retained. No additional retries or limit changes were made. Fresh hosted full checks and merged coverage passed; the local gap remains visible for parent judgment.

One official isolated Codex autoreview of the complete candidate against current main passed with no actionable findings at the skill's default P0 threshold. Credential scanning, restricted reviewer isolation and high effort were preserved; the candidate is unchanged since review.

Every consumer install requests only `@openclaw/fs-safe@0.6.0`, with its exact optional dependencies unchanged, from a finite loopback registry. Proof checks root metadata/integrity, consumer-local resolution, selected-only installation, safe imports, native-required SHA-256, auto/off, removed-binary fallback/failure, and omitted-optionals behavior. All foreign metadata/tarball endpoints are validated before installation. Six synthetic non-executable foreign payloads are confined to disposable host-smoke fixtures: they prove installer filtering, not compilation or execution.

PR CI builds and executes four real hosts: Linux x64 glibc, Linux x64 musl, macOS arm64 and Windows x64. The seven-target source build and full collection matrix remains release-tag coverage; this PR does not claim execution on every architecture.

Historical preparation failures remain historical: the old head had local load-related test failures and a Windows coverage hash assertion failure. The latter event lacked identity traces and remains unattributed; integrating #158 does not retrospectively explain it. Only current-head results can establish this candidate's readiness.

## Before release, separately

All seven package names and their package-specific npm trusted-publisher records must be verified before the first 0.6 release tag. This is a separate pre-release requirement, not a merge prerequisite being provisioned here. No package creation, registry provisioning, credentials, tags, release, or npm publication are part of this work.

Thanks @RomneyDa; original contributor commits and Dallin Romney's credit are preserved. Final landing requires parent approval of the exact head, tree and current base after green checks.
