### PR TITLE
fix(atomic): retain staged file ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Retain async and sync atomic replacement temp descriptors across `beforeRename`, retries, copy fallback, and final publication; reject substituted, non-regular, or hardlinked stages and preserve unowned cleanup paths.
 - Pin callback-produced sibling temps through requested mode application, opt-in fsync, rename, and exact publication checks; reject symlink, non-regular, hardlinked, and replaced stages and preserve unverified cleanup paths while retaining producer modes, disabled sync defaults, best-effort file and directory chmod, and read-only descriptor admission unless file sync is requested in `writeSiblingTempFile`.
 - Make durable queue directory creation, claims, acknowledgement, quarantine, marker cleanup, and retirement transitions fsync affected directories and propagate durability failures.
 - Fsync synchronous file-store temps before rename and parent directories after publication, matching the documented durability contract.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Security and Correctness
 
-- Retain async and sync atomic replacement temp descriptors across `beforeRename`, retries, copy fallback, and final publication; reject substituted, non-regular, or hardlinked stages and preserve unowned cleanup paths.
+- Retain async and sync atomic replacement temp descriptors across `beforeRename`, retries, copy fallback, and final publication; reject substituted, non-regular, or hardlinked stages, preserve unowned cleanup paths, and add explicit locked content verification for rename-unstable FUSE mounts.
 - Pin callback-produced sibling temps through requested mode application, opt-in fsync, rename, and exact publication checks; reject symlink, non-regular, hardlinked, and replaced stages and preserve unverified cleanup paths while retaining producer modes, disabled sync defaults, best-effort file and directory chmod, and read-only descriptor admission unless file sync is requested in `writeSiblingTempFile`.
 - Make durable queue directory creation, claims, acknowledgement, quarantine, marker cleanup, and retirement transitions fsync affected directories and propagate durability failures.
 - Fsync synchronous file-store temps before rename and parent directories after publication, matching the documented durability contract.

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -58,7 +58,7 @@ type ReplaceFileAtomicOptions = {
 
 ### `beforeRename`
 
-Runs after the temp file is fully written and before the rename. Use it to take a backup snapshot, capture the about-to-be-replaced contents, or notify an observer:
+Runs after the temp file is fully written and before the rename. Use it to take a backup snapshot, capture the about-to-be-replaced contents, or notify an observer. The helper retains the staged descriptor and exact bigint identity across the hook; replacing, deleting, hardlinking, or changing the temp entry to a non-regular file is rejected before publication:
 
 ```ts
 await replaceFileAtomic({
@@ -70,7 +70,9 @@ await replaceFileAtomic({
 });
 ```
 
-If `beforeRename` throws, the rename is skipped and the temp file is removed — the destination is unchanged.
+If `beforeRename` throws, the rename is skipped and the owned temp file is removed — the destination is unchanged. Cleanup unlinks only the exact admitted single-link file; a substitute observed at the temp name is preserved and removed from cleanup authority. The same identity is rechecked before every rename retry, when entering copy fallback, and at the final name after rename. A post-rename verification failure reports the race without rolling back or deleting the published name.
+
+Identity checks and pathname rename/unlink remain separate syscalls, not atomic conditional mutations. Use an approved writable parent plus cooperative locking or OS isolation when arbitrary concurrent namespace mutation is in scope.
 
 ### `EPERM` and copy fallback
 

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -48,6 +48,7 @@ type ReplaceFileAtomicOptions = {
   copyFallbackRestore?: "restore-original" | "none"; // default: "none"
   maxRestoreBytes?: number;          // required with "restore-original"
   destinationHardlinks?: "reject"; // default unset (no destination nlink policy)
+  renameIdentity?: "strict" | "verify-content-with-lock"; // default "strict"
   syncTempFile?: boolean;           // fsync(temp) before rename, or the final file after copy fallback; default false
   syncParentDir?: boolean;          // fsync(parent) after rename, POSIX only; default false
   throwOnCleanupError?: boolean;    // report temp cleanup failure; default false
@@ -73,6 +74,12 @@ await replaceFileAtomic({
 If `beforeRename` throws, the rename is skipped and the owned temp file is removed — the destination is unchanged. Cleanup unlinks only the exact admitted single-link file; a substitute observed at the temp name is preserved and removed from cleanup authority. The same identity is rechecked before every rename retry, when entering copy fallback, and at the final name after rename. A post-rename verification failure reports the race without rolling back or deleting the published name.
 
 Identity checks and pathname rename/unlink remain separate syscalls, not atomic conditional mutations. Use an approved writable parent plus cooperative locking or OS isolation when arbitrary concurrent namespace mutation is in scope.
+
+### FUSE mounts and unstable rename identity
+
+Strict source-to-destination identity is the default. Some FUSE mounts assign a different inode to the destination during rename even without concurrency. Set `renameIdentity: "verify-content-with-lock"` to accept that boundary only when the re-opened no-follow destination has the exact requested SHA-256 content under an exclusive hashed sidecar lock in the destination parent. The newly accepted descriptor and identity remain pinned through parent sync and final verification. The synchronous helper provides the same policy with the synchronous lock implementation.
+
+This is the same explicit weaker contract available on `Root` writes: cooperating writers are serialized, stale locks fail closed, and mismatched content is rejected after publication without rollback. A same-authority actor that ignores the advisory lock can still substitute another file with identical bytes, so do not use this compatibility policy in directories writable by untrusted same-UID processes.
 
 ### `EPERM` and copy fallback
 

--- a/src/atomic.ts
+++ b/src/atomic.ts
@@ -1,6 +1,7 @@
 export {
   replaceFileAtomic,
   replaceFileAtomicSync,
+  type RenameIdentityPolicy,
   type ReplaceFileAtomicFileSystem,
   type ReplaceFileAtomicOptions,
   type ReplaceFileAtomicRestoreCleanup,

--- a/src/replace-file-copy-fallback.ts
+++ b/src/replace-file-copy-fallback.ts
@@ -1,7 +1,8 @@
-import syncFs, { type Stats } from "node:fs";
+import syncFs, { type BigIntStats, type Stats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
+import { readOwnedCopySource, readOwnedCopySourceSync } from "./replace-file-copy-source.js";
 
 export type ReplaceFileDestinationHardlinkPolicy = "reject";
 export type ReplaceFileCopyFallbackRestorePolicy = "restore-original" | "none";
@@ -309,22 +310,17 @@ export async function copyFallbackReplace(params: {
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
   restore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
+  expectedSourceIdentity?: BigIntStats;
   sync: boolean;
 }): Promise<void> {
-  const sourcePreview = await params.fsModule.lstat(params.src);
-  if (sourcePreview.isSymbolicLink() || !sourcePreview.isFile()) {
-    throw new Error(`Refusing copy fallback from non-file source: ${params.src}`);
-  }
-  const sourceHandle = await params.fsModule.open(params.src, OPEN_READ_FLAGS);
+  const source = await readOwnedCopySource({
+    fsModule: params.fsModule,
+    src: params.src,
+    expectedIdentity: params.expectedSourceIdentity,
+  });
+  const { replacement } = source;
   let destHandle: FileHandle | null = null;
   try {
-    const sourceStat = await sourceHandle.stat();
-    const sourceCurrent = await params.fsModule.lstat(params.src);
-    if (!sourceStat.isFile() || sourceCurrent.isSymbolicLink() || !sameFileIdentity(sourceStat, sourceCurrent)) {
-      throw new FsSafeError("path-mismatch", `Copy fallback source changed while opening: ${params.src}`);
-    }
-    const replacement = await sourceHandle.readFile();
-
     if (params.restore === "restore-original") {
       const pinned = await openPinnedDestination(
         params.fsModule,
@@ -337,7 +333,7 @@ export async function copyFallbackReplace(params: {
           destHandle,
           replacement,
           params.maxRestoreBytes!,
-          sourceStat.mode,
+          source.mode,
         );
       }
     }
@@ -361,17 +357,16 @@ export async function copyFallbackReplace(params: {
       destHandle = await params.fsModule.open(
         params.dest,
         OPEN_WRITE_EXCLUSIVE_FLAGS,
-        sourceStat.mode & 0o777,
+        source.mode & 0o777,
       );
       await destHandle.writeFile(replacement);
-      await destHandle.chmod(sourceStat.mode);
+      await destHandle.chmod(source.mode);
       if (params.sync) {
         await destHandle.sync();
       }
     }
   } finally {
     await destHandle?.close().catch(() => undefined);
-    await sourceHandle.close().catch(() => undefined);
   }
 }
 
@@ -382,23 +377,18 @@ export function copyFallbackReplaceSync(params: {
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
   restore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
+  expectedSourceIdentity?: BigIntStats;
   fchmodSync?: (fd: number, mode: number) => void;
   sync: boolean;
 }): void {
-  const sourcePreview = params.fsModule.lstatSync(params.src);
-  if (sourcePreview.isSymbolicLink() || !sourcePreview.isFile()) {
-    throw new Error(`Refusing copy fallback from non-file source: ${params.src}`);
-  }
-  const sourceFd = params.fsModule.openSync(params.src, OPEN_READ_FLAGS);
+  const source = readOwnedCopySourceSync({
+    fsModule: params.fsModule,
+    src: params.src,
+    expectedIdentity: params.expectedSourceIdentity,
+  });
+  const { replacement } = source;
   let destFd: number | undefined;
   try {
-    const sourceStat = params.fsModule.fstatSync(sourceFd);
-    const sourceCurrent = params.fsModule.lstatSync(params.src);
-    if (!sourceStat.isFile() || sourceCurrent.isSymbolicLink() || !sameFileIdentity(sourceStat, sourceCurrent)) {
-      throw new FsSafeError("path-mismatch", `Copy fallback source changed while opening: ${params.src}`);
-    }
-    const replacement = readBoundedSync(params.fsModule, sourceFd, Number.MAX_SAFE_INTEGER);
-
     if (params.restore === "restore-original") {
       const pinned = openPinnedDestinationSync(
         params.fsModule,
@@ -412,7 +402,7 @@ export function copyFallbackReplaceSync(params: {
           destFd,
           replacement,
           params.maxRestoreBytes!,
-          sourceStat.mode,
+          source.mode,
           params.fchmodSync,
         );
       }
@@ -439,10 +429,10 @@ export function copyFallbackReplaceSync(params: {
       destFd = params.fsModule.openSync(
         params.dest,
         OPEN_WRITE_EXCLUSIVE_FLAGS,
-        sourceStat.mode & 0o777,
+        source.mode & 0o777,
       );
       writeAllSync(params.fsModule, destFd, replacement);
-      params.fchmodSync?.(destFd, sourceStat.mode);
+      params.fchmodSync?.(destFd, source.mode);
       if (params.sync) {
         params.fsModule.fsyncSync(destFd);
       }
@@ -454,11 +444,6 @@ export function copyFallbackReplaceSync(params: {
       } catch {
         // Best-effort close after fallback replacement.
       }
-    }
-    try {
-      params.fsModule.closeSync(sourceFd);
-    } catch {
-      // Best-effort close after fallback replacement.
     }
   }
 }

--- a/src/replace-file-copy-source.ts
+++ b/src/replace-file-copy-source.ts
@@ -1,0 +1,141 @@
+import syncFs, { type BigIntStats } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import { FsSafeError } from "./errors.js";
+import { sameFileIdentity } from "./file-identity.js";
+import { inspectFileIdentity, inspectFileIdentitySync } from "./strict-file-identity.js";
+
+type AsyncSourceFileSystem = Pick<typeof import("node:fs/promises"), "lstat" | "open">;
+type SyncSourceFileSystem = Pick<
+  typeof syncFs,
+  "closeSync" | "fstatSync" | "lstatSync" | "openSync" | "readSync"
+>;
+
+const NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in syncFs.constants
+  ? syncFs.constants.O_NOFOLLOW
+  : 0;
+const NONBLOCK = process.platform !== "win32" && "O_NONBLOCK" in syncFs.constants
+  ? syncFs.constants.O_NONBLOCK
+  : 0;
+const OPEN_READ_FLAGS = syncFs.constants.O_RDONLY | NOFOLLOW | NONBLOCK;
+const READ_CHUNK_BYTES = 64 * 1024;
+
+function assertSourcePreview(source: import("node:fs").Stats, src: string): void {
+  if (source.isSymbolicLink()) {
+    throw new FsSafeError("symlink", `Refusing copy fallback from non-file source: ${src}`);
+  }
+  if (!source.isFile()) {
+    throw new FsSafeError("not-file", `Refusing copy fallback from non-file source: ${src}`);
+  }
+  if (source.nlink !== 1) {
+    throw new FsSafeError("hardlink", `Hardlinked copy fallback source not allowed: ${src}`);
+  }
+}
+
+function sourceSymlinkError(src: string, cause: unknown): FsSafeError {
+  return new FsSafeError("symlink", `Refusing copy fallback from non-file source: ${src}`, {
+    cause,
+  });
+}
+
+async function openSource(fsModule: AsyncSourceFileSystem, src: string): Promise<FileHandle> {
+  try {
+    return await fsModule.open(src, OPEN_READ_FLAGS);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+      throw sourceSymlinkError(src, error);
+    }
+    throw error;
+  }
+}
+
+function openSourceSync(fsModule: SyncSourceFileSystem, src: string): number {
+  try {
+    return fsModule.openSync(src, OPEN_READ_FLAGS);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+      throw sourceSymlinkError(src, error);
+    }
+    throw error;
+  }
+}
+
+function readAllSync(fsModule: SyncSourceFileSystem, fd: number): Buffer {
+  const chunks: Buffer[] = [];
+  let position = 0;
+  while (true) {
+    const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+    const bytesRead = fsModule.readSync(fd, buffer, 0, buffer.length, position);
+    if (bytesRead === 0) break;
+    position += bytesRead;
+    chunks.push(buffer.subarray(0, bytesRead));
+  }
+  return Buffer.concat(chunks, position);
+}
+
+export async function readOwnedCopySource(params: {
+  fsModule: AsyncSourceFileSystem;
+  src: string;
+  expectedIdentity?: BigIntStats;
+}): Promise<{ replacement: Buffer; mode: number }> {
+  assertSourcePreview(await params.fsModule.lstat(params.src), params.src);
+  const handle = await openSource(params.fsModule, params.src);
+  try {
+    if (params.expectedIdentity) {
+      const exact = await inspectFileIdentity(
+        () => handle.stat({ bigint: true }),
+        params.expectedIdentity,
+      );
+      await inspectFileIdentity(
+        () => params.fsModule.lstat(params.src, { bigint: true }),
+        exact,
+      );
+    }
+    const opened = await handle.stat();
+    const current = await params.fsModule.lstat(params.src);
+    if (!opened.isFile() || current.isSymbolicLink() || !sameFileIdentity(opened, current)) {
+      throw new FsSafeError("path-mismatch", `Copy fallback source changed while opening: ${params.src}`);
+    }
+    if (opened.nlink !== 1) {
+      throw new FsSafeError("hardlink", `Hardlinked copy fallback source not allowed: ${params.src}`);
+    }
+    return { replacement: await handle.readFile(), mode: opened.mode };
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
+export function readOwnedCopySourceSync(params: {
+  fsModule: SyncSourceFileSystem;
+  src: string;
+  expectedIdentity?: BigIntStats;
+}): { replacement: Buffer; mode: number } {
+  assertSourcePreview(params.fsModule.lstatSync(params.src), params.src);
+  const fd = openSourceSync(params.fsModule, params.src);
+  try {
+    if (params.expectedIdentity) {
+      const exact = inspectFileIdentitySync(
+        () => params.fsModule.fstatSync(fd, { bigint: true }),
+        params.expectedIdentity,
+      );
+      inspectFileIdentitySync(
+        () => params.fsModule.lstatSync(params.src, { bigint: true }),
+        exact,
+      );
+    }
+    const opened = params.fsModule.fstatSync(fd);
+    const current = params.fsModule.lstatSync(params.src);
+    if (!opened.isFile() || current.isSymbolicLink() || !sameFileIdentity(opened, current)) {
+      throw new FsSafeError("path-mismatch", `Copy fallback source changed while opening: ${params.src}`);
+    }
+    if (opened.nlink !== 1) {
+      throw new FsSafeError("hardlink", `Hardlinked copy fallback source not allowed: ${params.src}`);
+    }
+    return { replacement: readAllSync(params.fsModule, fd), mode: opened.mode };
+  } finally {
+    try {
+      params.fsModule.closeSync(fd);
+    } catch {
+      // Best-effort close after reading a copy-fallback source.
+    }
+  }
+}

--- a/src/replace-file-descriptor.ts
+++ b/src/replace-file-descriptor.ts
@@ -2,6 +2,7 @@ import syncFs, { type BigIntStats, type Stats } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
+import { inspectFileIdentity, inspectFileIdentitySync } from "./strict-file-identity.js";
 
 type AsyncTempFileSystem = Pick<typeof fs, "lstat" | "open" | "writeFile">;
 type SyncTempFileSystem = Pick<
@@ -92,9 +93,12 @@ export async function writeTempFile(params: {
   content: string | Uint8Array;
   mode: number;
   sync: boolean;
-}): Promise<BigIntStats> {
+  onIdentity?: (identity: BigIntStats) => void;
+}): Promise<{ handle: FileHandle; identity: BigIntStats }> {
   const handle = await params.fsModule.open(params.tempPath, "wx", params.mode);
   try {
+    const identity = await inspectFileIdentity(() => handle.stat({ bigint: true }));
+    params.onIdentity?.(identity);
     await params.fsModule.writeFile(handle, params.content);
     await handle.chmod(params.mode);
     if (params.sync) {
@@ -106,9 +110,15 @@ export async function writeTempFile(params: {
         }
       }
     }
-    return await handle.stat({ bigint: true });
-  } finally {
-    await handle.close();
+    await inspectFileIdentity(() => handle.stat({ bigint: true }), identity);
+    return { handle, identity };
+  } catch (error) {
+    try {
+      await handle.close();
+    } catch (closeError) {
+      throw new AggregateError([error, closeError], "Atomic temp write and close failed");
+    }
+    throw error;
   }
 }
 
@@ -119,9 +129,12 @@ export function writeTempFileSync(params: {
   mode: number;
   fchmodSync?: SyncFchmod;
   sync: boolean;
-}): BigIntStats {
+  onIdentity?: (identity: BigIntStats) => void;
+}): { fd: number; identity: BigIntStats } {
   const fd = params.fsModule.openSync(params.tempPath, "wx", params.mode);
   try {
+    const identity = inspectFileIdentitySync(() => params.fsModule.fstatSync(fd, { bigint: true }));
+    params.onIdentity?.(identity);
     params.fsModule.writeFileSync(fd, params.content);
     params.fchmodSync?.(fd, params.mode);
     if (params.sync) {
@@ -133,8 +146,14 @@ export function writeTempFileSync(params: {
         }
       }
     }
-    return params.fsModule.fstatSync(fd, { bigint: true });
-  } finally {
-    params.fsModule.closeSync(fd);
+    inspectFileIdentitySync(() => params.fsModule.fstatSync(fd, { bigint: true }), identity);
+    return { fd, identity };
+  } catch (error) {
+    try {
+      params.fsModule.closeSync(fd);
+    } catch (closeError) {
+      throw new AggregateError([error, closeError], "Atomic temp write and close failed");
+    }
+    throw error;
   }
 }

--- a/src/replace-file-rename-policy.ts
+++ b/src/replace-file-rename-policy.ts
@@ -1,0 +1,43 @@
+import path from "node:path";
+import { withFileLock, withFileLockSync } from "./file-lock.js";
+import { sha256Hex } from "./file-identity.js";
+import type { RenameIdentityPolicy } from "./pinned-write.js";
+
+export type { RenameIdentityPolicy };
+
+export function validateRenameIdentity(policy: RenameIdentityPolicy | undefined): void {
+  if (policy !== undefined && policy !== "strict" && policy !== "verify-content-with-lock") {
+    throw new RangeError("renameIdentity must be strict or verify-content-with-lock");
+  }
+}
+
+export function atomicExpectedContentHash(
+  policy: RenameIdentityPolicy | undefined,
+  content: string | Uint8Array,
+): string | undefined {
+  if (policy !== "verify-content-with-lock") return undefined;
+  return sha256Hex(typeof content === "string" ? content : Buffer.from(content));
+}
+
+function lockOptions(filePath: string) {
+  const resolved = path.resolve(filePath);
+  return {
+    managerKey: `fs-safe.atomic:${resolved}`,
+    lockPath: path.join(path.dirname(resolved), `.fs-safe-atomic-${sha256Hex(resolved)}.lock`),
+    staleMs: 30_000,
+    timeoutMs: 5_000,
+    payload: () => ({ pid: process.pid, createdAt: new Date().toISOString() }),
+    retry: { retries: 5, minTimeout: 100, maxTimeout: 2_000, factor: 2 },
+  } as const;
+}
+
+export async function withAtomicRenameIdentityLock<T>(
+  filePath: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return await withFileLock(filePath, lockOptions(filePath), fn);
+}
+
+export function withAtomicRenameIdentityLockSync<T>(filePath: string, fn: () => T): T {
+  return withFileLockSync(filePath, lockOptions(filePath), fn);
+}

--- a/src/replace-file-temp-owner.ts
+++ b/src/replace-file-temp-owner.ts
@@ -1,15 +1,24 @@
 import syncFs, { type BigIntStats } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
-import { sameFileIdentityForCleanup } from "./file-identity.js";
+import { sameFileIdentityForCleanup, sha256Hex } from "./file-identity.js";
 import { inspectFileIdentity, inspectFileIdentitySync } from "./strict-file-identity.js";
 import { registerTempPathForExit, type TempPathRegistration } from "./temp-cleanup.js";
 
-type AsyncOwnerFileSystem = Pick<typeof fs, "lstat" | "unlink">;
+type AsyncOwnerFileSystem = Pick<typeof fs, "lstat" | "open" | "unlink">;
 type SyncOwnerFileSystem = Pick<
   typeof syncFs,
-  "closeSync" | "fstatSync" | "lstatSync" | "unlinkSync"
+  "closeSync" | "fstatSync" | "lstatSync" | "openSync" | "readFileSync" | "unlinkSync"
 >;
+
+const PUBLISHED_READ_FLAGS =
+  syncFs.constants.O_RDONLY |
+  (process.platform !== "win32" && typeof syncFs.constants.O_NOFOLLOW === "number"
+    ? syncFs.constants.O_NOFOLLOW
+    : 0) |
+  (process.platform !== "win32" && typeof syncFs.constants.O_NONBLOCK === "number"
+    ? syncFs.constants.O_NONBLOCK
+    : 0);
 
 function assertOwnedFile(stat: BigIntStats, pathname: string, pathnameEntry: boolean): void {
   if (stat.isSymbolicLink()) {
@@ -148,6 +157,54 @@ export class AsyncAtomicTempOwner {
     }
   }
 
+  async assertPublished(
+    fsModule: AsyncOwnerFileSystem,
+    pathname: string,
+    expectedHash?: string,
+  ): Promise<void> {
+    try {
+      await this.assertCurrent(fsModule, pathname);
+      return;
+    } catch (error) {
+      if (!(error instanceof FsSafeError) || error.code !== "path-mismatch" || !expectedHash) {
+        throw error;
+      }
+    }
+
+    let published: FileHandle | undefined;
+    try {
+      try {
+        published = await fsModule.open(pathname, PUBLISHED_READ_FLAGS);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+          throw new FsSafeError("symlink", `Atomic replace published file became a symlink: ${pathname}`, {
+            cause: error,
+          });
+        }
+        throw error;
+      }
+      const identity = await inspectFileIdentity(async () => {
+        const stat = await published!.stat({ bigint: true });
+        assertOwnedFile(stat, pathname, false);
+        return stat;
+      });
+      await inspectFileIdentity(async () => {
+        const stat = await fsModule.lstat(pathname, { bigint: true });
+        assertOwnedFile(stat, pathname, true);
+        return stat;
+      }, identity);
+      if (sha256Hex(await published.readFile()) !== expectedHash) {
+        throw new FsSafeError("path-mismatch", `Atomic replace published content changed: ${pathname}`);
+      }
+      await this.#handle?.close();
+      this.#handle = published;
+      this.#identity = identity;
+      published = undefined;
+    } finally {
+      await published?.close().catch(() => undefined);
+    }
+  }
+
   markRenamed(): void {
     this.#exists = false;
     this.#unregister();
@@ -238,6 +295,60 @@ export class SyncAtomicTempOwner {
         throw missingOwnedFile(pathname, error);
       }
       throw error;
+    }
+  }
+
+  assertPublished(
+    fsModule: SyncOwnerFileSystem,
+    pathname: string,
+    expectedHash?: string,
+  ): void {
+    try {
+      this.assertCurrent(fsModule, pathname);
+      return;
+    } catch (error) {
+      if (!(error instanceof FsSafeError) || error.code !== "path-mismatch" || !expectedHash) {
+        throw error;
+      }
+    }
+
+    let publishedFd: number | undefined;
+    try {
+      try {
+        publishedFd = fsModule.openSync(pathname, PUBLISHED_READ_FLAGS);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+          throw new FsSafeError("symlink", `Atomic replace published file became a symlink: ${pathname}`, {
+            cause: error,
+          });
+        }
+        throw error;
+      }
+      const identity = inspectFileIdentitySync(() => {
+        const stat = fsModule.fstatSync(publishedFd!, { bigint: true });
+        assertOwnedFile(stat, pathname, false);
+        return stat;
+      });
+      inspectFileIdentitySync(() => {
+        const stat = fsModule.lstatSync(pathname, { bigint: true });
+        assertOwnedFile(stat, pathname, true);
+        return stat;
+      }, identity);
+      if (sha256Hex(fsModule.readFileSync(publishedFd)) !== expectedHash) {
+        throw new FsSafeError("path-mismatch", `Atomic replace published content changed: ${pathname}`);
+      }
+      fsModule.closeSync(this.#fd!);
+      this.#fd = publishedFd;
+      this.#identity = identity;
+      publishedFd = undefined;
+    } finally {
+      if (publishedFd !== undefined) {
+        try {
+          fsModule.closeSync(publishedFd);
+        } catch {
+          // Best-effort close after a rejected content verification.
+        }
+      }
     }
   }
 

--- a/src/replace-file-temp-owner.ts
+++ b/src/replace-file-temp-owner.ts
@@ -1,0 +1,286 @@
+import syncFs, { type BigIntStats } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import { FsSafeError } from "./errors.js";
+import { sameFileIdentityForCleanup } from "./file-identity.js";
+import { inspectFileIdentity, inspectFileIdentitySync } from "./strict-file-identity.js";
+import { registerTempPathForExit, type TempPathRegistration } from "./temp-cleanup.js";
+
+type AsyncOwnerFileSystem = Pick<typeof fs, "lstat" | "unlink">;
+type SyncOwnerFileSystem = Pick<
+  typeof syncFs,
+  "closeSync" | "fstatSync" | "lstatSync" | "unlinkSync"
+>;
+
+function assertOwnedFile(stat: BigIntStats, pathname: string, pathnameEntry: boolean): void {
+  if (stat.isSymbolicLink()) {
+    throw new FsSafeError("symlink", `Atomic replace owned file became a symlink: ${pathname}`);
+  }
+  if (!stat.isFile()) {
+    throw new FsSafeError("not-file", `Atomic replace owned file must remain regular: ${pathname}`);
+  }
+  if (stat.nlink > 1n || (pathnameEntry && stat.nlink !== 1n)) {
+    throw new FsSafeError("hardlink", `Atomic replace owned file must retain one link: ${pathname}`);
+  }
+}
+
+function missingOwnedFile(pathname: string, cause: unknown): FsSafeError {
+  return new FsSafeError("path-mismatch", `Atomic replace owned file disappeared: ${pathname}`, {
+    cause,
+  });
+}
+
+function cleanupFailure(originalError: unknown, cleanupError: unknown): Error {
+  if (originalError !== undefined) {
+    return new Error(
+      `Atomic file replace failed (${String(originalError)}); cleanup also failed (${String(cleanupError)})`,
+      { cause: originalError },
+    );
+  }
+  return cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError));
+}
+
+async function cleanupOwnedPath(params: {
+  fsModule: AsyncOwnerFileSystem;
+  pathname: string;
+  identity?: BigIntStats;
+  originalError?: unknown;
+  throwOnCleanupError: boolean;
+}): Promise<boolean> {
+  if (!params.identity) return true;
+  try {
+    const current = await params.fsModule.lstat(params.pathname, { bigint: true });
+    if (
+      current.isSymbolicLink() ||
+      !current.isFile() ||
+      current.nlink !== 1n ||
+      !sameFileIdentityForCleanup(current, params.identity)
+    ) {
+      return true;
+    }
+    await params.fsModule.unlink(params.pathname);
+    return true;
+  } catch (cleanupError) {
+    if ((cleanupError as NodeJS.ErrnoException).code === "ENOENT") return true;
+    if (params.throwOnCleanupError) {
+      throw cleanupFailure(params.originalError, cleanupError);
+    }
+    return false;
+  }
+}
+
+function cleanupOwnedPathSync(params: {
+  fsModule: SyncOwnerFileSystem;
+  pathname: string;
+  identity?: BigIntStats;
+  originalError?: unknown;
+  throwOnCleanupError: boolean;
+}): boolean {
+  if (!params.identity) return true;
+  try {
+    const current = params.fsModule.lstatSync(params.pathname, { bigint: true });
+    if (
+      current.isSymbolicLink() ||
+      !current.isFile() ||
+      current.nlink !== 1n ||
+      !sameFileIdentityForCleanup(current, params.identity)
+    ) {
+      return true;
+    }
+    params.fsModule.unlinkSync(params.pathname);
+    return true;
+  } catch (cleanupError) {
+    if ((cleanupError as NodeJS.ErrnoException).code === "ENOENT") return true;
+    if (params.throwOnCleanupError) {
+      throw cleanupFailure(params.originalError, cleanupError);
+    }
+    return false;
+  }
+}
+
+export class AsyncAtomicTempOwner {
+  readonly pathname: string;
+  #handle: FileHandle | undefined;
+  #identity: BigIntStats | undefined;
+  #exists = false;
+  #unregister: TempPathRegistration;
+
+  constructor(pathname: string) {
+    this.pathname = pathname;
+    this.#unregister = registerTempPathForExit(pathname, { singleLinkFile: true });
+  }
+
+  start(): void {
+    this.#exists = true;
+  }
+
+  readonly onIdentity = (identity: BigIntStats): void => {
+    this.#identity = identity;
+    this.#unregister.setIdentity(identity);
+  };
+
+  adopt(temp: { handle: FileHandle; identity: BigIntStats }): void {
+    this.#handle = temp.handle;
+    this.onIdentity(temp.identity);
+  }
+
+  get identity(): BigIntStats {
+    if (!this.#identity) throw new Error("Atomic temp owner has no identity");
+    return this.#identity;
+  }
+
+  async assertCurrent(fsModule: AsyncOwnerFileSystem, pathname = this.pathname): Promise<void> {
+    const opened = await inspectFileIdentity(async () => {
+      const stat = await this.#handle!.stat({ bigint: true });
+      assertOwnedFile(stat, pathname, false);
+      return stat;
+    }, this.identity);
+    try {
+      await inspectFileIdentity(async () => {
+        const stat = await fsModule.lstat(pathname, { bigint: true });
+        assertOwnedFile(stat, pathname, true);
+        return stat;
+      }, opened);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw missingOwnedFile(pathname, error);
+      }
+      throw error;
+    }
+  }
+
+  markRenamed(): void {
+    this.#exists = false;
+    this.#unregister();
+  }
+
+  async finish(params: {
+    fsModule: AsyncOwnerFileSystem;
+    originalError?: unknown;
+    throwOnCleanupError: boolean;
+  }): Promise<void> {
+    let deferredError: unknown;
+    let cleanupComplete = !this.#exists;
+    if (this.#exists) {
+      try {
+        cleanupComplete = await cleanupOwnedPath({
+          fsModule: params.fsModule,
+          pathname: this.pathname,
+          identity: this.#identity,
+          originalError: params.originalError,
+          throwOnCleanupError: params.throwOnCleanupError,
+        });
+      } catch (error) {
+        deferredError = error;
+      }
+    }
+    if (cleanupComplete) this.#unregister();
+    try {
+      await this.#handle?.close();
+    } catch (closeError) {
+      deferredError = deferredError
+        ? new AggregateError([deferredError, closeError], "Atomic temp cleanup and close failed")
+        : params.originalError !== undefined
+          ? new AggregateError(
+              [params.originalError, closeError],
+              "Atomic file replace and close failed",
+            )
+          : closeError;
+    }
+    if (deferredError) throw deferredError;
+  }
+}
+
+export class SyncAtomicTempOwner {
+  readonly pathname: string;
+  #fd: number | undefined;
+  #identity: BigIntStats | undefined;
+  #exists = false;
+  #unregister: TempPathRegistration;
+
+  constructor(pathname: string) {
+    this.pathname = pathname;
+    this.#unregister = registerTempPathForExit(pathname, { singleLinkFile: true });
+  }
+
+  start(): void {
+    this.#exists = true;
+  }
+
+  readonly onIdentity = (identity: BigIntStats): void => {
+    this.#identity = identity;
+    this.#unregister.setIdentity(identity);
+  };
+
+  adopt(temp: { fd: number; identity: BigIntStats }): void {
+    this.#fd = temp.fd;
+    this.onIdentity(temp.identity);
+  }
+
+  get identity(): BigIntStats {
+    if (!this.#identity) throw new Error("Atomic temp owner has no identity");
+    return this.#identity;
+  }
+
+  assertCurrent(fsModule: SyncOwnerFileSystem, pathname = this.pathname): void {
+    const opened = inspectFileIdentitySync(() => {
+      const stat = fsModule.fstatSync(this.#fd!, { bigint: true });
+      assertOwnedFile(stat, pathname, false);
+      return stat;
+    }, this.identity);
+    try {
+      inspectFileIdentitySync(() => {
+        const stat = fsModule.lstatSync(pathname, { bigint: true });
+        assertOwnedFile(stat, pathname, true);
+        return stat;
+      }, opened);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw missingOwnedFile(pathname, error);
+      }
+      throw error;
+    }
+  }
+
+  markRenamed(): void {
+    this.#exists = false;
+    this.#unregister();
+  }
+
+  finish(params: {
+    fsModule: SyncOwnerFileSystem;
+    originalError?: unknown;
+    throwOnCleanupError: boolean;
+  }): void {
+    let deferredError: unknown;
+    let cleanupComplete = !this.#exists;
+    if (this.#exists) {
+      try {
+        cleanupComplete = cleanupOwnedPathSync({
+          fsModule: params.fsModule,
+          pathname: this.pathname,
+          identity: this.#identity,
+          originalError: params.originalError,
+          throwOnCleanupError: params.throwOnCleanupError,
+        });
+      } catch (error) {
+        deferredError = error;
+      }
+    }
+    if (cleanupComplete) this.#unregister();
+    if (this.#fd !== undefined) {
+      try {
+        params.fsModule.closeSync(this.#fd);
+      } catch (closeError) {
+        deferredError = deferredError
+          ? new AggregateError([deferredError, closeError], "Atomic temp cleanup and close failed")
+          : params.originalError !== undefined
+            ? new AggregateError(
+                [params.originalError, closeError],
+                "Atomic file replace and close failed",
+              )
+            : closeError;
+      }
+    }
+    if (deferredError) throw deferredError;
+  }
+}

--- a/src/replace-file.ts
+++ b/src/replace-file.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
-import syncFs from "node:fs";
-import type { Stats } from "node:fs";
+import syncFs, { type BigIntStats, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -20,8 +19,8 @@ import {
   writeTempFile,
   writeTempFileSync,
 } from "./replace-file-descriptor.js";
+import { AsyncAtomicTempOwner, SyncAtomicTempOwner } from "./replace-file-temp-owner.js";
 import { assertSafePathPrefix } from "./safe-path-segment.js";
-import { registerTempPathForExit } from "./temp-cleanup.js";
 import { sleep, sleepSync } from "./timing.js";
 import { serializePathWrite } from "./write-queue.js";
 
@@ -94,11 +93,13 @@ type ReplaceFileAtomicBaseOptions = {
 
 export type ReplaceFileAtomicOptions = ReplaceFileAtomicBaseOptions & {
   fileSystem?: ReplaceFileAtomicFileSystem;
+  /** Runs while the exact staged file is retained; replacing or hardlinking it is rejected. */
   beforeRename?: (params: { filePath: string; tempPath: string }) => Promise<void>;
 };
 
 export type ReplaceFileAtomicSyncOptions = ReplaceFileAtomicBaseOptions & {
   fileSystem?: ReplaceFileAtomicSyncFileSystem;
+  /** Runs while the exact staged file is retained; replacing or hardlinking it is rejected. */
   beforeRename?: (params: { filePath: string; tempPath: string }) => void;
 };
 
@@ -125,9 +126,12 @@ async function renameWithRetry(params: {
   copyFallbackRestore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
+  sourceIdentity: BigIntStats;
+  assertSourceCurrent: () => Promise<void>;
   syncFallback: boolean;
 }): Promise<ReplaceFileAtomicResult> {
   for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
+    await params.assertSourceCurrent();
     try {
       await params.fsModule.rename(params.src, params.dest);
       return { method: "rename" };
@@ -144,6 +148,7 @@ async function renameWithRetry(params: {
           destinationHardlinks: params.destinationHardlinks,
           restore: params.copyFallbackRestore,
           maxRestoreBytes: params.maxRestoreBytes,
+          expectedSourceIdentity: params.sourceIdentity,
           sync: params.syncFallback,
         });
         return { method: "copy-fallback" };
@@ -164,10 +169,13 @@ function renameWithRetrySync(params: {
   copyFallbackRestore: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
+  sourceIdentity: BigIntStats;
+  assertSourceCurrent: () => void;
   fchmodSync?: SyncFchmod;
   syncFallback: boolean;
 }): ReplaceFileAtomicResult {
   for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
+    params.assertSourceCurrent();
     try {
       params.fsModule.renameSync(params.src, params.dest);
       return { method: "rename" };
@@ -184,6 +192,7 @@ function renameWithRetrySync(params: {
           destinationHardlinks: params.destinationHardlinks,
           restore: params.copyFallbackRestore,
           maxRestoreBytes: params.maxRestoreBytes,
+          expectedSourceIdentity: params.sourceIdentity,
           fchmodSync: params.fchmodSync,
           sync: params.syncFallback,
         });
@@ -290,28 +299,6 @@ function syncDirectoryBestEffortSync(
   }
 }
 
-async function cleanupTempFile(params: {
-  fsModule: ReplaceFileAtomicFileSystem["promises"];
-  tempPath: string;
-  originalError?: unknown;
-  throwOnCleanupError: boolean;
-}): Promise<boolean> {
-  const cleanupError = await params.fsModule
-    .rm(params.tempPath, { force: true })
-    .catch((error) => error);
-  if (!cleanupError) return true;
-  if (params.throwOnCleanupError) {
-    if (params.originalError !== undefined) {
-      throw new Error(
-        `Atomic file replace failed (${String(params.originalError)}); cleanup also failed (${String(cleanupError)})`,
-        { cause: params.originalError },
-      );
-    }
-    throw cleanupError;
-  }
-  return false;
-}
-
 export async function replaceFileAtomic(
   options: ReplaceFileAtomicOptions,
 ): Promise<ReplaceFileAtomicResult> {
@@ -332,23 +319,25 @@ async function replaceFileAtomicUnserialized(
   const dirMode = options.dirMode ?? 0o700;
   const mode = await resolveMode(options);
   const tempPath = buildReplaceTempPath(filePath, options.tempPrefix);
-  const unregisterTempPath = registerTempPathForExit(tempPath);
-  let tempExists = false;
+  const tempOwner = new AsyncAtomicTempOwner(tempPath);
   let originalError: unknown;
   try {
     await fsModule.mkdir(dir, { recursive: true, mode: dirMode });
     await applyDirectoryMode({ fsModule, dirPath: dir, mode: dirMode });
-    tempExists = true;
-    unregisterTempPath.setIdentity(await writeTempFile({
+    tempOwner.start();
+    tempOwner.adopt(await writeTempFile({
       fsModule,
       tempPath,
       content: options.content,
       mode,
       sync: options.syncTempFile === true,
+      onIdentity: tempOwner.onIdentity,
     }));
+    await tempOwner.assertCurrent(fsModule);
     if (options.beforeRename) {
       await options.beforeRename({ filePath, tempPath });
     }
+    await tempOwner.assertCurrent(fsModule);
     await assertDestinationHardlinkPolicy(fsModule, filePath, options.destinationHardlinks);
     const result = await renameWithRetry({
       fsModule,
@@ -360,30 +349,32 @@ async function replaceFileAtomicUnserialized(
       copyFallbackRestore: options.copyFallbackRestore ?? "none",
       maxRestoreBytes: options.maxRestoreBytes,
       destinationHardlinks: options.destinationHardlinks,
+      sourceIdentity: tempOwner.identity,
+      assertSourceCurrent: () => tempOwner.assertCurrent(fsModule),
       syncFallback: options.syncTempFile === true,
     });
     if (result.method === "rename") {
-      tempExists = false;
-      unregisterTempPath();
+      tempOwner.markRenamed();
+      await tempOwner.assertCurrent(fsModule, filePath);
+    } else {
+      await tempOwner.assertCurrent(fsModule);
     }
     if (options.syncParentDir) {
       await syncDirectoryBestEffort(fsModule, dir);
+    }
+    if (result.method === "rename") {
+      await tempOwner.assertCurrent(fsModule, filePath);
     }
     return result;
   } catch (error) {
     originalError = error;
     throw error;
   } finally {
-    let tempRemoved = !tempExists;
-    if (tempExists) {
-      tempRemoved = await cleanupTempFile({
-        fsModule,
-        tempPath,
-        originalError,
-        throwOnCleanupError: options.throwOnCleanupError === true,
-      });
-    }
-    if (tempRemoved) unregisterTempPath();
+    await tempOwner.finish({
+      fsModule,
+      originalError,
+      throwOnCleanupError: options.throwOnCleanupError === true,
+    });
   }
 }
 
@@ -409,24 +400,26 @@ export function replaceFileAtomicSync(
     throw missingFchmodSyncError();
   }
   const tempPath = buildReplaceTempPath(filePath, options.tempPrefix);
-  const unregisterTempPath = registerTempPathForExit(tempPath);
-  let tempExists = false;
+  const tempOwner = new SyncAtomicTempOwner(tempPath);
   let originalError: unknown;
   try {
     fsModule.mkdirSync(dir, { recursive: true, mode: dirMode });
     applyDirectoryModeSync({ fsModule, dirPath: dir, mode: dirMode, fchmodSync });
-    tempExists = true;
-    unregisterTempPath.setIdentity(writeTempFileSync({
+    tempOwner.start();
+    tempOwner.adopt(writeTempFileSync({
       fsModule,
       tempPath,
       content: options.content,
       mode,
       fchmodSync,
       sync: options.syncTempFile === true,
+      onIdentity: tempOwner.onIdentity,
     }));
+    tempOwner.assertCurrent(fsModule);
     if (options.beforeRename) {
       options.beforeRename({ filePath, tempPath });
     }
+    tempOwner.assertCurrent(fsModule);
     assertDestinationHardlinkPolicySync(fsModule, filePath, options.destinationHardlinks);
     const result = renameWithRetrySync({
       fsModule,
@@ -438,39 +431,32 @@ export function replaceFileAtomicSync(
       copyFallbackRestore: options.copyFallbackRestore ?? "none",
       maxRestoreBytes: options.maxRestoreBytes,
       destinationHardlinks: options.destinationHardlinks,
+      sourceIdentity: tempOwner.identity,
+      assertSourceCurrent: () => tempOwner.assertCurrent(fsModule),
       fchmodSync,
       syncFallback: options.syncTempFile === true,
     });
     if (result.method === "rename") {
-      tempExists = false;
-      unregisterTempPath();
+      tempOwner.markRenamed();
+      tempOwner.assertCurrent(fsModule, filePath);
+    } else {
+      tempOwner.assertCurrent(fsModule);
     }
     if (options.syncParentDir) {
       syncDirectoryBestEffortSync(fsModule, dir);
+    }
+    if (result.method === "rename") {
+      tempOwner.assertCurrent(fsModule, filePath);
     }
     return result;
   } catch (error) {
     originalError = error;
     throw error;
   } finally {
-    let tempRemoved = !tempExists;
-    if (tempExists) {
-      try {
-        fsModule.rmSync(tempPath, { force: true });
-        tempRemoved = true;
-      } catch (cleanupError) {
-        if (options.throwOnCleanupError) {
-          if (originalError !== undefined) {
-            throw new Error(
-              `Atomic file replace failed (${String(originalError)}); cleanup also failed (${String(cleanupError)})`,
-              { cause: originalError },
-            );
-          }
-          throw cleanupError;
-        }
-        // The temp file is best-effort cleanup after write failure.
-      }
-    }
-    if (tempRemoved) unregisterTempPath();
+    tempOwner.finish({
+      fsModule,
+      originalError,
+      throwOnCleanupError: options.throwOnCleanupError === true,
+    });
   }
 }

--- a/src/replace-file.ts
+++ b/src/replace-file.ts
@@ -19,6 +19,13 @@ import {
   writeTempFile,
   writeTempFileSync,
 } from "./replace-file-descriptor.js";
+import {
+  atomicExpectedContentHash,
+  type RenameIdentityPolicy,
+  validateRenameIdentity,
+  withAtomicRenameIdentityLock,
+  withAtomicRenameIdentityLockSync,
+} from "./replace-file-rename-policy.js";
 import { AsyncAtomicTempOwner, SyncAtomicTempOwner } from "./replace-file-temp-owner.js";
 import { assertSafePathPrefix } from "./safe-path-segment.js";
 import { sleep, sleepSync } from "./timing.js";
@@ -67,6 +74,7 @@ export type ReplaceFileAtomicSyncFileSystem = Pick<
 };
 
 export type {
+  RenameIdentityPolicy,
   ReplaceFileAtomicRestoreCleanup,
   ReplaceFileAtomicRestoreFailureDetails,
   ReplaceFileCopyFallbackRestorePolicy,
@@ -86,6 +94,8 @@ type ReplaceFileAtomicBaseOptions = {
   copyFallbackRestore?: ReplaceFileCopyFallbackRestorePolicy;
   maxRestoreBytes?: number;
   destinationHardlinks?: ReplaceFileDestinationHardlinkPolicy;
+  /** Strict by default; locked content verification is an explicit FUSE compatibility policy. */
+  renameIdentity?: RenameIdentityPolicy;
   syncTempFile?: boolean;
   syncParentDir?: boolean;
   throwOnCleanupError?: boolean;
@@ -305,8 +315,17 @@ export async function replaceFileAtomic(
   const filePath = options.filePath;
   validateReplaceFilePath(filePath);
   validateRestoreOptions(options);
+  validateRenameIdentity(options.renameIdentity);
   return await serializePathWrite(path.resolve(filePath), async () => {
-    return await replaceFileAtomicUnserialized(options);
+    if (options.renameIdentity !== "verify-content-with-lock") {
+      return await replaceFileAtomicUnserialized(options);
+    }
+    await (options.fileSystem?.promises ?? fs).mkdir(path.dirname(filePath), {
+      recursive: true,
+      mode: options.dirMode ?? 0o700,
+    });
+    return await withAtomicRenameIdentityLock(filePath, async () =>
+      await replaceFileAtomicUnserialized(options));
   });
 }
 
@@ -318,6 +337,7 @@ async function replaceFileAtomicUnserialized(
   const dir = path.dirname(filePath);
   const dirMode = options.dirMode ?? 0o700;
   const mode = await resolveMode(options);
+  const expectedHash = atomicExpectedContentHash(options.renameIdentity, options.content);
   const tempPath = buildReplaceTempPath(filePath, options.tempPrefix);
   const tempOwner = new AsyncAtomicTempOwner(tempPath);
   let originalError: unknown;
@@ -355,7 +375,7 @@ async function replaceFileAtomicUnserialized(
     });
     if (result.method === "rename") {
       tempOwner.markRenamed();
-      await tempOwner.assertCurrent(fsModule, filePath);
+      await tempOwner.assertPublished(fsModule, filePath, expectedHash);
     } else {
       await tempOwner.assertCurrent(fsModule);
     }
@@ -363,7 +383,7 @@ async function replaceFileAtomicUnserialized(
       await syncDirectoryBestEffort(fsModule, dir);
     }
     if (result.method === "rename") {
-      await tempOwner.assertCurrent(fsModule, filePath);
+      await tempOwner.assertPublished(fsModule, filePath, expectedHash);
     }
     return result;
   } catch (error) {
@@ -384,10 +404,27 @@ export function replaceFileAtomicSync(
   const filePath = options.filePath;
   validateReplaceFilePath(filePath);
   validateRestoreOptions(options);
+  validateRenameIdentity(options.renameIdentity);
+  if (options.renameIdentity !== "verify-content-with-lock") {
+    return replaceFileAtomicSyncUnserialized(options);
+  }
+  (options.fileSystem ?? syncFs).mkdirSync(path.dirname(filePath), {
+    recursive: true,
+    mode: options.dirMode ?? 0o700,
+  });
+  return withAtomicRenameIdentityLockSync(filePath, () =>
+    replaceFileAtomicSyncUnserialized(options));
+}
+
+function replaceFileAtomicSyncUnserialized(
+  options: ReplaceFileAtomicSyncOptions,
+): ReplaceFileAtomicResult {
+  const filePath = options.filePath;
   const fsModule = options.fileSystem ?? syncFs;
   const dir = path.dirname(filePath);
   const dirMode = options.dirMode ?? 0o700;
   const mode = resolveModeSync(options);
+  const expectedHash = atomicExpectedContentHash(options.renameIdentity, options.content);
   const fchmodSync = options.fileSystem?.fchmodSync ?? (
     options.fileSystem === undefined ? syncFs.fchmodSync : undefined
   );
@@ -438,7 +475,7 @@ export function replaceFileAtomicSync(
     });
     if (result.method === "rename") {
       tempOwner.markRenamed();
-      tempOwner.assertCurrent(fsModule, filePath);
+      tempOwner.assertPublished(fsModule, filePath, expectedHash);
     } else {
       tempOwner.assertCurrent(fsModule);
     }
@@ -446,7 +483,7 @@ export function replaceFileAtomicSync(
       syncDirectoryBestEffortSync(fsModule, dir);
     }
     if (result.method === "rename") {
-      tempOwner.assertCurrent(fsModule, filePath);
+      tempOwner.assertPublished(fsModule, filePath, expectedHash);
     }
     return result;
   } catch (error) {

--- a/test/atomic-callback-substitution.test.ts
+++ b/test/atomic-callback-substitution.test.ts
@@ -244,6 +244,124 @@ describe("atomic beforeRename ownership", () => {
     expect(fsSync.readFileSync(movedPath, "utf8")).toBe("new");
   });
 
+  it("keeps strict async identity checks on rename-unstable filesystems", async () => {
+    const root = await tempRoot("fs-safe-atomic-fuse-strict-async-");
+    const filePath = path.join(root, "target");
+    await fs.writeFile(filePath, "old");
+    await expect(replaceFileAtomic({
+      filePath,
+      content: "new",
+      fileSystem: {
+        promises: {
+          ...fs,
+          rename: async (source, destination) => {
+            await fs.copyFile(source, destination);
+            await fs.unlink(source);
+          },
+        },
+      },
+    })).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(await fs.readFile(filePath, "utf8")).toBe("new");
+  });
+
+  it("keeps strict sync identity checks on rename-unstable filesystems", async () => {
+    const root = await tempRoot("fs-safe-atomic-fuse-strict-sync-");
+    const filePath = path.join(root, "target");
+    fsSync.writeFileSync(filePath, "old");
+    expect(() => replaceFileAtomicSync({
+      filePath,
+      content: "new",
+      fileSystem: {
+        ...fsSync,
+        renameSync: (source, destination) => {
+          fsSync.copyFileSync(source, destination);
+          fsSync.unlinkSync(source);
+        },
+      },
+    })).toThrow(expect.objectContaining({ code: "path-mismatch" }));
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("new");
+  });
+
+  it("accepts async rename-unstable publication only with locked content verification", async () => {
+    const root = await tempRoot("fs-safe-atomic-fuse-async-");
+    const filePath = path.join(root, "target");
+    await fs.writeFile(filePath, "old");
+    await expect(replaceFileAtomic({
+      filePath,
+      content: "new",
+      renameIdentity: "verify-content-with-lock",
+      syncParentDir: true,
+      fileSystem: {
+        promises: {
+          ...fs,
+          rename: async (source, destination) => {
+            await fs.copyFile(source, destination);
+            await fs.unlink(source);
+          },
+        },
+      },
+    })).resolves.toEqual({ method: "rename" });
+    expect(await fs.readFile(filePath, "utf8")).toBe("new");
+    expect((await fs.readdir(root)).filter((name) => name.startsWith(".fs-safe-atomic-")))
+      .toEqual([]);
+  });
+
+  it("accepts sync rename-unstable publication only with locked content verification", async () => {
+    const root = await tempRoot("fs-safe-atomic-fuse-sync-");
+    const filePath = path.join(root, "target");
+    fsSync.writeFileSync(filePath, "old");
+    expect(replaceFileAtomicSync({
+      filePath,
+      content: "new",
+      renameIdentity: "verify-content-with-lock",
+      syncParentDir: true,
+      fileSystem: {
+        ...fsSync,
+        renameSync: (source, destination) => {
+          fsSync.copyFileSync(source, destination);
+          fsSync.unlinkSync(source);
+        },
+      },
+    })).toEqual({ method: "rename" });
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("new");
+    expect(fsSync.readdirSync(root).filter((name) => name.startsWith(".fs-safe-atomic-")))
+      .toEqual([]);
+  });
+
+  it("rejects mismatched content under the rename-unstable compatibility policy", async () => {
+    const root = await tempRoot("fs-safe-atomic-fuse-tampered-");
+    const filePath = path.join(root, "target");
+    await fs.writeFile(filePath, "old");
+    await expect(replaceFileAtomic({
+      filePath,
+      content: "new",
+      renameIdentity: "verify-content-with-lock",
+      fileSystem: {
+        promises: {
+          ...fs,
+          rename: async (source, destination) => {
+            await fs.writeFile(destination, "tampered");
+            await fs.unlink(source);
+          },
+        },
+      },
+    })).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(await fs.readFile(filePath, "utf8")).toBe("tampered");
+    expect((await fs.readdir(root)).filter((name) => name.startsWith(".fs-safe-atomic-")))
+      .toEqual([]);
+  });
+
+  it("rejects an invalid rename identity policy before mutation", async () => {
+    const root = await tempRoot("fs-safe-atomic-fuse-policy-");
+    const filePath = path.join(root, "target");
+    await expect(replaceFileAtomic({
+      filePath,
+      content: "new",
+      renameIdentity: "unknown" as "strict",
+    })).rejects.toThrow("renameIdentity must be strict or verify-content-with-lock");
+    await expect(fs.lstat(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("rejects an async source replacement entering copy fallback", async () => {
     const root = await tempRoot("fs-safe-atomic-fallback-source-async-");
     const filePath = path.join(root, "target");

--- a/test/atomic-callback-substitution.test.ts
+++ b/test/atomic-callback-substitution.test.ts
@@ -1,0 +1,362 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { replaceFileAtomic, replaceFileAtomicSync } from "../src/atomic.js";
+import { __cleanupRegisteredTempPathsForTest } from "../src/temp-cleanup.js";
+import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  __cleanupRegisteredTempPathsForTest();
+});
+
+type Substitute = "file" | "directory" | "missing" | "symlink" | "hardlink";
+
+function expectedCode(substitute: Substitute): string {
+  if (substitute === "directory") return "not-file";
+  if (substitute === "symlink") return "symlink";
+  if (substitute === "hardlink") return "hardlink";
+  return "path-mismatch";
+}
+
+async function installAsyncSubstitute(params: {
+  substitute: Substitute;
+  tempPath: string;
+  movedPath: string;
+  outsidePath: string;
+}): Promise<void> {
+  await fs.rename(params.tempPath, params.movedPath);
+  if (params.substitute === "file") await fs.writeFile(params.tempPath, "replacement");
+  if (params.substitute === "directory") {
+    await fs.mkdir(params.tempPath);
+    await fs.writeFile(path.join(params.tempPath, "sentinel"), "keep");
+  }
+  if (params.substitute === "symlink") await fs.symlink(params.outsidePath, params.tempPath);
+  if (params.substitute === "hardlink") await fs.link(params.outsidePath, params.tempPath);
+}
+
+function installSyncSubstitute(params: {
+  substitute: Substitute;
+  tempPath: string;
+  movedPath: string;
+  outsidePath: string;
+}): void {
+  fsSync.renameSync(params.tempPath, params.movedPath);
+  if (params.substitute === "file") fsSync.writeFileSync(params.tempPath, "replacement");
+  if (params.substitute === "directory") {
+    fsSync.mkdirSync(params.tempPath);
+    fsSync.writeFileSync(path.join(params.tempPath, "sentinel"), "keep");
+  }
+  if (params.substitute === "symlink") fsSync.symlinkSync(params.outsidePath, params.tempPath);
+  if (params.substitute === "hardlink") fsSync.linkSync(params.outsidePath, params.tempPath);
+}
+
+async function expectAsyncSubstitutePreserved(substitute: Substitute): Promise<void> {
+  const root = await tempRoot(`fs-safe-atomic-hook-${substitute}-`);
+  const filePath = path.join(root, "target");
+  const outsidePath = path.join(root, "outside");
+  await fs.writeFile(filePath, "old");
+  await fs.writeFile(outsidePath, "outside");
+  let tempPath = "";
+  let movedPath = "";
+
+  await expect(replaceFileAtomic({
+    filePath,
+    content: "new",
+    beforeRename: async ({ tempPath: candidate }) => {
+      tempPath = candidate;
+      movedPath = `${candidate}.owned`;
+      await installAsyncSubstitute({ substitute, tempPath, movedPath, outsidePath });
+    },
+  })).rejects.toMatchObject({ code: expectedCode(substitute) });
+
+  expect(await fs.readFile(filePath, "utf8")).toBe("old");
+  expect(await fs.readFile(movedPath, "utf8")).toBe("new");
+  __cleanupRegisteredTempPathsForTest();
+  if (substitute === "missing") {
+    await expect(fs.lstat(tempPath)).rejects.toMatchObject({ code: "ENOENT" });
+  } else if (substitute === "directory") {
+    expect(await fs.readFile(path.join(tempPath, "sentinel"), "utf8")).toBe("keep");
+  } else if (substitute === "symlink") {
+    expect((await fs.lstat(tempPath)).isSymbolicLink()).toBe(true);
+    expect(await fs.readFile(outsidePath, "utf8")).toBe("outside");
+  } else {
+    expect(await fs.readFile(tempPath, "utf8")).toBe(substitute === "file" ? "replacement" : "outside");
+  }
+}
+
+async function expectSyncSubstitutePreserved(substitute: Substitute): Promise<void> {
+  const root = await tempRoot(`fs-safe-atomic-hook-sync-${substitute}-`);
+  const filePath = path.join(root, "target");
+  const outsidePath = path.join(root, "outside");
+  fsSync.writeFileSync(filePath, "old");
+  fsSync.writeFileSync(outsidePath, "outside");
+  let tempPath = "";
+  let movedPath = "";
+
+  expect(() => replaceFileAtomicSync({
+    filePath,
+    content: "new",
+    beforeRename: ({ tempPath: candidate }) => {
+      tempPath = candidate;
+      movedPath = `${candidate}.owned`;
+      installSyncSubstitute({ substitute, tempPath, movedPath, outsidePath });
+    },
+  })).toThrow(expect.objectContaining({ code: expectedCode(substitute) }));
+
+  expect(fsSync.readFileSync(filePath, "utf8")).toBe("old");
+  expect(fsSync.readFileSync(movedPath, "utf8")).toBe("new");
+  __cleanupRegisteredTempPathsForTest();
+  if (substitute === "missing") {
+    expect(() => fsSync.lstatSync(tempPath)).toThrow(expect.objectContaining({ code: "ENOENT" }));
+  } else if (substitute === "directory") {
+    expect(fsSync.readFileSync(path.join(tempPath, "sentinel"), "utf8")).toBe("keep");
+  } else if (substitute === "symlink") {
+    expect(fsSync.lstatSync(tempPath).isSymbolicLink()).toBe(true);
+    expect(fsSync.readFileSync(outsidePath, "utf8")).toBe("outside");
+  } else {
+    expect(fsSync.readFileSync(tempPath, "utf8")).toBe(substitute === "file" ? "replacement" : "outside");
+  }
+}
+
+describe("atomic beforeRename ownership", () => {
+  it.each(["file", "directory", "missing"] as const)(
+    "rejects and preserves an async %s substitution",
+    expectAsyncSubstitutePreserved,
+  );
+  itPosix.each(["symlink", "hardlink"] as const)(
+    "rejects and preserves an async %s substitution",
+    expectAsyncSubstitutePreserved,
+  );
+  it.each(["file", "directory", "missing"] as const)(
+    "rejects and preserves a sync %s substitution",
+    expectSyncSubstitutePreserved,
+  );
+  itPosix.each(["symlink", "hardlink"] as const)(
+    "rejects and preserves a sync %s substitution",
+    expectSyncSubstitutePreserved,
+  );
+
+  it("detects an async final-name replacement after rename without rollback", async () => {
+    const root = await tempRoot("fs-safe-atomic-published-async-");
+    const filePath = path.join(root, "target");
+    const movedPath = path.join(root, "moved");
+    await fs.writeFile(filePath, "old");
+    await expect(replaceFileAtomic({
+      filePath,
+      content: "new",
+      fileSystem: {
+        promises: {
+          ...fs,
+          rename: async (source, destination) => {
+            await fs.rename(source, destination);
+            await fs.rename(destination, movedPath);
+            await fs.writeFile(destination, "replacement");
+          },
+        },
+      },
+    })).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(await fs.readFile(filePath, "utf8")).toBe("replacement");
+    expect(await fs.readFile(movedPath, "utf8")).toBe("new");
+  });
+
+  it("detects a sync final-name replacement after rename without rollback", async () => {
+    const root = await tempRoot("fs-safe-atomic-published-sync-");
+    const filePath = path.join(root, "target");
+    const movedPath = path.join(root, "moved");
+    fsSync.writeFileSync(filePath, "old");
+    expect(() => replaceFileAtomicSync({
+      filePath,
+      content: "new",
+      fileSystem: {
+        ...fsSync,
+        renameSync: (source, destination) => {
+          fsSync.renameSync(source, destination);
+          fsSync.renameSync(destination, movedPath);
+          fsSync.writeFileSync(destination, "replacement");
+        },
+      },
+    })).toThrow(expect.objectContaining({ code: "path-mismatch" }));
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("replacement");
+    expect(fsSync.readFileSync(movedPath, "utf8")).toBe("new");
+  });
+
+  it("rechecks the async final name after parent sync", async () => {
+    const root = await tempRoot("fs-safe-atomic-parent-sync-async-");
+    const filePath = path.join(root, "target");
+    const movedPath = path.join(root, "moved");
+    await fs.writeFile(filePath, "old");
+    let swapped = false;
+    await expect(replaceFileAtomic({
+      filePath,
+      content: "new",
+      syncParentDir: true,
+      fileSystem: {
+        promises: {
+          ...fs,
+          open: async (...args) => {
+            const handle = await fs.open(...args);
+            if (args[0] === root) {
+              const sync = handle.sync.bind(handle);
+              handle.sync = async () => {
+                if (!swapped) {
+                  swapped = true;
+                  await fs.rename(filePath, movedPath);
+                  await fs.writeFile(filePath, "replacement");
+                }
+                await sync();
+              };
+            }
+            return handle;
+          },
+        },
+      },
+    })).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(await fs.readFile(filePath, "utf8")).toBe("replacement");
+    expect(await fs.readFile(movedPath, "utf8")).toBe("new");
+  });
+
+  it("rechecks the sync final name after parent sync", async () => {
+    const root = await tempRoot("fs-safe-atomic-parent-sync-sync-");
+    const filePath = path.join(root, "target");
+    const movedPath = path.join(root, "moved");
+    fsSync.writeFileSync(filePath, "old");
+    let swapped = false;
+    expect(() => replaceFileAtomicSync({
+      filePath,
+      content: "new",
+      syncParentDir: true,
+      fileSystem: {
+        ...fsSync,
+        fsyncSync: (fd) => {
+          if (!swapped) {
+            swapped = true;
+            fsSync.renameSync(filePath, movedPath);
+            fsSync.writeFileSync(filePath, "replacement");
+          }
+          fsSync.fsyncSync(fd);
+        },
+      },
+    })).toThrow(expect.objectContaining({ code: "path-mismatch" }));
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("replacement");
+    expect(fsSync.readFileSync(movedPath, "utf8")).toBe("new");
+  });
+
+  it("rejects an async source replacement entering copy fallback", async () => {
+    const root = await tempRoot("fs-safe-atomic-fallback-source-async-");
+    const filePath = path.join(root, "target");
+    await fs.writeFile(filePath, "old");
+    let tempPath = "";
+    const movedPath = path.join(root, "moved");
+    await expect(replaceFileAtomic({
+      filePath,
+      content: "new",
+      copyFallbackOnPermissionError: true,
+      beforeRename: async ({ tempPath: candidate }) => {
+        tempPath = candidate;
+      },
+      fileSystem: {
+        promises: {
+          ...fs,
+          rename: async () => {
+            await fs.rename(tempPath, movedPath);
+            await fs.writeFile(tempPath, "replacement");
+            throw Object.assign(new Error("rename denied"), { code: "EPERM" });
+          },
+        },
+      },
+    })).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(await fs.readFile(filePath, "utf8")).toBe("old");
+    expect(await fs.readFile(tempPath, "utf8")).toBe("replacement");
+    expect(await fs.readFile(movedPath, "utf8")).toBe("new");
+  });
+
+  it("rejects a sync source replacement entering copy fallback", async () => {
+    const root = await tempRoot("fs-safe-atomic-fallback-source-sync-");
+    const filePath = path.join(root, "target");
+    fsSync.writeFileSync(filePath, "old");
+    let tempPath = "";
+    const movedPath = path.join(root, "moved");
+    expect(() => replaceFileAtomicSync({
+      filePath,
+      content: "new",
+      copyFallbackOnPermissionError: true,
+      beforeRename: ({ tempPath: candidate }) => {
+        tempPath = candidate;
+      },
+      fileSystem: {
+        ...fsSync,
+        renameSync: () => {
+          fsSync.renameSync(tempPath, movedPath);
+          fsSync.writeFileSync(tempPath, "replacement");
+          throw Object.assign(new Error("rename denied"), { code: "EPERM" });
+        },
+      },
+    })).toThrow(expect.objectContaining({ code: "path-mismatch" }));
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("old");
+    expect(fsSync.readFileSync(tempPath, "utf8")).toBe("replacement");
+    expect(fsSync.readFileSync(movedPath, "utf8")).toBe("new");
+  });
+
+  it("rechecks async ownership before a rename retry", async () => {
+    const root = await tempRoot("fs-safe-atomic-retry-source-async-");
+    const filePath = path.join(root, "target");
+    await fs.writeFile(filePath, "old");
+    let tempPath = "";
+    let renames = 0;
+    await expect(replaceFileAtomic({
+      filePath,
+      content: "new",
+      renameMaxRetries: 1,
+      renameRetryBaseDelayMs: 0,
+      beforeRename: async ({ tempPath: candidate }) => {
+        tempPath = candidate;
+      },
+      fileSystem: {
+        promises: {
+          ...fs,
+          rename: async () => {
+            renames += 1;
+            await fs.rename(tempPath, `${tempPath}.owned`);
+            await fs.writeFile(tempPath, "replacement");
+            throw Object.assign(new Error("busy"), { code: "EBUSY" });
+          },
+        },
+      },
+    })).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(renames).toBe(1);
+    expect(await fs.readFile(filePath, "utf8")).toBe("old");
+    expect(await fs.readFile(tempPath, "utf8")).toBe("replacement");
+  });
+
+  it("rechecks sync ownership before a rename retry", async () => {
+    const root = await tempRoot("fs-safe-atomic-retry-source-sync-");
+    const filePath = path.join(root, "target");
+    fsSync.writeFileSync(filePath, "old");
+    let tempPath = "";
+    let renames = 0;
+    expect(() => replaceFileAtomicSync({
+      filePath,
+      content: "new",
+      renameMaxRetries: 1,
+      renameRetryBaseDelayMs: 0,
+      beforeRename: ({ tempPath: candidate }) => {
+        tempPath = candidate;
+      },
+      fileSystem: {
+        ...fsSync,
+        renameSync: () => {
+          renames += 1;
+          fsSync.renameSync(tempPath, `${tempPath}.owned`);
+          fsSync.writeFileSync(tempPath, "replacement");
+          throw Object.assign(new Error("busy"), { code: "EBUSY" });
+        },
+      },
+    })).toThrow(expect.objectContaining({ code: "path-mismatch" }));
+    expect(renames).toBe(1);
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("old");
+    expect(fsSync.readFileSync(tempPath, "utf8")).toBe("replacement");
+  });
+});

--- a/test/atomic-fchmod-regression.test.ts
+++ b/test/atomic-fchmod-regression.test.ts
@@ -103,7 +103,7 @@ describe("atomic descriptor modes", () => {
 
     const previousUmask = process.umask(0o077);
     try {
-      await replaceFileAtomic({
+      await expect(replaceFileAtomic({
         filePath,
         content: "new",
         mode: 0o600,
@@ -122,7 +122,7 @@ describe("atomic descriptor modes", () => {
             },
           },
         },
-      });
+      })).rejects.toMatchObject({ code: "symlink" });
     } finally {
       process.umask(previousUmask);
     }
@@ -132,6 +132,7 @@ describe("atomic descriptor modes", () => {
       publishedMode,
       victimMode: (await fs.stat(victimPath)).mode & 0o777,
     }).toEqual({ chmodPaths: [], publishedMode: 0o600, victimMode: 0o644 });
+    expect((await fs.lstat(filePath)).isSymbolicLink()).toBe(true);
   });
 
   itPosix("does not chmod a sync destination swapped for a symlink after rename", async () => {
@@ -158,7 +159,12 @@ describe("atomic descriptor modes", () => {
 
     const previousUmask = process.umask(0o077);
     try {
-      replaceFileAtomicSync({ filePath, content: "new", mode: 0o600, fileSystem });
+      expect(() => replaceFileAtomicSync({
+        filePath,
+        content: "new",
+        mode: 0o600,
+        fileSystem,
+      })).toThrow(expect.objectContaining({ code: "symlink" }));
     } finally {
       process.umask(previousUmask);
     }
@@ -168,6 +174,7 @@ describe("atomic descriptor modes", () => {
       publishedMode,
       victimMode: fsSync.statSync(victimPath).mode & 0o777,
     }).toEqual({ chmodPaths: [], publishedMode: 0o600, victimMode: 0o644 });
+    expect(fsSync.lstatSync(filePath).isSymbolicLink()).toBe(true);
   });
 
   itPosix("applies exact async and sync modes through temp descriptors despite umask", async () => {

--- a/test/atomic.test.ts
+++ b/test/atomic.test.ts
@@ -180,8 +180,8 @@ describe("atomic helpers", () => {
         fileSystem: {
           promises: {
             ...fs,
-            lstat: async (candidate) => {
-              const stat = await fs.lstat(candidate);
+            lstat: async (candidate, options) => {
+              const stat = await fs.lstat(candidate, options as never);
               return candidate === filePath
                 ? new Proxy(stat, { get: (target, property) => property === "nlink" ? 1 : Reflect.get(target, property) })
                 : stat;

--- a/test/findings-regression.test.ts
+++ b/test/findings-regression.test.ts
@@ -307,8 +307,8 @@ describe("security finding regressions", () => {
           rename: async () => {
             throw Object.assign(new Error("forced EPERM"), { code: "EPERM" });
           },
-          lstat: async (candidate) => {
-            const stat = await originalLstat(candidate);
+          lstat: async (candidate, options) => {
+            const stat = await originalLstat(candidate, options as never);
             if (!swapped && candidate === target) {
               swapped = true;
               await fsp.rm(target);

--- a/test/public-api.json
+++ b/test/public-api.json
@@ -497,6 +497,7 @@
       ],
       "types": [
         "MovePathWithCopyFallbackOptions",
+        "RenameIdentityPolicy",
         "ReplaceDirectoryAtomicOptions",
         "ReplaceFileAtomicFileSystem",
         "ReplaceFileAtomicOptions",

--- a/test/sidecar-lock-helpers-failure.test.ts
+++ b/test/sidecar-lock-helpers-failure.test.ts
@@ -82,8 +82,10 @@ describe("sidecar lock helper failure handling", () => {
     const second = path.join(root, "second");
     await fs.writeFile(first, "one");
     await fs.writeFile(second, "two");
-    const firstStat = await fs.stat(first);
-    const secondStat = await fs.stat(second);
+    // Windows can report zero as an unknown file identity, so use known,
+    // distinct receipts for this pure snapshot-comparison unit test.
+    const firstStat = Object.assign(await fs.stat(first), { dev: 1, ino: 1 });
+    const secondStat = Object.assign(await fs.stat(second), { dev: 2, ino: 2 });
     expect(sidecarLockSnapshotMatches({ payload: null, stat: secondStat }, { payload: null, stat: firstStat })).toBe(false);
     expect(sidecarLockSnapshotMatches({ payload: null, raw: "one" }, { payload: null, raw: "one" })).toBe(true);
     expect(sidecarLockSnapshotMatches({ payload: null, raw: "two" }, { payload: null, raw: "one" })).toBe(false);


### PR DESCRIPTION
## Summary

- retain the exact async/sync atomic replacement descriptor and bigint identity across `beforeRename`, every rename retry, copy fallback, cleanup, and final-name verification
- reject deleted, substituted, symlinked, non-regular, or hardlinked stages while preserving unowned replacements and moved originals
- split the ownership, copy-source, and rename-policy state machines into bounded shared modules, including explicit locked content verification for rename-unstable FUSE mounts

## Root cause

`replaceFileAtomic()` and `replaceFileAtomicSync()` closed the staged file after writing, then exposed its pathname to `beforeRename`. The hook or a concurrent actor could move the original and install a regular file, symlink, directory, hardlink, or missing entry at the same name. Later rename, copy fallback, and best-effort cleanup trusted that mutable pathname, so the helper could publish or delete a substitute.

The staged writer now returns its retained descriptor plus an exact bigint identity. One owner verifies the descriptor and current pathname before and after the hook, before each rename attempt, at copy-fallback source admission, immediately after rename, and again after optional parent sync. Copy fallback opens the source no-follow/nonblocking, requires the original identity when called from atomic replacement, and reads only the pinned file. Cleanup unlinks only the admitted single-link identity; observed substitutes are preserved and removed from exit-cleanup authority.

A post-rename verification failure does not roll back or delete the final name. Strict identity remains the default. Callers on confirmed rename-unstable FUSE mounts can explicitly choose `renameIdentity: "verify-content-with-lock"`; async and sync variants then accept only a no-follow re-opened destination whose SHA-256 matches the requested bytes while an exclusive hashed sidecar lock is held, and pin that new descriptor through parent sync. Identity checks and pathname rename/unlink remain separate syscalls, so approved writable parents plus cooperative locking or OS isolation remain required against arbitrary concurrent namespace mutation.

## Live behavior proof

A fresh npm consumer installed the packed package and exercised the public async and sync atomic APIs:

```json
{"stable":{"content":"stable","events":["hook-open","rename","close"]},"asyncSubstitution":{"error":{"name":"FsSafeError","code":"path-mismatch","message":"file identity changed or could not be verified"},"target":"old","replacement":"replacement","owned":"new"},"syncSubstitution":{"error":{"name":"FsSafeError","code":"path-mismatch","message":"file identity changed or could not be verified"},"target":"old","replacement":"replacement","owned":"new"},"publishedReplacement":{"error":{"name":"FsSafeError","code":"path-mismatch","message":"file identity changed or could not be verified"},"target":"replacement","owned":"new"},"fallbackSourceReplacement":{"error":{"name":"FsSafeError","code":"path-mismatch","message":"file identity changed or could not be verified"},"target":"old","replacement":"replacement","owned":"new"},"renameUnstable":{"strict":{"error":{"name":"FsSafeError","code":"path-mismatch","message":"file identity changed or could not be verified"},"content":"new"},"compatible":{"result":{"method":"rename"},"content":"new"},"compatibleSync":{"result":{"method":"rename"},"content":"new"},"lockNames":[]}}
```

The stable trace proves the descriptor remains open through the hook and rename, then closes. Async/sync hook substitutions leave the destination unchanged and preserve both the foreign replacement and moved owned stage. Final-name replacement is reported without rollback. A source swap between failed rename and copy fallback is rejected before destination mutation. Simulated FUSE copy/delete rename remains strict by default, succeeds through explicit async/sync locked content verification, and leaves no sidecar lock.

## Verification

- focused atomic ownership, mode, directory, fallback, publication, and primitive suites: 7 files, 150 tests passed, 4 skipped
- complete `CI=1 pnpm check`: 142 files passed, 1 skipped; 2,346 tests passed, 25 skipped; package/API validation passed
- build, docs examples, pack, file-size, filesystem-boundary, and diff checks passed
- fresh packed npm consumer proof passed
- Codex autoreview at P1: clean
- exact-head hosted Linux/macOS/Windows checks and ClawSweeper review remain landing gates
