### PR TITLE
fix(store): verify durable queue read identities losslessly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security and Correctness
+
+- Verify durable JSON queue reads with lossless bigint identities and reject persistent unknown Windows identities before reading entry bytes.
+
 ## 0.6.0 - 2026-08-29
 
 ### Highlights

--- a/docs/store.md
+++ b/docs/store.md
@@ -68,6 +68,12 @@ Use `ackJsonDurableQueueEntry()` after durable processing succeeds and
 `moveJsonDurableQueueEntryToFailed()` when the caller wants to quarantine an
 entry for inspection.
 
+Queue entry reads verify lossless file identities before opening, on the opened
+descriptor, and at the current pathname before reading bytes. On Windows, an
+unknown identity gets one bounded reinspection; persistent ambiguity or a
+mismatch rejects with `queue entry changed during read`. Each inspection still
+rejects non-files, symlinks, hardlinks, and entries over the byte limit.
+
 ## Related pages
 
 - [`fileStore`](file-store.md) — full API for the multi-file store.

--- a/src/json-durable-queue.ts
+++ b/src/json-durable-queue.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
+import fs, { type BigIntStats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
-import { sameFileIdentity } from "./file-identity.js";
+import { inspectFileIdentity } from "./strict-file-identity.js";
 import { stringifyJsonDocument } from "./json-stringify.js";
 import { replaceFileAtomic } from "./replace-file.js";
 import { assertSafePathSegment } from "./safe-path-segment.js";
@@ -280,39 +280,50 @@ export async function writeJsonDurableQueueEntry(params: {
   });
 }
 
