### PR TITLE
fix(json): bind mode enforcement to identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Bind `writeJsonSync()` best-effort file-mode tightening to the staged bigint identity and a reopened single-link regular descriptor, preserving swapped paths without chmodding them.
 - Open attacker-raceable secure, secret, archive, queue, publication, fallback, and lock-file read paths nonblocking on POSIX, rejecting FIFO substitutions before reads, deadlines, or cleanup verification can stall.
 - Retain async and sync atomic replacement temp descriptors across `beforeRename`, retries, copy fallback, and final publication; reject substituted, non-regular, or hardlinked stages, preserve unowned cleanup paths, and add explicit locked content verification for rename-unstable FUSE mounts.
 - Pin callback-produced sibling temps through requested mode application, opt-in fsync, rename, and exact publication checks; reject symlink, non-regular, hardlinked, and replaced stages and preserve unverified cleanup paths while retaining producer modes, disabled sync defaults, best-effort file and directory chmod, and read-only descriptor admission unless file sync is requested in `writeSiblingTempFile`.

--- a/docs/json.md
+++ b/docs/json.md
@@ -135,10 +135,14 @@ where lower latency matters more than crash-durability.
 
 Synchronous variant. It pretty-prints with two spaces, appends a newline,
 creates parents at `0o700`, writes at `0o600`, and synchronizes the parent
