### PR TITLE
fix(archive): join timeout cleanup before rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Security and Correctness
 
-- Keep archive timeout failures joined to extraction ownership, stopping new destination mutations at the deadline and waiting for in-flight publication and staging cleanup before rejecting.
+- Stop archive destination publication at the timeout boundary and join only an in-flight destination mutation and rollback before rejecting, preserving prompt deadlines for non-mutating work.
 - Verify durable JSON queue reads with lossless bigint identities and reject persistent unknown Windows identities before reading entry bytes.
 
 ## 0.6.0 - 2026-08-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Keep archive timeout failures joined to extraction ownership, stopping new destination mutations at the deadline and waiting for in-flight publication and staging cleanup before rejecting.
 - Verify durable JSON queue reads with lossless bigint identities and reject persistent unknown Windows identities before reading entry bytes.
 
 ## 0.6.0 - 2026-08-29

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -23,7 +23,7 @@ await extractArchive({
   archivePath: "/srv/uploads/plugin.zip",
   destDir: "/srv/workspace/plugins/plugin",
   kind: "zip",                        // optional; resolveArchiveKind() can infer
-  timeoutMs: 15_000,                  // hard ceiling for the whole extraction
+  timeoutMs: 15_000,                  // cancellation budget; rejection waits for cleanup
   stripComponents: 0,                 // tar-style strip-leading-dirs
   entryModes: "clamp",                // default; use "preserve" for archive rwx bits
   entryFilter: ({ path, kind, size }) => "extract",
@@ -45,7 +45,7 @@ await extractArchive({
 type ExtractArchiveOptions = {
   archivePath: string;          // absolute path to the archive
   destDir: string;              // absolute destination directory; must already exist
-  timeoutMs: number;            // positive wall-clock cap; <= 0/non-finite disables it
+  timeoutMs: number;            // positive cancellation budget; <= 0/non-finite disables it
   kind?: ArchiveKind;           // "zip" | "tar" | "tar-zstd" | "tar-bzip2"
   stripComponents?: number;     // strip N leading dirs from entry paths
   tarGzip?: boolean;            // when archive is .tar.gz/.tgz
@@ -118,7 +118,7 @@ of leaving a paused parser to drain indefinitely. The native path finishes its
 bounded manifest read before TypeScript policy evaluation, so a rejected plan
 never starts the extraction worker.
 
-If `kind` is omitted, the helper calls `resolveArchiveKind(archivePath)` and throws if the extension is not recognized. Pass `kind` explicitly when the archive name doesn't carry the type (e.g. content-addressed names). A positive finite `timeoutMs` is a wall-clock budget; zero, negative, `NaN`, and infinity disable the deadline.
+If `kind` is omitted, the helper calls `resolveArchiveKind(archivePath)` and throws if the extension is not recognized. Pass `kind` explicitly when the archive name doesn't carry the type (e.g. content-addressed names). A positive finite `timeoutMs` starts cancellation when the wall-clock budget expires; the promise rejects only after in-flight filesystem work has unwound and staging/input cleanup is complete, so settlement can follow the deadline when a filesystem operation cannot be interrupted. Zero, negative, `NaN`, and infinity disable the deadline.
 
 ### Limits
 
@@ -165,7 +165,7 @@ codes remain `"destination-not-directory"`, `"destination-symlink"`, and
 - **TOCTOU during merge:** extraction first writes to a private temp dir, then merges into `destDir` using the same boundary checks as `root().write()`. Destination symlink swaps are checked with the selected platform mechanism; non-Linux routes retain the best-effort race window documented in the [security model](security-model.md#containment-guarantees-by-platform).
 - **Zip bombs:** `maxExtractedBytes` and `maxEntryBytes` apply to *post-decompression* bytes, so highly-compressed payloads hit the cap before they exhaust disk.
 - **Corrupt ZIP payloads:** streamed output must match both the central-directory CRC and declared uncompressed size before it can leave private staging.
-- **Slow-loris archives:** `timeoutMs` is a hard wall-clock budget. Extraction is aborted on overrun.
+- **Slow-loris archives:** `timeoutMs` starts cancellation on overrun. No new destination mutation begins after the deadline, and the promise waits for owned filesystem work and cleanup to quiesce before rejecting.
 - **Metadata bombs:** a streaming pass-through reader rejects oversized PAX, GNU long-name, and GNU long-link bodies before either TAR implementation buffers them. It understands octal and base-256 fixed sizes and validates bounded local PAX bodies before using their size overrides for member framing. Original archive bytes remain unchanged.
 
 ### Bounded local PAX support

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -23,7 +23,7 @@ await extractArchive({
   archivePath: "/srv/uploads/plugin.zip",
   destDir: "/srv/workspace/plugins/plugin",
   kind: "zip",                        // optional; resolveArchiveKind() can infer
-  timeoutMs: 15_000,                  // cancellation budget; rejection waits for cleanup
+  timeoutMs: 15_000,                  // hard budget; active destination mutation is joined
   stripComponents: 0,                 // tar-style strip-leading-dirs
   entryModes: "clamp",                // default; use "preserve" for archive rwx bits
   entryFilter: ({ path, kind, size }) => "extract",
@@ -45,7 +45,7 @@ await extractArchive({
 type ExtractArchiveOptions = {
   archivePath: string;          // absolute path to the archive
   destDir: string;              // absolute destination directory; must already exist
-  timeoutMs: number;            // positive cancellation budget; <= 0/non-finite disables it
+  timeoutMs: number;            // positive wall-clock budget; <= 0/non-finite disables it
   kind?: ArchiveKind;           // "zip" | "tar" | "tar-zstd" | "tar-bzip2"
   stripComponents?: number;     // strip N leading dirs from entry paths
   tarGzip?: boolean;            // when archive is .tar.gz/.tgz
@@ -118,7 +118,7 @@ of leaving a paused parser to drain indefinitely. The native path finishes its
 bounded manifest read before TypeScript policy evaluation, so a rejected plan
 never starts the extraction worker.
 
-If `kind` is omitted, the helper calls `resolveArchiveKind(archivePath)` and throws if the extension is not recognized. Pass `kind` explicitly when the archive name doesn't carry the type (e.g. content-addressed names). A positive finite `timeoutMs` starts cancellation when the wall-clock budget expires; the promise rejects only after in-flight filesystem work has unwound and staging/input cleanup is complete, so settlement can follow the deadline when a filesystem operation cannot be interrupted. Zero, negative, `NaN`, and infinity disable the deadline.
+If `kind` is omitted, the helper calls `resolveArchiveKind(archivePath)` and throws if the extension is not recognized. Pass `kind` explicitly when the archive name doesn't carry the type (e.g. content-addressed names). A positive finite `timeoutMs` is a wall-clock budget; zero, negative, `NaN`, and infinity disable the deadline. Non-mutating work rejects promptly when the budget expires. If a live destination mutation is already in flight, rejection waits only for that mutation and any rollback to finish; no later destination mutation can begin.
 
 ### Limits
 
@@ -165,7 +165,7 @@ codes remain `"destination-not-directory"`, `"destination-symlink"`, and
 - **TOCTOU during merge:** extraction first writes to a private temp dir, then merges into `destDir` using the same boundary checks as `root().write()`. Destination symlink swaps are checked with the selected platform mechanism; non-Linux routes retain the best-effort race window documented in the [security model](security-model.md#containment-guarantees-by-platform).
 - **Zip bombs:** `maxExtractedBytes` and `maxEntryBytes` apply to *post-decompression* bytes, so highly-compressed payloads hit the cap before they exhaust disk.
 - **Corrupt ZIP payloads:** streamed output must match both the central-directory CRC and declared uncompressed size before it can leave private staging.
-- **Slow-loris archives:** `timeoutMs` starts cancellation on overrun. No new destination mutation begins after the deadline, and the promise waits for owned filesystem work and cleanup to quiesce before rejecting.
+- **Slow-loris archives:** `timeoutMs` is a hard wall-clock budget for non-mutating work. Extraction is aborted on overrun; if a destination mutation is already in flight, that mutation and rollback are joined before rejection so archive-controlled publication cannot continue afterward.
 - **Metadata bombs:** a streaming pass-through reader rejects oversized PAX, GNU long-name, and GNU long-link bodies before either TAR implementation buffers them. It understands octal and base-256 fixed sizes and validates bounded local PAX bodies before using their size overrides for member framing. Original archive bytes remain unchanged.
 
 ### Bounded local PAX support

--- a/src/archive-deadline.ts
+++ b/src/archive-deadline.ts
@@ -1,8 +1,17 @@
 export type ExtractionDeadline = {
   signal: AbortSignal;
   check: () => void;
+  ownDestinationMutation: <T>(run: () => Promise<T>) => Promise<T>;
+  waitForDestinationMutations: () => Promise<void>;
   dispose: () => void;
 };
+
+export async function ownExtractionDestinationMutation<T>(
+  deadline: ExtractionDeadline | undefined,
+  run: () => Promise<T>,
+): Promise<T> {
+  return deadline ? await deadline.ownDestinationMutation(run) : await run();
+}
 
 function signalReason(signal: AbortSignal, fallback?: Error): Error {
   const reason = signal.reason;
@@ -48,26 +57,55 @@ export async function waitForDeadline<T>(
   ]);
 }
 
+function createDestinationMutationOwner(check: () => void): Pick<
+  ExtractionDeadline,
+  "ownDestinationMutation" | "waitForDestinationMutations"
+> {
+  const active = new Set<Promise<void>>();
+  return {
+    ownDestinationMutation: async <T>(run: () => Promise<T>): Promise<T> => {
+      check();
+      const operation = Promise.resolve().then(run);
+      const tracked = operation.then(
+        () => undefined,
+        () => undefined,
+      );
+      active.add(tracked);
+      void tracked.finally(() => active.delete(tracked));
+      return await operation;
+    },
+    waitForDestinationMutations: async (): Promise<void> => {
+      while (active.size > 0) {
+        await Promise.all(active);
+      }
+    },
+  };
+}
+
 function createExtractionDeadline(timeoutMs: number, label: string): ExtractionDeadline {
   const controller = new AbortController();
+  const timeoutError = new Error(`${label} timed out after ${timeoutMs}ms`);
+  const check = (): void => {
+    if (controller.signal.aborted) {
+      throw signalReason(controller.signal, timeoutError);
+    }
+  };
+  const mutationOwner = createDestinationMutationOwner(check);
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return {
       signal: controller.signal,
-      check: () => undefined,
+      check,
+      ...mutationOwner,
       dispose: () => undefined,
     };
   }
-  const timeoutError = new Error(`${label} timed out after ${timeoutMs}ms`);
   const timeoutId = setTimeout(() => {
     controller.abort(timeoutError);
   }, timeoutMs);
   return {
     signal: controller.signal,
-    check: () => {
-      if (controller.signal.aborted) {
-        throw signalReason(controller.signal, timeoutError);
-      }
-    },
+    check,
+    ...mutationOwner,
     dispose: () => {
       clearTimeout(timeoutId);
     },
@@ -87,9 +125,9 @@ export async function withExtractionDeadline<T>(
       return await waitForDeadline(operation, deadline);
     } catch (error) {
       if (deadline.signal.aborted && error === deadlineReason(deadline)) {
-        // The deadline requests cancellation, but extraction still owns staging,
-        // descriptors, and destination mutations until the operation unwinds.
-        await operation.catch(() => undefined);
+        // Preserve prompt timeout settlement for non-mutating work, but never
+        // return while live destination publication or rollback is still owned.
+        await deadline.waitForDestinationMutations();
       }
       throw error;
     }

--- a/src/archive-deadline.ts
+++ b/src/archive-deadline.ts
@@ -80,9 +80,19 @@ export async function withExtractionDeadline<T>(
   run: (deadline: ExtractionDeadline) => Promise<T>,
 ): Promise<T> {
   const deadline = createExtractionDeadline(timeoutMs, label);
+  const operation = Promise.resolve().then(async () => await run(deadline));
   try {
     deadline.check();
-    return await waitForDeadline(run(deadline), deadline);
+    try {
+      return await waitForDeadline(operation, deadline);
+    } catch (error) {
+      if (deadline.signal.aborted && error === deadlineReason(deadline)) {
+        // The deadline requests cancellation, but extraction still owns staging,
+        // descriptors, and destination mutations until the operation unwinds.
+        await operation.catch(() => undefined);
+      }
+      throw error;
+    }
   } finally {
     deadline.dispose();
   }

--- a/src/archive-native.ts
+++ b/src/archive-native.ts
@@ -186,7 +186,9 @@ export async function extractNativeArchive(params: {
           sourceDir: stagingDir,
           destinationDir: params.destDir,
           destinationRealDir,
+          deadline: params.deadline,
         });
+        params.deadline.check();
       },
     });
   } finally {

--- a/src/archive-staging.ts
+++ b/src/archive-staging.ts
@@ -6,7 +6,10 @@ import {
   createAsyncDirectoryGuard,
   type AsyncDirectoryGuard,
 } from "./directory-guard.js";
-import type { ExtractionDeadline } from "./archive-deadline.js";
+import {
+  ownExtractionDestinationMutation,
+  type ExtractionDeadline,
+} from "./archive-deadline.js";
 import {
   ArchiveSecurityError,
   type ArchiveSecurityErrorCode,
@@ -172,18 +175,24 @@ export async function prepareArchiveOutputPath(params: {
   if (params.isDirectory) {
     await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("mkdir", params.outPath);
     checkExtractionDeadline(params.deadline);
-    await assertDirectoryIdentityGuard(destinationGuard);
-    checkExtractionDeadline(params.deadline);
-    await mkdirArchiveOutput({ targetRoot, relativePath: relPath, originalPath: params.originalPath });
-    checkExtractionDeadline(params.deadline);
-    await assertDirectoryIdentityGuard(destinationGuard);
-    checkExtractionDeadline(params.deadline);
-    await assertResolvedInsideDestination({
-      destinationRealDir: params.destinationRealDir,
-      targetPath: params.outPath,
-      originalPath: params.originalPath,
+    await ownExtractionDestinationMutation(params.deadline, async () => {
+      await assertDirectoryIdentityGuard(destinationGuard);
+      checkExtractionDeadline(params.deadline);
+      await mkdirArchiveOutput({
+        targetRoot,
+        relativePath: relPath,
+        originalPath: params.originalPath,
+      });
+      checkExtractionDeadline(params.deadline);
+      await assertDirectoryIdentityGuard(destinationGuard);
+      checkExtractionDeadline(params.deadline);
+      await assertResolvedInsideDestination({
+        destinationRealDir: params.destinationRealDir,
+        targetPath: params.outPath,
+        originalPath: params.originalPath,
+      });
+      checkExtractionDeadline(params.deadline);
     });
-    checkExtractionDeadline(params.deadline);
     return;
   }
 
@@ -191,16 +200,18 @@ export async function prepareArchiveOutputPath(params: {
   if (parentRel !== ".") {
     await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("mkdir", path.dirname(params.outPath));
     checkExtractionDeadline(params.deadline);
-    await assertDirectoryIdentityGuard(destinationGuard);
-    checkExtractionDeadline(params.deadline);
-    await mkdirArchiveOutput({
-      targetRoot,
-      relativePath: parentRel,
-      originalPath: params.originalPath,
+    await ownExtractionDestinationMutation(params.deadline, async () => {
+      await assertDirectoryIdentityGuard(destinationGuard);
+      checkExtractionDeadline(params.deadline);
+      await mkdirArchiveOutput({
+        targetRoot,
+        relativePath: parentRel,
+        originalPath: params.originalPath,
+      });
+      checkExtractionDeadline(params.deadline);
+      await assertDirectoryIdentityGuard(destinationGuard);
+      checkExtractionDeadline(params.deadline);
     });
-    checkExtractionDeadline(params.deadline);
-    await assertDirectoryIdentityGuard(destinationGuard);
-    checkExtractionDeadline(params.deadline);
   }
   await assertResolvedInsideDestination({
     destinationRealDir: params.destinationRealDir,
@@ -250,10 +261,12 @@ async function chmodInsideDestinationBestEffort(params: {
     if (!isPathInside(params.destinationRealDir, realPath)) {
       throw symlinkTraversalError(params.originalPath);
     }
-    await handle.chmod(params.mode).catch(() => undefined);
-    checkExtractionDeadline(params.deadline);
-    await assertDirectoryIdentityGuard(destinationGuard);
-    checkExtractionDeadline(params.deadline);
+    await ownExtractionDestinationMutation(params.deadline, async () => {
+      await handle.chmod(params.mode).catch(() => undefined);
+      checkExtractionDeadline(params.deadline);
+      await assertDirectoryIdentityGuard(destinationGuard);
+      checkExtractionDeadline(params.deadline);
+    });
   } finally {
     await handle.close().catch(() => undefined);
   }
@@ -385,33 +398,23 @@ export async function mergeExtractedTreeIntoDestination(params: {
   destinationRealDir: string;
   deadline?: ExtractionDeadline;
 }): Promise<void> {
-  checkExtractionDeadline(params.deadline);
   const targetRoot = await root(params.destinationRealDir);
-  checkExtractionDeadline(params.deadline);
   const sourceRootGuard = await createDirectoryIdentityGuard(params.sourceDir);
-  checkExtractionDeadline(params.deadline);
   const sourceRootReal = sourceRootGuard.realPath;
   const walk = async (currentSourceDir: string): Promise<void> => {
-    checkExtractionDeadline(params.deadline);
     await assertDirectoryIdentityGuard(sourceRootGuard);
-    checkExtractionDeadline(params.deadline);
     const entries = await fs.readdir(currentSourceDir, { withFileTypes: true });
-    checkExtractionDeadline(params.deadline);
     for (const entry of entries) {
-      checkExtractionDeadline(params.deadline);
       await assertDirectoryIdentityGuard(sourceRootGuard);
-      checkExtractionDeadline(params.deadline);
       const sourcePath = path.join(currentSourceDir, entry.name);
       const relPath = path.relative(params.sourceDir, sourcePath);
       const originalPath = relPath.split(path.sep).join("/");
       const destinationPath = path.join(params.destinationDir, relPath);
       const sourceStat = await fs.lstat(sourcePath);
-      checkExtractionDeadline(params.deadline);
       if (sourceStat.isSymbolicLink()) {
         throw symlinkTraversalError(originalPath);
       }
       const sourceReal = await fs.realpath(sourcePath);
-      checkExtractionDeadline(params.deadline);
       if (!isPathInside(sourceRootReal, sourceReal)) {
         throw symlinkTraversalError(originalPath);
       }
@@ -426,9 +429,7 @@ export async function mergeExtractedTreeIntoDestination(params: {
           isDirectory: true,
           deadline: params.deadline,
         });
-        checkExtractionDeadline(params.deadline);
         await walk(sourcePath);
-        checkExtractionDeadline(params.deadline);
         await applyStagedEntryMode({
           destinationRealDir: params.destinationRealDir,
           relPath,
@@ -436,7 +437,6 @@ export async function mergeExtractedTreeIntoDestination(params: {
           originalPath,
           deadline: params.deadline,
         });
-        checkExtractionDeadline(params.deadline);
         continue;
       }
 
@@ -455,39 +455,42 @@ export async function mergeExtractedTreeIntoDestination(params: {
         isDirectory: false,
         deadline: params.deadline,
       });
-      checkExtractionDeadline(params.deadline);
-      try {
-        await targetRoot.copyIn(relPath, sourcePath, { mkdir: true });
-        checkExtractionDeadline(params.deadline);
-        await assertExtractedFileHasNoHardlinkAlias({
-          destinationRealDir: params.destinationRealDir,
-          relPath,
-          originalPath,
-        });
-        checkExtractionDeadline(params.deadline);
-        await applyStagedEntryMode({
-          destinationRealDir: params.destinationRealDir,
-          relPath,
-          mode: sourceStat.mode & 0o777,
-          originalPath,
-          deadline: params.deadline,
-        });
-        checkExtractionDeadline(params.deadline);
-      } catch (err) {
-        await removeExtractedDestinationFile({
-          destinationRealDir: params.destinationRealDir,
-          relPath,
-        });
-        if (err instanceof FsSafeError && (err.code === "hardlink" || err.code === "path-alias")) {
-          throw symlinkTraversalError(originalPath);
+      await ownExtractionDestinationMutation(params.deadline, async () => {
+        try {
+          await targetRoot.copyIn(relPath, sourcePath, { mkdir: true });
+          checkExtractionDeadline(params.deadline);
+          await assertExtractedFileHasNoHardlinkAlias({
+            destinationRealDir: params.destinationRealDir,
+            relPath,
+            originalPath,
+          });
+          checkExtractionDeadline(params.deadline);
+          await applyStagedEntryMode({
+            destinationRealDir: params.destinationRealDir,
+            relPath,
+            mode: sourceStat.mode & 0o777,
+            originalPath,
+            deadline: params.deadline,
+          });
+          checkExtractionDeadline(params.deadline);
+        } catch (err) {
+          await removeExtractedDestinationFile({
+            destinationRealDir: params.destinationRealDir,
+            relPath,
+          });
+          if (
+            err instanceof FsSafeError &&
+            (err.code === "hardlink" || err.code === "path-alias")
+          ) {
+            throw symlinkTraversalError(originalPath);
+          }
+          throw err;
         }
-        throw err;
-      }
+      });
     }
   };
 
   await walk(params.sourceDir);
-  checkExtractionDeadline(params.deadline);
 }
 
 export function createArchiveSymlinkTraversalError(originalPath: string): ArchiveSecurityError {

--- a/src/archive-staging.ts
+++ b/src/archive-staging.ts
@@ -6,6 +6,7 @@ import {
   createAsyncDirectoryGuard,
   type AsyncDirectoryGuard,
 } from "./directory-guard.js";
+import type { ExtractionDeadline } from "./archive-deadline.js";
 import {
   ArchiveSecurityError,
   type ArchiveSecurityErrorCode,
@@ -19,6 +20,10 @@ import { getFsSafeTestHooks } from "./test-hooks.js";
 
 const ERROR_ARCHIVE_ENTRY_TRAVERSES_SYMLINK = "archive entry traverses symlink in destination";
 const ARCHIVE_STAGING_MODE = 0o700;
+
+function checkExtractionDeadline(deadline?: ExtractionDeadline): void {
+  deadline?.check();
+}
 
 export { ArchiveSecurityError, type ArchiveSecurityErrorCode } from "./archive-errors.js";
 
@@ -149,45 +154,60 @@ export async function prepareArchiveOutputPath(params: {
   outPath: string;
   originalPath: string;
   isDirectory: boolean;
+  deadline?: ExtractionDeadline;
 }): Promise<void> {
+  checkExtractionDeadline(params.deadline);
   const targetRoot = await root(params.destinationRealDir);
+  checkExtractionDeadline(params.deadline);
   const destinationGuard = await createDirectoryIdentityGuard(params.destinationRealDir);
+  checkExtractionDeadline(params.deadline);
   const relPath = params.relPath.split(path.sep).join(path.posix.sep);
   await assertNoSymlinkTraversal({
     rootDir: params.destinationDir,
     relPath,
     originalPath: params.originalPath,
   });
+  checkExtractionDeadline(params.deadline);
 
   if (params.isDirectory) {
     await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("mkdir", params.outPath);
+    checkExtractionDeadline(params.deadline);
     await assertDirectoryIdentityGuard(destinationGuard);
+    checkExtractionDeadline(params.deadline);
     await mkdirArchiveOutput({ targetRoot, relativePath: relPath, originalPath: params.originalPath });
+    checkExtractionDeadline(params.deadline);
     await assertDirectoryIdentityGuard(destinationGuard);
+    checkExtractionDeadline(params.deadline);
     await assertResolvedInsideDestination({
       destinationRealDir: params.destinationRealDir,
       targetPath: params.outPath,
       originalPath: params.originalPath,
     });
+    checkExtractionDeadline(params.deadline);
     return;
   }
 
   const parentRel = path.posix.dirname(relPath);
   if (parentRel !== ".") {
     await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("mkdir", path.dirname(params.outPath));
+    checkExtractionDeadline(params.deadline);
     await assertDirectoryIdentityGuard(destinationGuard);
+    checkExtractionDeadline(params.deadline);
     await mkdirArchiveOutput({
       targetRoot,
       relativePath: parentRel,
       originalPath: params.originalPath,
     });
+    checkExtractionDeadline(params.deadline);
     await assertDirectoryIdentityGuard(destinationGuard);
+    checkExtractionDeadline(params.deadline);
   }
   await assertResolvedInsideDestination({
     destinationRealDir: params.destinationRealDir,
     targetPath: path.dirname(params.outPath),
     originalPath: params.originalPath,
   });
+  checkExtractionDeadline(params.deadline);
 }
 
 async function chmodInsideDestinationBestEffort(params: {
@@ -195,10 +215,14 @@ async function chmodInsideDestinationBestEffort(params: {
   destinationPath: string;
   mode: number;
   originalPath: string;
+  deadline?: ExtractionDeadline;
 }): Promise<void> {
   await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("chmod", params.destinationPath);
+  checkExtractionDeadline(params.deadline);
   const destinationGuard = await createDirectoryIdentityGuard(params.destinationRealDir);
+  checkExtractionDeadline(params.deadline);
   await assertDirectoryIdentityGuard(destinationGuard);
+  checkExtractionDeadline(params.deadline);
   const noFollowFlag =
     process.platform !== "win32" && "O_NOFOLLOW" in fsSync.constants
       ? fsSync.constants.O_NOFOLLOW
@@ -206,8 +230,10 @@ async function chmodInsideDestinationBestEffort(params: {
   const handle = await fs
     .open(params.destinationPath, fsSync.constants.O_RDONLY | noFollowFlag)
     .catch(() => null);
+  checkExtractionDeadline(params.deadline);
   if (!handle) {
     const stat = await fs.lstat(params.destinationPath).catch(() => null);
+    checkExtractionDeadline(params.deadline);
     if (stat?.isSymbolicLink()) {
       throw symlinkTraversalError(params.originalPath);
     }
@@ -215,15 +241,19 @@ async function chmodInsideDestinationBestEffort(params: {
   }
   try {
     const stat = await handle.stat();
+    checkExtractionDeadline(params.deadline);
     if (!stat.isDirectory() && !stat.isFile()) {
       return;
     }
     const realPath = await resolveOpenedFileRealPathForHandle(handle, params.destinationPath);
+    checkExtractionDeadline(params.deadline);
     if (!isPathInside(params.destinationRealDir, realPath)) {
       throw symlinkTraversalError(params.originalPath);
     }
     await handle.chmod(params.mode).catch(() => undefined);
+    checkExtractionDeadline(params.deadline);
     await assertDirectoryIdentityGuard(destinationGuard);
+    checkExtractionDeadline(params.deadline);
   } finally {
     await handle.close().catch(() => undefined);
   }
@@ -234,21 +264,26 @@ async function applyStagedEntryMode(params: {
   relPath: string;
   mode: number;
   originalPath: string;
+  deadline?: ExtractionDeadline;
 }): Promise<void> {
+  checkExtractionDeadline(params.deadline);
   const destinationPath = path.join(params.destinationRealDir, params.relPath);
   await assertResolvedInsideDestination({
     destinationRealDir: params.destinationRealDir,
     targetPath: destinationPath,
     originalPath: params.originalPath,
   });
+  checkExtractionDeadline(params.deadline);
   if (params.mode !== 0) {
     await chmodInsideDestinationBestEffort({
       destinationRealDir: params.destinationRealDir,
       destinationPath,
       mode: params.mode,
       originalPath: params.originalPath,
+      deadline: params.deadline,
     });
   }
+  checkExtractionDeadline(params.deadline);
 }
 
 async function assertExtractedFileHasNoHardlinkAlias(params: {
@@ -348,24 +383,35 @@ export async function mergeExtractedTreeIntoDestination(params: {
   sourceDir: string;
   destinationDir: string;
   destinationRealDir: string;
+  deadline?: ExtractionDeadline;
 }): Promise<void> {
+  checkExtractionDeadline(params.deadline);
   const targetRoot = await root(params.destinationRealDir);
+  checkExtractionDeadline(params.deadline);
   const sourceRootGuard = await createDirectoryIdentityGuard(params.sourceDir);
+  checkExtractionDeadline(params.deadline);
   const sourceRootReal = sourceRootGuard.realPath;
   const walk = async (currentSourceDir: string): Promise<void> => {
+    checkExtractionDeadline(params.deadline);
     await assertDirectoryIdentityGuard(sourceRootGuard);
+    checkExtractionDeadline(params.deadline);
     const entries = await fs.readdir(currentSourceDir, { withFileTypes: true });
+    checkExtractionDeadline(params.deadline);
     for (const entry of entries) {
+      checkExtractionDeadline(params.deadline);
       await assertDirectoryIdentityGuard(sourceRootGuard);
+      checkExtractionDeadline(params.deadline);
       const sourcePath = path.join(currentSourceDir, entry.name);
       const relPath = path.relative(params.sourceDir, sourcePath);
       const originalPath = relPath.split(path.sep).join("/");
       const destinationPath = path.join(params.destinationDir, relPath);
       const sourceStat = await fs.lstat(sourcePath);
+      checkExtractionDeadline(params.deadline);
       if (sourceStat.isSymbolicLink()) {
         throw symlinkTraversalError(originalPath);
       }
       const sourceReal = await fs.realpath(sourcePath);
+      checkExtractionDeadline(params.deadline);
       if (!isPathInside(sourceRootReal, sourceReal)) {
         throw symlinkTraversalError(originalPath);
       }
@@ -378,14 +424,19 @@ export async function mergeExtractedTreeIntoDestination(params: {
           outPath: destinationPath,
           originalPath,
           isDirectory: true,
+          deadline: params.deadline,
         });
+        checkExtractionDeadline(params.deadline);
         await walk(sourcePath);
+        checkExtractionDeadline(params.deadline);
         await applyStagedEntryMode({
           destinationRealDir: params.destinationRealDir,
           relPath,
           mode: sourceStat.mode & 0o777,
           originalPath,
+          deadline: params.deadline,
         });
+        checkExtractionDeadline(params.deadline);
         continue;
       }
 
@@ -402,20 +453,26 @@ export async function mergeExtractedTreeIntoDestination(params: {
         outPath: destinationPath,
         originalPath,
         isDirectory: false,
+        deadline: params.deadline,
       });
+      checkExtractionDeadline(params.deadline);
       try {
         await targetRoot.copyIn(relPath, sourcePath, { mkdir: true });
+        checkExtractionDeadline(params.deadline);
         await assertExtractedFileHasNoHardlinkAlias({
           destinationRealDir: params.destinationRealDir,
           relPath,
           originalPath,
         });
+        checkExtractionDeadline(params.deadline);
         await applyStagedEntryMode({
           destinationRealDir: params.destinationRealDir,
           relPath,
           mode: sourceStat.mode & 0o777,
           originalPath,
+          deadline: params.deadline,
         });
+        checkExtractionDeadline(params.deadline);
       } catch (err) {
         await removeExtractedDestinationFile({
           destinationRealDir: params.destinationRealDir,
@@ -430,6 +487,7 @@ export async function mergeExtractedTreeIntoDestination(params: {
   };
 
   await walk(params.sourceDir);
+  checkExtractionDeadline(params.deadline);
 }
 
 export function createArchiveSymlinkTraversalError(originalPath: string): ArchiveSecurityError {

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -148,6 +148,7 @@ async function prepareZipOutputPath(params: {
   outPath: string;
   originalPath: string;
   isDirectory: boolean;
+  deadline: ExtractionDeadline;
 }): Promise<void> {
   await prepareArchiveOutputPath(params);
 }
@@ -285,6 +286,7 @@ async function extractZip(params: {
             outPath: output.outPath,
             originalPath: entry.name,
             isDirectory: entry.dir,
+            deadline: params.deadline,
           });
           if (entry.dir) {
             await fs.chmod(output.outPath, mode);
@@ -305,6 +307,7 @@ async function extractZip(params: {
           sourceDir: stagingRealDir,
           destinationDir: params.destDir,
           destinationRealDir,
+          deadline: params.deadline,
         });
         params.deadline.check();
       },
@@ -447,18 +450,21 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
               throw normalizeTarParserError(createPipelineTimeoutError(error, deadline));
             }
             for (const accepted of acceptedEntries) {
+              deadline.check();
               const outputPath = resolveArchiveOutputPath({
                 rootDir: stagingDir,
                 relPath: accepted.path,
                 originalPath: accepted.path,
               });
               await fs.chmod(outputPath, accepted.mode);
+              deadline.check();
             }
             deadline.check();
             await mergeExtractedTreeIntoDestination({
               sourceDir: stagingDir,
               destinationDir: params.destDir,
               destinationRealDir,
+              deadline,
             });
             deadline.check();
           },

--- a/test/archive-timeout-lifetime.test.ts
+++ b/test/archive-timeout-lifetime.test.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import JSZip from "jszip";
+import { afterEach, describe, expect, it } from "vitest";
+import { extractArchive } from "../src/archive.js";
+import { withExtractionDeadline } from "../src/archive-deadline.js";
+import { __resetFsSafeNativeConfigForTest, configureFsSafeNative } from "../src/native-config.js";
+import {
+  __loadBundledNativeForTest,
+  __resetNativeLoaderForTest,
+  __setNativeLoaderForTest,
+  type NativeBinding,
+} from "../src/native.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { tarFixture } from "./helpers/archive-fuzz.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+let native: NativeBinding | undefined;
+try {
+  native = __loadBundledNativeForTest();
+} catch (error) {
+  if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error;
+}
+
+const { tempRoot: createTempRoot } = useTempDirs();
+const backends = native ? (["native", "javascript"] as const) : (["javascript"] as const);
+
+function useBackend(backend: (typeof backends)[number]): void {
+  if (backend === "native") {
+    __setNativeLoaderForTest(() => native!);
+    configureFsSafeNative({ mode: "require" });
+  } else {
+    configureFsSafeNative({ mode: "off" });
+  }
+}
+
+afterEach(() => {
+  __setFsSafeTestHooksForTest(undefined);
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+describe("archive timeout lifetime", () => {
+  it("waits for non-cooperative owned work to quiesce after the deadline", async () => {
+    let release: (() => void) | undefined;
+    let finished = false;
+    let settled = false;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const operation = withExtractionDeadline(1, "extract tar", async () => {
+      await blocked;
+      finished = true;
+    });
+    void operation.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled).toBe(false);
+    expect(finished).toBe(false);
+
+    release?.();
+    await expect(operation).rejects.toThrow("extract tar timed out after 1ms");
+    expect(finished).toBe(true);
+  });
+
+  describe.each(backends)("%s extraction", (backend) => {
+    it.each(["zip", "tar"] as const)(
+      "quiesces the live %s merge before reporting timeout",
+      async (kind) => {
+        useBackend(backend);
+        const root = await createTempRoot("fs-safe-archive-timeout-");
+        const archivePath = path.join(root, `fixture.${kind}`);
+        const destination = path.join(root, "destination");
+        const outputDir = path.join(destination, "package");
+        const outputPath = path.join(outputDir, "hello.txt");
+        if (kind === "zip") {
+          const zip = new JSZip();
+          zip.file("package/hello.txt", "archive-content");
+          await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+        } else {
+          await fs.writeFile(
+            archivePath,
+            tarFixture([{ path: "package/hello.txt", body: "archive-content" }]),
+          );
+        }
+        await fs.mkdir(destination);
+
+        let enterMerge: (() => void) | undefined;
+        let releaseMerge: (() => void) | undefined;
+        let blocked = false;
+        const mergeEntered = new Promise<void>((resolve) => {
+          enterMerge = resolve;
+        });
+        const mergeRelease = new Promise<void>((resolve) => {
+          releaseMerge = resolve;
+        });
+        __setFsSafeTestHooksForTest({
+          async beforeArchiveOutputMutation(operation, targetPath) {
+            if (!blocked && operation === "mkdir" && targetPath === outputDir) {
+              blocked = true;
+              enterMerge?.();
+              await mergeRelease;
+            }
+          },
+        });
+
+        let settled = false;
+        const extraction = extractArchive({
+          archivePath,
+          destDir: destination,
+          kind,
+          timeoutMs: 1_000,
+        });
+        void extraction.then(
+          () => {
+            settled = true;
+          },
+          () => {
+            settled = true;
+          },
+        );
+        await mergeEntered;
+        await new Promise((resolve) => setTimeout(resolve, 1_050));
+        expect(settled).toBe(false);
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.writeFile(outputPath, "trusted-recovery");
+
+        releaseMerge?.();
+        await expect(extraction).rejects.toThrow(`extract ${kind} timed out after 1000ms`);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        await expect(fs.readFile(outputPath, "utf8")).resolves.toBe("trusted-recovery");
+      },
+      10_000,
+    );
+  });
+});

--- a/test/archive-timeout-lifetime.test.ts
+++ b/test/archive-timeout-lifetime.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import JSZip from "jszip";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { extractArchive } from "../src/archive.js";
 import { withExtractionDeadline } from "../src/archive-deadline.js";
 import { __resetFsSafeNativeConfigForTest, configureFsSafeNative } from "../src/native-config.js";
@@ -38,19 +38,41 @@ afterEach(() => {
   __setFsSafeTestHooksForTest(undefined);
   __resetFsSafeNativeConfigForTest();
   __resetNativeLoaderForTest();
+  vi.restoreAllMocks();
 });
 
 describe("archive timeout lifetime", () => {
-  it("waits for non-cooperative owned work to quiesce after the deadline", async () => {
-    let release: (() => void) | undefined;
+  it("preserves prompt deadlines around non-mutating work", async () => {
     let finished = false;
+    const startedAt = Date.now();
+
+    await expect(
+      withExtractionDeadline(1, "extract tar", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        finished = true;
+      }),
+    ).rejects.toThrow("extract tar timed out after 1ms");
+
+    expect(Date.now() - startedAt).toBeLessThan(75);
+    expect(finished).toBe(false);
+  });
+
+  it("joins a destination mutation already in flight at the deadline", async () => {
+    let enterMutation: (() => void) | undefined;
+    let releaseMutation: (() => void) | undefined;
     let settled = false;
-    const blocked = new Promise<void>((resolve) => {
-      release = resolve;
+    const mutationEntered = new Promise<void>((resolve) => {
+      enterMutation = resolve;
     });
-    const operation = withExtractionDeadline(1, "extract tar", async () => {
-      await blocked;
-      finished = true;
+    const mutationRelease = new Promise<void>((resolve) => {
+      releaseMutation = resolve;
+    });
+    const operation = withExtractionDeadline(10, "extract tar", async (deadline) => {
+      await deadline.ownDestinationMutation(async () => {
+        enterMutation?.();
+        await mutationRelease;
+        deadline.check();
+      });
     });
     void operation.then(
       () => {
@@ -61,13 +83,11 @@ describe("archive timeout lifetime", () => {
       },
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await mutationEntered;
+    await new Promise((resolve) => setTimeout(resolve, 25));
     expect(settled).toBe(false);
-    expect(finished).toBe(false);
-
-    release?.();
-    await expect(operation).rejects.toThrow("extract tar timed out after 1ms");
-    expect(finished).toBe(true);
+    releaseMutation?.();
+    await expect(operation).rejects.toThrow("extract tar timed out after 10ms");
   });
 
   describe.each(backends)("%s extraction", (backend) => {
@@ -80,6 +100,15 @@ describe("archive timeout lifetime", () => {
         const destination = path.join(root, "destination");
         const outputDir = path.join(destination, "package");
         const outputPath = path.join(outputDir, "hello.txt");
+        const stagedDirs: string[] = [];
+        const realMkdtemp = fs.mkdtemp.bind(fs);
+        vi.spyOn(fs, "mkdtemp").mockImplementation(
+          async (...args: Parameters<typeof fs.mkdtemp>) => {
+            const dir = await realMkdtemp(...args);
+            if (String(args[0]).includes("fs-safe-archive")) stagedDirs.push(dir);
+            return dir;
+          },
+        );
         if (kind === "zip") {
           const zip = new JSZip();
           zip.file("package/hello.txt", "archive-content");
@@ -111,30 +140,30 @@ describe("archive timeout lifetime", () => {
           },
         });
 
-        let settled = false;
         const extraction = extractArchive({
           archivePath,
           destDir: destination,
           kind,
           timeoutMs: 1_000,
         });
-        void extraction.then(
-          () => {
-            settled = true;
-          },
-          () => {
-            settled = true;
-          },
-        );
         await mergeEntered;
-        await new Promise((resolve) => setTimeout(resolve, 1_050));
-        expect(settled).toBe(false);
+        await expect(extraction).rejects.toThrow(`extract ${kind} timed out after 1000ms`);
         await fs.mkdir(outputDir, { recursive: true });
         await fs.writeFile(outputPath, "trusted-recovery");
 
         releaseMerge?.();
-        await expect(extraction).rejects.toThrow(`extract ${kind} timed out after 1000ms`);
-        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(stagedDirs.length).toBeGreaterThan(0);
+        await expect
+          .poll(async () => {
+            const existing = await Promise.all(
+              stagedDirs.map(async (dir) => await fs.access(dir).then(
+                () => true,
+                () => false,
+              )),
+            );
+            return existing.every((value) => !value);
+          })
+          .toBe(true);
         await expect(fs.readFile(outputPath, "utf8")).resolves.toBe("trusted-recovery");
       },
       10_000,

--- a/test/archive.test.ts
+++ b/test/archive.test.ts
@@ -11,7 +11,6 @@ import {
   extractArchive,
   resolvePackedRootDir,
 } from "../src/archive.js";
-import { withExtractionDeadline } from "../src/archive-deadline.js";
 import { __resetFsSafeNativeConfigForTest, configureFsSafeNative } from "../src/native-config.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 import {
@@ -76,21 +75,6 @@ afterEach(async () => {
 });
 
 describe("archive extraction", () => {
-  it("enforces deadlines around non-cooperative archive awaits", async () => {
-    let finished = false;
-    const startedAt = Date.now();
-
-    await expect(
-      withExtractionDeadline(1, "extract tar", async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        finished = true;
-      }),
-    ).rejects.toThrow("extract tar timed out after 1ms");
-
-    expect(Date.now() - startedAt).toBeLessThan(75);
-    expect(finished).toBe(false);
-  });
-
   it("extracts zip archives through safe destination checks", async () => {
     const root = await tempRoot("fs-safe-archive-");
     const archivePath = path.join(root, "pkg.zip");
@@ -208,28 +192,6 @@ describe("archive extraction", () => {
     await extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 });
     const mode = (await fs.stat(path.join(destDir, "bin", "tool"))).mode & 0o777;
     expect(mode).toBe(0o755);
-  });
-
-  it("rejects zip extraction when the deadline elapses before file writes", async () => {
-    const root = await tempRoot("fs-safe-archive-timeout-");
-    const archivePath = path.join(root, "pkg.zip");
-    const destDir = path.join(root, "dest");
-    await fs.mkdir(destDir, { recursive: true });
-
-    const zip = new JSZip();
-    zip.file("package/hello.txt", "hi");
-    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
-
-    __setFsSafeTestHooksForTest({
-      async beforeArchiveOutputMutation() {
-        await new Promise((resolve) => setTimeout(resolve, 20));
-      },
-    });
-
-    await expect(
-      extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 1 }),
-    ).rejects.toThrow("extract zip timed out after 1ms");
-    await expect(fs.readdir(destDir)).resolves.toEqual([]);
   });
 
   it("does not truncate existing destination files when zip extraction fails", async () => {


### PR DESCRIPTION
## Summary

- preserve the released prompt-timeout behavior for non-mutating archive work
- track ownership only while a live destination mutation and its rollback are in flight
- prevent any new destination mutation from starting after the deadline across JavaScript ZIP/TAR and native extraction
- add deterministic JavaScript/native ZIP/TAR regressions for both prompt rejection and in-flight mutation joining

## Root cause

The public timeout used `Promise.race()`, while the staged-to-destination merge did not observe the deadline between awaited guards and live mutations. A merge paused before destination creation could therefore outlive the public rejection, resume later, and overwrite trusted recovery content.

The fix keeps the hard timeout path for non-mutating work. Destination mutations now register with the deadline owner only for their live mutation/validation/rollback scope. On timeout, the public promise waits only when such a scope is already active; otherwise it rejects promptly. Checks after every awaited pre-mutation boundary prevent an abandoned merge from starting publication later.

## Live behavior proof

A fresh npm consumer installed the packed current package and invoked the public `extractArchive()` API on Node 24.20.0/npm 11.19.0. The probe paused the live destination validation boundary through Node's public filesystem module, waited for a 500 ms timeout, wrote trusted recovery content after rejection, released the abandoned merge, and verified both the recovery bytes and private staging cleanup.

JavaScript fallback:

```json
{"mode":"off","timeoutMessage":"extract zip timed out after 500ms","elapsedMs":502,"rejectedBeforeRelease":true,"content":"trusted-recovery","stagingClean":true,"stagedDirCount":2}
```

Native-required path:

```json
{"mode":"require","timeoutMessage":"extract zip timed out after 500ms","elapsedMs":512,"rejectedBeforeRelease":true,"content":"trusted-recovery","stagingClean":true,"stagedDirCount":2}
```

## Verification

- `CI=1 pnpm check` — 133 test files passed, 1 skipped; 2,194 tests passed, 25 skipped
- all archive-prefixed tests — 15 files, 453 tests passed
- focused timeout lifetime suite covers prompt non-mutating rejection, in-flight mutation joining, and JavaScript/native ZIP/TAR post-timeout publication rejection
- packed npm consumer proof above passed in native `off` and `require` modes
- Codex autoreview — clean, no accepted/actionable findings
- `git diff --check`