+async function inspectQueueEntry(
+  inspect: () => Promise<BigIntStats>,
+  maxBytes: number,
+  expected?: BigIntStats,
+): Promise<BigIntStats> {
+  let inspectionFailed = false;
+  try {
+    return await inspectFileIdentity(async () => {
+      try {
+        const stat = await inspect();
+        if (stat.isSymbolicLink() || !stat.isFile()) {
+          throw new Error("queue entry is not a regular file");
+        }
+        if (stat.nlink > 1n) throw new Error("queue entry hardlinks are not allowed");
+        if (stat.size > maxBytes) throw new Error(`queue entry exceeds ${maxBytes} bytes`);
+        return stat;
+      } catch (error) {
+        inspectionFailed = true;
+        throw error;
+      }
+    }, expected);
+  } catch (error) {
+    // Translate only the identity helper's rejection, never inspection errors.
+    if (inspectionFailed) throw error;
+    throw new Error("queue entry changed during read", { cause: error });
+  }
+}
+
 async function readBoundedUtf8File(params: {
   filePath: string;
   maxBytes: number;
 }): Promise<string> {
-  const initialStat = await fs.promises.lstat(params.filePath);
-  if (initialStat.isSymbolicLink() || !initialStat.isFile()) {
-    throw new Error("queue entry is not a regular file");
-  }
-  if (initialStat.nlink > 1) {
-    throw new Error("queue entry hardlinks are not allowed");
-  }
-  if (initialStat.size > params.maxBytes) {
-    throw new Error(`queue entry exceeds ${params.maxBytes} bytes`);
-  }
+  const inspectPath = () => fs.promises.lstat(params.filePath, { bigint: true });
+  const initialStat = await inspectQueueEntry(inspectPath, params.maxBytes);
   const noFollow =
     typeof fs.constants.O_NOFOLLOW === "number" && process.platform !== "win32"
       ? fs.constants.O_NOFOLLOW
       : 0;
   const handle = await fs.promises.open(params.filePath, fs.constants.O_RDONLY | noFollow);
   try {
-    const openedStat = await handle.stat();
-    const pathStat = await fs.promises.lstat(params.filePath);
-    if (
-      !openedStat.isFile() ||
-      pathStat.isSymbolicLink() ||
-      !pathStat.isFile() ||
-      openedStat.nlink > 1 ||
-      pathStat.nlink > 1 ||
-      !sameFileIdentity(initialStat, openedStat) ||
-      !sameFileIdentity(pathStat, openedStat)
-    ) {
-      throw new Error("queue entry changed during read");
-    }
+    const openedStat = await inspectQueueEntry(
+      () => handle.stat({ bigint: true }), params.maxBytes, initialStat,
+    );
+    await inspectQueueEntry(inspectPath, params.maxBytes, openedStat);
     const chunks: Buffer[] = [];
     const scratch = Buffer.allocUnsafe(Math.min(64 * 1024, params.maxBytes + 1));
     let total = 0;

--- a/test/helpers/queue-read-identity.ts
+++ b/test/helpers/queue-read-identity.ts
@@ -1,0 +1,78 @@
+import { type BigIntStats, type Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { vi } from "vitest";
+
+export const queueIdentity = { dev: 7n, ino: 9007199254806528n };
+export const queuePayload = '{"entry":"original"}';
+export type QueueBoundary = "preview" | "descriptor" | "current";
+type Sample = Partial<typeof queueIdentity> & {
+  kind?: "symlink" | "not-file";
+  nlink?: bigint;
+  size?: bigint;
+};
+export type QueueSamples = Partial<Record<QueueBoundary, (Sample | Error)[]>>;
+
+// Real local I/O with modeled Windows stat receipts, including the numeric
+// projection returned when a caller omits bigint. This is not kernel proof.
+export async function observeQueueRead(directory: string, samples: QueueSamples = {}) {
+  const filePath = path.join(directory, "entry.json");
+  await fs.writeFile(filePath, queuePayload);
+  const events: string[] = [];
+  const counts = { preview: 0, descriptor: 0, current: 0 };
+  const observations: { boundary: QueueBoundary; bigint: boolean }[] = [];
+  const handles: fs.FileHandle[] = [];
+  const read = vi.fn();
+  const close = vi.fn();
+
+  function observe(boundary: QueueBoundary, stat: Stats | BigIntStats, bigint: boolean) {
+    events.push(boundary);
+    observations.push({ boundary, bigint });
+    const sequence = samples[boundary];
+    const attempt = counts[boundary]++;
+    const sample = sequence?.[Math.min(attempt, sequence.length - 1)] ?? {};
+    if (sample instanceof Error) throw sample;
+    const identity = { ...queueIdentity, ...sample };
+    stat.dev = bigint ? identity.dev : Number(identity.dev);
+    stat.ino = bigint ? identity.ino : Number(identity.ino);
+    if (sample.nlink !== undefined) stat.nlink = bigint ? sample.nlink : Number(sample.nlink);
+    if (sample.size !== undefined) stat.size = bigint ? sample.size : Number(sample.size);
+    if (sample.kind) {
+      stat.isSymbolicLink = () => sample.kind === "symlink";
+      stat.isFile = () => false;
+    }
+    return stat;
+  }
+
+  const lstat = fs.lstat.bind(fs);
+  vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    const stat = await lstat(...args);
+    if (args[0] !== filePath) return stat;
+    return observe(handles.length === 0 ? "preview" : "current", stat, args[1]?.bigint === true);
+  });
+  const actualOpen = fs.open.bind(fs);
+  const open = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await actualOpen(...args);
+    if (args[0] !== filePath) return handle;
+    events.push("open");
+    handles.push(handle);
+    const stat = handle.stat.bind(handle);
+    vi.spyOn(handle, "stat").mockImplementation(async (options) =>
+      observe("descriptor", await stat(options), options?.bigint === true),
+    );
+    const actualRead = handle.read.bind(handle);
+    vi.spyOn(handle, "read").mockImplementation(async (...args) => {
+      events.push("read");
+      read(handle.fd);
+      return await actualRead(...args);
+    });
+    const actualClose = handle.close.bind(handle);
+    vi.spyOn(handle, "close").mockImplementation(async () => {
+      events.push("close");
+      close(handle.fd);
+      await actualClose();
+    });
+    return handle;
+  });
+  return { filePath, events, counts, observations, handles, open, read, close };
+}

--- a/test/json-durable-queue-failure.test.ts
+++ b/test/json-durable-queue-failure.test.ts
@@ -117,6 +117,29 @@ describe("durable JSON queue failure recovery", () => {
     );
   });
 
