### PR TITLE
fix(archive): reject invalid filter policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Reject invalid runtime archive `onFiltered` policies before extraction instead of treating unknown values as entry-skipping opt-in.
 - Claim durable queue generations under a fail-closed cross-process lock with no-replace hardlinks and recoverable source retirement so acknowledgement and quarantine cannot delete or move a newer same-ID replacement; acknowledgement now requires a processing claim, and quarantine preserves existing failed-entry evidence on collisions.
 - Validate async/sync lock retry and deadline numbers and clamp synchronous backoff to the remaining finite deadline instead of overshooting or blocking forever.
 - Propagate asynchronous sidecar-lock release and failed-acquire deletion failures, preserve paired errors, and retain failed release state for safe retry through the same handle or manager drain.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -85,8 +85,10 @@ depth checks, collision checks, writes, and mode application agree.
 An `entryFilter` sees the validated effective archive path **before stripping**
 (including a local PAX `path` override), entry kind, and declared size.
 Returning `"skip"` rejects the whole archive unless `onFiltered` is
-explicitly `"skip-entry"`. Path traversal and archive-wide entry-count checks
-still apply to skipped entries.
+explicitly `"skip-entry"`. Runtime values other than `"reject-archive"` and
+`"skip-entry"` reject before extraction starts instead of falling through to
+skip behavior. Path traversal and archive-wide entry-count checks still apply
+to skipped entries.
 
 For example, a fleet restore can omit regenerated cache entries while rejecting
 any other policy mismatch by default:

--- a/src/archive-policy.ts
+++ b/src/archive-policy.ts
@@ -32,15 +32,26 @@ export function resolveArchiveEntryMode(params: {
   return archivedMode & 0o100 ? 0o755 : 0o644;
 }
 
+export function resolveArchiveFilteredEntryPolicy(
+  value: unknown,
+): ArchiveFilteredEntryPolicy {
+  if (value === undefined || value === "reject-archive") return "reject-archive";
+  if (value === "skip-entry") return "skip-entry";
+  throw new RangeError(
+    'archive onFiltered must be "reject-archive" or "skip-entry"',
+  );
+}
+
 export function shouldExtractArchiveEntry(params: {
   filter?: ArchiveEntryFilter;
   onFiltered?: ArchiveFilteredEntryPolicy;
   entry: Parameters<ArchiveEntryFilter>[0];
 }): boolean {
+  const onFiltered = resolveArchiveFilteredEntryPolicy(params.onFiltered);
   if (!params.filter || params.filter(params.entry) === "extract") {
     return true;
   }
-  if ((params.onFiltered ?? "reject-archive") === "reject-archive") {
+  if (onFiltered === "reject-archive") {
     throw new ArchiveSecurityError(
       "entry-filtered",
       `archive entry rejected by filter: ${formatErrorDetail(params.entry.path)}`,

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -54,6 +54,7 @@ import { stageArchiveFileForExtraction } from "./archive-input.js";
 import { getNativeBinding } from "./native.js";
 import {
   resolveArchiveEntryMode,
+  resolveArchiveFilteredEntryPolicy,
   shouldExtractArchiveEntry,
 } from "./archive-policy.js";
 import { importOptionalTar, normalizeTarParserError } from "./archive-tar-runtime.js";
@@ -318,6 +319,7 @@ async function extractZip(params: {
 }
 
 export async function extractArchive(params: ExtractArchiveOptions): Promise<void> {
+  const onFiltered = resolveArchiveFilteredEntryPolicy(params.onFiltered);
   const kind = params.kind ?? resolveArchiveKind(params.archivePath);
   if (!kind) {
     throw new Error(`unsupported archive: ${params.archivePath}`);
@@ -337,7 +339,7 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
         deadline,
         entryModes: params.entryModes,
         entryFilter: params.entryFilter,
-        onFiltered: params.onFiltered,
+        onFiltered,
       }),
     );
     return;
@@ -376,7 +378,7 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
               stripComponents: params.stripComponents,
               limits,
               entryFilter: params.entryFilter,
-              onFiltered: params.onFiltered,
+              onFiltered,
             });
             const acceptedEntries: Array<{ path: string; mode: number }> = [];
             // A canonical cwd is not enough here: tar can still follow
@@ -485,7 +487,7 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
       deadline,
       entryModes: params.entryModes,
       entryFilter: params.entryFilter,
-      onFiltered: params.onFiltered,
+      onFiltered,
     }),
   );
 }

