### PR TITLE
chore(release): open next unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 0.6.0 - 2026-08-29
 
 ### Highlights


### PR DESCRIPTION
## Summary

Open the next development section after the verified [fs-safe 0.6.0 release](https://github.com/openclaw/fs-safe/releases/tag/v0.6.0). This adds only an empty `## Unreleased` heading above the dated 0.6.0 section: one file, two added lines.

Every byte of the released section and older changelog is unchanged. Package versions and optional pins remain 0.6.0; no source behavior, published notes, tag, Release, or registry state changes.

## Validation

- Explicit and default release-note generation both preserve the exact 5,507-byte published notes, SHA256 `0a1d7bfc35b65d2c0b0fd6717e1c7a6e7ddf1cb8e7909090c57a80fefcc2f948`.
- Byte comparison preserves the released section and all older changelog content.
- Release-proof tests: 3 passed; documentation examples check passed.
- Complete candidate `git diff --check origin/main..HEAD` passed.
- Isolated Codex review of the complete candidate found no actionable blockers.
- Candidate: `07612fd5528c1032916408caa1eec666a5909253`. Fresh exact-head hosted checks passed: [benchmarks](https://github.com/openclaw/fs-safe/actions/runs/33271843250) (1 jobs), [ci](https://github.com/openclaw/fs-safe/actions/runs/33271843194) (15 jobs), [CodeQL](https://github.com/openclaw/fs-safe/actions/runs/33271843115) (2 jobs), [coverage](https://github.com/openclaw/fs-safe/actions/runs/33271843093) (4 jobs). No failed jobs or reruns; coverage includes Windows and merged coverage.

Merge remains held for exact parent approval after hosted checks.