+  it("bounds growth after all identity inspections and closes the descriptor", async () => {
+    const root = await tempRoot("fs-safe-queue-growth-after-inspection-");
+    const filePath = path.join(root, "entry.json");
+    await fs.writeFile(filePath, "{}");
+    const realOpen = fs.open.bind(fs);
+    let opened: fs.FileHandle | undefined;
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      if (args[0] !== filePath) return handle;
+      opened = handle;
+      const read = handle.read.bind(handle);
+      vi.spyOn(handle, "read").mockImplementationOnce(async (...readArgs) => {
+        await fs.appendFile(filePath, "1234");
+        return await read(...readArgs);
+      });
+      return handle;
+    });
+    await expect(readJsonDurableQueueEntry(filePath, { maxBytes: 3 })).rejects.toThrow(
+      "queue entry exceeds 3 bytes",
+    );
+    expect(opened?.fd).toBe(-1);
+  });
+
   itPosix("rejects symlink and hardlink queue entries without reading their contents", async () => {
     const root = await tempRoot("fs-safe-queue-links-");
     const target = path.join(root, "target.json");
@@ -199,16 +222,38 @@ describe("durable JSON queue failure recovery", () => {
     const root = await tempRoot("fs-safe-queue-read-swap-");
     const filePath = path.join(root, "entry.json");
     const oldPath = path.join(root, "old.json");
-    await fs.writeFile(filePath, "{}");
+    const unrelatedPath = path.join(root, "unrelated.json");
+    await fs.writeFile(filePath, '{"entry":"original"}');
+    await fs.writeFile(unrelatedPath, "{}");
+    const events: string[] = [];
+    let targetOpens = 0;
     const realOpen = fs.open.bind(fs);
-    vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+    const open = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
       const handle = await realOpen(...args);
+      if (args[0] !== filePath) return handle;
+      expect(++targetOpens).toBe(1);
+      events.push("opened original");
       await fs.rename(filePath, oldPath);
-      await fs.writeFile(filePath, "{}");
+      events.push("retained original");
+      await fs.writeFile(filePath, '{"entry":"replacement"}');
+      events.push("wrote replacement");
       return handle;
     });
+    const unrelated = await fs.open(unrelatedPath, "r");
+    await unrelated.close();
+    expect(targetOpens).toBe(0);
     await expect(readJsonDurableQueueEntry(filePath)).rejects.toThrow(
       "queue entry changed during read",
     );
+    expect(targetOpens).toBe(1);
+    expect(open.mock.calls.filter(([target]) => target === filePath)).toHaveLength(1);
+    expect(events).toEqual(["opened original", "retained original", "wrote replacement"]);
+    expect(fsSync.readFileSync(oldPath, "utf8")).toBe('{"entry":"original"}');
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe('{"entry":"replacement"}');
+    const originalStat = await fs.lstat(oldPath, { bigint: true });
+    const replacementStat = await fs.lstat(filePath, { bigint: true });
+    if (originalStat.ino !== 0n && replacementStat.ino !== 0n) {
+      expect(originalStat.ino).not.toBe(replacementStat.ino);
+    }
   });
 });

