### PR TITLE
fix(ci): align Crabbox AWS root volume with runner image

### DIFF
--- a/.crabbox.yaml
+++ b/.crabbox.yaml
@@ -24,7 +24,8 @@ actions:
   ephemeral: true
 aws:
   region: eu-west-1
-  rootGB: 160
+  # Keep this at least as large as the configured AWS image's root snapshot.
+  rootGB: 400
 sync:
   delete: true
   checksum: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Docs and Tooling
 
+- Raise the Crabbox AWS root volume to 400 GiB to meet the runner image's snapshot minimum and avoid allocation failures before checks run.
 - Restore six missing documentation navigation entries, remove the dangling page, correct the lock-config link, and reject missing, nonexistent, or duplicate registrations before replacing site output. Thanks @Yigtwxx.
 - Fix the standalone native smoke script to use the numeric descriptor returned by `openBeneath()` for identity checks and cleanup.
 - Accept npm 11 array and npm 12 package-name-keyed pack results while validating the intended package and its file metadata.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the repository's AWS Crabbox checks fail during allocation, before any test runs: the configured 160 GiB root volume is smaller than the runner image's 400 GiB root snapshot, so AWS rejects the request with `InvalidBlockDeviceMapping`.

## Why This Change Was Made

Set the repository-owned `aws.rootGB` to 400 GiB and document the snapshot-size constraint. This matches the verified Crabbox client/broker default and the minimum reported by the failed allocation. Removing the field or setting it to zero would not provide image-aware sizing; either can inherit a smaller user configuration.

This is only the root-volume configuration fix. It does not include pathname-hashing work or changes from [PR157](https://github.com/openclaw/fs-safe/pull/157), and it preserves the AWS provider, capacity policy, hydration, and all other resolved settings. A broader provider implementation change is not needed for this repository correction.

## User Impact

Maintainer tooling requests a root volume large enough for the observed runner snapshot. There is no package API, filesystem-safety, or runtime behavior change.

## Evidence

- Installed Crabbox configuration checks confirm that 160 → 400 GiB is the only resolved configuration change.
- Four isolated configuration cases passed: omitted size with default configuration resolves to 400; omitted or zero size with a smaller user configuration resolves to 160; the fixed repository overrides that user configuration with 400.
- `pnpm pack:check` and `git diff --check` passed.
- Local `pnpm check` passed lint, filesystem-boundary, build, and documentation checks, then reported 1,509 passed / 4 failed / 326 skipped tests. The failures were timeout-related in the unchanged archive-fuzz tests. A focused rerun also failed with timeout/cleanup errors (7 passed / 10 failed / 2 skipped); no test limits or source files were changed.
- The saved AWS error establishes the 400 GiB minimum for the failed allocation. Fresh verification of the broker-selected image was unavailable with the accessible read-only metadata path. No new cloud allocation was performed, and no successful live allocation is claimed.

- [x] Configuration behavior checked with the installed CLI
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated
- [x] No credentials, private paths, private hosts, snapshot IDs, or sensitive logs included