--- a/test/archive-adjacent-errors.test.ts
+++ b/test/archive-adjacent-errors.test.ts
@@ -12,7 +12,12 @@ import {
 import { writeFileHandleFully } from "../src/archive-input.js";
 import { stageArchiveFileForExtraction } from "../src/archive-input.js";
 import { resolveExtractLimits } from "../src/archive-limits.js";
-import { archiveEntryKindFromTarType, resolveArchiveEntryMode } from "../src/archive-policy.js";
+import {
+  archiveEntryKindFromTarType,
+  resolveArchiveEntryMode,
+  resolveArchiveFilteredEntryPolicy,
+  shouldExtractArchiveEntry,
+} from "../src/archive-policy.js";
 import { readZipCentralDirectoryEntryCount } from "../src/archive-zip-preflight.js";
 
 const { tempRoot } = useTempDirs();
@@ -248,5 +253,15 @@ describe("malformed ZIP central directories", () => {
     expect(archiveEntryKindFromTarType("CharacterDevice")).toBe("other");
     expect(resolveArchiveEntryMode({ kind: "directory", policy: "preserve" })).toBe(0o755);
     expect(resolveArchiveEntryMode({ kind: "file", policy: "preserve" })).toBe(0o644);
+  });
+
+  it.each(["", "unknown-policy"])("rejects invalid filtered-entry policy %j", (onFiltered) => {
+    expect(() => resolveArchiveFilteredEntryPolicy(onFiltered)).toThrow(
+      'archive onFiltered must be "reject-archive" or "skip-entry"',
+    );
+    expect(() => shouldExtractArchiveEntry({
+      entry: { path: "entry", kind: "file", size: 1 },
+      onFiltered: onFiltered as never,
+    })).toThrow(RangeError);
   });
 });

--- a/test/archive-policy.test.ts
+++ b/test/archive-policy.test.ts
@@ -78,6 +78,33 @@ describe("archive entry policy", () => {
     await expect(fs.access(path.join(skipped, "skip.txt"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it.each(["off", "require"] as const)(
+    "rejects invalid runtime filter policy before extraction in %s mode",
+    async (mode) => {
+      configureFsSafeNative({ mode });
+      const root = await tempRoot(`fs-safe-archive-filter-policy-${mode}-`);
+      const archivePath = path.join(root, "package.zip");
+      const zip = new JSZip();
+      zip.file("skip.txt", "skip");
+      await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+
+      for (const [index, onFiltered] of ["", "unknown-policy"].entries()) {
+        const destination = path.join(root, `destination-${index}`);
+        await fs.mkdir(destination);
+        await expect(extractArchive({
+          archivePath,
+          destDir: destination,
+          timeoutMs: 10_000,
+          entryFilter: () => "skip",
+          onFiltered: onFiltered as never,
+        })).rejects.toThrow(
+          'archive onFiltered must be "reject-archive" or "skip-entry"',
+        );
+        await expect(fs.readdir(destination)).resolves.toEqual([]);
+      }
+    },
+  );
+
   itPosix("applies TAR mode and filtering policy in staging", async () => {
     const root = await tempRoot("fs-safe-tar-policy-");
     const input = path.join(root, "input");


### PR DESCRIPTION
## Summary

- validate runtime `onFiltered` values through one shared archive-policy resolver
- reject values other than `reject-archive` and `skip-entry` before kind resolution, native selection, staging, or destination mutation
- pass the normalized policy consistently through ZIP, TAR, and native extraction paths

## Root cause

`shouldExtractArchiveEntry()` rejected filtered entries only when `(onFiltered ?? "reject-archive") === "reject-archive"`. Any other runtime value—including an empty string or unknown policy supplied from JavaScript, JSON, or an untyped boundary—fell through to `false`, silently granting skip-entry behavior that is documented as explicit opt-in.

`resolveArchiveFilteredEntryPolicy()` now owns the runtime contract. `extractArchive()` resolves it before any extraction work and forwards only the normalized enum. The shared entry-policy helper also validates directly, so internal or independently tested callers cannot retain the old fallback.

## Live behavior proof

A fresh npm consumer installed the packed package and exercised public ZIP extraction with empty and unknown policy values in native `off` and `require` modes:

```json
[{"mode":"off","onFiltered":"","error":{"name":"RangeError","message":"archive onFiltered must be \"reject-archive\" or \"skip-entry\""},"entries":[]},{"mode":"off","onFiltered":"unknown-policy","error":{"name":"RangeError","message":"archive onFiltered must be \"reject-archive\" or \"skip-entry\""},"entries":[]},{"mode":"require","onFiltered":"","error":{"name":"RangeError","message":"archive onFiltered must be \"reject-archive\" or \"skip-entry\""},"entries":[]},{"mode":"require","onFiltered":"unknown-policy","error":{"name":"RangeError","message":"archive onFiltered must be \"reject-archive\" or \"skip-entry\""},"entries":[]}]
```

Every case rejected before writing destination entries.

## Verification

- focused archive policy/native-equivalence suite — 3 files, 74 tests passed
- complete `CI=1 pnpm check` — 136 files passed, 1 skipped; 2,238 tests passed, 25 skipped; package check passed
- file-size, filesystem-boundary, typecheck, documentation, and diff checks passed
- Codex autoreview at P1 — clean
- fresh exact-head hosted checks and ClawSweeper review remain the landing gate
