### PR TITLE
fix(hash): verify pathname identity before hashing

### DIFF
--- a/.github/workflows/hash-identity-proof.yml
+++ b/.github/workflows/hash-identity-proof.yml
@@ -1,0 +1,165 @@
+name: hash identity Windows proof
+
+on:
+  pull_request:
+    paths:
+      - src/file-hash.ts
+      - test/file-hash.test.ts
+      - test/file-hash-identity.test.ts
+      - test/helpers/file-hash-identity.ts
+      - scripts/hash-identity-proof.mjs
+      - scripts/hash-identity-proof-windows.ps1
+      - .github/workflows/hash-identity-proof.yml
+
+permissions:
+  contents: read
+
+jobs:
+  windows-proof:
+    name: Windows Node ${{ matrix.node }} hash proof
+    runs-on: windows-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["22.23.2", "24.20.0"]
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Check out candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 11.24.0
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node }}
+          architecture: x64
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Create isolated proof directories
+        run: |
+          $root = Join-Path $env:RUNNER_TEMP ('hash-identity-proof-' + [guid]::NewGuid().ToString('N'))
+          [void](New-Item -ItemType Directory -Path $root)
+          [void](New-Item -ItemType Directory -Path (Join-Path $root 'receipts'))
+          [void](New-Item -ItemType Directory -Path (Join-Path $root 'baseline'))
+          "HASH_PROOF_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Build candidate and immutable baseline archive
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $baseline = 'f8876aab64bca29d2a4f742c816ddd33ea8555cb'
+          $baselineRepo = Join-Path $env:HASH_PROOF_ROOT 'baseline'
+          $archive = Join-Path $env:HASH_PROOF_ROOT 'baseline.tar'
+          $receipt = [ordered]@{ baselineCommit = $baseline; passed = $false; commands = @() }
+          function Run-Checked([string]$Program, [string[]]$Arguments) {
+            & $Program @Arguments
+            $code = $LASTEXITCODE
+            $receipt.commands += @{ program = $Program; arguments = $Arguments; exitCode = $code }
+            if ($code -ne 0) { throw "$Program failed with exit $code" }
+          }
+          try {
+            $candidate = & git rev-parse HEAD
+            if ($LASTEXITCODE -ne 0 -or $candidate -notmatch '^[a-f0-9]{40}$') { throw 'Missing candidate commit.' }
+            $receipt.candidateCommit = $candidate
+            $receipt.candidateIsPullRequestMergeCommit = $true
+            Run-Checked 'pnpm' @('install', '--frozen-lockfile')
+            Run-Checked 'pnpm' @('build')
+            Run-Checked 'git' @('archive', '--format=tar', "--output=$archive", $baseline)
+            $receipt.baselineArchiveSha256 = (Get-FileHash -LiteralPath $archive).Hash.ToLowerInvariant()
+            Run-Checked 'tar' @('-xf', $archive, '-C', $baselineRepo)
+            Push-Location $baselineRepo
+            try {
+              Run-Checked 'pnpm' @('install', '--frozen-lockfile')
+              Run-Checked 'pnpm' @('build')
+            } finally { Pop-Location }
+            $receipt.fingerprints = @{}
+            foreach ($variant in @('baseline', 'patched')) {
+              $repo = if ($variant -eq 'baseline') { $baselineRepo } else { $env:GITHUB_WORKSPACE }
+              $files = @{}
+              foreach ($file in @('src/file-hash.ts', 'dist/file-hash.js', 'pnpm-lock.yaml', 'vitest.config.ts')) {
+                $files[$file] = (Get-FileHash -LiteralPath (Join-Path $repo $file)).Hash.ToLowerInvariant()
+              }
+              $receipt.fingerprints[$variant] = $files
+            }
+            $receipt.passed = $true
+            "HASH_PROOF_CANDIDATE=$candidate" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          } catch { $receipt.error = $_.Exception.Message; throw }
+          finally {
+            $receipt | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $env:HASH_PROOF_ROOT 'receipts/build-provenance.json')
+          }
+
+      - name: Serialized diagnostic and focused test gates
+        env:
+          HASH_PROOF_NODE: ${{ matrix.node }}
+        run: |
+          & ./scripts/hash-identity-proof-windows.ps1 `
+            -BaselineRepo (Join-Path $env:HASH_PROOF_ROOT 'baseline') `
+            -PatchedRepo $env:GITHUB_WORKSPACE `
+            -Output (Join-Path $env:HASH_PROOF_ROOT 'receipts/diagnostics') `
+            -Work (Join-Path $env:HASH_PROOF_ROOT 'work') `
+            -NodeVersion $env:HASH_PROOF_NODE -PatchedCommit $env:HASH_PROOF_CANDIDATE
+          exit $LASTEXITCODE
+
+      - name: Upload curated proof receipts
+        id: proof-artifact
+        if: always() && env.HASH_PROOF_ROOT != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hash-identity-windows-node-${{ matrix.node }}-${{ github.run_id }}-${{ github.run_attempt }}
+          # No workspace, dependencies, baseline archive, raw V8 directory, or test temp tree.
+          # Fixture bytes/identities are already embedded in the scenario JSON receipts.
+          path: |
+            ${{ env.HASH_PROOF_ROOT }}/receipts/build-provenance.json
+            ${{ env.HASH_PROOF_ROOT }}/receipts/diagnostics/*.json
+            ${{ env.HASH_PROOF_ROOT }}/receipts/diagnostics/*/*.json
+            ${{ env.HASH_PROOF_ROOT }}/receipts/diagnostics/*/*.txt
+          if-no-files-found: error
+
+      - name: Summarize proof boundaries and outcome
+        if: always()
+        env:
+          PROOF_ARTIFACT_URL: ${{ steps.proof-artifact.outputs.artifact-url }}
+          PROOF_JOB_STATUS: ${{ job.status }}
+        run: |
+          $lines = @(
+            '## Pathname hash Windows proof', '',
+            "Job status: $env:PROOF_JOB_STATUS", '',
+            'Baseline lanes are observations. Replacement admission is NOT a security pass.',
+            'Patched lanes require rejection before hash creation/read/native dispatch and exactly one owned close.',
+            'Stable controls must hash original bytes. The unscoped injection is a controlled hazard, not a coverage attribution.',
+            'Original historical event remains unattributed. Companion stats are separate, non-atomic observations.',
+            'Raw V8 module presence is distinct from focused Vitest threshold evidence.',
+            'Focused coverage: src/file-hash.ts only; lines 85, functions 84.9, statements 85, branches 76.',
+            'Mock-native tests prove dispatch only; no real native-binding proof is claimed.',
+            'General CI and coverage workflows provide the separate full-suite proof.', ''
+          )
+          if ($env:PROOF_ARTIFACT_URL) { $lines += "[Curated diagnostic and focused coverage receipts]($env:PROOF_ARTIFACT_URL)" }
+          if ($env:HASH_PROOF_ROOT) {
+            foreach ($variant in @('baseline', 'patched')) {
+              foreach ($mode in @('plain', 'raw-v8')) {
+                $file = Join-Path $env:HASH_PROOF_ROOT "receipts/diagnostics/$variant-$mode-receipts/summary.json"
+                if (Test-Path -LiteralPath $file) {
+                  $receipt = Get-Content -LiteralPath $file -Raw | ConvertFrom-Json
+                  $lines += "${variant}/${mode}: diagnostic invariants met = $($receipt.passed)"
+                  foreach ($case in $receipt.cases) { $lines += "- $($case.name): $($case.classification); invariants met = $($case.passed)" }
+                } else { $lines += "${variant}/${mode}: incomplete; no normal summary receipt." }
+              }
+            }
+            $auditPath = Join-Path $env:HASH_PROOF_ROOT 'receipts/diagnostics/focused-coverage-audit.json'
+            if (Test-Path -LiteralPath $auditPath) {
+              $audit = Get-Content -LiteralPath $auditPath -Raw | ConvertFrom-Json
+              $lines += "Focused Vitest coverage audit passed = $($audit.passed)"
+            } else { $lines += 'Focused Vitest coverage: incomplete; no audit receipt.' }
+          }
+          $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/hash-identity-proof.yml
+++ b/.github/workflows/hash-identity-proof.yml
@@ -75,7 +75,8 @@ jobs:
             $receipt.candidateIsPullRequestMergeCommit = $true
             Run-Checked 'pnpm' @('install', '--frozen-lockfile')
             Run-Checked 'pnpm' @('build')
-            Run-Checked 'git' @('archive', '--format=tar', "--output=$archive", $baseline)
+            # Git archive honors EOL conversion; keep the baseline's committed bytes.
+            Run-Checked 'git' @('-c', 'core.autocrlf=false', '-c', 'core.eol=lf', 'archive', '--format=tar', "--output=$archive", $baseline)
             $receipt.baselineArchiveSha256 = (Get-FileHash -LiteralPath $archive).Hash.ToLowerInvariant()
             Run-Checked 'tar' @('-xf', $archive, '-C', $baselineRepo)
             Push-Location $baselineRepo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Verify pathname SHA-256 hashing with lossless pre-open, descriptor, and current-path identities; fail closed on unknown Windows identities after one bounded retry without reopening the file.
 - Preserve underlying command diagnostics (command, timing, timeout flag, exit code/signal, and sanitized stderr) and cause on Windows ACL `permission-unverified` errors without changing verification semantics.
 - Verify secure and secret read identities with lossless bigint stats, reject replaced paths and retargeted aliases, and fail closed on unknown Windows identities after one bounded re-inspection; preserve the secure reader's numeric `Stats` receipt and permission options without letting them bypass identity checks.
 - Apply the same exact identity checks to guarded root reads, rejecting parent-directory replacements even when distinct Windows file IDs round to the same number; retain numeric read receipts and keep Windows write reopens anchored to the writer's exact retained identity.

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -210,10 +210,17 @@ try {
 The result is `{ bytes, digest }`, where `digest` is lowercase hexadecimal.
 The handle overload never closes the caller's descriptor and uses positioned
 reads, so it does not alter the descriptor's current offset. The path overload
-rejects symbolic links and non-regular files, verifies the opened descriptor
-still names the requested path, and closes its own handle. POSIX opens are
-nonblocking, so a raced FIFO or device is rejected after descriptor inspection
-rather than waiting for a writer.
+rejects symbolic links and non-regular files, compares lossless bigint identities
+from the pre-open pathname inspection to the opened descriptor and from that
+descriptor to the current pathname, and closes its own handle. All identity
+checks complete before any JavaScript or native hashing. Each inspection allows
+one bounded retry for unknown Windows identity components, retaining known
+components and rejecting known differences immediately. Persistent unknown
+identity fails closed with `path-mismatch`, even for benign files: this trades
+availability for verifiable identity. Retries inspect the same descriptor or
+pathname without reopening the file and repeat the symlink and file-type checks.
+POSIX opens are nonblocking, so a raced FIFO or device is rejected after
+descriptor inspection rather than waiting for a writer.
 
 When the optional binding is active, hashing runs as an async native task and
 does not occupy the JavaScript event loop with digest updates. With native mode

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -134,6 +134,12 @@ type FsSafeErrorCode =
 | `too-large` | A read or bounded walk exceeded its configured budget. | Caller gave a too-permissive file or traversal limit. |
 | `unsupported-platform` | Reserved compatibility code for a platform-specific operation. | No current public helper emits this `FsSafeError` code. Platform-specific APIs currently return a typed unsupported result or use `helper-unavailable`; keep the union member when exhaustively switching across supported package versions. |
 
+Pathname `sha256File()` also reports `path-mismatch` when pre-open, descriptor,
+or current-path identity remains unknown after one bounded Windows retry, even
+if the file is benign. It never reopens to recover identity. Preview symlinks
+report `symlink`, preview or descriptor non-files report `not-file`, and a
+current-path symlink or non-file reports `path-mismatch`.
+
 ## Branching
 
 ```ts

