### PR TITLE
fix(store): fsync synchronous writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Fsync synchronous file-store temps before rename and parent directories after publication, matching the documented durability contract.
 - Reject invalid runtime archive `onFiltered` policies before extraction instead of treating unknown values as entry-skipping opt-in.
 - Claim durable queue generations under a fail-closed cross-process lock with no-replace hardlinks and recoverable source retirement so acknowledgement and quarantine cannot delete or move a newer same-ID replacement; acknowledgement now requires a processing claim, and quarantine preserves existing failed-entry evidence on collisions.
 - Validate async/sync lock retry and deadline numbers and clamp synchronous backoff to the remaining finite deadline instead of overshooting or blocking forever.

--- a/src/file-store-sync-write.ts
+++ b/src/file-store-sync-write.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { syncDirectorySync } from "./directory-durability.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import {
@@ -63,14 +64,35 @@ export function writeFileSyncAtomic(params: {
     if (parentGuard) {
       assertSyncDirectoryGuard(parentGuard);
     }
-    fs.writeFileSync(tempPath, params.content, { flag: "wx", mode: params.mode });
-    tempExists = true;
-    try {
-      fs.chmodSync(tempPath, params.mode);
-    } catch {
-      // Best-effort on platforms that do not enforce POSIX modes.
+    const tempStat = (() => {
+      const descriptor = fs.openSync(tempPath, "wx", params.mode);
+      tempExists = true;
+      try {
+        fs.writeFileSync(descriptor, params.content);
+        try {
+          fs.fchmodSync(descriptor, params.mode);
+        } catch {
+          // Best-effort on platforms that do not enforce POSIX modes.
+        }
+        const opened = fs.fstatSync(descriptor);
+        if (!opened.isFile() || opened.nlink > 1) {
+          throw new FsSafeError("path-mismatch", "store temp is not an owned regular file");
+        }
+        fs.fsyncSync(descriptor);
+        return opened;
+      } finally {
+        fs.closeSync(descriptor);
+      }
+    })();
+    const tempPathStat = fs.lstatSync(tempPath);
+    if (
+      tempPathStat.isSymbolicLink() ||
+      !tempPathStat.isFile() ||
+      tempPathStat.nlink > 1 ||
+      !sameFileIdentity(tempPathStat, tempStat)
+    ) {
+      throw new FsSafeError("path-mismatch", "store temp changed before publication");
     }
-    const tempStat = fs.lstatSync(tempPath);
     if (parentGuard) {
       assertSyncDirectoryGuard(parentGuard);
     }
@@ -96,6 +118,15 @@ export function writeFileSyncAtomic(params: {
       throw new FsSafeError("path-mismatch", "store target changed after write", {
         cause: error instanceof Error ? error : undefined,
       });
+    }
+    if (parentGuard) {
+      assertSyncDirectoryGuard(parentGuard);
+      syncDirectorySync({
+        path: parentGuard.dir,
+        realPath: parentGuard.realPath,
+        identity: parentGuard.stat,
+      }, { label: "store parent" });
+      assertSyncDirectoryGuard(parentGuard);
     }
     return filePath;
   } finally {

--- a/test/file-store-sync-write-validation.test.ts
+++ b/test/file-store-sync-write-validation.test.ts
@@ -13,6 +13,75 @@ afterEach(() => {
 });
 
 describe("sync file-store write validation", () => {
+  it("retains a write-capable temp descriptor through fsync", async () => {
+    const root = await tempRoot("fs-safe-sync-store-write-handle-");
+    const realOpenSync = fsSync.openSync;
+    let tempFlags: string | number | undefined;
+    vi.spyOn(fsSync, "openSync").mockImplementation((filePath, flags, mode) => {
+      if (filePath.toString().endsWith(".tmp")) tempFlags = flags;
+      return realOpenSync(filePath, flags, mode);
+    });
+
+    const store = fileStoreSync({ rootDir: root });
+    expect(store.writeText("value.txt", "value")).toBe(path.join(root, "value.txt"));
+    expect(tempFlags).toBe("wx");
+    await expect(fs.readFile(path.join(root, "value.txt"), "utf8")).resolves.toBe("value");
+  });
+
+  itPosix.each([false, true])(
+    "fsyncs the temp before rename and the parent after publication (private=%s)",
+    async (privateMode) => {
+      const root = await tempRoot("fs-safe-sync-store-durability-order-");
+      const events: string[] = [];
+      const realFsyncSync = fsSync.fsyncSync;
+      const realRenameSync = fsSync.renameSync;
+      vi.spyOn(fsSync, "fsyncSync").mockImplementation((descriptor) => {
+        events.push("fsync");
+        realFsyncSync(descriptor);
+      });
+      vi.spyOn(fsSync, "renameSync").mockImplementation((source, target) => {
+        events.push("rename");
+        realRenameSync(source, target);
+      });
+
+      const store = fileStoreSync({ rootDir: root, private: privateMode });
+      expect(store.writeText("value.txt", "value")).toBe(path.join(root, "value.txt"));
+      expect(events).toEqual(["fsync", "rename", "fsync"]);
+      await expect(fs.readFile(path.join(root, "value.txt"), "utf8")).resolves.toBe("value");
+    },
+  );
+
+  itPosix("preserves the destination when temp fsync fails", async () => {
+    const root = await tempRoot("fs-safe-sync-store-temp-fsync-");
+    const failure = Object.assign(new Error("temp fsync failed"), { code: "EIO" });
+    vi.spyOn(fsSync, "fsyncSync").mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    const store = fileStoreSync({ rootDir: root });
+    expect(() => store.writeText("value.txt", "value")).toThrow("temp fsync failed");
+    await expect(fs.access(path.join(root, "value.txt"))).rejects.toMatchObject({ code: "ENOENT" });
+    expect((await fs.readdir(root)).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
+  });
+
+  itPosix("reports parent fsync failure after publication", async () => {
+    const root = await tempRoot("fs-safe-sync-store-parent-fsync-");
+    const realFsyncSync = fsSync.fsyncSync;
+    let syncCalls = 0;
+    vi.spyOn(fsSync, "fsyncSync").mockImplementation((descriptor) => {
+      syncCalls += 1;
+      if (syncCalls === 2) {
+        throw Object.assign(new Error("parent fsync failed"), { code: "EIO" });
+      }
+      realFsyncSync(descriptor);
+    });
+
+    const store = fileStoreSync({ rootDir: root });
+    expect(() => store.writeText("value.txt", "value")).toThrow("parent fsync failed");
+    expect(syncCalls).toBe(2);
+    await expect(fs.readFile(path.join(root, "value.txt"), "utf8")).resolves.toBe("value");
+  });
+
   itPosix.each([false, true])(
     "rejects a post-rename symlink swap without chmodding its target (private=%s)",
     async (privateMode) => {


### PR DESCRIPTION
## Summary

- keep the synchronous temp file open through write, descriptor-mode application, identity verification, and fsync
- rename only after the write-capable descriptor has been flushed
- fsync the guarded parent directory after publication and propagate durability failures with the published file left intact

## Root cause

The file-store documentation says every write fsyncs both the sibling temp and parent directory. The asynchronous path does, but `writeFileSyncAtomic()` used path-based `writeFileSync()` followed by rename and returned without either durability fence.

Synchronous writes now open the temp with `wx`, write and apply mode through that retained descriptor, verify it is a singly-linked regular file, and call `fsyncSync()` before close. The pathname is revalidated against the opened identity before rename. After publication and target-identity validation, `syncDirectorySync()` fsyncs the guarded parent and revalidates the same directory receipt before and after.

Temp-fsync failure happens before rename, so cleanup removes the temp and no destination is published. Parent-fsync failure occurs after rename, so the new file remains available while the write reports that durability was not established.

## Live behavior proof

A fresh npm consumer installed the packed package and exercised `fileStoreSync()` while observing and injecting the two fsync boundaries:

```json
{"events":["fsync","rename","fsync"],"publishedPath":"ordered.txt","published":"ordered","tempFailure":"temp fsync failed","tempPublished":false,"parentFailure":"parent fsync failed","parentPublished":"parent"}
```

The temp was flushed before rename, the parent was flushed afterward, pre-publication failure left no target, and post-publication failure preserved the new file while propagating the error.

## Verification

- focused sync-store durability/stress/contract suite — 3 files, 33 tests passed
- complete `CI=1 pnpm check` — 136 files passed, 1 skipped; 2,243 tests passed, 25 skipped; package check passed
- cross-platform regression verifies the temp descriptor is opened with write capability through fsync
- file-size, filesystem-boundary, typecheck, and diff checks passed
- Codex autoreview at P1 — clean after the Windows descriptor fix
- fresh exact-head hosted checks and ClawSweeper review remain the landing gate
