### PR TITLE
fix(read): reject FIFO swaps without blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Open attacker-raceable secure, secret, archive, queue, publication, fallback, and lock-file read paths nonblocking on POSIX, rejecting FIFO substitutions before reads, deadlines, or cleanup verification can stall.
 - Retain async and sync atomic replacement temp descriptors across `beforeRename`, retries, copy fallback, and final publication; reject substituted, non-regular, or hardlinked stages, preserve unowned cleanup paths, and add explicit locked content verification for rename-unstable FUSE mounts.
 - Pin callback-produced sibling temps through requested mode application, opt-in fsync, rename, and exact publication checks; reject symlink, non-regular, hardlinked, and replaced stages and preserve unverified cleanup paths while retaining producer modes, disabled sync defaults, best-effort file and directory chmod, and read-only descriptor admission unless file sync is requested in `writeSiblingTempFile`.
 - Make durable queue directory creation, claims, acknowledgement, quarantine, marker cleanup, and retirement transitions fsync affected directories and propagate durability failures.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -120,7 +120,7 @@ of leaving a paused parser to drain indefinitely. The native path finishes its
 bounded manifest read before TypeScript policy evaluation, so a rejected plan
 never starts the extraction worker.
 
-If `kind` is omitted, the helper calls `resolveArchiveKind(archivePath)` and throws if the extension is not recognized. Pass `kind` explicitly when the archive name doesn't carry the type (e.g. content-addressed names). A positive finite `timeoutMs` is a wall-clock budget; zero, negative, `NaN`, and infinity disable the deadline. Non-mutating work rejects promptly when the budget expires. If a live destination mutation is already in flight, rejection waits only for that mutation and any rollback to finish; no later destination mutation can begin.
+If `kind` is omitted, the helper calls `resolveArchiveKind(archivePath)` and throws if the extension is not recognized. Pass `kind` explicitly when the archive name doesn't carry the type (e.g. content-addressed names). Archive inputs must remain regular files from preview through descriptor admission; POSIX opens are no-follow and nonblocking, so a FIFO swap cannot stall before deadline checks resume. A positive finite `timeoutMs` is a wall-clock budget; zero, negative, `NaN`, and infinity disable the deadline. Non-mutating work rejects promptly when the budget expires. If a live destination mutation is already in flight, rejection waits only for that mutation and any rollback to finish; no later destination mutation can begin.
 
 ### Limits
 

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -90,7 +90,7 @@ target fails with `FsSafeError("path-mismatch")`.
 ## Exclusive file publication
 
 `publishFileExclusive()` materializes one file without clobbering an existing
-target. It pins the source with `O_NOFOLLOW`, optionally verifies
+target. It pins the source with nonblocking `O_NOFOLLOW`, optionally verifies
 `expectedSourceIdentity`, tries a hardlink first, then synchronizes the target
 parent directory.
 

--- a/docs/secret-file.md
+++ b/docs/secret-file.md
@@ -90,7 +90,9 @@ the same pinned-handle validation, byte cap, trimming, error codes, and strict
 versus missing-is-undefined naming semantics.
 
 Both sync and async readers compare lossless bigint identities from the preview,
-opened descriptor, resolved target, and current input path before reading. An
+opened descriptor, resolved target, and current input path before reading. POSIX
+opens are nonblocking, so a raced FIFO is rejected by descriptor type instead of
+waiting for a writer. An
 allowed symlink must still point to the opened file. On Windows, a zero device
 or inode is unverified: that inspection is retried once without reopening the
 file, preserving known identity components and link checks. Definite mismatches