--- a/scripts/hash-identity-proof-windows.ps1
+++ b/scripts/hash-identity-proof-windows.ps1
@@ -1,0 +1,233 @@
+#Requires -Version 7.0
+# Runs prepared builds on one selected Windows runtime. No installs, builds, or Git writes.
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$BaselineRepo,
+    [Parameter(Mandatory)][string]$PatchedRepo,
+    [Parameter(Mandatory)][string]$Output,
+    [Parameter(Mandatory)][string]$Work,
+    [Parameter(Mandatory)][ValidateSet('22.23.2', '24.20.0')][string]$NodeVersion,
+    [Parameter(Mandatory)][ValidatePattern('^[a-f0-9]{40}$')][string]$PatchedCommit
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+# Both directories must be new. Never remove or reuse another invocation's receipts.
+[void](New-Item -ItemType Directory -Path $Output)
+[void](New-Item -ItemType Directory -Path $Work)
+$Output = (Resolve-Path -LiteralPath $Output).Path
+$Work = (Resolve-Path -LiteralPath $Work).Path
+$summary = [ordered]@{
+    startedAt = [DateTime]::UtcNow.ToString('o'); passed = $false
+    baselineCommit = 'f8876aab64bca29d2a4f742c816ddd33ea8555cb'; patchedCommit = $PatchedCommit
+    runs = [Collections.Generic.List[object]]::new()
+    limitations = @('Baseline replacement admission is observational, never a security pass.',
+        'Original historical event remains unattributed; all swaps here are controlled.',
+        'Companion stats are additional non-atomic syscalls, not simultaneous identity samples.',
+        'Raw V8 presence is not Vitest threshold evidence. Focused coverage is not repo-wide.',
+        'Native is off in diagnostics. Mock-native tests prove dispatch only, not a real binding.')
+}
+function Write-Json([string]$File, [object]$Value) {
+    $stream = [IO.File]::Open($File, [IO.FileMode]::CreateNew)
+    try {
+        $bytes = [Text.UTF8Encoding]::new($false).GetBytes(($Value | ConvertTo-Json -Depth 60) + "`n")
+        $stream.Write($bytes, 0, $bytes.Length)
+    } finally { $stream.Dispose() }
+}
+function Invoke-Lane {
+    param([string]$Label, [string]$Executable, [string[]]$Arguments,
+        [string]$Directory, [int]$TimeoutSeconds = 90, [string]$RawCoverage = '')
+    $lane = Join-Path $Output $Label
+    [void](New-Item -ItemType Directory -Path $lane)
+    $start = [Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = $Executable; $start.WorkingDirectory = $Directory
+    $start.UseShellExecute = $false; $start.CreateNoWindow = $true
+    $start.RedirectStandardOutput = $true; $start.RedirectStandardError = $true
+    foreach ($argument in $Arguments) { $start.ArgumentList.Add($argument) }
+    [void]$start.Environment.Remove('NODE_V8_COVERAGE')
+    if ($RawCoverage) { $start.Environment['NODE_V8_COVERAGE'] = $RawCoverage }
+    $start.Environment['TEMP'] = $Work; $start.Environment['TMP'] = $Work
+    $start.Environment['CI'] = '1'
+    Write-Json (Join-Path $lane 'command.json') @{
+        executable = $Executable; arguments = $Arguments; workingDirectory = $Directory
+        timeoutSeconds = $TimeoutSeconds; rawV8Coverage = $RawCoverage
+        temp = $Work; executableSha256 = (Get-FileHash -LiteralPath $Executable).Hash.ToLowerInvariant()
+    }
+    $process = [Diagnostics.Process]::new(); $process.StartInfo = $start
+    $result = [ordered]@{ label = $Label; exitCode = $null; timedOut = $false; passed = $false }
+    $stdout = ''; $stderr = ''
+    try {
+        if (-not $process.Start()) { throw 'Child did not start.' }
+        $outTask = $process.StandardOutput.ReadToEndAsync()
+        $errTask = $process.StandardError.ReadToEndAsync()
+        if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+            $result.timedOut = $true
+            $process.Kill($true)
+            if (-not $process.WaitForExit(10000)) { throw 'Timed-out child did not exit after termination.' }
+        }
+        $stdout = $outTask.GetAwaiter().GetResult(); $stderr = $errTask.GetAwaiter().GetResult()
+        $result.exitCode = $process.ExitCode
+        $result.passed = $process.ExitCode -eq 0 -and -not $result.timedOut
+    } catch { $result.error = $_.Exception.Message }
+    finally {
+        $process.Dispose()
+        # Only this known command's output; never a workspace or environment dump.
+        [IO.File]::WriteAllText((Join-Path $lane 'stdout.txt'), $stdout)
+        [IO.File]::WriteAllText((Join-Path $lane 'stderr.txt'), $stderr)
+        Write-Json (Join-Path $lane 'result.json') $result
+        $summary.runs.Add($result)
+    }
+    Write-Host "$Label : exit=$($result.exitCode) timedOut=$($result.timedOut)"
+    return [pscustomobject]@{ Result = $result; Stdout = $stdout; Lane = $lane }
+}
+function Invoke-Pnpm([string]$Label, [string[]]$Arguments) {
+    # A fresh PowerShell process runs the installed pnpm shim, without assuming its packaging.
+    # Quote each literal argument before encoding; no interpolation of shell expressions.
+    $quoted = @($Arguments | ForEach-Object { "'" + $_.Replace("'", "''") + "'" }) -join ' '
+    $command = '$ErrorActionPreference = ''Stop''; & pnpm ' + $quoted + '; exit $LASTEXITCODE'
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($command))
+    return Invoke-Lane -Label $Label -Executable $script:pwsh -Directory $PatchedRepo -TimeoutSeconds 300 -Arguments @(
+        '-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', $encoded)
+}
+try {
+    if (-not $IsWindows) { throw 'Requires real Windows; no platform adapters are permitted.' }
+    if ([Environment]::GetEnvironmentVariable('NODE_OPTIONS')) {
+        throw 'Inherited NODE_OPTIONS is nonempty; value withheld. Use a clean runner.'
+    }
+    $BaselineRepo = (Resolve-Path -LiteralPath $BaselineRepo).Path
+    $PatchedRepo = (Resolve-Path -LiteralPath $PatchedRepo).Path
+    if ($BaselineRepo -eq $PatchedRepo -or (Test-Path -LiteralPath (Join-Path $BaselineRepo '.git'))) {
+        throw 'Baseline must be a separate archive, not a checkout or worktree.'
+    }
+    $node = (Get-Command node -CommandType Application | Select-Object -First 1).Source
+    $script:pwsh = (Get-Command pwsh -CommandType Application | Select-Object -First 1).Source
+    $runtime = Invoke-Lane -Label 'runtime' -Executable $node -Directory $PatchedRepo -Arguments @(
+        '-e', 'console.log(JSON.stringify({node:process.version,versions:process.versions,platform:process.platform,arch:process.arch}))')
+    if (-not $runtime.Result.passed) { throw 'Runtime probe failed.' }
+    $summary.runtime = $runtime.Stdout | ConvertFrom-Json
+    if ($summary.runtime.platform -ne 'win32' -or $summary.runtime.arch -ne 'x64' -or
+        $summary.runtime.node -ne "v$NodeVersion") { throw 'Expected the pinned native Windows x64 runtime.' }
+    $pnpm = Invoke-Pnpm 'pnpm-version' @('--version')
+    if (-not $pnpm.Result.passed -or $pnpm.Stdout.Trim() -ne '11.24.0') { throw 'Expected pnpm 11.24.0.' }
+    # Selected fields only: no hostname, username, label, serial, or environment inventory.
+    $facts = [ordered]@{
+        powershell = $PSVersionTable.PSVersion.ToString()
+        os = @(Get-CimInstance Win32_OperatingSystem -Property Caption, Version, BuildNumber, OSArchitecture |
+            Select-Object Caption, Version, BuildNumber, OSArchitecture)
+        volumes = [Collections.Generic.List[object]]::new()
+    }
+    $summary.filesystemFacts = $facts
+    if ($facts.os.Count -ne 1 -or -not $facts.os[0].BuildNumber) { throw 'Missing Windows build observation.' }
+    # Get-Volume receives an existing file at each measured location.
+    foreach ($directory in @($Output, $Work)) {
+        [void](New-Item -ItemType File -Path (Join-Path $directory 'volume-probe.bin'))
+    }
+    foreach ($location in @(@{ role = 'workspace'; path = $PatchedRepo; probe = 'package.json' },
+        @{ role = 'baseline'; path = $BaselineRepo; probe = 'package.json' },
+        @{ role = 'diagnostic-fixtures'; path = $Output; probe = 'volume-probe.bin' },
+        @{ role = 'test-fixtures'; path = $Work; probe = 'volume-probe.bin' })) {
+        $volume = @(Get-Volume -FilePath (Join-Path $location.path $location.probe) |
+            Select-Object DriveLetter, @{ Name = 'FileSystemType'; Expression = { $_.FileSystemType.ToString() } },
+                @{ Name = 'DriveType'; Expression = { $_.DriveType.ToString() } })
+        if ($volume.Count -ne 1 -or -not $volume[0].FileSystemType -or $volume[0].FileSystemType -eq 'Unknown') {
+            throw 'Expected a measured filesystem type for each proof location.'
+        }
+        $drive = [IO.Path]::GetPathRoot($location.path).TrimEnd('\')
+        if ($drive -notmatch '^[A-Za-z]:$') { throw 'Proof inputs must use local drive paths.' }
+        $logical = @(Get-CimInstance Win32_LogicalDisk -Filter "DeviceID='$drive'" -Property DeviceID, DriveType, FileSystem |
+            Select-Object DeviceID, DriveType, FileSystem)
+        if ($logical.Count -ne 1 -or -not $logical[0].FileSystem) { throw 'Missing logical-disk observation.' }
+        $facts.volumes.Add(@{ role = $location.role; path = $location.path; getVolume = $volume; logicalDisk = $logical
+            note = 'Get-Volume measures the path; LogicalDisk describes the drive root, not mounted subvolumes.' })
+    }
+    Write-Json (Join-Path $Output 'windows-filesystem.json') $facts
+    $hashes = @{}
+    foreach ($variant in @('baseline', 'patched')) {
+        $repo = if ($variant -eq 'baseline') { $BaselineRepo } else { $PatchedRepo }
+        $hashes[$variant] = (Get-FileHash -LiteralPath (Join-Path $repo 'dist/file-hash.js')).Hash.ToLowerInvariant()
+    }
+    if ($hashes.baseline -eq $hashes.patched) { throw 'Baseline and patched builds must differ.' }
+    $summary.compiledSha256 = $hashes
+    $summary.driverSha256 = (Get-FileHash -LiteralPath $PSCommandPath).Hash.ToLowerInvariant()
+    $harness = Join-Path $PSScriptRoot 'hash-identity-proof.mjs'
+    # All lanes are ordered and fresh processes, including after a diagnostic failure.
+    foreach ($variant in @('baseline', 'patched')) {
+        $repo = if ($variant -eq 'baseline') { $BaselineRepo } else { $PatchedRepo }
+        $commit = if ($variant -eq 'baseline') { $summary.baselineCommit } else { $PatchedCommit }
+        foreach ($mode in @('plain', 'raw-v8')) {
+            $label = "$variant-$mode"
+            $diagnostic = Join-Path $Output "$label-receipts"
+            $raw = if ($mode -eq 'raw-v8') { Join-Path $Work "$label-raw" } else { '' }
+            $run = Invoke-Lane -Label $label -Executable $node -Directory $repo -RawCoverage $raw -Arguments @(
+                $harness, '--repo', $repo, '--output', $diagnostic, '--variant', $variant,
+                '--source-ref', $commit, '--compiled-sha256', $hashes[$variant], '--require-windows', '--include-unscoped')
+            if ($raw) {
+                $audit = @{ label = "$label-presence"; passed = $false; rawV8Only = $true; vitestThresholdGate = $false }
+                try {
+                    $selected = @()
+                    $preflight = Get-Content -LiteralPath (Join-Path $diagnostic 'preflight.json') -Raw | ConvertFrom-Json
+                    $expectedUrl = $preflight.importedHashModuleUrl
+                    if (-not $expectedUrl) { throw 'Missing imported module URL.' }
+                    foreach ($file in @(Get-ChildItem -LiteralPath $raw -Filter '*.json' -File)) {
+                        $data = Get-Content -LiteralPath $file.FullName -Raw | ConvertFrom-Json
+                        $modules = @($data.result | Where-Object { $_.url -ceq $expectedUrl })
+                        if ($modules.Count) {
+                            $selected += @{ rawFile = $file.Name; rawSha256 = (Get-FileHash $file.FullName).Hash.ToLowerInvariant()
+                                result = $modules }
+                        }
+                    }
+                    $audit.passed = $run.Result.passed -and $selected.Count -gt 0
+                    $audit.selectedModules = $selected
+                    $audit.note = 'Only the exact imported dist/file-hash.js entry is retained; other raw V8 entries are not uploaded.'
+                } catch { $audit.error = $_.Exception.Message }
+                Write-Json (Join-Path $Output "$label-presence.json") $audit
+                $summary.runs.Add($audit)
+            }
+        }
+    }
+    $tests = @('test/file-hash.test.ts', 'test/file-hash-identity.test.ts')
+    $plainArguments = @('run', 'test') + $tests + @('--maxWorkers=1', '--no-file-parallelism')
+    $plain = Invoke-Pnpm 'focused-tests-plain' $plainArguments
+    $reports = Join-Path $Work 'focused-coverage'
+    $coverageArguments = @('run', 'test:coverage') + $tests + @('--maxWorkers=1', '--no-file-parallelism',
+        '--coverage.include=src/file-hash.ts', '--coverage.reporter=json-summary', "--coverage.reportsDirectory=$reports")
+    $covered = Invoke-Pnpm 'focused-tests-coverage' $coverageArguments
+    $gate = @{ label = 'focused-coverage-audit'; passed = $false; scope = 'src/file-hash.ts only, not repo-wide'
+        required = @{ lines = 85; functions = 84.9; statements = 85; branches = 76 }
+        plainArguments = $plainArguments; coverageArguments = $coverageArguments }
+    try {
+        $reportPath = Join-Path $reports 'coverage-summary.json'
+        $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -AsHashtable
+        Copy-Item -LiteralPath $reportPath -Destination (Join-Path $Output 'focused-coverage-summary.json')
+        $keys = @($report.Keys | Where-Object { $_ -ne 'total' })
+        $target = (Join-Path $PatchedRepo 'src/file-hash.ts').Replace('\', '/')
+        $gate.files = $keys
+        $gate.passed = $covered.Result.passed -and $keys.Count -eq 1 -and $keys[0].Replace('\', '/') -eq $target
+        foreach ($key in @('total') + $keys) {
+            foreach ($metric in $gate.required.Keys) {
+                $value = $report[$key][$metric]
+                if ($null -eq $value -or $value.total -le 0 -or $value.pct -isnot [ValueType] -or
+                    [double]::IsNaN([double]$value.pct) -or $value.pct -lt $gate.required[$metric]) { $gate.passed = $false }
+            }
+        }
+        # Audit the unchanged config as well as measured coverage: no lowered configured thresholds.
+        $config = Get-Content -LiteralPath (Join-Path $PatchedRepo 'vitest.config.ts') -Raw
+        $block = [regex]::Match($config, '(?s)thresholds:\s*\{([^}]+)\}')
+        if (-not $block.Success) { $gate.passed = $false }
+        foreach ($metric in $gate.required.Keys) {
+            $match = [regex]::Match($block.Groups[1].Value, "\b${metric}:\s*([0-9.]+)\s*,")
+            if (-not $match.Success -or [double]::Parse($match.Groups[1].Value, [Globalization.CultureInfo]::InvariantCulture) -ne
+                $gate.required[$metric]) { $gate.passed = $false }
+        }
+    } catch { $gate.passed = $false; $gate.error = $_.Exception.Message }
+    Write-Json (Join-Path $Output 'focused-coverage-audit.json') $gate
+    $summary.runs.Add($gate)
+    $summary.compiledUnchanged = (
+        (Get-FileHash -LiteralPath (Join-Path $BaselineRepo 'dist/file-hash.js')).Hash.ToLowerInvariant() -eq $hashes.baseline -and
+        (Get-FileHash -LiteralPath (Join-Path $PatchedRepo 'dist/file-hash.js')).Hash.ToLowerInvariant() -eq $hashes.patched)
+    $summary.passed = $summary.compiledUnchanged -and @($summary.runs | Where-Object { -not $_.passed }).Count -eq 0
+} catch { $summary.error = $_.Exception.Message }
+finally {
+    $summary.finishedAt = [DateTime]::UtcNow.ToString('o')
+    Write-Json (Join-Path $Output 'driver-summary.json') $summary
+}
+if (-not $summary.passed) { exit 1 }

--- a/scripts/hash-identity-proof.mjs
+++ b/scripts/hash-identity-proof.mjs
@@ -1,0 +1,394 @@
+// Controlled pathname identity proof against the selected build, never a hash implementation.
+// Usage: node scripts/hash-identity-proof.mjs --repo BUILT_REPO --output NEW_DIR
+//   --variant baseline|patched [--source-ref COMMIT] [--require-windows] [--include-unscoped]
+// Companion stats are additional, non-atomic observations. Keep local smoke receipts private.
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { constants, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import crypto from 'node:crypto';
+import { createRequire, syncBuiltinESMExports } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({ options: {
+  repo: { type: 'string' }, output: { type: 'string' }, variant: { type: 'string' },
+  'compiled-sha256': { type: 'string' }, 'source-ref': { type: 'string' },
+  companions: { type: 'string', default: 'after' },
+  'include-unscoped': { type: 'boolean', default: false },
+  'require-windows': { type: 'boolean', default: false },
+  'timeout-ms': { type: 'string', default: '20000' },
+} });
+if (!values.repo || !values.output || !['baseline', 'patched'].includes(values.variant)) {
+  throw new Error('Required: --repo BUILT_COPY --output NEW_DIRECTORY --variant baseline|patched');
+}
+const repo = realpathSync(values.repo);
+const output = path.resolve(values.output);
+// Creating an exclusive directory prevents receipts/fixtures from earlier runs being overwritten.
+mkdirSync(output);
+const json = value => JSON.stringify(value, (_, item) => typeof item === 'bigint' ? `${item}n` : item, 2) + '\n';
+const write = (name, value) => writeFileSync(path.join(output, name), json(value), { flag: 'wx', mode: 0o600 });
+const actualCreateHash = crypto.createHash;
+const digest = value => actualCreateHash('sha256').update(value).digest('hex');
+const errorInfo = error => ({ name: error?.name, code: error?.code, message: error?.message ?? String(error) });
+const runtime = {
+  node: process.version, versions: { ...process.versions }, platform: process.platform, arch: process.arch,
+  pid: process.pid, executableSha256: digest(readFileSync(process.execPath)),
+  rawV8CoverageEnabled: Boolean(process.env.NODE_V8_COVERAGE),
+  platformOverride: false, osAndFilesystem: 'Collected separately by the PowerShell driver.',
+};
+const summary = {
+  schema: 1, startedAt: new Date().toISOString(), runtime,
+  variant: values.variant, sourceRefLabel: values['source-ref'] ?? null,
+  sourceRefLabelIsNotGitVerification: true, baselineCommit: 'f8876aab64bca29d2a4f742c816ddd33ea8555cb',
+  options: values, cases: [],
+  importedHashModuleUrl: pathToFileURL(path.join(repo, 'dist/file-hash.js')).href,
+  interpretation: [
+    'A baseline admission is an observation, never a security pass.',
+    'Known distinct retained bigint identities are required; unknown host identities make this proof incomplete.',
+    'Real host scenarios do not emulate unknown identities; the focused model tests cover bounded retry semantics.',
+    'No historical-event attribution. All swaps are controlled test injections.',
+    'All stat values are actual host results, with no platform or stat adapters.',
+    'Companion stats and retained-file evidence are separate syscalls, never atomic pairs.',
+    'Native mode is off; a test-loader tripwire counts unexpected native activity. This is not native binding proof.',
+    'Raw NODE_V8_COVERAGE is runtime instrumentation, not Vitest coverage or a threshold gate.',
+  ],
+};
+const actual = Object.fromEntries(['open', 'lstat', 'readFile', 'writeFile', 'rename'].map(k => [k, fs[k].bind(fs)]));
+let activeCase;
+let timer;
+let fingerprintBefore;
+const fingerprintFiles = [
+  'package.json', 'pnpm-lock.yaml', 'vitest.config.ts', 'src/file-hash.ts',
+  'src/file-identity.ts', 'src/strict-file-identity.ts', 'test/file-hash.test.ts',
+];
+async function fingerprint() {
+  const dist = (await fs.readdir(path.join(repo, 'dist'))).filter(n => n.endsWith('.js')).sort();
+  const patchTests = values.variant === 'patched' ? ['test/file-hash-identity.test.ts', 'test/helpers/file-hash-identity.ts'] : [];
+  const files = [...fingerprintFiles, ...patchTests, ...dist.map(n => `dist/${n}`)];
+  return Object.fromEntries(files.map(name => [name, digest(readFileSync(path.join(repo, name)))]));
+}
+function atom(value) {
+  return { type: typeof value, value: typeof value === 'undefined' ? null : value,
+    numberIsSafeInteger: typeof value === 'number' ? Number.isSafeInteger(value) : null };
+}
+function stats(stat) {
+  const fields = {};
+  for (const name of ['dev', 'ino', 'mode', 'nlink', 'uid', 'gid', 'rdev', 'size', 'blksize', 'blocks',
+    'atimeMs', 'mtimeMs', 'ctimeMs', 'birthtimeMs', 'atimeNs', 'mtimeNs', 'ctimeNs', 'birthtimeNs']) {
+    if (name in stat) fields[name] = atom(stat[name]);
+  }
+  return { fields, regular: stat.isFile(), symlink: stat.isSymbolicLink(), directory: stat.isDirectory() };
+}
+function identity(stat) { return { dev: stat.dev, ino: stat.ino }; }
+function known(id) { return typeof id.dev === 'bigint' && typeof id.ino === 'bigint' &&
+  (process.platform !== 'win32' || (id.dev !== 0n && id.ino !== 0n)); }
+function equalId(a, b) { return a.dev === b.dev && a.ino === b.ino; }
+
+try {
+  assert(['after', 'none'].includes(values.companions), 'invalid companions option');
+  const timeout = Number(values['timeout-ms']);
+  assert(Number.isInteger(timeout) && timeout >= 1000 && timeout <= 60000, 'timeout range is 1000..60000ms');
+  if (values['require-windows']) {
+    assert.equal(process.platform, 'win32'); assert.equal(process.arch, 'x64');
+    assert([22, 24].includes(Number(process.versions.node.split('.')[0])), 'Windows proof needs Node 22 or 24');
+  }
+  fingerprintBefore = await fingerprint();
+  summary.fingerprintBefore = fingerprintBefore;
+  summary.harnessSha256 = digest(readFileSync(fileURLToPath(import.meta.url)));
+  if (values['compiled-sha256']) assert.equal(fingerprintBefore['dist/file-hash.js'], values['compiled-sha256']);
+  if (values.variant === 'baseline') {
+    assert.equal(fingerprintBefore['src/file-hash.ts'],
+      '11d6640fe917831e2c49b0778e770bb6309201662c1ffe5b2127ef3e281c9b4f',
+      'baseline must preserve the source from the documented baseline commit');
+  }
+  const vitestPackage = realpathSync(path.join(repo, 'node_modules/vitest/package.json'));
+  const require = createRequire(vitestPackage);
+  const spyModule = require.resolve('@vitest/spy');
+  const { spyOn } = await import(pathToFileURL(spyModule).href);
+  summary.spy = { implementation: '@vitest/spy', vitestVersion: JSON.parse(readFileSync(vitestPackage)).version,
+    moduleSha256: digest(readFileSync(spyModule)) };
+  const { sha256File } = await import(pathToFileURL(path.join(repo, 'dist/file-hash.js')).href);
+  const { configureFsSafeNative, __resetFsSafeNativeConfigForTest } =
+    await import(pathToFileURL(path.join(repo, 'dist/native-config.js')).href);
+  const { __setNativeLoaderForTest, __resetNativeLoaderForTest } =
+    await import(pathToFileURL(path.join(repo, 'dist/native.js')).href);
+  write('preflight.json', summary);
+
+  async function scenario(name, kind) {
+    const dir = path.join(output, name);
+    mkdirSync(dir);
+    const target = path.join(dir, 'payload.bin');
+    const displaced = path.join(dir, 'payload.displaced');
+    const unrelated = path.join(dir, 'unrelated.bin');
+    const receipt = {
+      schema: 1, name, kind, runtime, expectedImplementation: values.variant,
+      compiledSha256: fingerprintBefore['dist/file-hash.js'],
+      spy: summary.spy, companions: values.companions,
+      labels: { statSource: 'real host kernel observations; no synthetic adapter',
+        injection: kind === 'unscoped' ? 'CONTROLLED unscoped one-shot hazard injection before preview; NOT coverage-caused' :
+          kind === 'replacement' ? 'CONTROLLED target-scoped replacement after preview' : 'stable real fixture control' },
+      fixture: { target, displaced, unrelated }, events: [], invariants: [],
+      counts: { hashCalls: 0, jsHashCreates: 0, targetOpens: 0, unrelatedOpens: 0, otherOpens: 0, algorithmLstats: 0,
+        descriptorStats: 0, companionStats: 0, reads: 0, bytesRead: 0, closes: 0, closed: 0,
+        unrelatedCloses: 0, nativeLoaderCalls: 0, nativeCalls: 0, rescueCloses: 0, swaps: 0 },
+    };
+    activeCase = receipt;
+    let armed = kind !== 'stable';
+    let swapped = false;
+    let targetOpenEntered = false;
+    let previewReturned = 0;
+    let hashStarted = false;
+    let openSpy, lstatSpy, hashSpy;
+    const handles = [];
+    const event = (type, data = {}) => {
+      assert(receipt.events.length < 150, 'event bound exceeded');
+      const entry = { order: receipt.events.length + 1, monotonicNs: process.hrtime.bigint(), type,
+        armed, swapped, hashStarted, ...data };
+      receipt.events.push(entry); return entry;
+    };
+    function check(name, condition) {
+      receipt.invariants.push({ name, passed: Boolean(condition) });
+    }
+    const classify = candidate => {
+      const candidatePath = candidate instanceof URL ? fileURLToPath(candidate) :
+        Buffer.isBuffer(candidate) ? candidate.toString('utf8') : candidate;
+      if (typeof candidatePath !== 'string') return 'other';
+      return candidatePath === target ? 'target' : candidatePath === unrelated ? 'unrelated' : 'other';
+    };
+    const argsRecord = args => args.map(arg => arg instanceof URL ? { type: 'URL', value: arg.href } :
+      Buffer.isBuffer(arg) ? { type: 'Buffer', utf8: arg.toString('utf8'), hex: arg.toString('hex') } : atom(arg));
+    async function retained(label, file) {
+      const stat = await actual.lstat(file, { bigint: true });
+      const content = await actual.readFile(file);
+      const record = { label, separateObservation: true, stat: stats(stat), identity: identity(stat),
+        contentUtf8: content.toString('utf8'), bytes: content.length, sha256: digest(content) };
+      event('additional-retained-evidence', record);
+      return record;
+    }
+    async function companion(method, stage, call, originalOptions, originalEvent) {
+      if (values.companions !== 'after') return;
+      const options = { bigint: !originalOptions?.bigint };
+      receipt.counts.companionStats++;
+      const start = event('additional-stat-enter', { method, stage, options: atom(options), afterOriginalEvent: originalEvent });
+      try {
+        const stat = await call(options);
+        event('additional-stat-return', { entered: start.order, method, stage, result: stats(stat),
+          separateSyscall: true, atomicWithOriginal: false });
+      } catch (error) {
+        event('additional-stat-error', { entered: start.order, error: errorInfo(error) });
+        throw error;
+      }
+    }
+    async function swap(candidate) {
+      assert(armed && !swapped, 'swap must be one-shot');
+      if (kind === 'replacement') {
+        assert.equal(classify(candidate), 'target');
+        assert(previewReturned > 0, 'target swap must follow original algorithm preview receipt');
+      }
+      armed = false;
+      event('swap-begin', { trigger: classify(candidate), previewReturned });
+      await actual.rename(target, displaced);
+      await actual.writeFile(target, 'replacement', { flag: 'wx' });
+      swapped = true;
+      receipt.counts.swaps++;
+      event('swap-complete', { trigger: classify(candidate), previewReturned });
+    }
+    async function trackOpen(args, doSwap) {
+      const classification = classify(args[0]);
+      const entry = event('open-spy-enter', { classification,
+        arguments: classification === 'other' ? '[unexpected non-fixture arguments withheld]' : argsRecord(args),
+        previewReturned });
+      if (classification === 'other') {
+        receipt.counts.otherOpens++;
+        throw new Error('Unexpected non-fixture fs.open: refusing interference and withholding unrelated path');
+      }
+      if (classification === 'target') {
+        targetOpenEntered = true;
+        assert(++receipt.counts.targetOpens <= 1, 'hash must not reopen target');
+      } else assert(++receipt.counts.unrelatedOpens <= 1, 'unexpected unrelated open');
+      if (doSwap) await swap(args[0]);
+      const handle = await actual.open(...args);
+      event('open-spy-return', { entered: entry.order, classification, fd: handle.fd });
+      const raw = { stat: handle.stat.bind(handle), read: handle.read.bind(handle), close: handle.close.bind(handle) };
+      const tracked = { handle, raw, classification, closed: false };
+      handles.push(tracked);
+      if (classification === 'target') {
+        handle.stat = async (...statArgs) => {
+          assert(++receipt.counts.descriptorStats <= 4, 'descriptor stat bound');
+          const start = event('algorithm-stat-enter', { method: 'FileHandle.stat', stage: 'descriptor',
+            descriptorOrdinal: receipt.counts.descriptorStats, arguments: argsRecord(statArgs) });
+          const stat = await raw.stat(...statArgs);
+          const end = event('algorithm-stat-return', { entered: start.order, method: 'FileHandle.stat',
+            stage: 'descriptor', result: stats(stat) });
+          await companion('FileHandle.stat', 'descriptor', raw.stat, statArgs[0], end.order);
+          return stat;
+        };
+        handle.read = async (...readArgs) => {
+          assert(++receipt.counts.reads <= 4, 'bounded tiny-fixture read count');
+          const start = event('algorithm-read-enter', { arguments: readArgs.map(arg =>
+            Buffer.isBuffer(arg) ? { type: 'Buffer', byteLength: arg.length, contents: 'not captured: allocation may be uninitialized' } : atom(arg)) });
+          const result = await raw.read(...readArgs);
+          receipt.counts.bytesRead += result.bytesRead;
+          event('algorithm-read-return', { entered: start.order, bytesRead: result.bytesRead });
+          return result;
+        };
+      }
+      handle.close = async (...closeArgs) => {
+        if (classification === 'target') receipt.counts.closes++;
+        else receipt.counts.unrelatedCloses++;
+        const start = event('close-enter', { classification, arguments: argsRecord(closeArgs) });
+        await raw.close(...closeArgs);
+        tracked.closed = true;
+        if (classification === 'target') receipt.counts.closed++;
+        event('close-return', { entered: start.order, classification });
+      };
+      return handle;
+    }
+    timer = setTimeout(() => {
+      receipt.timeout = { milliseconds: timeout, failClosed: true };
+      write(`${name}.timeout.json`, receipt);
+      summary.timeoutCase = name; write('summary.timeout.json', summary);
+      process.exit(124);
+    }, timeout);
+    try {
+      await actual.writeFile(target, 'original', { flag: 'wx' });
+      await actual.writeFile(unrelated, 'auxiliary', { flag: 'wx' });
+      receipt.beforeAdditional = await retained('initial-original: outside algorithm', target);
+      configureFsSafeNative({ mode: 'off' });
+      __setNativeLoaderForTest(() => {
+        receipt.counts.nativeLoaderCalls++;
+        return { sha256File() {
+          receipt.counts.nativeCalls++; event('unexpected-native-call');
+          throw new Error('Native activity is forbidden in this mode-off diagnostic');
+        } };
+      });
+      hashSpy = spyOn(crypto, 'createHash').mockImplementation((...args) => {
+        receipt.counts.jsHashCreates++;
+        event('algorithm-hash-create', { arguments: argsRecord(args) });
+        return actualCreateHash(...args);
+      });
+      syncBuiltinESMExports();
+      openSpy = spyOn(fs, 'open');
+      openSpy.mockImplementation((...args) => trackOpen(args, kind === 'replacement' && armed && classify(args[0]) === 'target'));
+      if (kind === 'unscoped') openSpy.mockImplementationOnce((...args) => trackOpen(args, true));
+      lstatSpy = spyOn(fs, 'lstat').mockImplementation(async (...args) => {
+        assert.equal(classify(args[0]), 'target', 'unexpected non-target lstat');
+        assert(++receipt.counts.algorithmLstats <= 4, 'pathname stat bound');
+        const stage = targetOpenEntered ? 'current-path' : 'preview';
+        const start = event('algorithm-stat-enter', { method: 'fs.lstat', stage, arguments: argsRecord(args) });
+        const stat = await actual.lstat(...args);
+        const end = event('algorithm-stat-return', { entered: start.order, method: 'fs.lstat', stage, result: stats(stat) });
+        await companion('fs.lstat', stage, options => actual.lstat(args[0], options), args[1], end.order);
+        if (stage === 'preview') previewReturned++;
+        return stat;
+      });
+      // Deliberate exported fs.open before sha256File and its first lstat, not an inferred coverage event.
+      event('controlled-unrelated-open-before-algorithm');
+      const auxiliary = await fs.open(unrelated, 'r');
+      await auxiliary.close();
+      check('unrelated call leaves target-scoped injection armed', kind !== 'replacement' || (armed && !swapped));
+      hashStarted = true;
+      receipt.counts.hashCalls++;
+      event('hash-call');
+      try { receipt.outcome = { resolved: await sha256File(target) }; }
+      catch (error) { receipt.outcome = { rejected: errorInfo(error) }; }
+      event('hash-settled', receipt.outcome);
+      receipt.openSpyCalls = openSpy.mock.calls.map((args, index) => ({ index: index + 1,
+        invocationOrder: openSpy.mock.invocationCallOrder[index], classification: classify(args[0]),
+        arguments: classify(args[0]) === 'other' ? '[withheld]' : argsRecord(args) }));
+      receipt.lstatSpyInvocationOrder = [...lstatSpy.mock.invocationCallOrder];
+      openSpy.mockRestore(); openSpy = undefined;
+      lstatSpy.mockRestore(); lstatSpy = undefined;
+      receipt.finalTarget = await retained(swapped ? 'replacement' : 'unchanged original', target);
+      if (swapped) receipt.finalDisplaced = await retained('rename-retained original', displaced);
+      const expectedContent = kind === 'stable' ? 'original' : 'replacement';
+      const resolved = receipt.outcome.resolved;
+      const rejected = receipt.outcome.rejected;
+      const shouldReject = kind === 'replacement' && values.variant === 'patched';
+      check('fixture content retained', receipt.finalTarget.contentUtf8 === expectedContent &&
+        (!swapped || receipt.finalDisplaced.contentUtf8 === 'original'));
+      check('exact initial and final original identity is known', known(receipt.beforeAdditional.identity) &&
+        known((receipt.finalDisplaced ?? receipt.finalTarget).identity));
+      check('rename retains original exact identity', equalId(receipt.beforeAdditional.identity,
+        (receipt.finalDisplaced ?? receipt.finalTarget).identity));
+      check('replacement exact identity known and distinct', !swapped ||
+        (known(receipt.finalTarget.identity) && !equalId(receipt.finalDisplaced.identity, receipt.finalTarget.identity)));
+      check('exactly one target open and close, one controlled unrelated open/close',
+        receipt.counts.targetOpens === 1 && receipt.counts.closes === 1 && receipt.counts.closed === 1 &&
+        receipt.counts.unrelatedOpens === 1 && receipt.counts.unrelatedCloses === 1 && receipt.counts.otherOpens === 0);
+      check('one hash invocation, no hash creation before rejection', receipt.counts.hashCalls === 1 &&
+        receipt.counts.jsHashCreates === (resolved ? 1 : 0));
+      check('native off tripwire untouched', receipt.counts.nativeCalls === 0 && receipt.counts.nativeLoaderCalls === 0);
+      check('one swap only for replacement cases', receipt.counts.swaps === (kind === 'stable' ? 0 : 1));
+      check('expected outcome', shouldReject ? rejected?.code === 'path-mismatch' :
+        kind === 'replacement' ? Boolean(resolved || rejected?.code === 'path-mismatch') : Boolean(resolved));
+      check('resolved digest and byte count match retained bytes', !resolved ||
+        (resolved.digest === digest(expectedContent) && resolved.bytes === Buffer.byteLength(expectedContent) &&
+          receipt.counts.bytesRead === resolved.bytes && receipt.counts.reads > 0));
+      check('rejection occurs before any read/native hash', !rejected ||
+        (receipt.counts.reads === 0 && receipt.counts.jsHashCreates === 0 && receipt.counts.nativeCalls === 0));
+      const previews = receipt.events.filter(e => e.type === 'algorithm-stat-return' && e.stage === 'preview');
+      const swapDone = receipt.events.find(e => e.type === 'swap-complete');
+      check('swap timing exactly as labeled', kind === 'stable' ||
+        (previews.length > 0 && (kind === 'replacement' ?
+          previews.every(e => e.order < swapDone.order && !e.swapped) :
+          previews.every(e => e.order > swapDone.order && e.swapped))));
+      const algorithmStats = receipt.events.filter(e => e.type === 'algorithm-stat-enter');
+      if (values.variant === 'baseline') {
+        check('baseline stat options remain numeric defaults', algorithmStats.every(e =>
+          e.method === 'fs.lstat' ? e.arguments.length === 1 : e.arguments.length === 0));
+      } else {
+        check('patched pathname identity stats request bigint', algorithmStats.filter(e => e.method === 'fs.lstat')
+          .every(e => e.arguments[1]?.value?.bigint === true));
+        const firstDescriptor = algorithmStats.find(e => e.method === 'FileHandle.stat');
+        check('patched descriptor identity stat requests bigint', firstDescriptor?.arguments[0]?.value?.bigint === true);
+      }
+      const targetCall = receipt.openSpyCalls.find(e => e.classification === 'target');
+      const flags = targetCall?.arguments[1]?.value;
+      const expectedFlags = constants.O_RDONLY | (process.platform === 'win32' ? 0 :
+        (constants.O_NOFOLLOW ?? 0) | (constants.O_NONBLOCK ?? 0));
+      check('target open flags unchanged', typeof flags === 'number' && flags === expectedFlags);
+      receipt.classification = kind === 'replacement' && resolved ?
+        (values.variant === 'baseline' ? 'BASELINE OBSERVATION: replacement admitted (NOT a security pass)' :
+          'PATCH GATE FAILURE: replacement admitted') :
+        kind === 'unscoped' ? 'CONTROLLED HAZARD: preview already observes replacement' :
+        rejected ? 'replacement rejected before read' : 'stable original hashed';
+    } catch (error) { receipt.harnessError = errorInfo(error); }
+    finally {
+      openSpy?.mockRestore(); lstatSpy?.mockRestore();
+      hashSpy?.mockRestore(); syncBuiltinESMExports();
+      __resetNativeLoaderForTest(); __resetFsSafeNativeConfigForTest();
+      for (const tracked of handles) if (!tracked.closed) {
+        receipt.counts.rescueCloses++;
+        try { await tracked.raw.close(); } catch (error) { receipt.cleanupError = errorInfo(error); }
+      }
+      clearTimeout(timer); timer = undefined;
+      receipt.passed = !receipt.harnessError && !receipt.cleanupError && receipt.counts.rescueCloses === 0 &&
+        receipt.invariants.length > 0 && receipt.invariants.every(i => i.passed);
+      write(`${name}.json`, receipt);
+      summary.cases.push({ name, passed: receipt.passed, classification: receipt.classification,
+        outcome: receipt.outcome, receipt: `${name}.json`, counts: receipt.counts });
+      activeCase = undefined;
+      console.log(`${name}: ${receipt.passed ? 'diagnostic invariants met' : 'FAIL'} (${receipt.classification ?? 'harness failure'})`);
+    }
+  }
+  await scenario('real-stable', 'stable');
+  await scenario('real-target-replacement', 'replacement');
+  if (values['include-unscoped']) await scenario('controlled-unscoped-before-preview', 'unscoped');
+} catch (error) { summary.error = errorInfo(error); }
+finally {
+  clearTimeout(timer);
+  if (fingerprintBefore) {
+    try {
+      summary.fingerprintAfter = await fingerprint();
+      summary.compiledAndSourceUnchanged = json(summary.fingerprintAfter) === json(fingerprintBefore);
+    } catch (error) { summary.fingerprintError = errorInfo(error); }
+  }
+  summary.finishedAt = new Date().toISOString();
+  summary.passed = !summary.error && !summary.fingerprintError && summary.compiledAndSourceUnchanged === true &&
+    summary.cases.length >= 2 && summary.cases.every(c => c.passed);
+  if (activeCase) summary.incompleteCase = activeCase;
+  write('summary.json', summary);
+  if (!summary.passed) process.exitCode = 1;
+}

--- a/src/file-hash.ts
+++ b/src/file-hash.ts
@@ -2,9 +2,9 @@ import { createHash } from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
-import { sameFileIdentity } from "./file-identity.js";
 import { getNativeBinding, type NativeBinding } from "./native.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
+import { inspectFileIdentity } from "./strict-file-identity.js";
 
 export type Sha256FileInput = string | FileHandle;
 
@@ -39,13 +39,16 @@ export async function hashFileHandle(
 }
 
 async function hashPath(filePath: string): Promise<Sha256FileResult> {
-  const before = await fs.lstat(filePath);
-  if (before.isSymbolicLink()) {
-    throw new FsSafeError("symlink", "SHA-256 path must not be a symbolic link");
-  }
-  if (!before.isFile()) {
-    throw new FsSafeError("not-file", "SHA-256 path is not a regular file");
-  }
+  const before = await inspectFileIdentity(async () => {
+    const stat = await fs.lstat(filePath, { bigint: true });
+    if (stat.isSymbolicLink()) {
+      throw new FsSafeError("symlink", "SHA-256 path must not be a symbolic link");
+    }
+    if (!stat.isFile()) {
+      throw new FsSafeError("not-file", "SHA-256 path is not a regular file");
+    }
+    return stat;
+  });
 
   let handle: FileHandle;
   try {
@@ -60,19 +63,20 @@ async function hashPath(filePath: string): Promise<Sha256FileResult> {
   }
 
   try {
-    const opened = await handle.stat();
-    const current = await fs.lstat(filePath);
-    if (!opened.isFile()) {
-      throw new FsSafeError("not-file", "SHA-256 path is not a regular file");
-    }
-    if (
-      current.isSymbolicLink() ||
-      !current.isFile() ||
-      !sameFileIdentity(before, opened) ||
-      !sameFileIdentity(opened, current)
-    ) {
-      throw new FsSafeError("path-mismatch", "SHA-256 path changed while opening");
-    }
+    const opened = await inspectFileIdentity(async () => {
+      const stat = await handle.stat({ bigint: true });
+      if (!stat.isFile()) {
+        throw new FsSafeError("not-file", "SHA-256 path is not a regular file");
+      }
+      return stat;
+    }, before);
+    await inspectFileIdentity(async () => {
+      const stat = await fs.lstat(filePath, { bigint: true });
+      if (stat.isSymbolicLink() || !stat.isFile()) {
+        throw new FsSafeError("path-mismatch", "SHA-256 path changed while opening");
+      }
+      return stat;
+    }, opened);
     return await hashFileHandle(handle);
   } finally {
     await handle.close().catch(() => undefined);

--- a/test/file-hash-identity.test.ts
+++ b/test/file-hash-identity.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sha256File } from "../src/file-hash.js";
+import { __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __resetNativeLoaderForTest } from "../src/native.js";
+import {
+  abcHash, expectedHashOpenFlags, hashIdentity, observeHashPath,
+  type HashBoundary, type HashSamples,
+} from "./helpers/file-hash-identity.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+const boundaries = ["preview", "descriptor", "current"] as const;
+const unknowns = [
+  { label: "dev", value: { dev: 0n } },
+  { label: "ino", value: { ino: 0n } },
+  { label: "both", value: { dev: 0n, ino: 0n } },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+async function fixture(samples: HashSamples = {}, mode: "off" | "mock-native" = "off") {
+  const directory = await tempRoot("fs-safe-hash-identity-");
+  Object.defineProperty(process, "platform", { value: "win32" });
+  return await observeHashPath(directory, samples, mode);
+}
+
+function expectedCounts(boundary: HashBoundary, attempts: number, succeeds = false) {
+  const stoppedAt = boundaries.indexOf(boundary);
+  return Object.fromEntries(boundaries.map((stage, index) =>
+    [stage, stage === boundary ? attempts : succeeds || index < stoppedAt ? 1 : 0],
+  )) as Record<HashBoundary, number>;
+}
+
+function assertTrace(
+  subject: Awaited<ReturnType<typeof fixture>>,
+  counts: Record<HashBoundary, number>,
+  hashing?: "off" | "mock-native",
+) {
+  expect(subject.counts).toEqual(counts);
+  const opened = counts.descriptor > 0;
+  const expected = [
+    ...Array(counts.preview).fill("preview"),
+    ...(opened ? ["open"] : []),
+    ...Array(counts.descriptor).fill("descriptor"),
+    ...Array(counts.current).fill("current"),
+    ...(hashing ? ["hash-stat", ...(hashing === "off" ? ["read", "read"] : ["native"])] : []),
+    ...(opened ? ["close"] : []),
+  ];
+  expect(subject.events).toEqual(expected);
+  expect(subject.open.mock.calls).toEqual(opened ? [[subject.filePath, expectedHashOpenFlags()]] : []);
+  expect(subject.handles).toHaveLength(opened ? 1 : 0);
+  expect(subject.close).toHaveBeenCalledTimes(opened ? 1 : 0);
+  expect(subject.read).toHaveBeenCalledTimes(hashing === "off" ? 2 : 0);
+  expect(subject.nativeHash).toHaveBeenCalledTimes(hashing === "mock-native" ? 1 : 0);
+  expect(subject.loader).toHaveBeenCalledTimes(hashing === "mock-native" ? 1 : 0);
+  if (opened) {
+    const fd = subject.close.mock.calls[0]![0];
+    expect(subject.descriptors).toEqual(Array(counts.descriptor).fill(fd));
+    expect(subject.handles[0]!.fd).toBe(-1);
+    if (hashing === "mock-native") expect(subject.nativeHash).toHaveBeenCalledWith(fd);
+    for (const call of subject.read.mock.calls) expect(call).toEqual([fd]);
+  }
+  for (const observation of subject.observations) {
+    expect(observation.bigint).toBe(true);
+    expect(typeof observation.dev).toBe("bigint");
+    expect(typeof observation.ino).toBe("bigint");
+  }
+}
+
+// These are Windows identity representation models over real local I/O, not
+// Windows kernel proof or an explanation of any particular coverage event.
+describe.each(["off", "mock-native"] as const)("pathname hash Windows identity model (%s)", (mode) => {
+  it("hashes only after all three stable identities are verified", async () => {
+    const subject = await fixture({}, mode);
+    await expect(sha256File(subject.filePath)).resolves.toEqual(abcHash);
+    assertTrace(subject, { preview: 1, descriptor: 1, current: 1 }, mode);
+  });
+
+  describe.each(boundaries)("%s boundary", (boundary) => {
+    it.each(unknowns)("recovers transient unknown $label with one retry", async ({ value }) => {
+      const subject = await fixture({ [boundary]: [value, {}] }, mode);
+      await expect(sha256File(subject.filePath)).resolves.toEqual(abcHash);
+      assertTrace(subject, expectedCounts(boundary, 2, true), mode);
+    });
+
+    it.each(unknowns)("rejects persistent unknown $label after one retry", async ({ value }) => {
+      const subject = await fixture({ [boundary]: [value] }, mode);
+      await expect(sha256File(subject.filePath)).rejects.toMatchObject({ code: "path-mismatch" });
+      assertTrace(subject, expectedCounts(boundary, 2));
+    });
+
+    it.each(["dev", "ino"] as const)("retains known %s across an unknown retry", async (knownField) => {
+      const unknownField = knownField === "dev" ? "ino" : "dev";
+      const subject = await fixture({ [boundary]: [
+        { [unknownField]: 0n },
+        { [knownField]: hashIdentity[knownField] + 1n },
+      ] }, mode);
+      await expect(sha256File(subject.filePath)).rejects.toMatchObject({ code: "path-mismatch" });
+      assertTrace(subject, expectedCounts(boundary, 2));
+    });
+
+    it("does not merge alternating unknown components into a complete receipt", async () => {
+      const subject = await fixture({ [boundary]: [{ dev: 0n }, { ino: 0n }] }, mode);
+      await expect(sha256File(subject.filePath)).rejects.toMatchObject({ code: "path-mismatch" });
+      assertTrace(subject, expectedCounts(boundary, 2));
+    });
+
+    it.each([false, true])("propagates inspection I/O errors without extra retry (retry=%s)", async (retry) => {
+      const failure = Object.assign(new Error("inspection denied"), { code: "EACCES" });
+      const subject = await fixture({ [boundary]: retry ? [{ ino: 0n }, failure] : [failure] }, mode);
+      await expect(sha256File(subject.filePath)).rejects.toBe(failure);
+      assertTrace(subject, expectedCounts(boundary, retry ? 2 : 1));
+    });
+  });
+
+  describe.each(["descriptor", "current"] as const)("%s expected receipt", (boundary) => {
+    it.each(["dev", "ino"] as const)("rejects known differing %s beside unknown immediately", async (knownField) => {
+      const unknownField = knownField === "dev" ? "ino" : "dev";
+      const subject = await fixture({ [boundary]: [
+        { [unknownField]: 0n, [knownField]: hashIdentity[knownField] + 1n }, {},
+      ] }, mode);
+      await expect(sha256File(subject.filePath)).rejects.toMatchObject({ code: "path-mismatch" });
+      assertTrace(subject, expectedCounts(boundary, 1));
+    });
+
+    it.each(["dev", "ino"] as const)("retains expected %s when the first observation makes it unknown", async (field) => {
+      const subject = await fixture({ [boundary]: [{ [field]: 0n }, { [field]: hashIdentity[field] + 1n }] }, mode);
+      await expect(sha256File(subject.filePath)).rejects.toMatchObject({ code: "path-mismatch" });
+      assertTrace(subject, expectedCounts(boundary, 2));
+    });
+
+    it("rejects distinct high inode IDs with colliding numeric projections", async () => {
+      expect(Number(hashIdentity.ino + 1n)).toBe(Number(hashIdentity.ino));
+      const subject = await fixture({ [boundary]: [{ ino: hashIdentity.ino + 1n }] }, mode);
+      await expect(sha256File(subject.filePath)).rejects.toMatchObject({ code: "path-mismatch" });
+      assertTrace(subject, expectedCounts(boundary, 1));
+    });
+  });
+
+  it.each([
+    { boundary: "preview", kind: "symlink", code: "symlink" },
+    { boundary: "preview", kind: "not-file", code: "not-file" },
+    { boundary: "descriptor", kind: "not-file", code: "not-file" },
+    { boundary: "current", kind: "symlink", code: "path-mismatch" },
+    { boundary: "current", kind: "not-file", code: "path-mismatch" },
+  ] as const)("repeats $boundary $kind check on unknown retry ($code)", async ({ boundary, kind, code }) => {
+    const subject = await fixture({ [boundary]: [{ ino: 0n }, { kind }] }, mode);
+    await expect(sha256File(subject.filePath)).rejects.toMatchObject({ code });
+    assertTrace(subject, expectedCounts(boundary, 2));
+  });
+
+  it("permits one retry independently at each boundary without reopening", async () => {
+    const subject = await fixture({
+      preview: [{ dev: 0n }, {}], descriptor: [{ ino: 0n }, {}], current: [{ dev: 0n, ino: 0n }, {}],
+    }, mode);
+    await expect(sha256File(subject.filePath)).resolves.toEqual(abcHash);
+    assertTrace(subject, { preview: 2, descriptor: 2, current: 2 }, mode);
+  });
+});

--- a/test/file-hash.test.ts
+++ b/test/file-hash.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { itPosix } from "./helpers/vitest.js";
+import { expectedHashOpenFlags, hashIdentity } from "./helpers/file-hash-identity.js";
 import { sha256File } from "../src/file-hash.js";
 import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
 import {
@@ -70,6 +71,90 @@ describe("sha256File", () => {
     }
   });
 
+  it.each(["read", "stat", "native"] as const)(
+    "keeps a caller-owned handle open and its offset unchanged on %s failure",
+    async (failureAt) => {
+      const root = await tempRoot();
+      const filePath = path.join(root, "position.bin");
+      await fs.writeFile(filePath, "abcdef");
+      const handle = await fs.open(filePath, "r");
+      const failure = new Error("hash failed");
+      configureFsSafeNative({ mode: failureAt === "native" ? "auto" : "off" });
+      try {
+        await handle.read(Buffer.alloc(2), 0, 2, null);
+        const close = vi.spyOn(handle, "close");
+        const open = vi.spyOn(fs, "open");
+        const lstat = vi.spyOn(fs, "lstat");
+        if (failureAt === "native") {
+          const nativeHash = vi.fn(async () => { throw failure; });
+          __setNativeLoaderForTest(() => ({ sha256File: nativeHash }) as unknown as NativeBinding);
+        } else {
+          vi.spyOn(handle, failureAt).mockRejectedValueOnce(failure);
+        }
+        await expect(sha256File(handle)).rejects.toBe(failure);
+        expect(close).not.toHaveBeenCalled();
+        expect(open).not.toHaveBeenCalled();
+        expect(lstat).not.toHaveBeenCalled();
+        const next = Buffer.alloc(1);
+        await handle.read(next, 0, next.length, null);
+        expect(next.toString()).toBe("c");
+      } finally {
+        await handle.close();
+      }
+    },
+  );
+
+  it.each(["ELOOP", "EACCES"])("preserves open failure mapping for %s", async (code) => {
+    const root = await tempRoot();
+    const filePath = path.join(root, "payload.bin");
+    await fs.writeFile(filePath, "abc");
+    const failure = Object.assign(new Error("open failed"), { code });
+    const realOpen = fs.open.bind(fs);
+    const open = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      if (args[0] === filePath) throw failure;
+      return await realOpen(...args);
+    });
+    const loader = vi.fn();
+    __setNativeLoaderForTest(loader);
+    if (code === "ELOOP") {
+      await expect(sha256File(filePath)).rejects.toMatchObject({ code: "symlink", cause: failure });
+    } else {
+      await expect(sha256File(filePath)).rejects.toBe(failure);
+    }
+    expect(open.mock.calls).toEqual([[filePath, expectedHashOpenFlags()]]);
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it.each(["read", "native"] as const)("closes its owned handle once on %s failure", async (failureAt) => {
+    const root = await tempRoot();
+    const filePath = path.join(root, "payload.bin");
+    await fs.writeFile(filePath, "abc");
+    const failure = new Error("hash failed");
+    configureFsSafeNative({ mode: failureAt === "native" ? "auto" : "off" });
+    const nativeHash = vi.fn(async () => { throw failure; });
+    __setNativeLoaderForTest(() => ({ sha256File: nativeHash }) as unknown as NativeBinding);
+    const realOpen = fs.open.bind(fs);
+    let close: ReturnType<typeof vi.spyOn> | undefined;
+    let read: ReturnType<typeof vi.spyOn> | undefined;
+    let handle: fs.FileHandle | undefined;
+    const open = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const opened = await realOpen(...args);
+      if (args[0] === filePath) {
+        handle = opened;
+        close = vi.spyOn(opened, "close");
+        read = vi.spyOn(opened, "read");
+        if (failureAt === "read") read.mockRejectedValueOnce(failure);
+      }
+      return opened;
+    });
+    await expect(sha256File(filePath)).rejects.toBe(failure);
+    expect(open.mock.calls).toEqual([[filePath, expectedHashOpenFlags()]]);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(handle!.fd).toBe(-1);
+    expect(read).toHaveBeenCalledTimes(failureAt === "read" ? 1 : 0);
+    expect(nativeHash).toHaveBeenCalledTimes(failureAt === "native" ? 1 : 0);
+  });
+
   it("uses the native async hash when the binding is available", async () => {
     const root = await tempRoot();
     const filePath = path.join(root, "native.bin");
@@ -96,20 +181,118 @@ describe("sha256File", () => {
     await expect(sha256File(linkPath)).rejects.toMatchObject({ code: "symlink" });
   });
 
-  it("rejects a regular file replaced between inspection and open", async () => {
+  it.each([
+    { model: "real", timing: "before-open" },
+    { model: "high-bigint", timing: "before-open" },
+    { model: "real", timing: "after-open" },
+    { model: "high-bigint", timing: "after-open" },
+  ] as const)("rejects a real retained replacement ($model, $timing)", async ({ model, timing }) => {
     const root = await tempRoot();
     const filePath = path.join(root, "payload.bin");
     const displacedPath = path.join(root, "payload.displaced");
+    const unrelatedPath = path.join(root, "unrelated.bin");
     await fs.writeFile(filePath, "original");
+    await fs.writeFile(unrelatedPath, "auxiliary");
     configureFsSafeNative({ mode: "off" });
+    const originalLstat = fs.lstat.bind(fs);
     const originalOpen = fs.open.bind(fs);
-    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+    const identity = (stat: fsSync.Stats | fsSync.BigIntStats) => ({ dev: stat.dev, ino: stat.ino });
+    const before = identity(await originalLstat(filePath, { bigint: true }));
+    const events: string[] = [];
+    const observations: { stage: string; bigint: boolean; raw: ReturnType<typeof identity>; delivered: ReturnType<typeof identity> }[] = [];
+    let armed = true;
+    let swaps = 0;
+    let close: ReturnType<typeof vi.spyOn> | undefined;
+    let read: ReturnType<typeof vi.spyOn> | undefined;
+    let opened: fs.FileHandle | undefined;
+
+    function observe(stage: string, stat: fsSync.Stats | fsSync.BigIntStats, bigint: boolean) {
+      events.push(stage);
+      const raw = identity(stat);
+      if (model === "high-bigint") {
+        // Only the representation is synthetic; both retained files and their
+        // opened descriptors are real. This does not model a specific CI event.
+        const isOriginal = bigint
+          ? raw.dev === before.dev && raw.ino === before.ino
+          : raw.dev === Number(before.dev) && raw.ino === Number(before.ino);
+        const ino = isOriginal ? hashIdentity.ino : hashIdentity.ino + 1n;
+        stat.dev = bigint ? hashIdentity.dev : Number(hashIdentity.dev);
+        stat.ino = bigint ? ino : Number(ino);
+      }
+      observations.push({ stage, bigint, raw, delivered: identity(stat) });
+      return stat;
+    }
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      const stat = await originalLstat(...args);
+      return args[0] === filePath
+        ? observe(opened ? "current" : "preview", stat, args[1]?.bigint === true)
+        : stat;
+    });
+    async function replace() {
+      expect(armed).toBe(true);
+      armed = false;
+      swaps++;
+      events.push("swap");
       await fs.rename(filePath, displacedPath);
       await fs.writeFile(filePath, "replacement");
-      return await originalOpen(...args);
+    }
+    const open = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      if (args[0] !== filePath) {
+        events.push("unrelated-open");
+        return await originalOpen(...args);
+      }
+      events.push("target-open");
+      if (armed && timing === "before-open") await replace();
+      const handle = await originalOpen(...args);
+      opened = handle;
+      close = vi.spyOn(handle, "close");
+      read = vi.spyOn(handle, "read");
+      const stat = handle.stat.bind(handle);
+      vi.spyOn(handle, "stat").mockImplementation(async (options) =>
+        observe("descriptor", await stat(options), options?.bigint === true),
+      );
+      if (armed && timing === "after-open") await replace();
+      return handle;
     });
 
+    // An unrelated open before preview cannot consume the armed injection.
+    const unrelated = await fs.open(unrelatedPath, "r");
+    await unrelated.close();
+    expect(armed).toBe(true);
+    expect(swaps).toBe(0);
     await expect(sha256File(filePath)).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(open.mock.calls).toEqual([[unrelatedPath, "r"], [filePath, expectedHashOpenFlags()]]);
+    expect(events).toEqual([
+      "unrelated-open", "preview", "target-open", "swap", "descriptor",
+      ...(timing === "after-open" ? ["current"] : []),
+    ]);
+    expect(swaps).toBe(1);
+    expect(armed).toBe(false);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(read).not.toHaveBeenCalled();
+    expect(opened!.fd).toBe(-1);
+    for (const observation of observations) {
+      expect(observation.bigint).toBe(true);
+      expect(typeof observation.delivered.dev).toBe("bigint");
+      expect(typeof observation.delivered.ino).toBe("bigint");
+    }
+    const displaced = identity(await originalLstat(displacedPath, { bigint: true }));
+    const replacement = identity(await originalLstat(filePath, { bigint: true }));
+    expect(displaced).toEqual(before);
+    expect(replacement.ino).not.toBe(displaced.ino);
+    expect(observations.map(({ raw }) => raw)).toEqual(
+      timing === "before-open" ? [before, replacement] : [before, before, replacement],
+    );
+    if (model === "high-bigint") {
+      expect(Number(hashIdentity.ino)).toBe(Number(hashIdentity.ino + 1n));
+      const exactOriginal = hashIdentity;
+      const exactReplacement = { ...hashIdentity, ino: hashIdentity.ino + 1n };
+      expect(observations.map(({ delivered }) => delivered)).toEqual(timing === "before-open"
+        ? [exactOriginal, exactReplacement] : [exactOriginal, exactOriginal, exactReplacement]);
+    }
+    await expect(fs.readFile(displacedPath, "utf8")).resolves.toBe("original");
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readFile(unrelatedPath, "utf8")).resolves.toBe("auxiliary");
   });
 
   itPosix("rejects a FIFO swapped in before open without blocking", async () => {
@@ -119,8 +302,12 @@ describe("sha256File", () => {
     await fs.writeFile(filePath, "payload");
     configureFsSafeNative({ mode: "off" });
     const originalOpen = fs.open.bind(fs);
-    vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
-      if (candidate === filePath) {
+    let armed = true;
+    let close: ReturnType<typeof vi.spyOn> | undefined;
+    let read: ReturnType<typeof vi.spyOn> | undefined;
+    const open = vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
+      if (candidate === filePath && armed) {
+        armed = false;
         expect(typeof flags).toBe("number");
         expect((flags as number) & fsSync.constants.O_NONBLOCK).toBe(
           fsSync.constants.O_NONBLOCK,
@@ -128,9 +315,17 @@ describe("sha256File", () => {
         await fs.rename(filePath, displacedPath);
         await createFifo(filePath);
       }
-      return await originalOpen(candidate, flags, mode);
+      const handle = await originalOpen(candidate, flags, mode);
+      if (candidate === filePath) {
+        close = vi.spyOn(handle, "close");
+        read = vi.spyOn(handle, "read");
+      }
+      return handle;
     });
 
     await expect(sha256File(filePath)).rejects.toMatchObject({ code: "not-file" });
+    expect(open.mock.calls).toEqual([[filePath, expectedHashOpenFlags()]]);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(read).not.toHaveBeenCalled();
   });
 });

--- a/test/helpers/file-hash-identity.ts
+++ b/test/helpers/file-hash-identity.ts
@@ -1,0 +1,100 @@
+import fsSync, { type BigIntStats, type Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { vi } from "vitest";
+import { configureFsSafeNative } from "../../src/native-config.js";
+import { __setNativeLoaderForTest, type NativeBinding } from "../../src/native.js";
+
+export const hashIdentity = { dev: 7n, ino: 9007199254806528n };
+export const abcHash = {
+  bytes: 3,
+  digest: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+};
+export type HashBoundary = "preview" | "descriptor" | "current";
+export type HashSample = Partial<typeof hashIdentity> & { kind?: "symlink" | "not-file" };
+export type HashSamples = Partial<Record<HashBoundary, (HashSample | Error)[]>>;
+
+export function expectedHashOpenFlags(): number {
+  return fsSync.constants.O_RDONLY | (process.platform === "win32" ? 0 :
+    (fsSync.constants.O_NOFOLLOW ?? 0) | (fsSync.constants.O_NONBLOCK ?? 0));
+}
+
+// Real files, opens, stats, reads and closes; only the delivered identity/type
+// observations are modeled. A mocked binding proves dispatch, not native hashing.
+export async function observeHashPath(
+  directory: string,
+  samples: HashSamples = {},
+  mode: "off" | "mock-native" = "off",
+) {
+  const filePath = path.join(directory, "payload.bin");
+  await fs.writeFile(filePath, "abc");
+  const events: string[] = [];
+  const counts = { preview: 0, descriptor: 0, current: 0 };
+  const observations: { boundary: HashBoundary; bigint: boolean; dev: unknown; ino: unknown }[] = [];
+  const descriptors: number[] = [];
+  const handles: fs.FileHandle[] = [];
+  const read = vi.fn();
+  const close = vi.fn();
+  const nativeHash = vi.fn(async (_fd: number) => {
+    events.push("native");
+    return abcHash;
+  });
+  const loader = vi.fn(() => ({ sha256File: nativeHash }) as unknown as NativeBinding);
+  __setNativeLoaderForTest(loader);
+  configureFsSafeNative({ mode: mode === "off" ? "off" : "auto" });
+
+  function observe(boundary: HashBoundary, stat: Stats | BigIntStats, bigint: boolean) {
+    events.push(boundary);
+    const sequence = samples[boundary];
+    const attempt = counts[boundary]++;
+    const sample = sequence?.[Math.min(attempt, sequence.length - 1)] ?? {};
+    if (sample instanceof Error) throw sample;
+    const identity = { ...hashIdentity, ...sample };
+    stat.dev = bigint ? identity.dev : Number(identity.dev);
+    stat.ino = bigint ? identity.ino : Number(identity.ino);
+    if (sample.kind) {
+      stat.isSymbolicLink = () => sample.kind === "symlink";
+      stat.isFile = () => false;
+    }
+    observations.push({ boundary, bigint, dev: stat.dev, ino: stat.ino });
+    return stat;
+  }
+
+  const lstat = fs.lstat.bind(fs);
+  vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    const stat = await lstat(...args);
+    if (args[0] !== filePath) return stat;
+    return observe(handles.length === 0 ? "preview" : "current", stat, args[1]?.bigint === true);
+  });
+  const actualOpen = fs.open.bind(fs);
+  const open = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await actualOpen(...args);
+    if (args[0] !== filePath) return handle;
+    events.push("open");
+    handles.push(handle);
+    const stat = handle.stat.bind(handle);
+    vi.spyOn(handle, "stat").mockImplementation(async (options) => {
+      const result = await stat(options);
+      if (!options?.bigint) {
+        events.push("hash-stat");
+        return result;
+      }
+      descriptors.push(handle.fd);
+      return observe("descriptor", result, true);
+    });
+    const actualRead = handle.read.bind(handle);
+    vi.spyOn(handle, "read").mockImplementation(async (...readArgs) => {
+      events.push("read");
+      read(handle.fd);
+      return await actualRead(...readArgs);
+    });
+    const actualClose = handle.close.bind(handle);
+    vi.spyOn(handle, "close").mockImplementation(async () => {
+      events.push("close");
+      close(handle.fd);
+      await actualClose();
+    });
+    return handle;
+  });
+  return { filePath, events, counts, observations, descriptors, handles, open, read, close, nativeHash, loader };
+}


### PR DESCRIPTION
## Summary

Use the existing strict read-identity helper only at the pathname SHA-256 owner: verify lossless bigint receipts from the pre-open pathname, the opened descriptor, and the current pathname before hashing. Keep the pre-open comparison, open flags, repeated file-type checks, descriptor cleanup, native dispatch, and caller-owned handle ownership/offset behavior.

This closes two independently reproducible gaps: unknown Windows identity components could be accepted as sufficient evidence, and distinct large inode IDs could round to the same Number. Unknown identity now receives one bounded re-inspection per boundary and fails closed if it remains ambiguous. Known mismatches reject immediately. The generic Windows compatibility policy is unchanged; the hashing availability tradeoff is documented.

The regression suite scopes replacement injection to the intended target, retains the original file, and covers exact-ID collisions, unknown-identity retries at all three boundaries, repeated type checks, read/native dispatch ordering, and failure closure. The Windows diagnostic workflow records actual runtime/libuv/filesystem facts, original stat observations, separately labeled companion observations, spy order, and retained file identities/content.

## Verified proof

Verified at head `dcbf6c778f719922fe5bb350496aa1d0eca40f3e`:

- [Full CI](https://github.com/openclaw/fs-safe/actions/runs/33237194420): all 15 jobs passed, including `pnpm check` on Windows/macOS/Linux with Node 22 and 24, native checks including musl, Cargo clippy/audit, and bundled-package smoke tests.
- [Instrumented Windows proof and retained artifacts](https://github.com/openclaw/fs-safe/actions/runs/33237194434): Windows Server 2025 build 26100, NTFS, x64; Node 22.23.2/libuv 1.51.0 and Node 24.20.0/libuv 1.52.1. Each runtime passed 114 focused tests both plain and with Vitest V8 coverage; the same two existing POSIX-only cases were skipped.
- Patched real replacement controls passed plain and under raw V8 instrumentation, with zero hash creations, reads, or native calls before `path-mismatch`, exactly one target open/close, and the original and replacement identities/content retained. Raw V8 module evidence is separate from the Vitest threshold gate.
- Focused hashing coverage: 97.5% lines, 95.12% statements, 95.23% branches, 85.71% functions. [Merged repository coverage](https://github.com/openclaw/fs-safe/actions/runs/33237194504) also passed: 93.93% lines, 92.81% statements, 88.66% branches, 91.42% functions. No threshold values changed.
- Independent Codex autoreviews of the runtime fix, diagnostic additions, and archive correction reported no blocking findings at the configured P0 scope. After marking this PR ready, [CodeQL](https://github.com/openclaw/fs-safe/actions/runs/33237881234) passed both Actions and JavaScript/TypeScript analyses.

Fresh real-file baseline controls also rejected replacement: the observed identities were known, distinct, and safely representable numerically. The high-ID regression models separately fail against the unchanged baseline—the before-open case hashes the 11-byte replacement, and the after-open case accepts the old descriptor despite a changed pathname. These are explicitly labeled representation models over real files, not observations of the earlier Windows runner. The earlier coverage event remains unattributed because its actual stats and spy arguments were not recorded; a later passing run does not establish its cause.

The first diagnostic workflow attempt caught Git archive's Windows CRLF conversion through its strict baseline checksum. Per-command Git EOL settings now preserve the committed baseline bytes; the checksum assertion was not weakened. Local focused tests/build/docs/guards/package checks passed; full local test attempts hit timeouts, followed by the successful isolated CI proof above.

## Scope

This is a focused prerequisite based on merged [PR156](https://github.com/openclaw/fs-safe/pull/156), kept separate from [PR157](https://github.com/openclaw/fs-safe/pull/157). PR157's prepared head `498db578f03c43d60d468489a30c3262b344e011` is preserved. No native packaging changes, global identity-tolerance changes, test/coverage relaxations, merge, or release actions are included.
