### PR TITLE
fix(temp): pin sibling temp publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Pin callback-produced sibling temps through mode application, fsync, rename, and exact publication checks; reject symlink, non-regular, hardlinked, and replaced stages, preserve unverified cleanup paths, and default `writeSiblingTempFile` to mode `0600` with file and best-effort parent sync.
 - Make durable queue directory creation, claims, acknowledgement, quarantine, marker cleanup, and retirement transitions fsync affected directories and propagate durability failures.
 - Fsync synchronous file-store temps before rename and parent directories after publication, matching the documented durability contract.
 - Reject invalid runtime archive `onFiltered` policies before extraction instead of treating unknown values as entry-skipping opt-in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Security and Correctness
 
-- Pin callback-produced sibling temps through mode application, fsync, rename, and exact publication checks; reject symlink, non-regular, hardlinked, and replaced stages, preserve unverified cleanup paths, and default `writeSiblingTempFile` to mode `0600` with file and best-effort parent sync.
+- Pin callback-produced sibling temps through requested mode application, opt-in fsync, rename, and exact publication checks; reject symlink, non-regular, hardlinked, and replaced stages and preserve unverified cleanup paths while retaining producer modes, disabled sync defaults, and best-effort directory chmod in `writeSiblingTempFile`.
 - Make durable queue directory creation, claims, acknowledgement, quarantine, marker cleanup, and retirement transitions fsync affected directories and propagate durability failures.
 - Fsync synchronous file-store temps before rename and parent directories after publication, matching the documented durability contract.
 - Reject invalid runtime archive `onFiltered` policies before extraction instead of treating unknown values as entry-skipping opt-in.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -118,7 +118,7 @@ component is followed by another segment, both helpers throw
 |---|---|---|
 | `stageFileInDirectory`, `StagedFile`, `StagedFileReceipt`, `PublishedFileReceipt`, `StagedFilePublication`, `StagedFileCleanupReceipt`, `StagedFileFailureDetails` | [staged-file.md](staged-file.md) | Native-required Linux/macOS lifecycle retaining the original directory for abort cleanup. |
 | `tempFile`, `withTempFile`, `TempFile`, `buildRandomTempFilePath`, `sanitizeTempFileName` | [temp.md](temp.md) | One-file temp primitive; prefer `tempWorkspace` from `@openclaw/fs-safe/temp` for the stable surface. |
-| `writeSiblingTempFile`, `writeViaSiblingTempPath`, `WriteSiblingTempFileOptions`, `WriteSiblingTempFileResult` | – | Sibling-temp write building block used by `replaceFileAtomic`. |
+| `writeSiblingTempFile`, `writeViaSiblingTempPath`, `WriteSiblingTempFileOptions`, `WriteSiblingTempFileResult` | – | Callback-produced file staging: verified sibling publication or private-workspace copy through a root. |
 
 ### Permissions
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -80,6 +80,14 @@ rename. If an error leaves the sibling temp in place and immediate cleanup
 fails, its verified identity remains registered for a best-effort process-exit
 cleanup retry.
 