--- a/test/json-durable-queue-identity.test.ts
+++ b/test/json-durable-queue-identity.test.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FsSafeError } from "../src/errors.js";
+import { readJsonDurableQueueEntry } from "../src/json-durable-queue.js";
+import {
+  observeQueueRead, queueIdentity, queuePayload, type QueueBoundary, type QueueSamples,
+} from "./helpers/queue-read-identity.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+const boundaries = ["preview", "descriptor", "current"] as const;
+const unknowns = [
+  { label: "dev", value: { dev: 0n } },
+  { label: "ino", value: { ino: 0n } },
+  { label: "both", value: { dev: 0n, ino: 0n } },
+];
+const changed = "queue entry changed during read";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+});
+
+async function fixture(samples: QueueSamples = {}) {
+  const directory = await tempRoot("fs-safe-queue-identity-");
+  Object.defineProperty(process, "platform", { value: "win32" });
+  return await observeQueueRead(directory, samples);
+}
+
+function countsFor(boundary: QueueBoundary, attempts: number, success = false) {
+  return Object.fromEntries(boundaries.map((stage, index) =>
+    [stage, stage === boundary ? attempts : success || index < boundaries.indexOf(boundary) ? 1 : 0],
+  )) as Record<QueueBoundary, number>;
+}
+
+function assertTrace(
+  subject: Awaited<ReturnType<typeof fixture>>,
+  counts: Record<QueueBoundary, number>,
+  success = false,
+) {
+  expect(subject.counts).toEqual(counts);
+  const opened = counts.descriptor > 0;
+  expect(subject.events).toEqual([
+    ...Array(counts.preview).fill("preview"),
+    ...(opened ? ["open"] : []),
+    ...Array(counts.descriptor).fill("descriptor"),
+    ...Array(counts.current).fill("current"),
+    ...(success ? ["read", "read"] : []),
+    ...(opened ? ["close"] : []),
+  ]);
+  expect(subject.open.mock.calls).toEqual(opened ? [[subject.filePath, fs.constants.O_RDONLY]] : []);
+  expect(subject.handles).toHaveLength(opened ? 1 : 0);
+  expect(subject.close).toHaveBeenCalledTimes(opened ? 1 : 0);
+  expect(subject.read).toHaveBeenCalledTimes(success ? 2 : 0);
+  if (opened) expect(subject.handles[0]!.fd).toBe(-1);
+  for (const observation of subject.observations) expect(observation.bigint).toBe(true);
+}
+
+// Deterministic representation models prove the owner contract, not the cause
+// of a particular Windows runner failure whose identities were not recorded.
+describe("durable queue Windows identity receipts", () => {
+  it("reads and parses only after stable preview, descriptor and current receipts", async () => {
+    const subject = await fixture();
+    const parse = vi.spyOn(JSON, "parse");
+    await expect(readJsonDurableQueueEntry(subject.filePath)).resolves.toEqual({ entry: "original" });
+    expect(parse).toHaveBeenCalledWith(queuePayload);
+    assertTrace(subject, { preview: 1, descriptor: 1, current: 1 }, true);
+  });
+
+  describe.each(boundaries)("%s boundary", (boundary) => {
+    it.each(unknowns)("recovers a transient unknown $label once", async ({ value: unknown }) => {
+      const subject = await fixture({ [boundary]: [unknown, {}] });
+      await expect(readJsonDurableQueueEntry(subject.filePath)).resolves.toEqual({ entry: "original" });
+      assertTrace(subject, countsFor(boundary, 2, true), true);
+    });
+
+    it.each(unknowns)("rejects persistent unknown $label before reading or parsing", async ({ value: unknown }) => {
+      const subject = await fixture({ [boundary]: [unknown] });
+      const parse = vi.spyOn(JSON, "parse");
+      await expect(readJsonDurableQueueEntry(subject.filePath)).rejects.toMatchObject({
+        message: changed, cause: { code: "path-mismatch" },
+      });
+      expect(parse).not.toHaveBeenCalledWith(queuePayload);
+      assertTrace(subject, countsFor(boundary, 2));
+    });
+
+    it.each(["dev", "ino"] as const)("retains known %s across an unknown retry", async (field) => {
+      const other = field === "dev" ? "ino" : "dev";
+      const subject = await fixture({ [boundary]: [{ [other]: 0n }, { [field]: queueIdentity[field] + 1n }] });
+      await expect(readJsonDurableQueueEntry(subject.filePath)).rejects.toThrow(changed);
+      assertTrace(subject, countsFor(boundary, 2));
+    });
+
+    it("does not combine incomplete receipts", async () => {
+      const subject = await fixture({ [boundary]: [{ dev: 0n }, { ino: 0n }] });
+      await expect(readJsonDurableQueueEntry(subject.filePath)).rejects.toThrow(changed);
+      assertTrace(subject, countsFor(boundary, 2));
+    });
+
+    it.each([false, true])("preserves callback failures without identity translation (retry=%s)", async (retry) => {
+      // Even a callback's path-mismatch error is not the helper's rejection.
+      const failure = new FsSafeError("path-mismatch", "inspection callback failed");
+      const subject = await fixture({ [boundary]: retry ? [{ ino: 0n }, failure] : [failure] });
+      await expect(readJsonDurableQueueEntry(subject.filePath)).rejects.toBe(failure);
+      assertTrace(subject, countsFor(boundary, retry ? 2 : 1));
+    });
+
+    it.each([
+      { sample: { kind: "not-file" }, message: "queue entry is not a regular file" },
+      { sample: { nlink: 2n }, message: "queue entry hardlinks are not allowed" },
+      { sample: { size: 100n }, message: "queue entry exceeds 64 bytes" },
+    ] as const)("revalidates $message on the bounded retry", async ({ sample, message }) => {
+      const subject = await fixture({ [boundary]: [{ ino: 0n }, sample] });
+      await expect(readJsonDurableQueueEntry(subject.filePath, { maxBytes: 64 })).rejects.toThrow(message);
+      assertTrace(subject, countsFor(boundary, 2));
+    });
+  });
+
+  describe.each(["descriptor", "current"] as const)("%s expected identity", (boundary) => {
+    it("rejects high inode identities with identical numeric projections", async () => {
+      expect(Number(queueIdentity.ino + 1n)).toBe(Number(queueIdentity.ino));
+      const subject = await fixture({ [boundary]: [{ ino: queueIdentity.ino + 1n }] });
+      await expect(readJsonDurableQueueEntry(subject.filePath)).rejects.toThrow(changed);
+      assertTrace(subject, countsFor(boundary, 1));
+    });
+
+    it.each(["dev", "ino"] as const)("rejects a known %s mismatch beside an unknown immediately", async (field) => {
+      const other = field === "dev" ? "ino" : "dev";
+      const subject = await fixture({ [boundary]: [{ [other]: 0n, [field]: queueIdentity[field] + 1n }, {}] });
+      await expect(readJsonDurableQueueEntry(subject.filePath)).rejects.toThrow(changed);
+      assertTrace(subject, countsFor(boundary, 1));
+    });
+  });
+
+  it.each(["preview", "current"] as const)("rejects a symlink on %s reinspection", async (boundary) => {
+    const subject = await fixture({ [boundary]: [{ ino: 0n }, { kind: "symlink" }] });
+    await expect(readJsonDurableQueueEntry(subject.filePath)).rejects.toThrow("queue entry is not a regular file");
+    assertTrace(subject, countsFor(boundary, 2));
+  });
+
+  it("reinspects each boundary at most once without reopening", async () => {
+    const subject = await fixture({ preview: [{ dev: 0n }, {}], descriptor: [{ ino: 0n }, {}], current: [{ dev: 0n, ino: 0n }, {}] });
+    await expect(readJsonDurableQueueEntry(subject.filePath)).resolves.toEqual({ entry: "original" });
+    assertTrace(subject, { preview: 2, descriptor: 2, current: 2 }, true);
+  });
+});


