### PR TITLE
fix(lock): enforce synchronous deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Validate async/sync lock retry and deadline numbers and clamp synchronous backoff to the remaining finite deadline instead of overshooting or blocking forever.
 - Propagate asynchronous sidecar-lock release and failed-acquire deletion failures, preserve paired errors, and retain failed release state for safe retry through the same handle or manager drain.
 - Stop archive destination publication at the timeout boundary and join only an in-flight destination mutation and rollback before rejecting, preserving prompt deadlines for non-mutating work.
 - Verify durable JSON queue reads with lossless bigint identities and reject persistent unknown Windows identities before reading entry bytes.

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -94,6 +94,7 @@ type FileLockRetryOptions = {
 ```
 
 `payload` is a function so you can re-evaluate it on each retry (e.g. timestamp, PID).
+Retry counts must be non-negative safe integers. Retry factors and delays must be finite and non-negative, and when both delay bounds are provided `minTimeout` cannot exceed `maxTimeout`. `timeoutMs` accepts a finite non-negative deadline or positive infinity for an unbounded wait; invalid numeric values reject before filesystem acquisition starts.
 `parsePayload` replaces JSON parsing for legacy or custom sidecars. Its `unknown`
 result is passed to `shouldReclaim` and `shouldRemoveStaleLock`, allowing PID,
 process-start, argv, or role schemas to remain application-owned.
@@ -184,6 +185,7 @@ invokes `onCompromised` once, matching the asynchronous `.catch(() => false)`
 contract. An explicit `verifyStillHeld()` call still propagates that I/O error.
 
 Both synchronous helpers consume the [process-wide lock defaults](config.md#configurefssafelocks-config).
+A synchronous retry sleep is clamped to the remaining finite deadline, so a long or jittered backoff cannot extend the configured timeout or block forever.
 Per-call options take precedence, including zero values; a per-call `retry`
 object replaces the entire configured retry object. A configured
 `staleRecovery: "remove-if-unchanged"` still needs per-call

--- a/src/file-lock-sync.ts
+++ b/src/file-lock-sync.ts
@@ -14,6 +14,8 @@ import {
 import {
   computeSidecarLockDelayMs,
   sidecarLockPayloadCreatedAtMs,
+  validateSidecarLockRetryOptions,
+  validateSidecarLockTimeoutMs,
 } from "./sidecar-lock-policy.js";
 import type {
   SidecarLockCompromisedInfo,
@@ -194,6 +196,11 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
   targetPath: string,
   options: FileLockSyncAcquireOptions<TPayload>,
 ): FileLockSyncHandle {
+  const defaults = getFsSafeLockConfig();
+  const retry = options.retry ?? defaults.retry ?? {};
+  const timeoutMs = options.timeoutMs ?? defaults.timeoutMs;
+  validateSidecarLockRetryOptions(retry);
+  validateSidecarLockTimeoutMs(timeoutMs);
   const normalizedTargetPath = normalizeTargetPath(targetPath);
   const lockPath = boundedLockPath(options.lockPath ?? `${normalizedTargetPath}.lock`, options.lockRoot);
   const heldLocks = getSyncHeldLocks();
@@ -209,10 +216,7 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
   }
   // Process defaults fill the same fields here as withLockDefaults() fills for
   // the asynchronous manager, so both acquirers honor configureFsSafeLocks().
-  const defaults = getFsSafeLockConfig();
   const staleMs = options.staleMs ?? defaults.staleMs ?? 30_000;
-  const retry = options.retry ?? defaults.retry ?? {};
-  const timeoutMs = options.timeoutMs ?? defaults.timeoutMs;
   const staleRecovery = options.staleRecovery ?? defaults.staleRecovery;
   const startedAt = Date.now();
   let attempt = 0;
@@ -227,7 +231,11 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
         normalizedTargetPath,
       });
     }
-    sleepSync(computeSidecarLockDelayMs(retry, attempt));
+    const remaining =
+      timeoutMs === undefined || timeoutMs === Number.POSITIVE_INFINITY
+        ? Number.POSITIVE_INFINITY
+        : Math.max(0, timeoutMs - elapsed);
+    sleepSync(Math.min(computeSidecarLockDelayMs(retry, attempt), remaining));
     attempt += 1;
   };
 

--- a/src/sidecar-lock-acquire.ts
+++ b/src/sidecar-lock-acquire.ts
@@ -8,6 +8,8 @@ import {
   defaultSidecarLockShouldReclaim,
   isTransientLockFileDenial,
   maxTransientLockDenials,
+  validateSidecarLockRetryOptions,
+  validateSidecarLockTimeoutMs,
 } from "./sidecar-lock-policy.js";
 import {
   readSidecarLockSnapshot,
@@ -67,6 +69,9 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
   options: SidecarLockAcquireOptions<TPayload>,
   context: SidecarLockAcquisitionContext,
 ): Promise<SidecarLockHandle> {
+  const retry = options.retry ?? {};
+  validateSidecarLockRetryOptions(retry);
+  validateSidecarLockTimeoutMs(options.timeoutMs);
   context.ensureExitCleanupRegistered();
   const normalizedTargetPath = await resolveNormalizedTargetPath(options.targetPath);
   const lockPath = options.lockPath ?? `${normalizedTargetPath}.lock`;
@@ -97,7 +102,6 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
   }
 
   const startedAt = Date.now();
-  const retry = options.retry ?? {};
   const maxRetries = options.timeoutMs === Number.POSITIVE_INFINITY ? undefined : retry.retries;
   const reclaimGuardPath = `${lockPath}.reclaim`;
   let ownsReclaimGuard = false;

--- a/src/sidecar-lock-policy.ts
+++ b/src/sidecar-lock-policy.ts
@@ -1,7 +1,39 @@
 import fs from "node:fs/promises";
 import type { SidecarLockRetryOptions } from "./sidecar-lock-types.js";
 
+function assertFiniteNonNegative(value: number, label: string): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError(`${label} must be a finite non-negative number`);
+  }
+}
+
+export function validateSidecarLockRetryOptions(retry: SidecarLockRetryOptions): void {
+  if (retry.retries !== undefined && (!Number.isSafeInteger(retry.retries) || retry.retries < 0)) {
+    throw new RangeError("lock retry.retries must be a non-negative safe integer");
+  }
+  if (retry.factor !== undefined) assertFiniteNonNegative(retry.factor, "lock retry.factor");
+  if (retry.minTimeout !== undefined) {
+    assertFiniteNonNegative(retry.minTimeout, "lock retry.minTimeout");
+  }
+  if (retry.maxTimeout !== undefined) {
+    assertFiniteNonNegative(retry.maxTimeout, "lock retry.maxTimeout");
+  }
+  if (
+    retry.minTimeout !== undefined &&
+    retry.maxTimeout !== undefined &&
+    retry.minTimeout > retry.maxTimeout
+  ) {
+    throw new RangeError("lock retry.minTimeout must not exceed retry.maxTimeout");
+  }
+}
+
+export function validateSidecarLockTimeoutMs(timeoutMs: number | undefined): void {
+  if (timeoutMs === undefined || timeoutMs === Number.POSITIVE_INFINITY) return;
+  assertFiniteNonNegative(timeoutMs, "lock timeoutMs");
+}
+
 export function computeSidecarLockDelayMs(retry: SidecarLockRetryOptions, attempt: number): number {
+  validateSidecarLockRetryOptions(retry);
   const minTimeout = retry.minTimeout ?? 50;
   const maxTimeout = retry.maxTimeout ?? 1000;
   const factor = retry.factor ?? 1;

--- a/test/file-lock-retry-validation.test.ts
+++ b/test/file-lock-retry-validation.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { acquireFileLock, acquireFileLockSync } from "../src/file-lock.js";
+import type { SidecarLockRetryOptions } from "../src/sidecar-lock.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+
+const invalidRetries: Array<{ label: string; retry: SidecarLockRetryOptions }> = [
+  { label: "negative retries", retry: { retries: -1 } },
+  { label: "fractional retries", retry: { retries: 1.5 } },
+  { label: "infinite retries", retry: { retries: Infinity } },
+  { label: "negative factor", retry: { factor: -1 } },
+  { label: "NaN factor", retry: { factor: Number.NaN } },
+  { label: "infinite factor", retry: { factor: Infinity } },
+  { label: "negative minimum", retry: { minTimeout: -1 } },
+  { label: "NaN minimum", retry: { minTimeout: Number.NaN } },
+  { label: "infinite minimum", retry: { minTimeout: Infinity } },
+  { label: "negative maximum", retry: { maxTimeout: -1 } },
+  { label: "NaN maximum", retry: { maxTimeout: Number.NaN } },
+  { label: "infinite maximum", retry: { maxTimeout: Infinity } },
+  { label: "inverted range", retry: { minTimeout: 2, maxTimeout: 1 } },
+];
+
+describe("file-lock retry validation", () => {
+  it.each(invalidRetries)("rejects $label before async or sync acquisition", async ({ retry }) => {
+    const directory = await tempRoot("fs-safe-lock-retry-invalid-");
+    const asyncTarget = path.join(directory, "async.json");
+    const syncTarget = path.join(directory, "sync.json");
+    const asyncPayload = vi.fn(async () => ({}));
+    const syncPayload = vi.fn(() => ({}));
+
+    await expect(acquireFileLock(asyncTarget, { payload: asyncPayload, retry })).rejects.toThrow(
+      RangeError,
+    );
+    expect(() => acquireFileLockSync(syncTarget, { payload: syncPayload, retry })).toThrow(
+      RangeError,
+    );
+    expect(asyncPayload).not.toHaveBeenCalled();
+    expect(syncPayload).not.toHaveBeenCalled();
+    await expect(fs.access(`${asyncTarget}.lock`)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.access(`${syncTarget}.lock`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.each([Number.NaN, Number.NEGATIVE_INFINITY, -1])(
+    "rejects invalid timeout %s before acquisition",
+    async (timeoutMs) => {
+      const directory = await tempRoot("fs-safe-lock-timeout-invalid-");
+      const asyncTarget = path.join(directory, "async.json");
+      const syncTarget = path.join(directory, "sync.json");
+
+      await expect(
+        acquireFileLock(asyncTarget, { payload: async () => ({}), timeoutMs }),
+      ).rejects.toThrow(RangeError);
+      expect(() =>
+        acquireFileLockSync(syncTarget, { payload: () => ({}), timeoutMs }),
+      ).toThrow(RangeError);
+    },
+  );
+});

--- a/test/file-lock-sync-config.test.ts
+++ b/test/file-lock-sync-config.test.ts
@@ -72,8 +72,7 @@ describe("synchronous file-lock process defaults", () => {
             acquireFileLockSync(targetPath, { payload });
           }
         }).toThrow(expect.objectContaining({ code: "file_lock_timeout" }));
-        // Keep the existing sync behavior: sleeps are not clamped to the deadline.
-        expect(delays).toEqual([50]);
+        expect(delays).toEqual([20]);
         expect(work).not.toHaveBeenCalled();
         if (held) expect(held.verifyStillHeld()).toBe(true);
         else expect(fs.readFileSync(lockPath, "utf8")).toBe(raw);
@@ -87,7 +86,7 @@ describe("synchronous file-lock process defaults", () => {
   it.each([
     { configured: 0, perCall: undefined, expectedDelays: [] },
     { configured: 100, perCall: 0, expectedDelays: [] },
-    { configured: 0, perCall: 20, expectedDelays: [50] },
+    { configured: 0, perCall: 20, expectedDelays: [20] },
   ])("resolves timeout $configured with per-call $perCall", async ({ configured, perCall, expectedDelays }) => {
     const { targetPath } = await fixture();
     configureFsSafeLocks({ timeoutMs: configured });
@@ -117,7 +116,7 @@ describe("synchronous file-lock process defaults", () => {
 
   it.each([
     { retry: { retries: 2 }, expectedDelays: [50, 50] },
-    { retry: {}, expectedDelays: [50, 50, 50] },
+    { retry: {}, expectedDelays: [50, 50, 25] },
     { retry: { retries: 0 }, expectedDelays: [] },
     { retry: { retries: 2, minTimeout: 0, maxTimeout: 0, factor: 0, randomize: false }, expectedDelays: [0, 0] },
   ])("replaces the entire configured retry object with $retry", async ({ retry, expectedDelays }) => {


### PR DESCRIPTION
## Summary

- clamp synchronous lock backoff to the remaining finite deadline instead of sleeping the full configured delay
- reject invalid async/sync retry counts, factors, delay bounds, and deadline values before filesystem acquisition starts
- preserve explicit zero values and positive infinity as the documented unbounded deadline
- add shared validation plus focused async/sync regressions

## Root cause

The synchronous contention loop checked `timeoutMs`, then slept the complete computed backoff without considering how little deadline remained. A 20 ms deadline with a 200 ms retry therefore returned roughly 200 ms late; an infinite retry delay could block the calling thread indefinitely. Invalid `NaN`, negative, fractional, and infinite retry values also reached `Atomics.wait()` or timer computation directly.

The synchronous path now uses the same remaining-budget clamp as the asynchronous manager. Shared validation runs before either acquisition path mutates the filesystem. Retry counts must be non-negative safe integers, factors and delays must be finite/non-negative, explicit delay ranges cannot be inverted, and lock deadlines must be finite/non-negative or positive infinity.

## Live behavior proof

A real built-package probe contended on an existing sidecar with `timeoutMs: 20` and a 200 ms backoff, then exercised invalid infinite retry delays through both public APIs:

```json
{"timeoutCode":"file_lock_timeout","elapsedMs":21,"syncInvalid":{"name":"RangeError","message":"lock retry.minTimeout must be a finite non-negative number"},"asyncInvalid":{"name":"RangeError","message":"lock retry.minTimeout must be a finite non-negative number"}}
```

The synchronous call returned at the deadline rather than after the 200 ms delay, and both APIs rejected the invalid delay immediately.

## Verification

- all lock-related tests — 11 files passed, 1 platform suite skipped; 123 tests passed, 8 skipped
- focused deadline/validation suites — 4 files; 67 tests passed, 1 skipped
- built-package live proof above passed
- Codex autoreview — clean, no accepted/actionable findings
- typecheck, file-size guard, filesystem-boundary guard, docs examples, and `git diff --check` passed

## Local full-suite note

The full local `pnpm check` reached 2,213 passing tests but hit four unrelated timeout-only failures while many other repository test processes were active on the host: archive timeout lifetime, two store stress cases, and archive property fuzz. The changed lock suites remained green; the archive timeout suite passed 6/6 immediately in isolation, and the complete lock suite passed. Exact-head hosted Linux/macOS/Windows CI remains the landing gate.