--- a/docs/secure-file.md
+++ b/docs/secure-file.md
@@ -18,8 +18,8 @@ const { buffer, realPath, permissions } = await readSecureFile({
 The helper:
 
 - requires a local absolute path and rejects UNC/network paths by default
-- rejects directories and, by default, symlink paths
-- opens the file before reading and verifies the opened fd still matches the path and realpath
+- rejects every non-regular preview and, by default, symlink paths
+- opens POSIX paths no-follow and nonblocking before reading, then verifies the opened fd still matches the path and realpath; a FIFO swap cannot block before `timeoutMs` owns the byte read
 - optionally requires the real path to live under one of `trust.trustedDirs`
 - rejects hard-to-verify or unsafe permissions unless `permissions.allowInsecure` is set
 - rejects files owned by another POSIX uid

--- a/docs/store.md
+++ b/docs/store.md
@@ -75,7 +75,8 @@ Queue and failed directory creation fsyncs every newly-created parent edge from 
 Failed destinations are create-only. Quarantine publishes the claimed file by hardlink, so the queue and failed directories must share a filesystem with hardlink support. If `failed/<id>.json` already exists, quarantine rejects while preserving both that earlier evidence and the current claimed entry instead of overwriting either file. The `read` callback continues to receive the logical `.json` path even though bytes are read and migrations are written through the claimed path.
 
 Queue entry reads verify lossless file identities before opening, on the opened
-descriptor, and at the current pathname before reading bytes. On Windows, an
+descriptor, and at the current pathname before reading bytes. POSIX opens are
+nonblocking, so a raced FIFO is rejected rather than stalling a consumer. On Windows, an
 unknown identity gets one bounded reinspection; persistent ambiguity or a
 mismatch rejects with `queue entry changed during read`. Each inspection still
 rejects non-files, symlinks, hardlinks, and entries over the byte limit.

--- a/src/archive-input.ts
+++ b/src/archive-input.ts
@@ -9,6 +9,7 @@ import {
   type ResolvedArchiveExtractLimits,
 } from "./archive-limits.js";
 import { sameFileIdentity } from "./file-identity.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { tempFile } from "./temp-target.js";
 
 export type StagedArchiveFile = { path: string; cleanup: () => Promise<void> };
@@ -52,9 +53,7 @@ export async function stageArchiveFileForExtraction(params: {
   if (initialStat.size > params.limits.maxArchiveBytes) {
     throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ARCHIVE_SIZE_EXCEEDS_LIMIT);
   }
-  const noFollow =
-    process.platform !== "win32" && "O_NOFOLLOW" in fsConstants ? fsConstants.O_NOFOLLOW : 0;
-  const handle = await fs.open(sourcePath, fsConstants.O_RDONLY | noFollow);
+  const handle = await fs.open(sourcePath, resolveReadOpenFlags());
   let staged: StagedArchiveFile | undefined;
   let output: FileHandle | undefined;
   try {

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -1,4 +1,3 @@
-import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { Readable } from "node:stream";
 import { readFileHandleBounded } from "./bounded-read.js";
@@ -31,6 +30,7 @@ import {
 import type { ZipEntry } from "./archive-zip-entry.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { getNativeBinding } from "./native.js";
 import { admitZipBuffer } from "./archive-zip-admission.js";
 import { resolveExtractLimits } from "./archive-limits.js";
@@ -98,11 +98,7 @@ async function stageArchiveInput(archivePath: string): Promise<{
   if (before.isSymbolicLink() || !before.isFile()) {
     throw new Error(`archive is not a regular file: ${archivePath}`);
   }
-  const noFollow =
-    process.platform !== "win32" && typeof fsSync.constants.O_NOFOLLOW === "number"
-      ? fsSync.constants.O_NOFOLLOW
-      : 0;
-  const handle = await fs.open(resolved, fsSync.constants.O_RDONLY | noFollow);
+  const handle = await fs.open(resolved, resolveReadOpenFlags());
   const staged = await tempFile({ prefix: "fs-safe-archive-read", fileName: "archive.bin" });
   try {
     const opened = await handle.stat();

--- a/src/archive-staging.ts
+++ b/src/archive-staging.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import fsSync from "node:fs";
 import path from "node:path";
 import {
   assertAsyncDirectoryGuard,
@@ -18,6 +17,7 @@ import { FsSafeError } from "./errors.js";
 import { formatErrorDetail } from "./error-detail.js";
 import { resolveOpenedFileRealPathForHandle, root } from "./root.js";
 import { isNotFoundPathError, isPathInside } from "./path.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { resolveSecureTempRoot } from "./secure-temp-dir.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
 
@@ -234,12 +234,8 @@ async function chmodInsideDestinationBestEffort(params: {
   checkExtractionDeadline(params.deadline);
   await assertDirectoryIdentityGuard(destinationGuard);
   checkExtractionDeadline(params.deadline);
-  const noFollowFlag =
-    process.platform !== "win32" && "O_NOFOLLOW" in fsSync.constants
-      ? fsSync.constants.O_NOFOLLOW
-      : 0;
   const handle = await fs
-    .open(params.destinationPath, fsSync.constants.O_RDONLY | noFollowFlag)
+    .open(params.destinationPath, resolveReadOpenFlags())
     .catch(() => null);
   checkExtractionDeadline(params.deadline);
   if (!handle) {

--- a/src/json-durable-queue.ts
+++ b/src/json-durable-queue.ts
@@ -9,6 +9,7 @@ import {
   moveDurableQueueEntryToFailed,
 } from "./json-durable-queue-ownership.js";
 import { stringifyJsonDocument } from "./json-stringify.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { replaceFileAtomic } from "./replace-file.js";
 import { assertSafePathSegment } from "./safe-path-segment.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
@@ -341,11 +342,7 @@ async function readBoundedUtf8File(params: {
 }): Promise<string> {
   const inspectPath = () => fs.promises.lstat(params.filePath, { bigint: true });
   const initialStat = await inspectQueueEntry(inspectPath, params.maxBytes);
-  const noFollow =
-    typeof fs.constants.O_NOFOLLOW === "number" && process.platform !== "win32"
-      ? fs.constants.O_NOFOLLOW
-      : 0;
-  const handle = await fs.promises.open(params.filePath, fs.constants.O_RDONLY | noFollow);
+  const handle = await fs.promises.open(params.filePath, resolveReadOpenFlags());
   try {
     const openedStat = await inspectQueueEntry(
       () => handle.stat({ bigint: true }), params.maxBytes, initialStat,

--- a/src/json.ts
+++ b/src/json.ts
@@ -70,6 +70,9 @@ function trySetSecureMode(pathname: string) {
   let fd: number | undefined;
   try {
     fd = fsSync.openSync(pathname, resolveReadOpenFlags());
+    if (!fsSync.fstatSync(fd).isFile()) {
+      return;
+    }
     fsSync.fchmodSync(fd, JSON_FILE_MODE);
   } catch {
     // best-effort on platforms without chmod support

--- a/src/json.ts
+++ b/src/json.ts
@@ -6,6 +6,7 @@ import { FsSafeError } from "./errors.js";
 import { stringifyJsonDocument } from "./json-stringify.js";
 import { readRegularFile, readRegularFileSync, statRegularFile } from "./regular-file.js";
 import { openRootFileSync, type RootFileOpenFailure } from "./root-file.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { writeTextAtomic, type WriteTextAtomicOptions } from "./text-atomic.js";
 import { sleep } from "./timing.js";
 
@@ -61,8 +62,6 @@ async function readRegularFileIfExistsWithRetry(
 
 const JSON_FILE_MODE = 0o600;
 const JSON_DIR_MODE = 0o700;
-const SUPPORTS_SYNC_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsSync.constants;
-
 function getErrorCode(err: unknown): string | undefined {
   return err instanceof Error ? (err as NodeJS.ErrnoException).code : undefined;
 }
@@ -70,11 +69,7 @@ function getErrorCode(err: unknown): string | undefined {
 function trySetSecureMode(pathname: string) {
   let fd: number | undefined;
   try {
-    fd = fsSync.openSync(
-      pathname,
-      fsSync.constants.O_RDONLY |
-        (SUPPORTS_SYNC_NOFOLLOW ? fsSync.constants.O_NOFOLLOW : 0),
-    );
+    fd = fsSync.openSync(pathname, resolveReadOpenFlags());
     fsSync.fchmodSync(fd, JSON_FILE_MODE);
   } catch {
     // best-effort on platforms without chmod support

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -14,6 +14,7 @@ import { mkdirPathComponentsWithGuards } from "./guarded-mkdir.js";
 import { runPinnedWriteNative } from "./native-pinned-write.js";
 import { getNativeBinding } from "./native.js";
 import { validatePinnedOperationPayload } from "./pinned-operation.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { withSidecarLock } from "./sidecar-lock.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
 
@@ -286,12 +287,7 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
           throw new FsSafeError("path-mismatch", "fallback target changed during write");
         }
         const expectedHash = sha256Hex(params.input.data, params.input.encoding);
-        const readFlags =
-          fsSync.constants.O_RDONLY |
-          (process.platform !== "win32" && "O_NOFOLLOW" in fsSync.constants
-            ? fsSync.constants.O_NOFOLLOW
-            : 0);
-        readHandle = await fs.open(targetPath, readFlags);
+        readHandle = await fs.open(targetPath, resolveReadOpenFlags());
         const readHandleStat = await readHandle.stat({ bigint: true });
         const actualHash = sha256Hex(await readHandle.readFile());
         if (actualHash !== expectedHash) {

--- a/src/publish-file.ts
+++ b/src/publish-file.ts
@@ -17,6 +17,7 @@ import {
 } from "./file-identity.js";
 import { syncNativeFileBestEffort } from "./native-operations.js";
 import { getNativeBinding, requireNativeBinding, type NativeBinding } from "./native.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import {
   directorySyncFailure,
   publicationFailure,
@@ -67,12 +68,7 @@ export function isHardlinkFallbackError(error: unknown): boolean {
 }
 
 function sourceOpenFlags(): number {
-  return (
-    fsSync.constants.O_RDONLY |
-    (process.platform !== "win32" && typeof fsSync.constants.O_NOFOLLOW === "number"
-      ? fsSync.constants.O_NOFOLLOW
-      : 0)
-  );
+  return resolveReadOpenFlags();
 }
 
 function directoryOpenFlags(): number {

--- a/src/replace-file-copy-fallback.ts
+++ b/src/replace-file-copy-fallback.ts
@@ -3,6 +3,7 @@ import type { FileHandle } from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { readOwnedCopySource, readOwnedCopySourceSync } from "./replace-file-copy-source.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 
 export type ReplaceFileDestinationHardlinkPolicy = "reject";
 export type ReplaceFileCopyFallbackRestorePolicy = "restore-original" | "none";
@@ -34,7 +35,7 @@ type SyncFallbackFs = Pick<
 
 const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in syncFs.constants;
 const NOFOLLOW = SUPPORTS_NOFOLLOW ? syncFs.constants.O_NOFOLLOW : 0;
-const OPEN_READ_FLAGS = syncFs.constants.O_RDONLY | NOFOLLOW;
+const OPEN_READ_FLAGS = resolveReadOpenFlags();
 const OPEN_READ_WRITE_FLAGS = syncFs.constants.O_RDWR | NOFOLLOW;
 const OPEN_WRITE_EXCLUSIVE_FLAGS =
   syncFs.constants.O_WRONLY | syncFs.constants.O_CREAT | syncFs.constants.O_EXCL | NOFOLLOW;

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -8,6 +8,7 @@ import { FsSafeError } from "./errors.js";
 import { sameFileIdentity, type FileIdentityStat } from "./file-identity.js";
 import { resolveHomeRelativePath } from "./home-dir.js";
 import { openPinnedFileSync } from "./pinned-open.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { runPinnedWriteHelper } from "./pinned-write.js";
 import {
   assertSecretFilePreview,
@@ -156,9 +157,7 @@ async function enforcePrivateFileIdentityAndMode(
   expectedIdentity: FileIdentityStat,
   expectedMode: number,
 ): Promise<void> {
-  const noFollowFlag =
-    process.platform !== "win32" && "O_NOFOLLOW" in fs.constants ? fs.constants.O_NOFOLLOW : 0;
-  const handle = await fsp.open(resolvedPath, fs.constants.O_RDONLY | noFollowFlag);
+  const handle = await fsp.open(resolvedPath, resolveReadOpenFlags());
   try {
     const openedStat = await handle.stat();
     if (!openedStat.isFile() || !sameFileIdentity(openedStat, expectedIdentity)) {

--- a/src/secret-read-async.ts
+++ b/src/secret-read-async.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import { readFileHandleBounded } from "./bounded-read.js";
 import { FsSafeError } from "./errors.js";
 import { resolveHomeRelativePath } from "./home-dir.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
 import {
   assertSecretFilePreview,
@@ -50,11 +51,7 @@ export async function readSecretFile(
   let raw: string;
   try {
     const realPath = await fs.realpath(resolvedPath);
-    const noFollow =
-      process.platform !== "win32" && "O_NOFOLLOW" in fsSync.constants
-        ? fsSync.constants.O_NOFOLLOW
-        : 0;
-    handle = await fs.open(realPath, fsSync.constants.O_RDONLY | noFollow);
+    handle = await fs.open(realPath, resolveReadOpenFlags());
     const openedHandle = handle;
     const openedStat = await inspectFileIdentity(async () => {
       const stat = await openedHandle.stat({ bigint: true });

--- a/src/secure-file.ts
+++ b/src/secure-file.ts
@@ -1,5 +1,4 @@
 import type { Stats } from "node:fs";
-import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -10,6 +9,7 @@ import { FsSafeError } from "./errors.js";
 import { isWindowsDriveLetterPath, isWindowsNetworkPath } from "./local-file-access.js";
 import { isPathInside, isSymlinkOpenError } from "./path.js";
 import { formatPermissionErrorDetail } from "./permission-exec.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import {
   inspectPathPermissions,
   isGroupReadable,
@@ -21,9 +21,6 @@ import {
   type PermissionCheckOptions,
 } from "./permissions.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
-
-const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsConstants;
-const OPEN_READ_FLAGS = fsConstants.O_RDONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 
 export type SecureFileReadOptions = {
   filePath: string;
@@ -89,16 +86,19 @@ async function openSecureHandle(options: SecureFileReadOptions): Promise<{
       cause: err,
     });
   });
-  if (preStat.isDirectory()) {
+  if (preStat.isSymbolicLink()) {
+    if (!options.trust?.allowSymlink) {
+      throw new FsSafeError("symlink", `${label(options)} must not be a symlink: ${options.filePath}`);
+    }
+  } else if (!preStat.isFile()) {
     throw new FsSafeError("not-file", `${label(options)} must be a file: ${options.filePath}`);
-  }
-  if (preStat.isSymbolicLink() && !options.trust?.allowSymlink) {
-    throw new FsSafeError("symlink", `${label(options)} must not be a symlink: ${options.filePath}`);
   }
 
   let handle: FileHandle;
   try {
-    handle = await fs.open(options.filePath, options.trust?.allowSymlink ? fsConstants.O_RDONLY : OPEN_READ_FLAGS);
+    handle = await fs.open(options.filePath, resolveReadOpenFlags({
+      followSymlinks: options.trust?.allowSymlink === true,
+    }));
   } catch (err) {
     if (isSymlinkOpenError(err)) {
       throw new FsSafeError("symlink", `${label(options)} symlink open blocked`, { cause: err });

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { readFileDescriptorBoundedSync, readFileHandleBounded } from "./bounded-read.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
 import type { Root } from "./root-impl.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
 
@@ -176,12 +177,14 @@ export function readSidecarLockSnapshotSync(
       }
       return null;
     }
-    const noFollow =
-      process.platform !== "win32" && typeof fsSync.constants.O_NOFOLLOW === "number"
-        ? fsSync.constants.O_NOFOLLOW
-        : 0;
-    fd = fsSync.openSync(lockPath, fsSync.constants.O_RDONLY | noFollow);
+    fd = fsSync.openSync(lockPath, resolveReadOpenFlags());
     const opened = fsSync.fstatSync(fd);
+    if (!opened.isFile()) {
+      if (options.rejectNonFile) {
+        throw new FsSafeError("not-file", `sidecar lock is not a regular file: ${lockPath}`);
+      }
+      return null;
+    }
     const raw = readFileDescriptorBoundedSync(fd, MAX_LOCK_PAYLOAD_BYTES).toString("utf8");
     const after = fsSync.lstatSync(lockPath);
     if (!sameFileIdentity(before, opened) || !sameFileIdentity(opened, after)) return null;

--- a/test/nonblocking-read-admission.test.ts
+++ b/test/nonblocking-read-admission.test.ts
@@ -7,6 +7,7 @@ import { stageArchiveFileForExtraction } from "../src/archive-input.js";
 import { resolveExtractLimits } from "../src/archive-limits.js";
 import { readArchiveEntry } from "../src/archive-read.js";
 import { readJsonDurableQueueEntry } from "../src/json-durable-queue.js";
+import { writeJsonSync } from "../src/json.js";
 import { publishFileExclusive } from "../src/publish-file.js";
 import { readSecureFile } from "../src/secure-file.js";
 import { readSecretFile } from "../src/secret-read-async.js";
@@ -185,5 +186,27 @@ describe("nonblocking regular-file admission", () => {
     });
     expect(() => readSidecarLockSnapshotSync(lockPath, undefined, { rejectNonFile: true }))
       .toThrow(expect.objectContaining({ code: "not-file" }));
+  });
+
+  itPosix("does not chmod a FIFO swapped into synchronous JSON mode enforcement", async () => {
+    const root = await tempRoot("fs-safe-json-mode-fifo-");
+    const filePath = path.join(root, "state.json");
+    const openSync = fsSync.openSync.bind(fsSync);
+    const fchmodSync = fsSync.fchmodSync.bind(fsSync);
+    vi.spyOn(fsSync, "openSync").mockImplementation((candidate, flags, mode) => {
+      if (candidate === filePath) {
+        expectNonblocking(flags);
+        fsSync.renameSync(filePath, `${filePath}.displaced`);
+        makeFifo(filePath);
+      }
+      return openSync(candidate, flags, mode);
+    });
+    vi.spyOn(fsSync, "fchmodSync").mockImplementation((fd, mode) => {
+      expect(fsSync.fstatSync(fd).isFile()).toBe(true);
+      fchmodSync(fd, mode);
+    });
+
+    writeJsonSync(filePath, { ok: true });
+    expect(fsSync.lstatSync(filePath).isFIFO()).toBe(true);
   });
 });

--- a/test/nonblocking-read-admission.test.ts
+++ b/test/nonblocking-read-admission.test.ts
@@ -1,0 +1,189 @@
+import { spawnSync } from "node:child_process";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, vi } from "vitest";
+import { stageArchiveFileForExtraction } from "../src/archive-input.js";
+import { resolveExtractLimits } from "../src/archive-limits.js";
+import { readArchiveEntry } from "../src/archive-read.js";
+import { readJsonDurableQueueEntry } from "../src/json-durable-queue.js";
+import { publishFileExclusive } from "../src/publish-file.js";
+import { readSecureFile } from "../src/secure-file.js";
+import { readSecretFile } from "../src/secret-read-async.js";
+import { readSidecarLockSnapshotSync } from "../src/sidecar-lock-reclaim.js";
+import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+function makeFifo(filePath: string): void {
+  expect(spawnSync("mkfifo", [filePath]).status).toBe(0);
+}
+
+async function swapForFifo(filePath: string): Promise<string> {
+  const displaced = `${filePath}.displaced`;
+  await fs.rename(filePath, displaced);
+  makeFifo(filePath);
+  return displaced;
+}
+
+function expectNonblocking(flags: string | number): void {
+  expect(typeof flags).toBe("number");
+  expect(Number(flags) & fsSync.constants.O_NONBLOCK).toBe(fsSync.constants.O_NONBLOCK);
+}
+
+function deadline() {
+  const signal = new AbortController().signal;
+  return {
+    signal,
+    check: vi.fn(),
+    ownDestinationMutation: async <T>(run: () => Promise<T>) => await run(),
+    waitForDestinationMutations: async () => undefined,
+    dispose: () => undefined,
+  };
+}
+
+describe("nonblocking regular-file admission", () => {
+  itPosix("rejects a secure-file FIFO preview before open", async () => {
+    const root = await tempRoot("fs-safe-secure-fifo-preview-");
+    const filePath = path.join(root, "secret");
+    makeFifo(filePath);
+    const open = vi.spyOn(fs, "open");
+    await expect(readSecureFile({
+      filePath,
+      permissions: { allowInsecure: true },
+      io: { timeoutMs: 10 },
+    })).rejects.toMatchObject({ code: "not-file" });
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  itPosix("rejects a secure-file FIFO swap before timeout ownership without blocking", async () => {
+    const root = await tempRoot("fs-safe-secure-fifo-swap-");
+    const filePath = path.join(root, "secret");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+      expectNonblocking(flags);
+      await swapForFifo(filePath);
+      return await open(candidate, flags, mode);
+    });
+    await expect(readSecureFile({
+      filePath,
+      permissions: { allowInsecure: true },
+      io: { timeoutMs: 10 },
+    })).rejects.toMatchObject({ code: "not-file" });
+  });
+
+  itPosix("keeps allowed-symlink opens nonblocking across a FIFO swap", async () => {
+    const root = await tempRoot("fs-safe-secure-fifo-link-");
+    const target = path.join(root, "target");
+    const filePath = path.join(root, "secret");
+    await fs.writeFile(target, "secret", { mode: 0o600 });
+    await fs.symlink(target, filePath);
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+      expectNonblocking(flags);
+      expect(Number(flags) & fsSync.constants.O_NOFOLLOW).toBe(0);
+      await fs.unlink(filePath);
+      makeFifo(filePath);
+      return await open(candidate, flags, mode);
+    });
+    await expect(readSecureFile({
+      filePath,
+      trust: { allowSymlink: true },
+      permissions: { allowInsecure: true },
+    })).rejects.toMatchObject({ code: "not-file" });
+  });
+
+  itPosix("rejects a secret-file FIFO swap without blocking", async () => {
+    const root = await tempRoot("fs-safe-secret-fifo-");
+    const filePath = path.join(root, "secret");
+    await fs.writeFile(filePath, "secret", { mode: 0o600 });
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+      expectNonblocking(flags);
+      await swapForFifo(filePath);
+      return await open(candidate, flags, mode);
+    });
+    await expect(readSecretFile(filePath, "token", { rejectSymlink: true }))
+      .rejects.toMatchObject({ code: "path-mismatch" });
+  });
+
+  itPosix("rejects an archive extraction input FIFO swap before its deadline can be bypassed", async () => {
+    const root = await tempRoot("fs-safe-archive-input-fifo-");
+    const archivePath = path.join(root, "archive.zip");
+    await fs.writeFile(archivePath, "archive");
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+      expectNonblocking(flags);
+      await swapForFifo(archivePath);
+      return await open(candidate, flags, mode);
+    });
+    await expect(stageArchiveFileForExtraction({
+      archivePath,
+      limits: resolveExtractLimits(),
+      deadline: deadline(),
+    })).rejects.toThrow("archive changed during validation");
+  });
+
+  itPosix("rejects an archive entry-read FIFO swap without blocking", async () => {
+    const root = await tempRoot("fs-safe-archive-read-fifo-");
+    const archivePath = path.join(root, "archive.zip");
+    await fs.writeFile(archivePath, "archive");
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+      expectNonblocking(flags);
+      await swapForFifo(archivePath);
+      return await open(candidate, flags, mode);
+    });
+    await expect(readArchiveEntry(archivePath, "entry", { maxBytes: 16, kind: "zip" }))
+      .rejects.toThrow("archive changed during validation");
+  });
+
+  itPosix("rejects a durable queue FIFO swap without blocking", async () => {
+    const root = await tempRoot("fs-safe-queue-fifo-");
+    const filePath = path.join(root, "entry.json");
+    await fs.writeFile(filePath, JSON.stringify({ ok: true }));
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+      expectNonblocking(flags);
+      await swapForFifo(filePath);
+      return await open(candidate, flags, mode);
+    });
+    await expect(readJsonDurableQueueEntry(filePath)).rejects.toThrow("queue entry is not a regular file");
+  });
+
+  itPosix("rejects an exclusive-publication source FIFO swap without blocking", async () => {
+    const root = await tempRoot("fs-safe-publish-fifo-");
+    const sourcePath = path.join(root, "source");
+    const targetPath = path.join(root, "target");
+    await fs.writeFile(sourcePath, "source");
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+      expectNonblocking(flags);
+      await swapForFifo(sourcePath);
+      return await open(candidate, flags, mode);
+    });
+    await expect(publishFileExclusive({
+      sourcePath,
+      targetPath,
+      strategy: "link-required",
+    })).rejects.toMatchObject({ code: "path-mismatch" });
+    await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  itPosix("rejects a synchronous sidecar-lock FIFO swap without blocking", async () => {
+    const root = await tempRoot("fs-safe-sidecar-fifo-");
+    const lockPath = path.join(root, "entry.lock");
+    fsSync.writeFileSync(lockPath, "{}");
+    const openSync = fsSync.openSync.bind(fsSync);
+    vi.spyOn(fsSync, "openSync").mockImplementationOnce((candidate, flags, mode) => {
+      expectNonblocking(flags);
+      fsSync.renameSync(lockPath, `${lockPath}.displaced`);
+      makeFifo(lockPath);
+      return openSync(candidate, flags, mode);
+    });
+    expect(() => readSidecarLockSnapshotSync(lockPath, undefined, { rejectNonFile: true }))
+      .toThrow(expect.objectContaining({ code: "not-file" }));
+  });
+});


### PR DESCRIPTION
## Summary

- route attacker-raceable secure, secret, archive, queue, publication, fallback, and lock-file admissions through the shared POSIX no-follow/nonblocking read-open policy
- reject non-regular secure-file previews before open and reject FIFO swaps from descriptor type without waiting for a writer
- align synchronous sidecar-lock inspection with the async path by checking the opened descriptor is still a regular file before reading

## Root cause

Several guarded readers previewed a regular file and then opened the mutable pathname with `O_RDONLY | O_NOFOLLOW`. If an attacker or concurrent actor replaced the path with a FIFO after preview, the open itself could block indefinitely waiting for a writer. For `readSecureFile`, that happened before `timeoutMs` started owning the byte read; archive deadlines and queue processing could be bypassed the same way.

All affected POSIX opens now include `O_NONBLOCK` through `resolveReadOpenFlags()`. Direct non-regular previews are rejected before open. A FIFO installed in the preview/open gap opens immediately, fails the existing descriptor regular-file or identity fence, and remains untouched. Windows retains its existing guarded identity behavior without POSIX-only flags.

The change also covers archive staging/chmod admission, secret-file post-write verification, JSON mode verification, copy-fallback destination pinning, locked FUSE content verification, exclusive publication sources, and synchronous sidecar-lock snapshots. Directory-only descriptors are unchanged.

## Live behavior proof

A fresh npm consumer installed the packed package and raced six public APIs from a regular preview or post-publication name to a FIFO:

```json
[{"name":"secure","elapsedMs":4,"nonblocking":true,"error":{"name":"FsSafeError","code":"not-file","message":"Secure file must be a file: <temp>/secure.txt"},"displaced":"secret","fifoPreserved":true},{"name":"secret","elapsedMs":3,"nonblocking":true,"error":{"name":"FsSafeError","code":"path-mismatch","message":"Failed to read token file at <temp>/secret.txt: FsSafeError: security validation failed"},"displaced":"secret","fifoPreserved":true},{"name":"archive","elapsedMs":5,"nonblocking":true,"error":{"name":"Error","message":"archive changed during validation"},"displaced":"archive","fifoPreserved":true},{"name":"queue","elapsedMs":4,"nonblocking":true,"error":{"name":"Error","message":"queue entry is not a regular file"},"displaced":"{\"ok\":true}","fifoPreserved":true},{"name":"publication","elapsedMs":4,"nonblocking":true,"error":{"name":"FsSafeError","code":"path-mismatch","message":"publication source identity did not match"},"displaced":"source","fifoPreserved":true},{"name":"json-mode","elapsedMs":48,"nonblocking":true,"fifoChmods":0,"displaced":{"ok":true},"fifoPreserved":true}]
```

Every admission observed `O_NONBLOCK`; reads and publication rejected in 3–5 ms before consuming FIFO bytes or mutating the destination. The synchronous JSON mode path completed without applying `fchmod` to the swapped FIFO. All displaced regular files and foreign FIFOs were preserved.

## Verification

- focused secure-file, secret, archive, queue, publication, JSON, fallback, and lock suites: 15 files, 162 tests passed, 2 skipped
- complete `CI=1 pnpm check`: 143 files passed, 1 skipped; 2,356 tests passed, 25 skipped; package/API validation passed
- build, docs examples, pack, file-size, filesystem-boundary, and diff checks passed
- fresh packed npm consumer proof passed
- Codex autoreview at P1 and exact-head hosted Linux/macOS/Windows checks remain landing gates
