### PR TITLE
fix(temp): publish read-only sibling output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Security and Correctness
 
-- Pin callback-produced sibling temps through requested mode application, opt-in fsync, rename, and exact publication checks; reject symlink, non-regular, hardlinked, and replaced stages and preserve unverified cleanup paths while retaining producer modes, disabled sync defaults, and best-effort directory chmod in `writeSiblingTempFile`.
+- Pin callback-produced sibling temps through requested mode application, opt-in fsync, rename, and exact publication checks; reject symlink, non-regular, hardlinked, and replaced stages and preserve unverified cleanup paths while retaining producer modes, disabled sync defaults, best-effort file and directory chmod, and read-only descriptor admission unless file sync is requested in `writeSiblingTempFile`.
 - Make durable queue directory creation, claims, acknowledgement, quarantine, marker cleanup, and retirement transitions fsync affected directories and propagate durability failures.
 - Fsync synchronous file-store temps before rename and parent directories after publication, matching the documented durability contract.
 - Reject invalid runtime archive `onFiltered` policies before extraction instead of treating unknown values as entry-skipping opt-in.

--- a/docs/temp.md
+++ b/docs/temp.md
@@ -212,8 +212,10 @@ files, hardlinks, and changes between the pre-open pathname, opened descriptor,
 and current pathname are rejected. The callback must finish and close its
 writer before returning. Its return value is preserved as `result`.
 
-The helper retains one write-capable descriptor through requested mode application,
-opt-in file synchronization, rename, and publication verification. Omitting
+The helper retains one descriptor through requested mode application, opt-in
+file synchronization, rename, and publication verification. It opens read-only
+unless file synchronization is requested, so closed read-only producer output
+remains publishable under the historical default. Omitting
 `mode` preserves the callback-produced mode without chmod; explicit modes,
 including `0`, are applied through that descriptor. File-mode errors are
 tolerated for compatibility with the helper's historical best-effort behavior.

--- a/src/sibling-staged-file.ts
+++ b/src/sibling-staged-file.ts
@@ -31,6 +31,7 @@ async function inspectStage(inspect: () => Promise<BigIntStats>, expected?: BigI
 
 // Callback paths are not owned until all three admission observations agree.
 // Keep one descriptor and one exact identity through mode, sync, rename and cleanup.
+// Read/write access is needed only when the caller requests file synchronization.
 export async function writeCallbackSibling<T>(params: {
   tempPath: string;
   write: (tempPath: string) => Promise<T>;
@@ -74,7 +75,8 @@ export async function writeCallbackSibling<T>(params: {
     const before = await inspectPath(params.tempPath);
     try {
       // No create/truncate flags; O_NONBLOCK also bounds a FIFO swap during open.
-      handle = await fs.open(params.tempPath, fsSync.constants.O_RDWR | resolveReadOpenFlags());
+      const access = params.syncTempFile ? fsSync.constants.O_RDWR : fsSync.constants.O_RDONLY;
+      handle = await fs.open(params.tempPath, access | resolveReadOpenFlags());
     } catch (error) {
       if ((error as NodeJS.ErrnoException)?.code === "ELOOP") {
         throw new FsSafeError("symlink", "symlink sibling temp not allowed", { cause: error });

--- a/test/sibling-temp-durability.test.ts
+++ b/test/sibling-temp-durability.test.ts
@@ -119,6 +119,32 @@ it.each([undefined, false] as const)("skips both syncs when options are %s", asy
   expect(await fs.readFile(f.final, "utf8")).toBe("new");
 });
 
+itPosix.each([
+  ["omitted", undefined],
+  ["explicit", 0o600],
+] as const)("publishes closed read-only producer output with %s mode", async (_label, mode) => {
+  const f = await fixture();
+  const open = fs.open.bind(fs);
+  let retainedFlags: number | undefined;
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === f.temp()) retainedFlags = Number(args[1]);
+    return handle;
+  });
+  await writeSiblingTempFile({
+    ...f.options,
+    writeTemp: async (candidate) => {
+      const result = await f.options.writeTemp(candidate);
+      await fs.chmod(candidate, 0o444);
+      return result;
+    },
+    ...(mode === undefined ? {} : { mode }),
+  });
+  expect(retainedFlags! & (fsSync.constants.O_WRONLY | fsSync.constants.O_RDWR)).toBe(0);
+  expect((await fs.stat(f.final)).mode & 0o777).toBe(mode ?? 0o444);
+  expect(await fs.readFile(f.final, "utf8")).toBe("new");
+});
+
 itPosix("preserves group-readable producer mode when output-sibling mode is omitted", async () => {
   const f = await fixture();
   await writeExternalFileViaSibling({ finalPath: f.final, write: f.options.writeTemp });

--- a/test/sibling-temp-platform.test.ts
+++ b/test/sibling-temp-platform.test.ts
@@ -43,7 +43,7 @@ it.each(["known", "transient-unknown", "unknown", "rounded-replacement"] as cons
       if (candidate === dir) throw Object.assign(new Error("directory open unsupported"), { code: "EISDIR" });
       const handle = await open(candidate, flags, mode);
       if (candidate === temporary) {
-        expect(flags).toBe(fsSync.constants.O_RDWR);
+        expect(flags).toBe(fsSync.constants.O_RDONLY);
         opened = true;
         const stat = handle.stat.bind(handle);
         vi.spyOn(handle, "stat").mockImplementation(async (options) => {


### PR DESCRIPTION
## Summary

- retain callback-produced sibling files with read-only descriptor access unless `syncTempFile: true` requires a writable handle
- preserve descriptor-bound explicit chmod and exact identity checks while allowing closed `0444` producer output to publish under historical defaults
- cover omitted mode, explicit mode, Windows identity simulation, and the existing opt-in read/write sync path

## Root cause

The descriptor-pinning hardening in [PR #172](https://github.com/openclaw/fs-safe/pull/172) opened every admitted sibling temp with `O_RDWR`. Before that hardening, `writeSiblingTempFile` could publish a closed read-only regular file when file sync was omitted. A producer that intentionally finalized output at `0444` therefore began failing at admission with `EACCES`, even though the helper did not need write access for rename or identity checks.

The retained descriptor now uses read-only access by default and upgrades to read/write only when `syncTempFile: true`. Descriptor chmod remains available for explicit modes, and the existing opt-in sync tests continue to prove `O_RDWR` admission. No create, truncate, follow-symlink, identity, link-count, size, publication, or cleanup policy changes.

## Live behavior proof

A fresh npm consumer installed the packed package, disabled native mode, and exercised the public `writeSiblingTempFile` API:

```json
{"accessModes":[0,0,2],"preserved":{"content":"preserved","mode":292},"explicitMode":{"content":"changed","mode":384},"synced":{"content":"synced"}}
```

The omitted-mode `0444` producer publishes unchanged, explicit mode changes a read-only producer to `0600`, and opt-in file sync still opens read/write. The access-mode trace is `[O_RDONLY, O_RDONLY, O_RDWR]`.

## Verification

- focused sibling publication, durability, platform, output, and stress suites: 7 files, 98 tests passed
- complete `CI=1 pnpm check`: 141 files passed, 1 skipped; 2,322 tests passed, 25 skipped; package/API validation passed
- fresh packed npm consumer proof passed in native mode `off`
- two unrelated local timeout flakes (`store-stress` and archive property fuzz) each passed immediately in focused reruns before the final complete gate passed
- Codex autoreview at P1 and exact-head hosted Linux/macOS/Windows checks remain landing gates