+Sibling staging shares the [callback sibling owner](temp.md#sibling-temp-writes):
+it checks exact pre-open, descriptor, and current-path identities, retains the
+descriptor through publication, and never chmods or reads a replacement by path.
+Cleanup preserves unverified paths, including partial output when the callback
+throws before admission. Native-off and Windows operation remain supported with
+the platform limits and non-atomic rename/unlink identity checks described there.
+When `mode` is omitted, output-sibling staging preserves the producer's mode.
+
 ## Why not pass the final path to the library?
 
 If a target parent can be swapped after validation, handing an external library

--- a/docs/temp.md
+++ b/docs/temp.md
@@ -205,11 +205,57 @@ const result = await writeSiblingTempFile<string>({
 // result.filePath, result.result (returned by writeTemp)
 ```
 
-`writeSiblingTempFile` chooses a random sibling name in `dir`, calls your `writeTemp()` callback, validates that `resolveFinalPath(result)` is still inside that same directory, and renames the temp file there.
+`writeSiblingTempFile` chooses a random, initially absent sibling name in `dir`
+and calls `writeTemp()`. After the callback succeeds, it validates the produced
+regular file before taking ownership: symlinks, directories, other non-regular
+files, hardlinks, and changes between the pre-open pathname, opened descriptor,
+and current pathname are rejected. The callback must finish and close its
+writer before returning. Its return value is preserved as `result`.
 
-By default it preserves the historical private-helper behavior of chmodding
-`dir` to `dirMode` (default `0o700`). Pass `chmodDir: false` when the directory
-is a public staging/output path whose existing mode must be preserved.
+The helper retains one write-capable descriptor through mode application,
+file synchronization, rename, and publication verification. The file mode
+defaults to `0o600`; explicit modes, including `0`, are applied through that
+descriptor and mode errors propagate. No chmod, content read, or reopen follows
+the staged or published pathname. `resolveFinalPath(result)` must resolve to a
+distinct direct child of the same directory. Final-path writes are serialized
+within the process, and the retained descriptor and current name must still
+have the admitted exact bigint identity and exactly one link before rename and
+after publication. A verification failure after rename does not roll back or
+delete the final name.
+
+`syncTempFile` defaults to `true`, synchronizing the descriptor before rename;
+file-sync errors propagate except for the existing `EPERM` compatibility case.
+`syncParentDir` defaults to `true`, requesting best-effort parent sync after
+rename. Explicit `false` skips the corresponding sync, never the identity
+checks. Parent synchronization can be unsupported or fail without rejecting
+the write, so success is not a strict crash-durability receipt.
+
+Cleanup only unlinks an admitted file while the parent, pathname identity, and
+single-link regular-file checks still agree. Observed substitutes are preserved,
+including during process-exit cleanup. Operational cleanup failures retain an
+identity-bound exit retry. If the callback throws or admission fails, no file
+has been adopted: even a regular partial file is left for caller-directed
+recovery. The helper never recursively removes a sibling temp.
+
+On POSIX, admission uses no-follow and nonblocking open flags, so a FIFO swap
+does not block the helper. Windows retains Node's guarded pathname-open behavior
+because Node has no portable no-follow flag there; metadata is checked before
+and after opening, and unknown Windows identities fail closed after one bounded
+re-inspection without reopening. These helpers remain available with native
+mode `off`; they do not acquire the native-required retained-directory contract
+of [`stageFileInDirectory`](staged-file.md).
+
+Identity checks and pathname rename/unlink are separate syscalls, not atomic
+conditional mutations. A hostile process can still replace a leaf or parent in
+the final syscall gap or mutate an open file's contents. Use an approved writable
+directory and cooperative locking or OS isolation; a moved parent can leave an
+unpublished original temp behind. Observed replacements are preserved, but
+arbitrary concurrent namespace changes cannot be prevented by these helpers.
+
+By default `dir` is set to `dirMode` (default `0o700`) through the shared verified
+POSIX directory-descriptor helper; errors propagate with no pathname chmod
+fallback. Windows only passes the directory mode to `mkdir`. Pass
+`chmodDir: false` when an existing staging/output directory mode must be preserved.
 
 ### `writeViaSiblingTempPath`
 
@@ -232,6 +278,9 @@ await writeViaSiblingTempPath({
 If `replaceFileAtomic` does what you need, prefer that. Use
 `writeViaSiblingTempPath` when the producer needs a concrete temp pathname but
 the final destination still needs root-boundary checks.
+Its private workspace uses the same identity-aware directory cleanup as
+`tempFile()`: moving and replacing the workspace preserves the replacement.
+This workspace owns its contents, unlike the unadmitted sibling pathname above.
 
 ## Secure temp root
 

--- a/docs/temp.md
+++ b/docs/temp.md
@@ -212,10 +212,11 @@ files, hardlinks, and changes between the pre-open pathname, opened descriptor,
 and current pathname are rejected. The callback must finish and close its
 writer before returning. Its return value is preserved as `result`.
 
-The helper retains one write-capable descriptor through mode application,
-file synchronization, rename, and publication verification. The file mode
-defaults to `0o600`; explicit modes, including `0`, are applied through that
-descriptor and mode errors propagate. No chmod, content read, or reopen follows
+The helper retains one write-capable descriptor through requested mode application,
+opt-in file synchronization, rename, and publication verification. Omitting
+`mode` preserves the callback-produced mode without chmod; explicit modes,
+including `0`, are applied through that descriptor and file-mode errors propagate.
+No chmod, content read, or reopen follows
 the staged or published pathname. `resolveFinalPath(result)` must resolve to a
 distinct direct child of the same directory. Final-path writes are serialized
 within the process, and the retained descriptor and current name must still
@@ -223,10 +224,11 @@ have the admitted exact bigint identity and exactly one link before rename and
 after publication. A verification failure after rename does not roll back or
 delete the final name.
 
-`syncTempFile` defaults to `true`, synchronizing the descriptor before rename;
+`syncTempFile` and `syncParentDir` retain their historical `false` defaults.
+Explicit `syncTempFile: true` synchronizes the descriptor before rename;
 file-sync errors propagate except for the existing `EPERM` compatibility case.
-`syncParentDir` defaults to `true`, requesting best-effort parent sync after
-rename. Explicit `false` skips the corresponding sync, never the identity
+Explicit `syncParentDir: true` requests best-effort parent sync after rename.
+Omitting either option or passing `false` skips that sync, never the identity
 checks. Parent synchronization can be unsupported or fail without rejecting
 the write, so success is not a strict crash-durability receipt.
 
@@ -252,9 +254,12 @@ directory and cooperative locking or OS isolation; a moved parent can leave an
 unpublished original temp behind. Observed replacements are preserved, but
 arbitrary concurrent namespace changes cannot be prevented by these helpers.
 
-By default `dir` is set to `dirMode` (default `0o700`) through the shared verified
-POSIX directory-descriptor helper; errors propagate with no pathname chmod
-fallback. Windows only passes the directory mode to `mkdir`. Pass
+By default the helper attempts to set `dir` to `dirMode` (default `0o700`)
+through the shared verified POSIX directory-descriptor helper. Only the actual
+descriptor chmod error is tolerated, preserving the historical best-effort
+directory-mode behavior. Directory lstat, open, type, identity, and close errors
+still propagate; there is no pathname chmod fallback. Windows only passes the
+directory mode to `mkdir`. Pass
 `chmodDir: false` when an existing staging/output directory mode must be preserved.
 
 ### `writeViaSiblingTempPath`

--- a/docs/temp.md
+++ b/docs/temp.md
@@ -215,7 +215,8 @@ writer before returning. Its return value is preserved as `result`.
 The helper retains one write-capable descriptor through requested mode application,
 opt-in file synchronization, rename, and publication verification. Omitting
 `mode` preserves the callback-produced mode without chmod; explicit modes,
-including `0`, are applied through that descriptor and file-mode errors propagate.
+including `0`, are applied through that descriptor. File-mode errors are
+tolerated for compatibility with the helper's historical best-effort behavior.
 No chmod, content read, or reopen follows
 the staged or published pathname. `resolveFinalPath(result)` must resolve to a
 distinct direct child of the same directory. Final-path writes are serialized

--- a/src/output-sibling.ts
+++ b/src/output-sibling.ts
@@ -1,21 +1,7 @@
 import { randomUUID } from "node:crypto";
-import fsSync from "node:fs";
-import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
-import { createAsyncDirectoryGuard } from "./directory-guard.js";
-import { syncDirectoryBestEffort } from "./directory-durability.js";
-import { FsSafeError } from "./errors.js";
-import { sameFileIdentity, sameFileIdentityForCleanup } from "./file-identity.js";
-import { withAsyncDirectoryGuards } from "./guarded-mutation.js";
 import { sanitizeUntrustedFileName } from "./filename.js";
-import { registerTempPathForExit } from "./temp-cleanup.js";
-import { serializePathWrite } from "./write-queue.js";
-
-const OPEN_READ_WRITE_NOFOLLOW =
-  fsSync.constants.O_RDWR |
-  (process.platform !== "win32" && typeof fsSync.constants.O_NOFOLLOW === "number"
-    ? fsSync.constants.O_NOFOLLOW
-    : 0);
+import { writeCallbackSibling } from "./sibling-staged-file.js";
 
 function safeFallbackFileName(fallbackFileName?: string): string {
   return sanitizeUntrustedFileName(fallbackFileName ?? "output.bin", "output.bin");
@@ -32,67 +18,6 @@ function buildSiblingTempPath(targetPath: string, fallbackFileName?: string): st
   );
 }
 
-function assertStagedFile(
-  pathname: Awaited<ReturnType<typeof fs.lstat>>,
-  opened: Awaited<ReturnType<FileHandle["stat"]>>,
-  maxBytes?: number,
-): void {
-  if (pathname.isSymbolicLink() || !pathname.isFile() || !opened.isFile()) {
-    throw new FsSafeError("not-file", "sibling-staged output must be a regular file");
-  }
-  if (!sameFileIdentity(pathname, opened)) {
-    throw new FsSafeError("path-mismatch", "sibling-staged output changed while opening");
-  }
-  if (opened.nlink > 1) {
-    throw new FsSafeError("hardlink", "hardlinked sibling-staged output not allowed");
-  }
-  if (maxBytes !== undefined && opened.size > maxBytes) {
-    throw new FsSafeError("too-large", `sibling-staged output exceeds maxBytes (${maxBytes})`);
-  }
-}
-
-async function openPinnedStagedFile(
-  tempPath: string,
-  maxBytes?: number,
-): Promise<{ handle: FileHandle; identity: Awaited<ReturnType<FileHandle["stat"]>> }> {
-  const preview = await fs.lstat(tempPath);
-  if (preview.isSymbolicLink()) {
-    throw new FsSafeError("symlink", "symlink sibling-staged output not allowed");
-  }
-  const handle = await fs.open(tempPath, OPEN_READ_WRITE_NOFOLLOW);
-  try {
-    const identity = await handle.stat();
-    assertStagedFile(await fs.lstat(tempPath), identity, maxBytes);
-    return { handle, identity };
-  } catch (error) {
-    await handle.close().catch(() => undefined);
-    throw error;
-  }
-}
-
-async function syncFile(handle: FileHandle): Promise<void> {
-  try {
-    await handle.sync();
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EPERM") throw error;
-  }
-}
-
-async function cleanupTempPath(
-  tempPath: string,
-  identity?: Awaited<ReturnType<FileHandle["stat"]>>,
-): Promise<boolean> {
-  try {
-    const current = await fs.lstat(tempPath);
-    if (!identity || (!current.isSymbolicLink() && sameFileIdentityForCleanup(current, identity))) {
-      await fs.rm(tempPath, { force: true });
-    }
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "ENOENT";
-  }
-}
-
 export async function writeExternalFileViaSibling<T>(params: {
   finalPath: string;
   write: (filePath: string) => Promise<T>;
@@ -101,48 +26,14 @@ export async function writeExternalFileViaSibling<T>(params: {
   mode?: number;
 }): Promise<T> {
   const finalPath = path.resolve(params.finalPath);
-  const parentPath = path.dirname(finalPath);
-  const parentGuard = await createAsyncDirectoryGuard(parentPath);
-  const tempPath = buildSiblingTempPath(finalPath, params.fallbackFileName);
-  const unregisterTempPath = registerTempPathForExit(tempPath);
-  let stagedIdentity: Awaited<ReturnType<FileHandle["stat"]>> | undefined;
-  let renamed = false;
-
-  try {
-    const result = await params.write(tempPath);
-    const pinned = await openPinnedStagedFile(tempPath, params.maxBytes);
-    stagedIdentity = pinned.identity;
-    unregisterTempPath.setIdentity(await pinned.handle.stat({ bigint: true }));
-    try {
-      if (params.mode !== undefined) {
-        await pinned.handle.chmod(params.mode);
-      }
-      await syncFile(pinned.handle);
-      await serializePathWrite(finalPath, async () => {
-        await withAsyncDirectoryGuards([parentGuard], async () => {
-          const currentIdentity = await pinned.handle.stat();
-          assertStagedFile(await fs.lstat(tempPath), currentIdentity, params.maxBytes);
-          if (!sameFileIdentity(currentIdentity, stagedIdentity!)) {
-            throw new FsSafeError("path-mismatch", "sibling-staged output changed before rename");
-          }
-          await fs.rename(tempPath, finalPath);
-          renamed = true;
-          const published = await fs.lstat(finalPath);
-          if (published.isSymbolicLink() || !sameFileIdentity(published, currentIdentity)) {
-            throw new FsSafeError("path-mismatch", "sibling-staged output changed during rename");
-          }
-        });
-        await syncDirectoryBestEffort(parentPath);
-      });
-    } finally {
-      await pinned.handle.close().catch(() => undefined);
-    }
-    return result;
-  } finally {
-    let cleanupComplete = renamed;
-    if (!renamed) {
-      cleanupComplete = await cleanupTempPath(tempPath, stagedIdentity);
-    }
-    if (cleanupComplete) unregisterTempPath();
-  }
+  const { result } = await writeCallbackSibling({
+    tempPath: buildSiblingTempPath(finalPath, params.fallbackFileName),
+    write: params.write,
+    resolveFinalPath: () => finalPath,
+    mode: params.mode,
+    maxBytes: params.maxBytes,
+    syncTempFile: true,
+    syncParentDir: true,
+  });
+  return result;
 }

--- a/src/replace-file-descriptor.ts
+++ b/src/replace-file-descriptor.ts
@@ -40,6 +40,8 @@ export async function applyDirectoryMode(params: {
   fsModule: AsyncTempFileSystem;
   dirPath: string;
   mode: number;
+  /** Compatibility for best-effort directory modes; admission and close still fail closed. */
+  ignoreChmodError?: boolean;
 }): Promise<void> {
   // Node does not enforce POSIX directory modes on Windows, and its directory
   // descriptors are not consistently openable. mkdir(mode) remains the only
@@ -53,7 +55,11 @@ export async function applyDirectoryMode(params: {
   const handle = await params.fsModule.open(params.dirPath, directoryOpenFlags());
   try {
     assertSameDirectory(expected, await handle.stat(), params.dirPath);
-    await handle.chmod(params.mode);
+    try {
+      await handle.chmod(params.mode);
+    } catch (error) {
+      if (params.ignoreChmodError !== true) throw error;
+    }
   } finally {
     await handle.close();
   }

--- a/src/sibling-staged-file.ts
+++ b/src/sibling-staged-file.ts
@@ -1,0 +1,144 @@
+import fsSync, { type BigIntStats } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard } from "./directory-guard.js";
+import { syncDirectoryBestEffort } from "./directory-durability.js";
+import { FsSafeError } from "./errors.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
+import { inspectFileIdentity } from "./strict-file-identity.js";
+import { registerTempPathForExit, type TempPathRegistration } from "./temp-cleanup.js";
+import { serializePathWrite } from "./write-queue.js";
+
+function assertRegularFile(stat: BigIntStats): void {
+  if (stat.isSymbolicLink()) {
+    throw new FsSafeError("symlink", "symlink sibling temp not allowed");
+  }
+  if (!stat.isFile()) {
+    throw new FsSafeError("not-file", "sibling temp must be a regular file");
+  }
+  if (stat.nlink !== 1n) {
+    throw new FsSafeError("hardlink", "sibling temp must have exactly one link");
+  }
+}
+
+async function inspectStage(inspect: () => Promise<BigIntStats>, expected?: BigIntStats) {
+  return await inspectFileIdentity(async () => {
+    const stat = await inspect();
+    assertRegularFile(stat);
+    return stat;
+  }, expected);
+}
+
+// Callback paths are not owned until all three admission observations agree.
+// Keep one descriptor and one exact identity through mode, sync, rename and cleanup.
+export async function writeCallbackSibling<T>(params: {
+  tempPath: string;
+  write: (tempPath: string) => Promise<T>;
+  resolveFinalPath: (result: T) => string;
+  mode?: number;
+  maxBytes?: number;
+  syncTempFile: boolean;
+  syncParentDir: boolean;
+}): Promise<{ filePath: string; result: T }> {
+  const parent = path.dirname(params.tempPath);
+  const guard = await createAsyncDirectoryGuard(parent);
+  const parentIdentity = await inspectFileIdentity(() => fs.lstat(parent, { bigint: true }));
+  const assertParent = async () => {
+    await assertAsyncDirectoryGuard(guard);
+    await inspectFileIdentity(() => fs.lstat(parent, { bigint: true }), parentIdentity);
+  };
+  let handle: FileHandle | undefined;
+  let identity: BigIntStats | undefined;
+  let unregister: TempPathRegistration | undefined;
+  let renamed = false;
+  let failure: { error: unknown } | undefined;
+  const inspectPath = (pathname: string, expected?: BigIntStats) =>
+    inspectStage(() => fs.lstat(pathname, { bigint: true }), expected);
+  const assertCurrent = async (pathname: string) => {
+    await assertParent();
+    const opened = await inspectStage(() => handle!.stat({ bigint: true }), identity);
+    const current = await inspectPath(pathname, opened);
+    if (
+      params.maxBytes !== undefined &&
+      (opened.size > params.maxBytes || current.size > params.maxBytes)
+    ) {
+      throw new FsSafeError("too-large", `sibling temp exceeds maxBytes (${params.maxBytes})`);
+    }
+  };
+
+  try {
+    const result = await params.write(params.tempPath);
+    await assertParent();
+    const before = await inspectPath(params.tempPath);
+    try {
+      // No create/truncate flags; O_NONBLOCK also bounds a FIFO swap during open.
+      handle = await fs.open(params.tempPath, fsSync.constants.O_RDWR | resolveReadOpenFlags());
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === "ELOOP") {
+        throw new FsSafeError("symlink", "symlink sibling temp not allowed", { cause: error });
+      }
+      throw error;
+    }
+    const opened = await inspectStage(() => handle!.stat({ bigint: true }), before);
+    await inspectPath(params.tempPath, opened);
+    await assertParent();
+    identity = opened;
+    unregister = registerTempPathForExit(params.tempPath, { identity, singleLinkFile: true });
+
+    const filePath = path.resolve(params.resolveFinalPath(result));
+    if (path.dirname(filePath) !== parent) {
+      throw new Error("Final path must be in the sibling temp directory.");
+    }
+    if (filePath === params.tempPath) {
+      throw new FsSafeError("invalid-path", "final path must differ from the sibling temp path");
+    }
+    await serializePathWrite(filePath, async () => {
+      await assertCurrent(params.tempPath);
+      if (params.mode !== undefined) await handle!.chmod(params.mode);
+      if (params.syncTempFile) {
+        await assertCurrent(params.tempPath);
+        try {
+          await handle!.sync();
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException)?.code !== "EPERM") throw error;
+        }
+      }
+      await assertCurrent(params.tempPath);
+      await fs.rename(params.tempPath, filePath);
+      // A later verification failure never authorizes rollback of the final name.
+      renamed = true;
+      unregister!();
+      await assertCurrent(filePath);
+      if (params.syncParentDir) await syncDirectoryBestEffort(parent);
+      await assertCurrent(filePath);
+    });
+    return { filePath, result };
+  } catch (error) {
+    failure = { error };
+    throw error;
+  } finally {
+    try {
+      if (!renamed && identity) {
+        try {
+          await assertParent();
+          await inspectStage(() => handle!.stat({ bigint: true }), identity);
+          await inspectPath(params.tempPath, identity);
+          await fs.unlink(params.tempPath);
+          unregister?.();
+        } catch (error) {
+          // Preserve observed substitutes; retry only operational cleanup failures.
+          if (error instanceof FsSafeError || (error as NodeJS.ErrnoException)?.code === "ENOENT") {
+            unregister?.();
+          }
+        }
+      }
+    } finally {
+      try {
+        await handle?.close();
+      } catch (error) {
+        if (failure) throw new AggregateError([failure.error, error], "sibling publication and close failed");
+        throw error;
+      }
+    }
+  }
+}

--- a/src/sibling-staged-file.ts
+++ b/src/sibling-staged-file.ts
@@ -36,6 +36,8 @@ export async function writeCallbackSibling<T>(params: {
   write: (tempPath: string) => Promise<T>;
   resolveFinalPath: (result: T) => string;
   mode?: number;
+  /** Preserve the caller's historical best-effort mode behavior. */
+  ignoreModeError?: boolean;
   maxBytes?: number;
   syncTempFile: boolean;
   syncParentDir: boolean;
@@ -94,7 +96,13 @@ export async function writeCallbackSibling<T>(params: {
     }
     await serializePathWrite(filePath, async () => {
       await assertCurrent(params.tempPath);
-      if (params.mode !== undefined) await handle!.chmod(params.mode);
+      if (params.mode !== undefined) {
+        try {
+          await handle!.chmod(params.mode);
+        } catch (error) {
+          if (!params.ignoreModeError) throw error;
+        }
+      }
       if (params.syncTempFile) {
         await assertCurrent(params.tempPath);
         try {

--- a/src/sibling-temp.ts
+++ b/src/sibling-temp.ts
@@ -56,6 +56,7 @@ export async function writeSiblingTempFile<T>(
     write: options.writeTemp,
     resolveFinalPath: options.resolveFinalPath,
     mode: options.mode,
+    ignoreModeError: true,
     syncTempFile: options.syncTempFile === true,
     syncParentDir: options.syncParentDir === true,
   });

--- a/src/sibling-temp.ts
+++ b/src/sibling-temp.ts
@@ -2,15 +2,14 @@ import crypto, { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard } from "./directory-guard.js";
-import { syncDirectoryBestEffort } from "./directory-durability.js";
-import { withAsyncDirectoryGuards } from "./guarded-mutation.js";
 import { sanitizeUntrustedFileName } from "./filename.js";
+import { applyDirectoryMode } from "./replace-file-descriptor.js";
 import { root } from "./root.js";
 import { assertSafePathPrefix } from "./safe-path-segment.js";
 import { resolveSecureTempRoot } from "./secure-temp-dir.js";
-import { registerTempPathForExit } from "./temp-cleanup.js";
+import { writeCallbackSibling } from "./sibling-staged-file.js";
+import { tempFile } from "./temp-target.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
-import { serializePathWrite } from "./write-queue.js";
 
 export type WriteSiblingTempFileOptions<T> = {
   dir: string;
@@ -19,8 +18,11 @@ export type WriteSiblingTempFileOptions<T> = {
   tempPrefix?: string;
   dirMode?: number;
   chmodDir?: boolean;
+  /** Final file mode; defaults to 0o600. Applied through the retained descriptor. */
   mode?: number;
+  /** Sync the staged descriptor before rename; defaults to true. */
   syncTempFile?: boolean;
+  /** Best-effort parent directory sync after rename; defaults to true. */
   syncParentDir?: boolean;
 };
 
@@ -36,71 +38,22 @@ function buildTempPath(dir: string, tempPrefix?: string): string {
   return path.join(dir, `${safePrefix}.${process.pid}.${randomUUID()}.tmp`);
 }
 
-async function syncFileBestEffort(filePath: string): Promise<void> {
-  const handle = await fs.open(filePath, "r+");
-  try {
-    await handle.sync();
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EPERM") {
-      throw error;
-    }
-  } finally {
-    await handle.close();
-  }
-}
-
-function assertFinalPathIsSibling(dir: string, filePath: string): void {
-  const resolvedDir = path.resolve(dir);
-  const resolvedFile = path.resolve(filePath);
-  if (path.dirname(resolvedFile) !== resolvedDir) {
-    throw new Error("Final path must be in the sibling temp directory.");
-  }
-}
-
 export async function writeSiblingTempFile<T>(
   options: WriteSiblingTempFileOptions<T>,
 ): Promise<WriteSiblingTempFileResult<T>> {
   const dir = path.resolve(options.dir);
   await fs.mkdir(dir, { recursive: true, mode: options.dirMode ?? 0o700 });
   if (options.chmodDir !== false) {
-    await fs.chmod(dir, options.dirMode ?? 0o700).catch(() => undefined);
+    await applyDirectoryMode({ fsModule: fs, dirPath: dir, mode: options.dirMode ?? 0o700 });
   }
-  const dirGuard = await createAsyncDirectoryGuard(dir);
-  const tempPath = buildTempPath(dir, options.tempPrefix);
-  const unregisterTempPath = registerTempPathForExit(tempPath);
-  let tempExists = false;
-  try {
-    tempExists = true;
-    const result = await options.writeTemp(tempPath);
-    unregisterTempPath.setIdentity(await fs.lstat(tempPath, { bigint: true }));
-    if (options.mode !== undefined) {
-      await fs.chmod(tempPath, options.mode).catch(() => undefined);
-    }
-    if (options.syncTempFile) {
-      await syncFileBestEffort(tempPath);
-    }
-    const filePath = path.resolve(options.resolveFinalPath(result));
-    assertFinalPathIsSibling(dir, filePath);
-    await serializePathWrite(filePath, async () => {
-      await withAsyncDirectoryGuards([dirGuard], async () => {
-        await fs.rename(tempPath, filePath);
-      });
-      tempExists = false;
-      unregisterTempPath();
-      if (options.mode !== undefined) {
-        await fs.chmod(filePath, options.mode).catch(() => undefined);
-      }
-      if (options.syncParentDir) {
-        await syncDirectoryBestEffort(dir);
-      }
-    });
-    return { filePath, result };
-  } finally {
-    if (tempExists) {
-      await fs.rm(tempPath, { force: true }).catch(() => undefined);
-    }
-    unregisterTempPath();
-  }
+  return await writeCallbackSibling({
+    tempPath: buildTempPath(dir, options.tempPrefix),
+    write: options.writeTemp,
+    resolveFinalPath: options.resolveFinalPath,
+    mode: options.mode ?? 0o600,
+    syncTempFile: options.syncTempFile !== false,
+    syncParentDir: options.syncParentDir !== false,
+  });
 }
 
 function buildSiblingTempPath(params: {
@@ -144,23 +97,20 @@ export async function writeViaSiblingTempPath(params: {
     throw new Error("Target path is outside the allowed root");
   }
   const rootGuard = await createAsyncDirectoryGuard(rootDir);
-  const tempDir = await fs.mkdtemp(
-    path.join(
-      resolveSecureTempRoot({
-        fallbackPrefix: "fs-safe-output",
-        unsafeFallbackLabel: "sibling temp output dir",
-        warn: () => undefined,
-      }),
-      "fs-safe-output-",
-    ),
-  );
-  const tempPath = buildSiblingTempPath({
-    targetPath: path.join(tempDir, path.basename(targetPath)),
-    fallbackFileName: params.fallbackFileName ?? "output.bin",
-    tempPrefix: params.tempPrefix ?? ".fs-safe-output-",
+  const workspace = await tempFile({
+    rootDir: resolveSecureTempRoot({
+      fallbackPrefix: "fs-safe-output",
+      unsafeFallbackLabel: "sibling temp output dir",
+      warn: () => undefined,
+    }),
+    prefix: "fs-safe-output",
   });
-  const unregisterTempPath = registerTempPathForExit(tempDir, { recursive: true });
   try {
+    const tempPath = buildSiblingTempPath({
+      targetPath: path.join(workspace.dir, path.basename(targetPath)),
+      fallbackFileName: params.fallbackFileName ?? "output.bin",
+      tempPrefix: params.tempPrefix ?? ".fs-safe-output-",
+    });
     await getFsSafeTestHooks()?.beforeSiblingTempWrite?.(tempPath);
     await params.writeTemp(tempPath);
     await assertAsyncDirectoryGuard(rootGuard);
@@ -168,7 +118,6 @@ export async function writeViaSiblingTempPath(params: {
     await targetRoot.copyIn(relativeTargetPath, tempPath, { mkdir: false });
     await assertAsyncDirectoryGuard(rootGuard);
   } finally {
-    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
-    unregisterTempPath();
+    await workspace.cleanup();
   }
 }

--- a/src/sibling-temp.ts
+++ b/src/sibling-temp.ts
@@ -18,11 +18,11 @@ export type WriteSiblingTempFileOptions<T> = {
   tempPrefix?: string;
   dirMode?: number;
   chmodDir?: boolean;
-  /** Final file mode; defaults to 0o600. Applied through the retained descriptor. */
+  /** Final file mode; omitted preserves the producer's mode. Applied through the retained descriptor. */
   mode?: number;
-  /** Sync the staged descriptor before rename; defaults to true. */
+  /** Sync the staged descriptor before rename; defaults to false. */
   syncTempFile?: boolean;
-  /** Best-effort parent directory sync after rename; defaults to true. */
+  /** Best-effort parent directory sync after rename; defaults to false. */
   syncParentDir?: boolean;
 };
 
@@ -44,15 +44,20 @@ export async function writeSiblingTempFile<T>(
   const dir = path.resolve(options.dir);
   await fs.mkdir(dir, { recursive: true, mode: options.dirMode ?? 0o700 });
   if (options.chmodDir !== false) {
-    await applyDirectoryMode({ fsModule: fs, dirPath: dir, mode: options.dirMode ?? 0o700 });
+    await applyDirectoryMode({
+      fsModule: fs,
+      dirPath: dir,
+      mode: options.dirMode ?? 0o700,
+      ignoreChmodError: true,
+    });
   }
   return await writeCallbackSibling({
     tempPath: buildTempPath(dir, options.tempPrefix),
     write: options.writeTemp,
     resolveFinalPath: options.resolveFinalPath,
-    mode: options.mode ?? 0o600,
-    syncTempFile: options.syncTempFile !== false,
-    syncParentDir: options.syncParentDir !== false,
+    mode: options.mode,
+    syncTempFile: options.syncTempFile === true,
+    syncParentDir: options.syncParentDir === true,
   });
 }
 

--- a/src/temp-cleanup.ts
+++ b/src/temp-cleanup.ts
@@ -11,6 +11,7 @@ type TempCleanupEntry = {
   path: string;
   recursive: boolean;
   identity?: FileIdentityStat;
+  singleLinkFile?: boolean;
 };
 
 const tempCleanupEntries = new Map<string, TempCleanupEntry>();
@@ -21,12 +22,11 @@ function pathStillMatchesReceipt(entry: TempCleanupEntry): boolean {
     return false;
   }
   try {
-    return sameFileIdentityForCleanup(
-      fsSync.lstatSync(entry.path, { bigint: true }),
-      entry.identity,
-    );
+    const current = fsSync.lstatSync(entry.path, { bigint: true });
+    return (!entry.singleLinkFile || (current.isFile() && current.nlink === 1n)) &&
+      sameFileIdentityForCleanup(current, entry.identity);
   } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "ENOENT";
+    return !entry.singleLinkFile && (error as NodeJS.ErrnoException).code === "ENOENT";
   }
 }
 
@@ -34,7 +34,7 @@ function cleanupRegisteredTempPathsSync(): void {
   for (const entry of tempCleanupEntries.values()) {
     try {
       if (pathStillMatchesReceipt(entry)) {
-        fsSync.rmSync(entry.path, { force: true, recursive: entry.recursive });
+        removeRegisteredPathSync(entry);
       }
     } catch {
       // Process-exit cleanup is best-effort.
@@ -43,9 +43,14 @@ function cleanupRegisteredTempPathsSync(): void {
   tempCleanupEntries.clear();
 }
 
+function removeRegisteredPathSync(entry: TempCleanupEntry): void {
+  if (entry.singleLinkFile) fsSync.unlinkSync(entry.path);
+  else fsSync.rmSync(entry.path, { force: true, recursive: entry.recursive });
+}
+
 export function registerTempPathForExit(
   tempPath: string,
-  options?: { recursive?: boolean; identity?: FileIdentityStat },
+  options?: { recursive?: boolean; identity?: FileIdentityStat; singleLinkFile?: boolean },
 ): TempPathRegistration {
   if (!cleanupRegistered) {
     cleanupRegistered = true;
@@ -55,6 +60,7 @@ export function registerTempPathForExit(
     path: tempPath,
     recursive: options?.recursive === true,
     identity: options?.identity,
+    singleLinkFile: options?.singleLinkFile,
   };
   if (!entry.identity) {
     try {
@@ -84,7 +90,7 @@ export function __cleanupRegisteredTempPathForTest(tempPath: string): void {
   }
   try {
     if (pathStillMatchesReceipt(entry)) {
-      fsSync.rmSync(entry.path, { force: true, recursive: entry.recursive });
+      removeRegisteredPathSync(entry);
     }
   } finally {
     tempCleanupEntries.delete(tempPath);

--- a/test/atomic-publication-stress.test.ts
+++ b/test/atomic-publication-stress.test.ts
@@ -180,18 +180,18 @@ describe("atomic publication stress regressions", () => {
     let tempPath = "";
     let cleanupAttempts = 0;
     const realRename = fs.rename.bind(fs);
-    const realRm = fs.rm.bind(fs);
+    const realUnlink = fs.unlink.bind(fs);
     vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
       if (from === tempPath) {
         throw Object.assign(new Error("publish denied"), { code: "EACCES" });
       }
       await realRename(from, to);
     });
-    vi.spyOn(fs, "rm").mockImplementation(async (candidate, options) => {
+    vi.spyOn(fs, "unlink").mockImplementation(async (candidate) => {
       if (candidate === tempPath && cleanupAttempts++ === 0) {
         throw Object.assign(new Error("temp busy"), { code: "EBUSY" });
       }
-      await realRm(candidate, options);
+      await realUnlink(candidate);
     });
 
     await expect(writeExternalFileWithinRoot({

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -98,7 +98,7 @@ describe("writeExternalFileWithinRoot", () => {
       .toEqual([]);
   });
 
-  it("cleans a sibling partial when the external writer fails", async () => {
+  it("preserves an unverified sibling partial when the external writer fails", async () => {
     const rootDir = await tempRoot("fs-safe-output-sibling-fail-");
     let stagedPath = "";
 
@@ -115,7 +115,7 @@ describe("writeExternalFileWithinRoot", () => {
       }),
     ).rejects.toThrow("producer failed");
 
-    await expect(fs.stat(stagedPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("partial");
     await expect(fs.stat(path.join(rootDir, "output.bin"))).rejects.toMatchObject({
       code: "ENOENT",
     });

--- a/test/sibling-temp-directory-mode.test.ts
+++ b/test/sibling-temp-directory-mode.test.ts
@@ -1,0 +1,127 @@
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, vi } from "vitest";
+import { replaceFileAtomic } from "../src/atomic.js";
+import { writeSiblingTempFile } from "../src/sibling-temp.js";
+import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+async function fixture() {
+  const root = await tempRoot("fs-safe-sibling-dirmode-");
+  const dir = path.join(root, "parent");
+  await fs.mkdir(dir);
+  await fs.chmod(dir, 0o755);
+  const final = path.join(dir, "final");
+  await fs.writeFile(final, "old");
+  const writeTemp = vi.fn(async (temporary: string) => {
+    await fs.writeFile(temporary, "new");
+  });
+  return { root, dir, final, options: { dir, writeTemp, resolveFinalPath: () => final } };
+}
+
+itPosix.each(["EPERM", "EIO"])("tolerates only directory descriptor chmod failure (%s)", async (code) => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  const failure = Object.assign(new Error("directory chmod failed"), { code });
+  const directoryChmod = vi.fn().mockRejectedValue(failure);
+  const pathnameChmod = vi.spyOn(fs, "chmod").mockRejectedValue(new Error("pathname chmod forbidden"));
+  let directory: FileHandle | undefined;
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === f.dir) {
+      directory = handle;
+      vi.spyOn(handle, "chmod").mockImplementation(directoryChmod);
+    }
+    return handle;
+  });
+  await writeSiblingTempFile(f.options);
+  expect(directoryChmod).toHaveBeenCalledExactlyOnceWith(0o700);
+  expect(directory?.fd).toBe(-1);
+  expect((await fs.stat(f.dir)).mode & 0o777).toBe(0o755);
+  expect(await fs.readFile(f.final, "utf8")).toBe("new");
+  expect(pathnameChmod).not.toHaveBeenCalled();
+});
+
+itPosix.each(["lstat", "open", "pathname-type", "stat", "descriptor-type", "identity", "close"] as const)(
+  "propagates directory %s failure before invoking the producer", async (phase) => {
+    const f = await fixture();
+    const open = fs.open.bind(fs);
+    const failure = Object.assign(new Error(`directory ${phase} failed`), { code: "EIO" });
+    const chmod = vi.fn();
+    let directory: FileHandle | undefined;
+    if (phase === "lstat") vi.spyOn(fs, "lstat").mockRejectedValueOnce(failure);
+    if (phase === "pathname-type") vi.spyOn(fs, "lstat").mockResolvedValueOnce(await fs.stat(f.final));
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      if (args[0] !== f.dir) return await open(...args);
+      if (phase === "open") throw failure;
+      if (phase === "identity") {
+        await fs.rename(f.dir, path.join(f.root, "moved"));
+        await fs.mkdir(f.dir);
+        await fs.writeFile(path.join(f.dir, "sentinel"), "keep");
+      }
+      directory = phase === "descriptor-type" ? await open(f.final, "r") : await open(...args);
+      vi.spyOn(directory, "chmod").mockImplementation(async () => {
+        chmod();
+        throw new Error("directory chmod denied");
+      });
+      if (phase === "stat") vi.spyOn(directory, "stat").mockRejectedValue(failure);
+      if (phase === "close") {
+        const close = directory.close.bind(directory);
+        vi.spyOn(directory, "close").mockImplementation(async () => {
+          await close();
+          throw failure;
+        });
+      }
+      return directory;
+    });
+    const operation = writeSiblingTempFile(f.options);
+    if (phase === "identity") await expect(operation).rejects.toMatchObject({ code: "path-mismatch" });
+    else if (phase.endsWith("type")) await expect(operation).rejects.toMatchObject({ code: "not-file" });
+    else await expect(operation).rejects.toBe(failure);
+    expect(f.options.writeTemp).not.toHaveBeenCalled();
+    if (directory) expect(directory.fd).toBe(-1);
+    expect(chmod).toHaveBeenCalledTimes(phase === "close" ? 1 : 0);
+    if (phase === "identity") {
+      expect(await fs.readFile(path.join(f.dir, "sentinel"), "utf8")).toBe("keep");
+      expect(await fs.readFile(path.join(f.root, "moved", "final"), "utf8")).toBe("old");
+    } else expect(await fs.readFile(f.final, "utf8")).toBe("old");
+  },
+);
+
+itPosix("still propagates an explicit staged-file mode error after tolerating directory chmod", async () => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  const fileFailure = new Error("staged chmod failed");
+  const directoryChmod = vi.fn().mockRejectedValue(new Error("directory chmod failed"));
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === f.dir) vi.spyOn(handle, "chmod").mockImplementation(directoryChmod);
+    else vi.spyOn(handle, "chmod").mockRejectedValue(fileFailure);
+    return handle;
+  });
+  await expect(writeSiblingTempFile({ ...f.options, mode: 0o600 })).rejects.toBe(fileFailure);
+  expect(directoryChmod).toHaveBeenCalledOnce();
+  expect(f.options.writeTemp).toHaveBeenCalledOnce();
+  expect(await fs.readFile(f.final, "utf8")).toBe("old");
+  expect(await fs.readdir(f.dir)).toEqual(["final"]);
+});
+
+itPosix("keeps other directory-mode callers strict by default", async () => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  const failure = new Error("directory chmod failed");
+  let directory: FileHandle | undefined;
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === f.dir) {
+      directory = handle;
+      vi.spyOn(handle, "chmod").mockRejectedValue(failure);
+    }
+    return handle;
+  });
+  await expect(replaceFileAtomic({ filePath: f.final, content: "new", dirMode: 0o700 })).rejects.toBe(failure);
+  expect(directory?.fd).toBe(-1);
+  expect(await fs.readFile(f.final, "utf8")).toBe("old");
+});

--- a/test/sibling-temp-directory-mode.test.ts
+++ b/test/sibling-temp-directory-mode.test.ts
@@ -90,7 +90,7 @@ itPosix.each(["lstat", "open", "pathname-type", "stat", "descriptor-type", "iden
   },
 );
 
-itPosix("still propagates an explicit staged-file mode error after tolerating directory chmod", async () => {
+itPosix("tolerates explicit staged-file mode errors after directory chmod", async () => {
   const f = await fixture();
   const open = fs.open.bind(fs);
   const fileFailure = new Error("staged chmod failed");
@@ -101,10 +101,10 @@ itPosix("still propagates an explicit staged-file mode error after tolerating di
     else vi.spyOn(handle, "chmod").mockRejectedValue(fileFailure);
     return handle;
   });
-  await expect(writeSiblingTempFile({ ...f.options, mode: 0o600 })).rejects.toBe(fileFailure);
+  await writeSiblingTempFile({ ...f.options, mode: 0o600 });
   expect(directoryChmod).toHaveBeenCalledOnce();
   expect(f.options.writeTemp).toHaveBeenCalledOnce();
-  expect(await fs.readFile(f.final, "utf8")).toBe("old");
+  expect(await fs.readFile(f.final, "utf8")).toBe("new");
   expect(await fs.readdir(f.dir)).toEqual(["final"]);
 });
 

--- a/test/sibling-temp-durability.test.ts
+++ b/test/sibling-temp-durability.test.ts
@@ -164,20 +164,20 @@ itPosix.each(["file", "parent"] as const)("enables only the explicitly requested
   expect(await fs.readFile(f.final, "utf8")).toBe("new");
 });
 
-it.each(["chmod", "sync"] as const)("propagates descriptor %s failures before publication and cleans the admitted stage", async (operation) => {
+it("propagates descriptor sync failures before publication and cleans the admitted stage", async () => {
   const f = await fixture();
   const open = fs.open.bind(fs);
-  const failure = Object.assign(new Error(`${operation} failed`), { code: "EIO" });
+  const failure = Object.assign(new Error("sync failed"), { code: "EIO" });
   let handle: FileHandle | undefined;
   vi.spyOn(fs, "open").mockImplementation(async (...args) => {
     const opened = await open(...args);
     if (args[0] === f.temp()) {
       handle = opened;
-      vi.spyOn(opened, operation).mockRejectedValue(failure);
+      vi.spyOn(opened, "sync").mockRejectedValue(failure);
     }
     return opened;
   });
-  await expect(writeSiblingTempFile({ ...f.options, mode: 0o600, syncTempFile: true })).rejects.toBe(failure);
+  await expect(writeSiblingTempFile({ ...f.options, syncTempFile: true })).rejects.toBe(failure);
   expect(await fs.readFile(f.final, "utf8")).toBe("old");
   await expect(fs.lstat(f.temp())).rejects.toMatchObject({ code: "ENOENT" });
   expect(handle?.fd).toBe(-1);

--- a/test/sibling-temp-durability.test.ts
+++ b/test/sibling-temp-durability.test.ts
@@ -1,0 +1,252 @@
+import fsSync from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { writeSiblingTempFile } from "../src/sibling-temp.js";
+import { __cleanupRegisteredTempPathsForTest } from "../src/temp-cleanup.js";
+import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  __cleanupRegisteredTempPathsForTest();
+});
+
+async function fixture() {
+  const dir = await tempRoot("fs-safe-sibling-durability-");
+  const final = path.join(dir, "final");
+  await fs.writeFile(final, "old");
+  let temporary = "";
+  const result = { filename: "final", opaque: {} };
+  const options = {
+    dir, chmodDir: false,
+    writeTemp: async (candidate: string) => {
+      temporary = candidate;
+      await fs.writeFile(candidate, "new", { mode: 0o644 });
+      return result;
+    },
+    resolveFinalPath: (value: typeof result) => path.join(dir, value.filename),
+  };
+  return { dir, final, options, result, temp: () => temporary };
+}
+
+itPosix.each([undefined, 0, 0o640])("retains one writable descriptor for mode %s, fsync, rename and verification", async (mode) => {
+  const f = await fixture();
+  const operations: string[] = [];
+  const open = fs.open.bind(fs);
+  const rename = fs.rename.bind(fs);
+  let retained = -1;
+  let stageOpens = 0;
+  let closed = 0;
+  vi.spyOn(fs, "chmod").mockRejectedValue(new Error("pathname chmod forbidden"));
+  vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, openMode) => {
+    const handle = await open(candidate, flags, openMode);
+    if (candidate === f.temp()) {
+      stageOpens++;
+      retained = handle.fd;
+      expect(Number(flags) & fsSync.constants.O_RDWR).toBe(fsSync.constants.O_RDWR);
+      expect(Number(flags) & (fsSync.constants.O_CREAT | fsSync.constants.O_TRUNC)).toBe(0);
+      const chmod = handle.chmod.bind(handle);
+      const sync = handle.sync.bind(handle);
+      const close = handle.close.bind(handle);
+      vi.spyOn(handle, "chmod").mockImplementation(async (value) => {
+        operations.push("chmod");
+        await chmod(value);
+      });
+      vi.spyOn(handle, "sync").mockImplementation(async () => {
+        operations.push("file-sync");
+        await sync();
+      });
+      vi.spyOn(handle, "close").mockImplementation(async () => {
+        closed++;
+        operations.push("close");
+        await close();
+      });
+    } else if (candidate === f.dir) {
+      const sync = handle.sync.bind(handle);
+      vi.spyOn(handle, "sync").mockImplementation(async () => {
+        operations.push("parent-sync");
+        await sync();
+      });
+    }
+    return handle;
+  });
+  vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+    operations.push("rename");
+    const descriptor = fsSync.fstatSync(retained, { bigint: true });
+    expect((await fs.lstat(from, { bigint: true })).ino).toBe(descriptor.ino);
+    expect(Number(descriptor.mode & 0o777n)).toBe(mode ?? 0o600);
+    await rename(from, to);
+  });
+  const actual = await writeSiblingTempFile({ ...f.options, mode });
+  expect(actual.result).toBe(f.result);
+  expect(actual.filePath).toBe(f.final);
+  expect(operations).toEqual(["chmod", "file-sync", "rename", "parent-sync", "close"]);
+  expect(stageOpens).toBe(1);
+  expect(closed).toBe(1);
+  expect((await fs.stat(f.final)).mode & 0o777).toBe(mode ?? 0o600);
+  expect(() => fsSync.fstatSync(retained)).toThrow(expect.objectContaining({ code: "EBADF" }));
+});
+
+it("honors explicit sync opt-outs without opting out of identity or mode checks", async () => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  const syncs = vi.fn();
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    vi.spyOn(handle, "sync").mockImplementation(async () => { syncs(); });
+    return handle;
+  });
+  await writeSiblingTempFile({ ...f.options, syncTempFile: false, syncParentDir: false });
+  expect(syncs).not.toHaveBeenCalled();
+  expect(await fs.readFile(f.final, "utf8")).toBe("new");
+});
+
+it.each(["chmod", "sync"] as const)("propagates descriptor %s failures before publication and cleans the admitted stage", async (operation) => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  const failure = Object.assign(new Error(`${operation} failed`), { code: "EIO" });
+  let handle: FileHandle | undefined;
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const opened = await open(...args);
+    if (args[0] === f.temp()) {
+      handle = opened;
+      vi.spyOn(opened, operation).mockRejectedValue(failure);
+    }
+    return opened;
+  });
+  await expect(writeSiblingTempFile(f.options)).rejects.toBe(failure);
+  expect(await fs.readFile(f.final, "utf8")).toBe("old");
+  await expect(fs.lstat(f.temp())).rejects.toMatchObject({ code: "ENOENT" });
+  expect(handle?.fd).toBe(-1);
+});
+
+it("retains the existing EPERM file-sync exception", async () => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === f.temp()) vi.spyOn(handle, "sync").mockRejectedValue(Object.assign(new Error("unsupported"), { code: "EPERM" }));
+    return handle;
+  });
+  await writeSiblingTempFile(f.options);
+  expect(await fs.readFile(f.final, "utf8")).toBe("new");
+});
+
+itPosix("keeps parent sync best-effort but still verifies the published name afterward", async () => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === f.dir) vi.spyOn(handle, "sync").mockRejectedValue(Object.assign(new Error("sync failed"), { code: "EIO" }));
+    return handle;
+  });
+  await writeSiblingTempFile(f.options);
+  expect(await fs.readFile(f.final, "utf8")).toBe("new");
+});
+
+itPosix("detects a published replacement during parent fsync without chmod or rollback", async () => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === f.dir) vi.spyOn(handle, "sync").mockImplementation(async () => {
+      await fs.rename(f.final, path.join(f.dir, "moved"));
+      await fs.writeFile(f.final, "replacement", { mode: 0o644 });
+    });
+    return handle;
+  });
+  await expect(writeSiblingTempFile(f.options)).rejects.toMatchObject({ code: "path-mismatch" });
+  expect(await fs.readFile(f.final, "utf8")).toBe("replacement");
+  expect((await fs.stat(f.final)).mode & 0o777).toBe(0o644);
+});
+
+it.each(["unchanged", "replaced", "hardlinked"] as const)("bounds cleanup retries to the admitted single-link identity (%s)", async (state) => {
+  const f = await fixture();
+  const rename = fs.rename.bind(fs);
+  vi.spyOn(fs, "rename").mockRejectedValue(Object.assign(new Error("denied"), { code: "EACCES" }));
+  vi.spyOn(fs, "unlink").mockRejectedValue(Object.assign(new Error("busy"), { code: "EBUSY" }));
+  await expect(writeSiblingTempFile(f.options)).rejects.toMatchObject({ code: "EACCES" });
+  expect(await fs.readFile(f.temp(), "utf8")).toBe("new");
+  if (state === "replaced") {
+    await rename(f.temp(), path.join(f.dir, "moved"));
+    await fs.writeFile(f.temp(), "replacement");
+  } else if (state === "hardlinked") await fs.link(f.temp(), path.join(f.dir, "alias"));
+  __cleanupRegisteredTempPathsForTest();
+  if (state === "unchanged") await expect(fs.lstat(f.temp())).rejects.toMatchObject({ code: "ENOENT" });
+  else expect(await fs.readFile(f.temp(), "utf8")).toBe(state === "replaced" ? "replacement" : "new");
+  expect(await fs.readFile(f.final, "utf8")).toBe("old");
+});
+
+it("preserves a replacement appearing after cleanup starts", async () => {
+  const f = await fixture();
+  const rename = fs.rename.bind(fs);
+  const open = fs.open.bind(fs);
+  let cleanup = false;
+  vi.spyOn(fs, "rename").mockImplementation(async () => {
+    cleanup = true;
+    throw Object.assign(new Error("denied"), { code: "EACCES" });
+  });
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === f.temp()) {
+      const stat = handle.stat.bind(handle);
+      vi.spyOn(handle, "stat").mockImplementation(async (options) => {
+        if (cleanup) {
+          cleanup = false;
+          await rename(f.temp(), path.join(f.dir, "moved"));
+          await fs.mkdir(f.temp());
+          await fs.writeFile(path.join(f.temp(), "sentinel"), "keep");
+        }
+        return await stat(options);
+      });
+    }
+    return handle;
+  });
+  await expect(writeSiblingTempFile(f.options)).rejects.toMatchObject({ code: "EACCES" });
+  __cleanupRegisteredTempPathsForTest();
+  expect(await fs.readFile(path.join(f.temp(), "sentinel"), "utf8")).toBe("keep");
+});
+
+itPosix("applies the directory mode through a descriptor and preserves chmodDir:false", async () => {
+  const f = await fixture();
+  await fs.chmod(f.dir, 0o755);
+  const chmod = vi.spyOn(fs, "chmod").mockRejectedValue(new Error("path chmod forbidden"));
+  await writeSiblingTempFile(f.options);
+  expect((await fs.stat(f.dir)).mode & 0o777).toBe(0o755);
+  await writeSiblingTempFile({ ...f.options, chmodDir: true });
+  expect((await fs.stat(f.dir)).mode & 0o777).toBe(0o700);
+  expect(chmod).not.toHaveBeenCalled();
+});
+
+it("preserves both an operation error and a descriptor-close error", async () => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  const failure = new Error("sync failed");
+  const closeFailure = new Error("close failed");
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === f.temp()) {
+      const close = handle.close.bind(handle);
+      vi.spyOn(handle, "sync").mockRejectedValue(failure);
+      vi.spyOn(handle, "close").mockImplementation(async () => {
+        await close();
+        throw closeFailure;
+      });
+    }
+    return handle;
+  });
+  await expect(writeSiblingTempFile(f.options)).rejects.toMatchObject({ errors: [failure, closeFailure] });
+  expect(await fs.readFile(f.final, "utf8")).toBe("old");
+  await expect(fs.lstat(f.temp())).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+it("validates resolver output before descriptor mutation and rejects its own temp name", async () => {
+  const f = await fixture();
+  await expect(writeSiblingTempFile({
+    ...f.options,
+    resolveFinalPath: () => f.temp(),
+  })).rejects.toMatchObject({ code: "invalid-path" });
+  await expect(fs.lstat(f.temp())).rejects.toMatchObject({ code: "ENOENT" });
+  expect(await fs.readFile(f.final, "utf8")).toBe("old");
+});

--- a/test/sibling-temp-durability.test.ts
+++ b/test/sibling-temp-durability.test.ts
@@ -2,6 +2,7 @@ import fsSync from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
+import { writeExternalFileViaSibling } from "../src/output-sibling.js";
 import { writeSiblingTempFile } from "../src/sibling-temp.js";
 import { __cleanupRegisteredTempPathsForTest } from "../src/temp-cleanup.js";
 import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
@@ -21,8 +22,14 @@ async function fixture() {
   const options = {
     dir, chmodDir: false,
     writeTemp: async (candidate: string) => {
+      const producer = await fs.open(candidate, "wx");
+      try {
+        await producer.writeFile("new");
+        await producer.chmod(0o640);
+      } finally {
+        await producer.close();
+      }
       temporary = candidate;
-      await fs.writeFile(candidate, "new", { mode: 0o644 });
       return result;
     },
     resolveFinalPath: (value: typeof result) => path.join(dir, value.filename),
@@ -30,7 +37,7 @@ async function fixture() {
   return { dir, final, options, result, temp: () => temporary };
 }
 
-itPosix.each([undefined, 0, 0o640])("retains one writable descriptor for mode %s, fsync, rename and verification", async (mode) => {
+itPosix.each([undefined, 0, 0o600])("retains producer mode or applies explicit mode %s with opt-in fsync", async (mode) => {
   const f = await fixture();
   const operations: string[] = [];
   const open = fs.open.bind(fs);
@@ -75,20 +82,27 @@ itPosix.each([undefined, 0, 0o640])("retains one writable descriptor for mode %s
     operations.push("rename");
     const descriptor = fsSync.fstatSync(retained, { bigint: true });
     expect((await fs.lstat(from, { bigint: true })).ino).toBe(descriptor.ino);
-    expect(Number(descriptor.mode & 0o777n)).toBe(mode ?? 0o600);
+    expect(Number(descriptor.mode & 0o777n)).toBe(mode ?? 0o640);
     await rename(from, to);
   });
-  const actual = await writeSiblingTempFile({ ...f.options, mode });
+  const actual = await writeSiblingTempFile({
+    ...f.options,
+    ...(mode === undefined ? {} : { mode }),
+    syncTempFile: true,
+    syncParentDir: true,
+  });
   expect(actual.result).toBe(f.result);
   expect(actual.filePath).toBe(f.final);
-  expect(operations).toEqual(["chmod", "file-sync", "rename", "parent-sync", "close"]);
+  expect(operations).toEqual([
+    ...(mode === undefined ? [] : ["chmod"]), "file-sync", "rename", "parent-sync", "close",
+  ]);
   expect(stageOpens).toBe(1);
   expect(closed).toBe(1);
-  expect((await fs.stat(f.final)).mode & 0o777).toBe(mode ?? 0o600);
+  expect((await fs.stat(f.final)).mode & 0o777).toBe(mode ?? 0o640);
   expect(() => fsSync.fstatSync(retained)).toThrow(expect.objectContaining({ code: "EBADF" }));
 });
 
-it("honors explicit sync opt-outs without opting out of identity or mode checks", async () => {
+it.each([undefined, false] as const)("skips both syncs when options are %s", async (sync) => {
   const f = await fixture();
   const open = fs.open.bind(fs);
   const syncs = vi.fn();
@@ -97,8 +111,56 @@ it("honors explicit sync opt-outs without opting out of identity or mode checks"
     vi.spyOn(handle, "sync").mockImplementation(async () => { syncs(); });
     return handle;
   });
-  await writeSiblingTempFile({ ...f.options, syncTempFile: false, syncParentDir: false });
+  await writeSiblingTempFile({
+    ...f.options,
+    ...(sync === undefined ? {} : { syncTempFile: sync, syncParentDir: sync }),
+  });
   expect(syncs).not.toHaveBeenCalled();
+  expect(await fs.readFile(f.final, "utf8")).toBe("new");
+});
+
+itPosix("preserves group-readable producer mode when output-sibling mode is omitted", async () => {
+  const f = await fixture();
+  await writeExternalFileViaSibling({ finalPath: f.final, write: f.options.writeTemp });
+  expect((await fs.stat(f.final)).mode & 0o777).toBe(0o640);
+  expect(await fs.readFile(f.final, "utf8")).toBe("new");
+});
+
+it.each([undefined, false] as const)("still rejects an identity swap when sync options are %s", async (sync) => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === f.temp()) {
+      await fs.rename(f.temp(), path.join(f.dir, "moved"));
+      await fs.writeFile(f.temp(), "replacement");
+    }
+    return handle;
+  });
+  await expect(writeSiblingTempFile({
+    ...f.options,
+    ...(sync === undefined ? {} : { syncTempFile: sync, syncParentDir: sync }),
+  })).rejects.toMatchObject({ code: "path-mismatch" });
+  expect(await fs.readFile(f.temp(), "utf8")).toBe("replacement");
+  expect(await fs.readFile(f.final, "utf8")).toBe("old");
+});
+
+itPosix.each(["file", "parent"] as const)("enables only the explicitly requested %s sync", async (requested) => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  const synced: string[] = [];
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    vi.spyOn(handle, "sync").mockImplementation(async () => {
+      synced.push(args[0] === f.dir ? "parent" : "file");
+    });
+    return handle;
+  });
+  await writeSiblingTempFile({
+    ...f.options,
+    ...(requested === "file" ? { syncTempFile: true } : { syncParentDir: true }),
+  });
+  expect(synced).toEqual([requested]);
   expect(await fs.readFile(f.final, "utf8")).toBe("new");
 });
 
@@ -115,7 +177,7 @@ it.each(["chmod", "sync"] as const)("propagates descriptor %s failures before pu
     }
     return opened;
   });
-  await expect(writeSiblingTempFile(f.options)).rejects.toBe(failure);
+  await expect(writeSiblingTempFile({ ...f.options, mode: 0o600, syncTempFile: true })).rejects.toBe(failure);
   expect(await fs.readFile(f.final, "utf8")).toBe("old");
   await expect(fs.lstat(f.temp())).rejects.toMatchObject({ code: "ENOENT" });
   expect(handle?.fd).toBe(-1);
@@ -129,7 +191,7 @@ it("retains the existing EPERM file-sync exception", async () => {
     if (args[0] === f.temp()) vi.spyOn(handle, "sync").mockRejectedValue(Object.assign(new Error("unsupported"), { code: "EPERM" }));
     return handle;
   });
-  await writeSiblingTempFile(f.options);
+  await writeSiblingTempFile({ ...f.options, syncTempFile: true });
   expect(await fs.readFile(f.final, "utf8")).toBe("new");
 });
 
@@ -141,7 +203,7 @@ itPosix("keeps parent sync best-effort but still verifies the published name aft
     if (args[0] === f.dir) vi.spyOn(handle, "sync").mockRejectedValue(Object.assign(new Error("sync failed"), { code: "EIO" }));
     return handle;
   });
-  await writeSiblingTempFile(f.options);
+  await writeSiblingTempFile({ ...f.options, syncParentDir: true });
   expect(await fs.readFile(f.final, "utf8")).toBe("new");
 });
 
@@ -156,7 +218,7 @@ itPosix("detects a published replacement during parent fsync without chmod or ro
     });
     return handle;
   });
-  await expect(writeSiblingTempFile(f.options)).rejects.toMatchObject({ code: "path-mismatch" });
+  await expect(writeSiblingTempFile({ ...f.options, syncParentDir: true })).rejects.toMatchObject({ code: "path-mismatch" });
   expect(await fs.readFile(f.final, "utf8")).toBe("replacement");
   expect((await fs.stat(f.final)).mode & 0o777).toBe(0o644);
 });
@@ -236,7 +298,7 @@ it("preserves both an operation error and a descriptor-close error", async () =>
     }
     return handle;
   });
-  await expect(writeSiblingTempFile(f.options)).rejects.toMatchObject({ errors: [failure, closeFailure] });
+  await expect(writeSiblingTempFile({ ...f.options, syncTempFile: true })).rejects.toMatchObject({ errors: [failure, closeFailure] });
   expect(await fs.readFile(f.final, "utf8")).toBe("old");
   await expect(fs.lstat(f.temp())).rejects.toMatchObject({ code: "ENOENT" });
 });

--- a/test/sibling-temp-platform.test.ts
+++ b/test/sibling-temp-platform.test.ts
@@ -1,0 +1,130 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { writeSiblingTempFile, writeViaSiblingTempPath } from "../src/sibling-temp.js";
+import { __cleanupRegisteredTempPathsForTest } from "../src/temp-cleanup.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  __cleanupRegisteredTempPathsForTest();
+});
+
+it.each(["known", "transient-unknown", "unknown", "rounded-replacement"] as const)(
+  "uses exact fail-closed Windows identity checks (%s)", async (state) => {
+    const dir = await tempRoot("fs-safe-sibling-windows-");
+    const final = path.join(dir, "final");
+    await fs.writeFile(final, "old");
+    let temporary = "";
+    let opened = false;
+    let inspections = 0;
+    const open = fs.open.bind(fs);
+    const lstat = fs.lstat.bind(fs);
+    const originalIno = 2n ** 53n;
+    const replacementIno = originalIno + 1n;
+    expect(Number(originalIno)).toBe(Number(replacementIno));
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.spyOn(fs, "lstat").mockImplementation(async (candidate, options) => {
+      const stat = await lstat(candidate, options);
+      if ((candidate === temporary || candidate === final) && options?.bigint) {
+        inspections++;
+        const unknown = state === "unknown" || (state === "transient-unknown" && inspections === 1);
+        return Object.assign(stat, {
+          dev: unknown ? 0n : 1n,
+          ino: unknown ? 0n : state === "rounded-replacement" && opened ? replacementIno : originalIno,
+        });
+      }
+      return stat;
+    });
+    const chmod = vi.spyOn(fs, "chmod");
+    vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
+      if (candidate === dir) throw Object.assign(new Error("directory open unsupported"), { code: "EISDIR" });
+      const handle = await open(candidate, flags, mode);
+      if (candidate === temporary) {
+        expect(flags).toBe(fsSync.constants.O_RDWR);
+        opened = true;
+        const stat = handle.stat.bind(handle);
+        vi.spyOn(handle, "stat").mockImplementation(async (options) => {
+          return Object.assign(await stat(options), { dev: 1n, ino: originalIno });
+        });
+        if (state === "rounded-replacement") {
+          await fs.rename(temporary, path.join(dir, "moved"));
+          await fs.writeFile(temporary, "replacement");
+        }
+      }
+      return handle;
+    });
+    const operation = writeSiblingTempFile({
+      dir,
+      writeTemp: async (candidate) => {
+        temporary = candidate;
+        await fs.writeFile(candidate, "new");
+      },
+      resolveFinalPath: () => final,
+    });
+    if (state === "known" || state === "transient-unknown") {
+      await operation;
+      expect(await fs.readFile(final, "utf8")).toBe("new");
+    } else {
+      await expect(operation).rejects.toMatchObject({ code: "path-mismatch" });
+      expect(await fs.readFile(final, "utf8")).toBe("old");
+      expect(await fs.readFile(temporary, "utf8")).toBe(state === "unknown" ? "new" : "replacement");
+      if (state === "unknown") {
+        expect(inspections).toBe(2);
+        expect(opened).toBe(false);
+      }
+    }
+    expect(chmod).not.toHaveBeenCalled();
+  },
+);
+
+it("preserves the original and replacement parent when the callback replaces the directory", async () => {
+  const dir = await tempRoot("fs-safe-sibling-parent-");
+  const parent = path.join(dir, "parent");
+  const moved = path.join(dir, "moved");
+  await fs.mkdir(parent);
+  let name = "";
+  await expect(writeSiblingTempFile({
+    dir: parent,
+    writeTemp: async (temporary) => {
+      name = path.basename(temporary);
+      await fs.writeFile(temporary, "producer");
+      await fs.rename(parent, moved);
+      await fs.mkdir(parent);
+      await fs.writeFile(path.join(parent, name), "replacement");
+    },
+    resolveFinalPath: () => path.join(parent, "final"),
+  })).rejects.toMatchObject({ code: "path-mismatch" });
+  __cleanupRegisteredTempPathsForTest();
+  expect(await fs.readFile(path.join(parent, name), "utf8")).toBe("replacement");
+  expect(await fs.readFile(path.join(moved, name), "utf8")).toBe("producer");
+});
+
+it("cleans only the original private workspace identity in writeViaSiblingTempPath", async () => {
+  const rootDir = await tempRoot("fs-safe-sibling-workspace-");
+  let workspace = "";
+  let moved = "";
+  try {
+    await expect(writeViaSiblingTempPath({
+      rootDir,
+      targetPath: path.join(rootDir, "final"),
+      writeTemp: async (temporary) => {
+        workspace = path.dirname(temporary);
+        moved = `${workspace}-moved`;
+        await fs.writeFile(temporary, "producer");
+        await fs.rename(workspace, moved);
+        await fs.mkdir(workspace);
+        await fs.writeFile(path.join(workspace, "sentinel"), "keep");
+        throw new Error("producer failed");
+      },
+    })).rejects.toThrow("producer failed");
+    __cleanupRegisteredTempPathsForTest();
+    expect(await fs.readFile(path.join(workspace, "sentinel"), "utf8")).toBe("keep");
+    await expect(fs.lstat(path.join(rootDir, "final"))).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    if (workspace) await fs.rm(workspace, { recursive: true, force: true });
+    if (moved) await fs.rm(moved, { recursive: true, force: true });
+  }
+});

--- a/test/sibling-temp-publication.test.ts
+++ b/test/sibling-temp-publication.test.ts
@@ -1,0 +1,235 @@
+import { execFile } from "node:child_process";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { writeExternalFileViaSibling } from "../src/output-sibling.js";
+import { writeSiblingTempFile } from "../src/sibling-temp.js";
+import { __cleanupRegisteredTempPathsForTest } from "../src/temp-cleanup.js";
+import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+beforeEach(() => configureFsSafeNative({ mode: "off" }));
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetFsSafeNativeConfigForTest();
+  __cleanupRegisteredTempPathsForTest();
+});
+
+for (const api of ["temp", "output"] as const) {
+  describe(`${api} sibling admission and publication (native off)`, () => {
+    async function fixture() {
+      const dir = await tempRoot("fs-safe-sibling-publication-");
+      const outsideDir = await tempRoot("fs-safe-sibling-outside-");
+      const outside = path.join(outsideDir, "outside");
+      const final = path.join(dir, "final");
+      const moved = path.join(dir, "moved");
+      await fs.writeFile(outside, "outside", { mode: 0o644 });
+      await fs.writeFile(final, "old");
+      let temporary = "";
+      const run = (write: (candidate: string) => Promise<unknown>) => {
+        const produce = async (candidate: string) => {
+          temporary = candidate;
+          return await write(candidate);
+        };
+        return api === "temp"
+          ? writeSiblingTempFile({ dir, chmodDir: false, mode: 0o600,
+              writeTemp: produce, resolveFinalPath: () => final })
+          : writeExternalFileViaSibling({ finalPath: final, mode: 0o600, write: produce });
+      };
+      return { dir, outside, final, moved, run, temp: () => temporary };
+    }
+
+    for (const kind of ["directory", "hardlink", "symlink", "fifo"] as const) {
+      const test = kind === "fifo" || kind === "symlink" ? itPosix : it;
+      test(`rejects callback ${kind} substitution without touching the replacement`, async () => {
+        const f = await fixture();
+        const before = await fs.lstat(f.outside, { bigint: true });
+        let replacement: fsSync.BigIntStats;
+        const realRename = fs.rename.bind(fs);
+        const rename = vi.spyOn(fs, "rename");
+        const chmod = vi.spyOn(fs, "chmod");
+        const code = kind === "symlink" ? "symlink" : kind === "hardlink" ? "hardlink" : "not-file";
+        await expect(f.run(async (candidate) => {
+          await fs.writeFile(candidate, "producer");
+          await realRename(candidate, f.moved);
+          if (kind === "directory") {
+            await fs.mkdir(candidate);
+            await fs.writeFile(path.join(candidate, "sentinel"), "keep");
+          } else if (kind === "hardlink") await fs.link(f.outside, candidate);
+          else if (kind === "symlink") await fs.symlink(f.outside, candidate);
+          else await promisify(execFile)("mkfifo", [candidate]);
+          replacement = await fs.lstat(candidate, { bigint: true });
+        })).rejects.toMatchObject({ code });
+        __cleanupRegisteredTempPathsForTest();
+        expect(await fs.lstat(f.temp(), { bigint: true })).toMatchObject({
+          dev: replacement!.dev, ino: replacement!.ino, mode: replacement!.mode,
+        });
+        expect(await fs.readFile(f.outside, "utf8")).toBe("outside");
+        expect((await fs.lstat(f.outside, { bigint: true })).mode).toBe(before.mode);
+        expect(await fs.readFile(f.final, "utf8")).toBe("old");
+        if (kind === "directory") expect(await fs.readFile(path.join(f.temp(), "sentinel"), "utf8")).toBe("keep");
+        expect(rename).not.toHaveBeenCalled();
+        expect(chmod).not.toHaveBeenCalled();
+      });
+    }
+
+    it.each(["before-open", "after-open"] as const)(
+      "rejects a same-name regular replacement %s before mode or publication", async (timing) => {
+        const f = await fixture();
+        const open = fs.open.bind(fs);
+        let retained = -1;
+        vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
+          if (candidate !== f.temp()) return await open(candidate, flags, mode);
+          const replace = async () => {
+            await fs.rename(f.temp(), f.moved);
+            await fs.writeFile(f.temp(), "replacement", { mode: 0o644 });
+          };
+          if (timing === "before-open") await replace();
+          const handle = await open(candidate, flags, mode);
+          retained = handle.fd;
+          if (timing === "after-open") await replace();
+          return handle;
+        });
+        await expect(f.run(async (candidate) => fs.writeFile(candidate, "producer")))
+          .rejects.toMatchObject({ code: "path-mismatch" });
+        __cleanupRegisteredTempPathsForTest();
+        expect(await fs.readFile(f.temp(), "utf8")).toBe("replacement");
+        if (process.platform !== "win32") expect((await fs.stat(f.temp())).mode & 0o777).toBe(0o644);
+        expect(await fs.readFile(f.final, "utf8")).toBe("old");
+        expect(() => fsSync.fstatSync(retained)).toThrow(expect.objectContaining({ code: "EBADF" }));
+      },
+    );
+
+    itPosix("does not block or adopt a FIFO swapped in between lstat and open", async () => {
+      const f = await fixture();
+      const open = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
+        if (candidate === f.temp()) {
+          expect(Number(flags) & fsSync.constants.O_NONBLOCK).not.toBe(0);
+          expect(Number(flags) & fsSync.constants.O_NOFOLLOW).not.toBe(0);
+          await fs.rename(f.temp(), f.moved);
+          await promisify(execFile)("mkfifo", [f.temp()]);
+        }
+        return await open(candidate, flags, mode);
+      });
+      await expect(f.run(async (candidate) => fs.writeFile(candidate, "producer")))
+        .rejects.toMatchObject({ code: "not-file" });
+      expect((await fs.lstat(f.temp())).isFIFO()).toBe(true);
+      expect(await fs.readFile(f.final, "utf8")).toBe("old");
+    });
+
+    itPosix("rejects a symlink swapped in at open without touching its referent", async () => {
+      const f = await fixture();
+      const open = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
+        if (candidate === f.temp()) {
+          await fs.rename(f.temp(), f.moved);
+          await fs.symlink(f.outside, f.temp());
+        }
+        return await open(candidate, flags, mode);
+      });
+      await expect(f.run(async (candidate) => fs.writeFile(candidate, "producer")))
+        .rejects.toMatchObject({ code: "symlink" });
+      expect((await fs.lstat(f.temp())).isSymbolicLink()).toBe(true);
+      expect(await fs.readFile(f.outside, "utf8")).toBe("outside");
+      expect((await fs.stat(f.outside)).mode & 0o777).toBe(0o644);
+      expect(await fs.readFile(f.final, "utf8")).toBe("old");
+    });
+
+    it.each(["sync", "rename"] as const)("rejects a hardlink added during %s and preserves both names", async (phase) => {
+      const f = await fixture();
+      const alias = path.join(path.dirname(f.outside), "alias");
+      const open = fs.open.bind(fs);
+      const rename = fs.rename.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const handle = await open(...args);
+        if (args[0] === f.temp() && phase === "sync") {
+          vi.spyOn(handle, "sync").mockImplementation(async () => { await fs.link(f.temp(), alias); });
+        }
+        return handle;
+      });
+      vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+        await rename(from, to);
+        if (from === f.temp() && phase === "rename") await fs.link(f.final, alias);
+      });
+      await expect(f.run(async (candidate) => fs.writeFile(candidate, "producer")))
+        .rejects.toMatchObject({ code: "hardlink" });
+      __cleanupRegisteredTempPathsForTest();
+      const stage = phase === "sync" ? f.temp() : f.final;
+      expect(await fs.readFile(stage, "utf8")).toBe("producer");
+      expect(await fs.readFile(alias, "utf8")).toBe("producer");
+      expect((await fs.stat(alias)).nlink).toBe(2);
+    });
+
+    it("rejects a replacement made during fsync and preserves it during cleanup", async () => {
+      const f = await fixture();
+      const open = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
+        const handle = await open(candidate, flags, mode);
+        if (candidate === f.temp()) {
+          vi.spyOn(handle, "sync").mockImplementation(async () => {
+            await fs.rename(f.temp(), f.moved);
+            await fs.writeFile(f.temp(), "replacement", { mode: 0o644 });
+          });
+        }
+        return handle;
+      });
+      await expect(f.run(async (candidate) => fs.writeFile(candidate, "producer")))
+        .rejects.toMatchObject({ code: "path-mismatch" });
+      __cleanupRegisteredTempPathsForTest();
+      expect(await fs.readFile(f.temp(), "utf8")).toBe("replacement");
+      expect(await fs.readFile(f.final, "utf8")).toBe("old");
+      if (process.platform !== "win32") expect((await fs.stat(f.temp())).mode & 0o777).toBe(0o644);
+    });
+
+    it("preserves a replacement installed by a failing rename", async () => {
+      const f = await fixture();
+      const rename = fs.rename.bind(fs);
+      vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+        if (from !== f.temp()) return await rename(from, to);
+        await rename(from, f.moved);
+        await fs.writeFile(f.temp(), "replacement");
+        throw Object.assign(new Error("rename failed"), { code: "EACCES" });
+      });
+      await expect(f.run(async (candidate) => fs.writeFile(candidate, "producer")))
+        .rejects.toMatchObject({ code: "EACCES" });
+      __cleanupRegisteredTempPathsForTest();
+      expect(await fs.readFile(f.temp(), "utf8")).toBe("replacement");
+      expect(await fs.readFile(f.final, "utf8")).toBe("old");
+    });
+
+    it("verifies the published identity and never cleans a final or recreated temp", async () => {
+      const f = await fixture();
+      const rename = fs.rename.bind(fs);
+      vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+        await rename(from, to);
+        if (from === f.temp()) {
+          await rename(f.final, f.moved);
+          await fs.writeFile(f.final, "published replacement", { mode: 0o644 });
+          await fs.writeFile(f.temp(), "new temp occupant", { mode: 0o644 });
+        }
+      });
+      await expect(f.run(async (candidate) => fs.writeFile(candidate, "producer")))
+        .rejects.toMatchObject({ code: "path-mismatch" });
+      __cleanupRegisteredTempPathsForTest();
+      expect(await fs.readFile(f.temp(), "utf8")).toBe("new temp occupant");
+      expect(await fs.readFile(f.final, "utf8")).toBe("published replacement");
+      if (process.platform !== "win32") expect((await fs.stat(f.final)).mode & 0o777).toBe(0o644);
+    });
+
+    it("preserves an unadmitted path when the callback throws", async () => {
+      const f = await fixture();
+      await expect(f.run(async (candidate) => {
+        await fs.mkdir(candidate);
+        await fs.writeFile(path.join(candidate, "sentinel"), "keep");
+        throw new Error("producer failed");
+      })).rejects.toThrow("producer failed");
+      __cleanupRegisteredTempPathsForTest();
+      expect(await fs.readFile(path.join(f.temp(), "sentinel"), "utf8")).toBe("keep");
+      expect(await fs.readFile(f.final, "utf8")).toBe("old");
+    });
+  });
+}

--- a/test/sibling-temp-publication.test.ts
+++ b/test/sibling-temp-publication.test.ts
@@ -35,7 +35,7 @@ for (const api of ["temp", "output"] as const) {
           return await write(candidate);
         };
         return api === "temp"
-          ? writeSiblingTempFile({ dir, chmodDir: false, mode: 0o600,
+          ? writeSiblingTempFile({ dir, chmodDir: false, mode: 0o600, syncTempFile: true, syncParentDir: true,
               writeTemp: produce, resolveFinalPath: () => final })
           : writeExternalFileViaSibling({ finalPath: final, mode: 0o600, write: produce });
       };


### PR DESCRIPTION
## Summary

- admit callback-produced sibling temps through one retained write-capable no-follow descriptor and exact bigint identity before any mode, sync, rename, or cleanup action
- reject symlink, directory/non-regular, hardlinked, oversized, unknown-identity, and replaced stages while preserving unverified callback paths and outside referents
- share the owner between `writeSiblingTempFile` and output-sibling publication, with descriptor mode/fsync, publication verification, and identity-bounded exit cleanup
- preserve producer-selected mode and disabled sync defaults when options are omitted, while applying explicit mode and opt-in file/parent sync through the retained owner

## Root cause

After the callback returned, sibling-temp publication trusted the generated pathname for chmod, reopen/sync, rename, and failure cleanup. A callback or concurrent actor could move the producer output and install a symlink, directory, FIFO, hardlink, or same-name replacement; later library operations could mutate, publish, block on, or delete that substitute.

Both callback-publication APIs now use one owner state machine: unadmitted pathname -> pre-open regular/single-link inspection -> retained read/write no-follow descriptor -> exact opened/current identity agreement -> requested descriptor mode and opt-in fsync -> serialized rename -> published-name identity verification -> close. No create or truncate flags are used during admission, and POSIX uses nonblocking open so FIFO substitution cannot hang the helper.

The final name is reverified through the retained descriptor after rename and after best-effort parent sync. A post-publication verification failure does not roll back or delete the final name. Failure cleanup only unlinks an admitted single-link regular file while parent, descriptor, and pathname identity still agree; observed replacements and all unadmitted callback output remain untouched and are removed from automatic cleanup authority.

## Live behavior proof

A fresh npm consumer installed the packed package and exercised the public `writeSiblingTempFile` API in native mode `off`:

```json
{"stable":{"result":{"filename":"stable.txt","token":7},"filePath":"stable.txt","content":"stable","mode":384,"events":["file-sync","rename"]},"producerModePreserved":{"content":"producer-mode","mode":416},"symlinkSubstitution":{"error":{"name":"FsSafeError","code":"symlink","message":"symlink sibling temp not allowed"},"tempIsSymlink":true,"outside":"outside","final":"old"},"directorySubstitution":{"error":{"name":"FsSafeError","code":"not-file","message":"sibling temp must be a regular file"},"retained":"keep","final":"old"}}
```

The explicit durability case synchronizes before rename, publishes at requested mode `0600`, and preserves the callback result. A second omitted-mode call preserves the producer's group-readable `0640`. Symlink and directory substitutions are rejected; both substitutes, the outside referent, and the previous final files remain unchanged.

## Verification

- focused sibling publication, compatibility, durability, platform, output, and stress suites: 7 files, 97 tests passed
- complete `CI=1 pnpm check`: 141 files passed, 1 skipped; 2,321 tests passed, 25 skipped; package/API validation passed
- build, docs examples, pack, file-size, filesystem-boundary, and diff checks passed
- fresh packed npm consumer proof passed
- Codex autoreview at P1: clean
- exact-head hosted Linux/macOS/Windows checks and ClawSweeper review remain the landing gate

## Compatibility and residual boundary

`writeSiblingTempFile` preserves historical defaults: omitted `mode` keeps the producer-selected permissions, and omitted sync options perform no file or parent sync. Explicit mode, `syncTempFile: true`, and `syncParentDir: true` use the retained owner; identity checks cannot be disabled. Default directory chmod remains best-effort only for the descriptor chmod call, while directory identity/open/type/close failures propagate. Callback failures and unadmitted outputs are intentionally preserved for caller-directed recovery instead of being deleted by pathname.

Identity checks and pathname rename/unlink remain separate syscalls. A hostile process can still change a leaf or parent in the final syscall gap or mutate bytes through another open descriptor. Use an approved writable directory plus cooperative locking or OS isolation when arbitrary concurrent namespace mutation is in scope. Parent sync remains best-effort rather than a strict durability receipt.