-directory best-effort. It has no options bag. On `EPERM`/`EEXIST`, its legacy
-compatibility path may replace by copy rather than atomic rename; use the async
-`writeJson()`/`replaceFileAtomic()` surfaces when fallback policy must be
-explicit.
+directory best-effort. File-mode tightening carries the staged bigint identity
+through rename and applies `fchmod` only when the reopened descriptor and current
+pathname still name that same single-link regular file; a swap is preserved and
+skips this best-effort step. It has no options bag. On `EPERM`/`EEXIST`, its legacy
+compatibility path removes the existing destination and retries the staged-file
+rename, so that fallback is temporarily non-atomic while retaining the staged
+file's `0600` mode; use the async `writeJson()`/`replaceFileAtomic()` surfaces
+when fallback policy must be explicit.
 
 ```ts
 writeJsonSync("./prefs.json", { theme: "dark" });

--- a/src/json.ts
+++ b/src/json.ts
@@ -3,6 +3,7 @@ import fsSync from "node:fs";
 import path from "node:path";
 import { readFileDescriptorBoundedSync } from "./bounded-read.js";
 import { FsSafeError } from "./errors.js";
+import { sameFileIdentityForCleanup, type FileIdentityStat } from "./file-identity.js";
 import { stringifyJsonDocument } from "./json-stringify.js";
 import { readRegularFile, readRegularFileSync, statRegularFile } from "./regular-file.js";
 import { openRootFileSync, type RootFileOpenFailure } from "./root-file.js";
@@ -66,16 +67,35 @@ function getErrorCode(err: unknown): string | undefined {
   return err instanceof Error ? (err as NodeJS.ErrnoException).code : undefined;
 }
 
-function trySetSecureMode(pathname: string) {
+function trySetSecureMode(pathname: string, expectedIdentity: FileIdentityStat): void {
   let fd: number | undefined;
   try {
+    const before = fsSync.lstatSync(pathname, { bigint: true });
+    if (
+      before.isSymbolicLink() ||
+      !before.isFile() ||
+      before.nlink !== 1n ||
+      !sameFileIdentityForCleanup(before, expectedIdentity)
+    ) {
+      return;
+    }
     fd = fsSync.openSync(pathname, resolveReadOpenFlags());
-    if (!fsSync.fstatSync(fd).isFile()) {
+    const opened = fsSync.fstatSync(fd, { bigint: true });
+    const current = fsSync.lstatSync(pathname, { bigint: true });
+    if (
+      !opened.isFile() ||
+      opened.nlink !== 1n ||
+      current.isSymbolicLink() ||
+      !current.isFile() ||
+      current.nlink !== 1n ||
+      !sameFileIdentityForCleanup(opened, expectedIdentity) ||
+      !sameFileIdentityForCleanup(current, opened)
+    ) {
       return;
     }
     fsSync.fchmodSync(fd, JSON_FILE_MODE);
   } catch {
-    // best-effort on platforms without chmod support
+    // Best-effort mode application never falls back to a mutable pathname.
   } finally {
     if (fd !== undefined) {
       try {
@@ -135,11 +155,12 @@ function renameJsonFileWithFallback(tmpPath: string, pathname: string) {
   }
 }
 
-function writeTempJsonFile(pathname: string, payload: string) {
+function writeTempJsonFile(pathname: string, payload: string): fsSync.BigIntStats {
   const fd = fsSync.openSync(pathname, "wx", JSON_FILE_MODE);
   try {
     fsSync.writeFileSync(fd, payload, "utf8");
     fsSync.fsyncSync(fd);
+    return fsSync.fstatSync(fd, { bigint: true });
   } finally {
     fsSync.closeSync(fd);
   }
@@ -171,10 +192,10 @@ export function writeJsonSync(pathname: string, data: unknown) {
 
   fsSync.mkdirSync(path.dirname(targetPath), { recursive: true, mode: JSON_DIR_MODE });
   try {
-    writeTempJsonFile(tmpPath, payload);
-    trySetSecureMode(tmpPath);
+    const tempIdentity = writeTempJsonFile(tmpPath, payload);
+    trySetSecureMode(tmpPath, tempIdentity);
     renameJsonFileWithFallback(tmpPath, targetPath);
-    trySetSecureMode(targetPath);
+    trySetSecureMode(targetPath, tempIdentity);
     trySyncDirectory(targetPath);
   } finally {
     try {

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -197,6 +198,31 @@ describe("json file helpers", () => {
     await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("{\"secret\":true}\n");
     await expect(fs.readFile(linkPath, "utf8")).resolves.toBe("{\n  \"ok\": true\n}\n");
     expect((await fs.lstat(linkPath)).isSymbolicLink()).toBe(false);
+  });
+
+  itPosix("keeps mode 0600 on the EPERM remove-and-retry fallback", async () => {
+    const root = await tempRoot("fs-safe-json-fallback-mode-");
+    const filePath = path.join(root, "state.json");
+    await fs.writeFile(filePath, "{\"old\":true}\n", { mode: 0o644 });
+    await fs.chmod(filePath, 0o644);
+    const renameSync = fsSync.renameSync.bind(fsSync);
+    let renames = 0;
+    const rename = vi.spyOn(fsSync, "renameSync").mockImplementation((source, destination) => {
+      renames += 1;
+      if (renames === 1) {
+        throw Object.assign(new Error("rename denied"), { code: "EPERM" });
+      }
+      renameSync(source, destination);
+    });
+    try {
+      writeJsonSync(filePath, { ok: true });
+    } finally {
+      rename.mockRestore();
+    }
+
+    expect(renames).toBe(2);
+    expect((await fs.stat(filePath)).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(await fs.readFile(filePath, "utf8"))).toEqual({ ok: true });
   });
 
   it("serializes work through createAsyncLock", async () => {

--- a/test/nonblocking-read-admission.test.ts
+++ b/test/nonblocking-read-admission.test.ts
@@ -173,6 +173,67 @@ describe("nonblocking regular-file admission", () => {
     await expect(fs.lstat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  itPosix("does not chmod a FIFO swapped into a synchronous JSON target", async () => {
+    const root = await tempRoot("fs-safe-json-fifo-");
+    const filePath = path.join(root, "state.json");
+    const displaced = `${filePath}.displaced`;
+    const openSync = fsSync.openSync.bind(fsSync);
+    const fchmodSync = fsSync.fchmodSync.bind(fsSync);
+    let fifoFd = -1;
+    let fifoChmods = 0;
+    vi.spyOn(fsSync, "openSync").mockImplementation((candidate, flags, mode) => {
+      if (String(candidate) === filePath && typeof flags === "number") {
+        expectNonblocking(flags);
+        fsSync.renameSync(filePath, displaced);
+        makeFifo(filePath);
+        fifoFd = openSync(candidate, flags, mode);
+        return fifoFd;
+      }
+      return openSync(candidate, flags, mode);
+    });
+    vi.spyOn(fsSync, "fchmodSync").mockImplementation((fd, mode) => {
+      if (fd === fifoFd) fifoChmods += 1;
+      return fchmodSync(fd, mode);
+    });
+
+    writeJsonSync(filePath, { ok: true });
+
+    expect(fifoChmods).toBe(0);
+    expect(fsSync.lstatSync(filePath).isFIFO()).toBe(true);
+    expect(JSON.parse(fsSync.readFileSync(displaced, "utf8"))).toEqual({ ok: true });
+  });
+
+  itPosix("does not chmod a regular file swapped into a synchronous JSON target", async () => {
+    const root = await tempRoot("fs-safe-json-regular-swap-");
+    const filePath = path.join(root, "state.json");
+    const displaced = `${filePath}.displaced`;
+    const openSync = fsSync.openSync.bind(fsSync);
+    const fchmodSync = fsSync.fchmodSync.bind(fsSync);
+    let replacementFd = -1;
+    let replacementChmods = 0;
+    vi.spyOn(fsSync, "openSync").mockImplementation((candidate, flags, mode) => {
+      if (String(candidate) === filePath && typeof flags === "number") {
+        fsSync.renameSync(filePath, displaced);
+        fsSync.writeFileSync(filePath, "foreign", { mode: 0o644 });
+        fsSync.chmodSync(filePath, 0o644);
+        replacementFd = openSync(candidate, flags, mode);
+        return replacementFd;
+      }
+      return openSync(candidate, flags, mode);
+    });
+    vi.spyOn(fsSync, "fchmodSync").mockImplementation((fd, mode) => {
+      if (fd === replacementFd) replacementChmods += 1;
+      return fchmodSync(fd, mode);
+    });
+
+    writeJsonSync(filePath, { ok: true });
+
+    expect(replacementChmods).toBe(0);
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("foreign");
+    expect(fsSync.statSync(filePath).mode & 0o777).toBe(0o644);
+    expect(JSON.parse(fsSync.readFileSync(displaced, "utf8"))).toEqual({ ok: true });
+  });
+
   itPosix("rejects a synchronous sidecar-lock FIFO swap without blocking", async () => {
     const root = await tempRoot("fs-safe-sidecar-fifo-");
     const lockPath = path.join(root, "entry.lock");
@@ -186,27 +247,5 @@ describe("nonblocking regular-file admission", () => {
     });
     expect(() => readSidecarLockSnapshotSync(lockPath, undefined, { rejectNonFile: true }))
       .toThrow(expect.objectContaining({ code: "not-file" }));
-  });
-
-  itPosix("does not chmod a FIFO swapped into synchronous JSON mode enforcement", async () => {
-    const root = await tempRoot("fs-safe-json-mode-fifo-");
-    const filePath = path.join(root, "state.json");
-    const openSync = fsSync.openSync.bind(fsSync);
-    const fchmodSync = fsSync.fchmodSync.bind(fsSync);
-    vi.spyOn(fsSync, "openSync").mockImplementation((candidate, flags, mode) => {
-      if (candidate === filePath) {
-        expectNonblocking(flags);
-        fsSync.renameSync(filePath, `${filePath}.displaced`);
-        makeFifo(filePath);
-      }
-      return openSync(candidate, flags, mode);
-    });
-    vi.spyOn(fsSync, "fchmodSync").mockImplementation((fd, mode) => {
-      expect(fsSync.fstatSync(fd).isFile()).toBe(true);
-      fchmodSync(fd, mode);
-    });
-
-    writeJsonSync(filePath, { ok: true });
-    expect(fsSync.lstatSync(filePath).isFIFO()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- carry `writeJsonSync()`'s staged bigint identity through rename into best-effort file-mode tightening
- apply descriptor `fchmodSync` only when the pre-open path, reopened descriptor, and current path remain the same single-link regular file
- preserve FIFO and regular-file substitutions without chmodding, deleting, or overwriting them

## Root cause

[PR #175](https://github.com/openclaw/fs-safe/pull/175) made synchronous JSON mode admission nonblocking and added a descriptor regular-file check. That prevents a swapped FIFO from being chmodded, but a same-type regular file substituted between publication and reopen could still receive the library's `0600` mode because no identity receipt crossed the rename boundary.

`writeTempJsonFile()` now returns the staged descriptor's lossless bigint identity. Both pre-rename and post-rename mode attempts preview the path, reopen no-follow/nonblocking, verify descriptor and current pathname type, single-link count, and exact identity, then call `fchmodSync`. Any unsupported mode operation or unverifiable/mismatched path remains best-effort and is preserved without a pathname fallback. The legacy `EPERM`/`EEXIST` path removes the destination and retries rename—it does not copy or retain the old destination inode—and focused proof confirms the staged `0600` mode survives that retry.

## Live behavior proof

A fresh npm consumer installed the packed package and exercised both post-publication substitutions:

```json
[{"name":"json-mode","elapsedMs":23,"nonblocking":true,"fifoChmods":0,"displaced":{"ok":true},"fifoPreserved":true},{"name":"json-regular-swap","replacementChmods":0,"replacement":"foreign","replacementMode":420,"displaced":{"ok":true}}]
```

The FIFO remains untouched, and a foreign regular replacement remains `0644` (`420`) rather than being tightened to `0600`. In both cases the library-authored JSON is preserved at the displaced name and no replacement descriptor is chmodded.

## Verification

- focused JSON, FIFO-admission, and security regression suites: 3 files, 46 tests passed
- complete `CI=1 pnpm check`: 143 files passed, 1 skipped; 2,358 tests passed, 25 skipped; package/API validation passed
- fresh packed npm consumer proof passed
- build, docs examples, pack, file-size, filesystem-boundary, and diff checks passed
- Codex autoreview at P1 and exact-head hosted Linux/macOS/Windows checks remain landing gates