### PR DESCRIPTION
## Problem

Post-release Windows coverage exposed a durable-queue swap check returning a parsed entry instead of rejecting. The runner did not record its device/inode values, so the exact mechanism of that event remains unattributed.

The queue pathname reader inherited numeric stat receipts and the generic Windows-compatible identity comparison. Deterministic regressions demonstrate that distinct high inode IDs can collapse to the same Number and that persistent unknown Windows identities can be accepted. The pathname hashing fix in #158 already established the stricter owner-level pattern.

## Change

Use the existing strict identity inspector and bigint receipts at the queue reader's pre-open pathname, opened descriptor, and current-path fences. Every bounded inspection validates regular-file, symlink, hardlink, and size constraints before bytes are read. Unknown Windows identities get one reinspection; mismatches or persistent ambiguity reject without reopening the descriptor.

Preserve the queue's `queue entry changed during read` message with the identity failure as its cause, while passing through inspection errors unchanged. The read-loop limit and finally-close remain intact. Generic identity tolerance and all unrelated callers are unchanged.

Add target-scoped retained-replacement proof, 52 deterministic owner identity cases, a growth-after-verification regression, queue documentation, and one Unreleased changelog bullet. No dependencies or native ABI changes.

## Validation

- Baseline: both high-inode collision cases and all nine persistent-unknown cases incorrectly returned the parsed entry; the new owner contract suite failed before the fix and passed afterward.
- Focused queue, strict identity, JSON and JSON-store suites: 122 passed; the final queue failure/growth suite: 11 passed.
- Build, file-size/boundary checks, documentation examples/site, package check, complete candidate diff hygiene, and isolated Codex review passed.
- One local `pnpm check`: 2,171 passed, 19 failed, 25 skipped. Failures were timeouts plus a late assertion from an already timed-out test after temporary-root cleanup; two accompanying cleanup errors were retained. Queue regressions passed. No full-check retry or threshold changes.
- Local security run: 75 passed, 3 timeout/hook failures with a cleanup error. A focused growth test briefly overlapped that run; this orchestration caveat is retained. Subsequent build/full-check/package commands were serialized.
- Fresh exact-head hosted checks are complete; see the resumed proof below.

The public [v0.6.0 release](https://github.com/openclaw/fs-safe/releases/tag/v0.6.0), immutable tag, package versions, optional pins, registry metadata, and dist-tags are unchanged. All released changelog bytes remain identical; generated 0.6.0 notes remain 5,507 bytes with SHA256 `0a1d7bfc35b65d2c0b0fd6717e1c7a6e7ddf1cb8e7909090c57a80fefcc2f948`. This fix is for a future patch; no new release is being published.

Merge is held for exact maintainer approval after the hosted gates.


## Resumed exact-head hosted proof

At unchanged head `6d228b78a8c5fab21b620162c9a31bae0594c528`:

- [CI](https://github.com/openclaw/fs-safe/actions/runs/33273203287): all 15 jobs passed, including Windows Node 22/24 checks, native checks, and bundled-package smoke.
- [Coverage](https://github.com/openclaw/fs-safe/actions/runs/33273203290): all four jobs passed, including Windows and merged coverage. Attempt 1 had one unrelated Ubuntu timeout in the unchanged JavaScript publication test (5 seconds, no assertion failure). One targeted job retry at the same head passed; no source or timeout changes and no further retries.
- [CodeQL](https://github.com/openclaw/fs-safe/actions/runs/33273203286): both analyses passed. [Benchmarks](https://github.com/openclaw/fs-safe/actions/runs/33273203282) passed.
- Real Windows after-fix execution is present in both the [coverage log](https://github.com/openclaw/fs-safe/actions/runs/33273203290/job/99155297073) and [normal Node 22 suite](https://github.com/openclaw/fs-safe/actions/runs/33273203287/job/99155297232): all 52 deterministic identity cases passed, and the queue failure suite passed 9 cases with only its two POSIX-only cases skipped. The original real-filesystem swap test and the new growth/descriptor-closure test are unconditional cases in that suite. The swap retains the original inode, writes a distinct replacement, invokes the production reader, and requires rejection. It does not model stat receipts.
- The Windows coverage artifact records 67 production `readJsonDurableQueueEntry` calls and 156 `inspectQueueEntry` calls. Stable queue reads pass; the deterministic boundary cases cover high-ID collisions and transient/persistent unknown receipts, rejected before reading/parsing, with descriptor closure.
- A fresh complete committed-branch Codex review against the unchanged main base completed with high reasoning and no actionable P0 finding. Scanner and restricted-workspace isolation remained enabled.

Evidence limit: the 52 deterministic cases model receipt values even when run on Windows. Neither these tests nor the original failing run record a spontaneous unknown-identity contention trace. The exact old Windows failure remains unattributed; successful real swap execution must not be read as proof that zero identities or numeric rounding specifically caused that event. Persistent unknown identity rejection is the intentional fail-closed contract.

The existing commit, all released changelog bytes, the v0.6.0 tag/Release, and npm latest 0.6.0 remain unchanged. Merge remains held for exact maintainer approval and fresh review/hold inspection.


Resumed local verification is complete: the eight serialized queue/identity/strict-helper/JSON-store suites passed 200 tests (2 skipped). Build, docs examples, package validation, and full diff hygiene passed. With the earlier raw logs no longer available, one authorized full `pnpm check` ran: 2,183 passed, 7 failed, 25 skipped. All seven failures were timeouts in unchanged archive/property-fuzz/store-stress cases under local load; queue suites passed, with no assertion or unhandled cleanup errors in this resumed run. No full-check rerun or timeout changes. The initial dependency-refresh attempt aborted before tests; existing installed dependencies were retained without lockfile changes. Hosted checks above are all green.
