### PR TITLE
fix(limits): normalize public byte budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Normalize public `maxBytes` budgets across Root, FileStore, secure/secret/regular reads, durable queues, and external output: reject invalid values, preserve explicit zero and positive `Infinity`, and keep configured defaults when callers forward `undefined`.
 - Bind `writeJsonSync()` best-effort file-mode tightening to the staged bigint identity and a reopened single-link regular descriptor, preserving swapped paths without chmodding them.
 - Open attacker-raceable secure, secret, archive, queue, publication, fallback, and lock-file read paths nonblocking on POSIX, rejecting FIFO substitutions before reads, deadlines, or cleanup verification can stall.
 - Retain async and sync atomic replacement temp descriptors across `beforeRename`, retries, copy fallback, and final publication; reject substituted, non-regular, or hardlinked stages, preserve unowned cleanup paths, and add explicit locked content verification for rename-unstable FUSE mounts.

--- a/docs/file-store.md
+++ b/docs/file-store.md
@@ -31,6 +31,8 @@ const cache = fileStore({
 });
 ```
 
+Store and per-call `maxBytes` values must be non-negative safe integers or positive `Infinity`. Zero is an active zero-byte cap; `Infinity` disables the cap. An omitted or explicitly `undefined` per-call value preserves the store-level limit. The same rule applies to buffer writes, streams, copies, async reads, and synchronous reads/writes.
+
 Use `private: true` for credentials, auth profiles, tokens, and other private
 state. Private mode keeps the same `FileStore` shape but routes writes through
 the secret-file atomic path, refusing symlink parent components and re-asserting

--- a/docs/output.md
+++ b/docs/output.md
@@ -48,6 +48,8 @@ The requested `path` must name a file. Missing destination parents are created
 by the helper because the operation is "produce this output file under the
 root"; callers should choose the filename before calling this API.
 
+`maxBytes` must be a non-negative safe integer or positive `Infinity`; zero is an active cap and `Infinity` disables it. Invalid values reject before the producer or filesystem staging runs.
+
 Use `maxBytes` when the external producer can create arbitrarily large files,
 and `mode` when the finalized file needs a specific POSIX mode. Both staging
 modes enforce them after the producer returns and before committing the target.

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -89,7 +89,7 @@ type RootReadOptions = {
 };
 ```
 
-`maxBytes` is enforced eagerly: the library reads up to `maxBytes + 1` and throws `too-large` if there is more, so a hostile target cannot silently exhaust memory.
+`maxBytes` is enforced eagerly: the library reads up to `maxBytes + 1` and throws `too-large` if there is more, so a hostile target cannot silently exhaust memory. Values must be non-negative safe integers or positive `Infinity`; zero is an active cap, while `Infinity` disables it. Explicitly forwarding `undefined` preserves the Root default.
 
 `nonBlockingRead` remains as a compatibility hint. Safe reads always add the platform's nonblocking open flag where available so a raced FIFO cannot pin a worker indefinitely; regular-file descriptor reads retain normal Node behavior.
 

--- a/docs/root.md
+++ b/docs/root.md
@@ -38,6 +38,8 @@ type DenyMutationPolicy = {
 
 `defaults` apply to every method on the returned handle. Per-call options on individual methods override the defaults for that call only, except `denyMutations`: root and per-call deny entries are merged so a call cannot clear a root-level deny.
 
+Every `maxBytes` value must be a non-negative safe integer or positive `Infinity`. Zero is an active zero-byte cap; `Infinity` explicitly disables the cap. An omitted or explicitly `undefined` per-call value preserves the configured Root default instead of clearing it.
+
 ## The `Root` interface
 
 Every method on the returned handle accepts paths relative to the root and rejects anything that would escape it.

--- a/docs/secret-file.md
+++ b/docs/secret-file.md
@@ -73,6 +73,8 @@ type SecretFileReadOptions = {
 };
 ```
 
+`maxBytes` must be a non-negative safe integer or positive `Infinity`; zero is an active cap, `Infinity` disables it, and omitted or explicitly `undefined` values preserve the 16 KiB default.
+
 The reader trims the file content and rejects empty results. Symlink paths are
 followed and pinned by default; set `rejectSymlink: true` when the pathname
 itself must not be an alias. Hardlinks are rejected by default so another

--- a/docs/secure-file.md
+++ b/docs/secure-file.md
@@ -57,6 +57,8 @@ type SecureFileReadOptions = {
 };
 ```
 
+`io.maxBytes` must be a non-negative safe integer or positive `Infinity`; zero is an active cap and `Infinity` disables the cap. Invalid limits reject before filesystem admission.
+
 `permissions.allowInsecure` is a migration escape hatch. Prefer fixing permissions and using [`formatPermissionRemediation`](permissions.md) to show the user what to run. `trust.allowNetworkPath` is off by default because UNC paths are remote authority, not local filesystem input. `inject` is for tests and platform adapters; production callers usually leave it unset.
 
 `permissions.allowInsecure` bypasses only permission checks. Neither it nor `inject.platform` changes filesystem identity verification, which always uses the actual process platform. `trust.allowSymlink` permits an alias but still requires its target and realpath to match the opened descriptor.

--- a/src/bounded-read-stream.ts
+++ b/src/bounded-read-stream.ts
@@ -1,13 +1,9 @@
 import { pipeline, Transform } from "node:stream";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { FsSafeError } from "./errors.js";
 
 export function createMaxBytesTransform(maxBytes: number): Transform {
-  if (
-    maxBytes !== Number.POSITIVE_INFINITY &&
-    (!Number.isSafeInteger(maxBytes) || maxBytes < 0)
-  ) {
-    throw new RangeError("maxBytes must be a non-negative safe integer or Infinity");
-  }
+  normalizeMaxBytes(maxBytes);
   let bytes = 0;
   return new Transform({
     transform(chunk, _encoding, callback) {

--- a/src/bounded-read.ts
+++ b/src/bounded-read.ts
@@ -1,19 +1,11 @@
 import fs from "node:fs";
 import type { FileHandle } from "node:fs/promises";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { FsSafeError } from "./errors.js";
 
 const READ_CHUNK_BYTES = 64 * 1024;
 
 type ReadableFileHandle = Pick<FileHandle, "read">;
-
-function assertMaxBytes(maxBytes: number): void {
-  if (maxBytes === Number.POSITIVE_INFINITY) {
-    return;
-  }
-  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
-    throw new RangeError("maxBytes must be a non-negative safe integer or Infinity");
-  }
-}
 
 function createScratchBuffer(maxBytes: number): Buffer {
   const initialReadBytes = Number.isFinite(maxBytes)
@@ -50,7 +42,7 @@ async function readBoundedAsync(
   maxBytes: number,
   readChunk: (scratch: Buffer, length: number) => Promise<number>,
 ): Promise<Buffer> {
-  assertMaxBytes(maxBytes);
+  normalizeMaxBytes(maxBytes);
   const chunks: Buffer[] = [];
   const scratch = createScratchBuffer(maxBytes);
   let total = 0;
@@ -99,7 +91,7 @@ export async function readFileDescriptorBounded(fd: number, maxBytes: number): P
 
 /** Sync bounded read from a numeric descriptor. The caller owns the descriptor. */
 export function readFileDescriptorBoundedSync(fd: number, maxBytes: number): Buffer {
-  assertMaxBytes(maxBytes);
+  normalizeMaxBytes(maxBytes);
   const chunks: Buffer[] = [];
   const scratch = createScratchBuffer(maxBytes);
   let total = 0;

--- a/src/byte-budget.ts
+++ b/src/byte-budget.ts
@@ -1,0 +1,13 @@
+export function normalizeMaxBytes(
+  value: number | undefined,
+  options: { defaultValue?: number; label?: string } = {},
+): number | undefined {
+  const selected = value === undefined ? options.defaultValue : value;
+  if (selected === undefined || selected === Number.POSITIVE_INFINITY) return selected;
+  if (!Number.isSafeInteger(selected) || selected < 0) {
+    throw new RangeError(
+      `${options.label ?? "maxBytes"} must be a non-negative safe integer or Infinity`,
+    );
+  }
+  return selected;
+}

--- a/src/file-store-boundary.ts
+++ b/src/file-store-boundary.ts
@@ -2,6 +2,7 @@ import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Transform, type Readable } from "node:stream";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { pipeline } from "node:stream/promises";
 import {
   assertSyncDirectoryGuard as assertDirectoryGuardSync,
@@ -39,9 +40,10 @@ export async function openWritableStoreRoot(params: {
   dirMode: number;
   maxBytes?: number;
 }): Promise<Root> {
+  const maxBytes = normalizeMaxBytes(params.maxBytes);
   await fs.mkdir(params.rootDir, { recursive: true, mode: params.dirMode });
   await fs.chmod(params.rootDir, params.dirMode).catch(() => undefined);
-  return await root(params.rootDir, { hardlinks: "reject", maxBytes: params.maxBytes });
+  return await root(params.rootDir, { hardlinks: "reject", maxBytes });
 }
 
 async function chmodDirectoryInRootBestEffort(
@@ -72,7 +74,8 @@ async function chmodDirectoryInRootBestEffort(
 }
 
 function createMaxBytesTransform(maxBytes: number | undefined): Transform | undefined {
-  if (maxBytes === undefined) {
+  const limit = normalizeMaxBytes(maxBytes);
+  if (limit === undefined) {
     return undefined;
   }
   let total = 0;
@@ -80,8 +83,8 @@ function createMaxBytesTransform(maxBytes: number | undefined): Transform | unde
     transform(chunk: Buffer | string, _encoding, callback) {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       total += buffer.byteLength;
-      if (total > maxBytes) {
-        callback(new FsSafeError("too-large", `file exceeds maximum size of ${maxBytes} bytes`));
+      if (total > limit) {
+        callback(new FsSafeError("too-large", `file exceeds maximum size of ${limit} bytes`));
         return;
       }
       callback(null, buffer);
@@ -94,6 +97,7 @@ export async function writeStreamToTempSource(params: {
   maxBytes?: number;
   mode: number;
 }): Promise<{ path: string; cleanup: () => Promise<void> }> {
+  const maxBytes = normalizeMaxBytes(params.maxBytes);
   const tempRoot = resolveSecureTempRoot({
     fallbackPrefix: "fs-safe-file-store",
     unsafeFallbackLabel: "file store temp dir",
@@ -109,7 +113,7 @@ export async function writeStreamToTempSource(params: {
     writable.once("close", () => {
       handleClosedByStream = true;
     });
-    const limiter = createMaxBytesTransform(params.maxBytes);
+    const limiter = createMaxBytesTransform(maxBytes);
     if (limiter) {
       await pipeline(params.stream, limiter, writable);
     } else {

--- a/src/file-store-limit.ts
+++ b/src/file-store-limit.ts
@@ -1,0 +1,9 @@
+import { normalizeMaxBytes } from "./byte-budget.js";
+import { FsSafeError } from "./errors.js";
+
+export function assertFileStoreMaxBytes(size: number, maxBytes?: number): void {
+  const limit = normalizeMaxBytes(maxBytes);
+  if (limit !== undefined && size > limit) {
+    throw new FsSafeError("too-large", `file exceeds maximum size of ${limit} bytes`);
+  }
+}

--- a/src/file-store.ts
+++ b/src/file-store.ts
@@ -2,8 +2,10 @@ import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { Readable } from "node:stream";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { readFileDescriptorBoundedSync } from "./bounded-read.js";
 import { FsSafeError } from "./errors.js";
+import { assertFileStoreMaxBytes } from "./file-store-limit.js";
 import { pruneExpiredStoreEntries, type FileStorePruneOptions } from "./file-store-prune.js";
 export type { FileStorePruneOptions } from "./file-store-prune.js";
 import {
@@ -127,16 +129,8 @@ function resolveStorePath(rootDir: string, relativePath: string): string {
   return resolveSafeRelativePath(rootDir, assertRelativePath(relativePath));
 }
 
-function assertMaxBytes(size: number, maxBytes?: number): void {
-  if (maxBytes !== undefined && size > maxBytes) {
-    throw new FsSafeError("too-large", `file exceeds maximum size of ${maxBytes} bytes`);
-  }
-}
-
 function isNotFound(error: unknown): boolean {
-  return error instanceof FsSafeError
-    ? error.code === "not-found"
-    : isNotFoundPathError(error);
+  return error instanceof FsSafeError ? error.code === "not-found" : isNotFoundPathError(error);
 }
 
 function handleSyncStoreReadOpenFailure(opened: RootFileOpenFailure): null {
@@ -176,7 +170,7 @@ async function readFileStoreCopySource(params: {
   if (sourceStat.isSymbolicLink() || !sourceStat.isFile()) {
     throw new FsSafeError("not-file", "source path is not a file");
   }
-  assertMaxBytes(sourceStat.size, params.maxBytes);
+  assertFileStoreMaxBytes(sourceStat.size, params.maxBytes);
   try {
     return (await readRegularFile({ filePath: params.sourcePath, maxBytes: params.maxBytes }))
       .buffer;
@@ -211,7 +205,7 @@ async function copyIntoRoot(params: {
   if (sourceStat.isSymbolicLink() || !sourceStat.isFile()) {
     throw new FsSafeError("not-file", "source path is not a file");
   }
-  assertMaxBytes(sourceStat.size, params.maxBytes);
+  assertFileStoreMaxBytes(sourceStat.size, params.maxBytes);
   const dirMode = params.dirMode ?? 0o700;
   const scopedRoot = await openWritableStoreRoot({
     rootDir: params.rootDir,
@@ -232,7 +226,7 @@ export function fileStore(options: FileStoreOptions): FileStore {
   const privateMode = options.private ?? false;
   const dirMode = options.dirMode ?? 0o700;
   const mode = options.mode ?? 0o600;
-  const maxBytes = options.maxBytes;
+  const maxBytes = normalizeMaxBytes(options.maxBytes);
 
   async function openRoot(): Promise<Root> {
     return await root(rootDir, { hardlinks: "reject", maxBytes });
@@ -246,7 +240,8 @@ export function fileStore(options: FileStoreOptions): FileStore {
     const safeRelativePath = assertRelativePath(relativePath);
     const destination = resolveStorePath(rootDir, safeRelativePath);
     const content = Buffer.isBuffer(data) ? data : Buffer.from(data);
-    assertMaxBytes(content.byteLength, writeOptions?.maxBytes ?? maxBytes);
+    const writeMaxBytes = normalizeMaxBytes(writeOptions?.maxBytes, { defaultValue: maxBytes });
+    assertFileStoreMaxBytes(content.byteLength, writeMaxBytes);
     if (privateMode) {
       await writeSecretFileAtomic({
         rootDir,
@@ -261,7 +256,7 @@ export function fileStore(options: FileStoreOptions): FileStore {
     const scopedRoot = await openWritableStoreRoot({
       rootDir,
       dirMode: writeDirMode,
-      maxBytes: writeOptions?.maxBytes ?? maxBytes,
+      maxBytes: writeMaxBytes,
     });
     await ensureParentInRoot(scopedRoot, safeRelativePath, writeDirMode);
     await scopedRoot.write(safeRelativePath, content, {
@@ -279,7 +274,8 @@ export function fileStore(options: FileStoreOptions): FileStore {
     writeStream: async (relativePath, stream, writeOptions) => {
       const safeRelativePath = assertRelativePath(relativePath);
       const destination = resolveStorePath(rootDir, safeRelativePath);
-      const limit = writeOptions?.maxBytes ?? maxBytes ?? (privateMode ? DEFAULT_ROOT_MAX_BYTES : undefined);
+      const configuredLimit = normalizeMaxBytes(writeOptions?.maxBytes, { defaultValue: maxBytes });
+      const limit = configuredLimit ?? (privateMode ? DEFAULT_ROOT_MAX_BYTES : undefined);
       if (privateMode) {
         const chunks: Buffer[] = [];
         let total = 0;
@@ -287,7 +283,7 @@ export function fileStore(options: FileStoreOptions): FileStore {
           const buffer =
             typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk as Uint8Array);
           total += buffer.byteLength;
-          assertMaxBytes(total, limit);
+          assertFileStoreMaxBytes(total, limit);
           chunks.push(buffer);
         }
         await writeSecretFileAtomic({
@@ -319,24 +315,25 @@ export function fileStore(options: FileStoreOptions): FileStore {
       }
       return destination;
     },
-    copyIn: async (relativePath, sourcePath, writeOptions) =>
-      privateMode
-        ? await (async () => {
-            const buffer = await readFileStoreCopySource({
-              sourcePath,
-              maxBytes: writeOptions?.maxBytes ?? maxBytes ?? DEFAULT_ROOT_MAX_BYTES,
-            });
-            return await write(relativePath, buffer, writeOptions);
-          })()
-        : await copyIntoRoot({
-            rootDir,
-            relativePath,
-            sourcePath,
-            dirMode: writeOptions?.dirMode ?? dirMode,
-            maxBytes: writeOptions?.maxBytes ?? maxBytes,
-            mode: writeOptions?.mode ?? mode,
-            tempPrefix: writeOptions?.tempPrefix,
-          }),
+    copyIn: async (relativePath, sourcePath, writeOptions) => {
+      const configuredLimit = normalizeMaxBytes(writeOptions?.maxBytes, { defaultValue: maxBytes });
+      if (privateMode) {
+        const buffer = await readFileStoreCopySource({
+          sourcePath,
+          maxBytes: configuredLimit ?? DEFAULT_ROOT_MAX_BYTES,
+        });
+        return await write(relativePath, buffer, writeOptions);
+      }
+      return await copyIntoRoot({
+        rootDir,
+        relativePath,
+        sourcePath,
+        dirMode: writeOptions?.dirMode ?? dirMode,
+        maxBytes: configuredLimit,
+        mode: writeOptions?.mode ?? mode,
+        tempPrefix: writeOptions?.tempPrefix,
+      });
+    },
     open: async (relativePath, readOptions) =>
       await (await openRoot()).open(assertRelativePath(relativePath), readOptions),
     read: async (relativePath, readOptions) =>
@@ -430,7 +427,7 @@ export function fileStoreSync(options: FileStoreOptions): FileStoreSync {
   const privateMode = options.private ?? false;
   const dirMode = options.dirMode ?? 0o700;
   const mode = options.mode ?? 0o600;
-  const maxBytes = options.maxBytes;
+  const maxBytes = normalizeMaxBytes(options.maxBytes);
 
   function write(
     relativePath: string,
@@ -439,7 +436,8 @@ export function fileStoreSync(options: FileStoreOptions): FileStoreSync {
   ): string {
     const destination = resolveStorePath(rootDir, relativePath);
     const content = Buffer.isBuffer(data) ? data : Buffer.from(data);
-    assertMaxBytes(content.byteLength, writeOptions?.maxBytes ?? maxBytes);
+    const writeMaxBytes = normalizeMaxBytes(writeOptions?.maxBytes, { defaultValue: maxBytes });
+    assertFileStoreMaxBytes(content.byteLength, writeMaxBytes);
     return writeFileSyncAtomic({
       rootDir,
       filePath: destination,
@@ -454,6 +452,7 @@ export function fileStoreSync(options: FileStoreOptions): FileStoreSync {
     rootDir,
     path: (relativePath) => resolveStorePath(rootDir, relativePath),
     readTextIfExists: (relativePath, readOptions) => {
+      const limit = normalizeMaxBytes(readOptions?.maxBytes, { defaultValue: maxBytes });
       const targetPath = resolveStorePath(rootDir, relativePath);
       const opened = openRootFileSync({
         absolutePath: targetPath,
@@ -465,8 +464,7 @@ export function fileStoreSync(options: FileStoreOptions): FileStoreSync {
         return handleSyncStoreReadOpenFailure(opened);
       }
       try {
-        assertMaxBytes(opened.stat.size, readOptions?.maxBytes ?? maxBytes);
-        const limit = readOptions?.maxBytes ?? maxBytes;
+        assertFileStoreMaxBytes(opened.stat.size, limit);
         try {
           return limit === undefined
             ? syncFs.readFileSync(opened.fd, "utf8")

--- a/src/json-durable-queue.ts
+++ b/src/json-durable-queue.ts
@@ -1,6 +1,7 @@
 import fs, { type BigIntStats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { syncQueueDirectoryCreation } from "./json-durable-queue-directory.js";
 import {
   acknowledgeDurableQueueEntry,
@@ -374,7 +375,9 @@ export async function readJsonDurableQueueEntry<T>(
   return JSON.parse(
     await readBoundedUtf8File({
       filePath,
-      maxBytes: options.maxBytes ?? DEFAULT_JSON_DURABLE_QUEUE_ENTRY_MAX_BYTES,
+      maxBytes: normalizeMaxBytes(options.maxBytes, {
+        defaultValue: DEFAULT_JSON_DURABLE_QUEUE_ENTRY_MAX_BYTES,
+      })!,
     }),
   ) as T;
 }

--- a/src/local-roots.ts
+++ b/src/local-roots.ts
@@ -1,5 +1,6 @@
 import fsSync from "node:fs";
 import path from "node:path";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { FsSafeError } from "./errors.js";
 import { expandHomePrefix, resolveUserPath } from "./home-dir.js";
 import { isFileUrl, safeFileURLToPath } from "./local-file-access.js";
@@ -168,6 +169,7 @@ export function resolveLocalPathFromRootsSync(
 export async function readLocalFileFromRoots(
   options: ReadLocalFileFromRootsOptions,
 ): Promise<LocalRootsReadResult | null> {
+  const maxBytes = normalizeMaxBytes(options.maxBytes);
   const label = options.label ?? "local roots";
   const requestedPath = path.resolve(resolveLocalPathInput(options.filePath, "file path"));
   const rootDirs = options.roots.map((rootEntry) => resolveLocalRootInput(rootEntry, label));
@@ -187,8 +189,8 @@ export async function readLocalFileFromRoots(
     };
     // Leave maxBytes absent when the caller omits it so Root's own default
     // cap remains in force instead of being overwritten by undefined.
-    if (options.maxBytes !== undefined) {
-      readOptions.maxBytes = options.maxBytes;
+    if (maxBytes !== undefined) {
+      readOptions.maxBytes = maxBytes;
     }
 
     // A trusted root symlink has two valid spellings. Preserve the caller's

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { FsSafeError } from "./errors.js";
 import { sanitizeUntrustedFileName } from "./filename.js";
 import { isPathInside } from "./path.js";
@@ -79,6 +80,7 @@ function assertFileTargetPath(targetPath: string): void {
 export async function writeExternalFileWithinRoot<T = void>(
   options: ExternalFileWriteOptions<T>,
 ): Promise<ExternalFileWriteResult<T>> {
+  const maxBytes = normalizeMaxBytes(options.maxBytes);
   const targetRoot = await root(options.rootDir);
   const requestedTargetPath = options.path;
   if (requestedTargetPath.length === 0) {
@@ -103,7 +105,7 @@ export async function writeExternalFileWithinRoot<T = void>(
       finalPath: siblingFinalPath,
       write: options.write,
       fallbackFileName: options.fallbackFileName,
-      maxBytes: options.maxBytes,
+      maxBytes,
       mode: options.mode,
     });
     return { path: siblingFinalPath, result };
@@ -116,7 +118,7 @@ export async function writeExternalFileWithinRoot<T = void>(
   try {
     const result = await options.write(staged.path);
     await targetRoot.copyIn(targetPath, staged.path, {
-      maxBytes: options.maxBytes,
+      maxBytes,
       mode: options.mode,
       mkdir: true,
       sourceHardlinks: "reject",

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -4,6 +4,7 @@ import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { Readable } from "node:stream";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { createAsyncDirectoryGuard, createNearestExistingDirectoryGuard, type AsyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { syncDirectoryBestEffort } from "./fsync.js";
@@ -110,20 +111,21 @@ export type PinnedWriteParams = {
 };
 
 export async function runPinnedWriteHelper(params: PinnedWriteParams): Promise<FileIdentityStat> {
+  const normalizedParams = { ...params, maxBytes: normalizeMaxBytes(params.maxBytes) };
   assertSafeBasename(params.basename);
   validatePinnedOperationPayload({
     relativeParentPath: params.relativeParentPath,
   });
   // The explicit compatibility policy uses the guarded Node fallback, where
   // content verification can replace the strict post-rename inode check.
-  if (params.onRenameIdentityMismatch === "verify-content") {
-    return await runPinnedWriteFallback(params);
+  if (normalizedParams.onRenameIdentityMismatch === "verify-content") {
+    return await runPinnedWriteFallback(normalizedParams);
   }
   const native = getNativeBinding();
   if (native) {
-    return await runPinnedWriteNative(native, params);
+    return await runPinnedWriteNative(native, normalizedParams);
   }
-  return await runPinnedWriteFallback(params);
+  return await runPinnedWriteFallback(normalizedParams);
 }
 
 export async function runPinnedWriteWithRenamePolicy(

--- a/src/read-opened-file.ts
+++ b/src/read-opened-file.ts
@@ -1,5 +1,6 @@
 import type { Stats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import type { ContainmentGuarantee } from "./containment.js";
 import { readFileHandleBounded } from "./bounded-read.js";
 import { FsSafeError } from "./errors.js";
@@ -22,16 +23,17 @@ export async function readOpenedFileSafely(params: {
   opened: OpenedFile;
   maxBytes?: number;
 }): Promise<ReadResult> {
-  if (params.maxBytes !== undefined && params.opened.stat.size > params.maxBytes) {
+  const maxBytes = normalizeMaxBytes(params.maxBytes);
+  if (maxBytes !== undefined && params.opened.stat.size > maxBytes) {
     throw new FsSafeError(
       "too-large",
-      `file exceeds limit of ${params.maxBytes} bytes (got ${params.opened.stat.size})`,
+      `file exceeds limit of ${maxBytes} bytes (got ${params.opened.stat.size})`,
     );
   }
   const buffer =
-    params.maxBytes === undefined
+    maxBytes === undefined
       ? await params.opened.handle.readFile()
-      : await readFileHandleBounded(params.opened.handle, params.maxBytes);
+      : await readFileHandleBounded(params.opened.handle, maxBytes);
   return {
     buffer,
     containment: params.opened.containment,

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -4,6 +4,7 @@ import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { readFileDescriptorBoundedSync, readFileHandleBounded } from "./bounded-read.js";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { assertNoUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
@@ -87,13 +88,14 @@ export async function readRegularFile(params: {
   filePath: string;
   maxBytes?: number;
 }): Promise<{ buffer: Buffer; stat: Stats }> {
+  const maxBytes = normalizeMaxBytes(params.maxBytes);
   assertNoUnsafeDeviceReadPath(params.filePath);
   const result = await statRegularFile(params.filePath);
   if (result.missing) {
     throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });
   }
-  if (params.maxBytes !== undefined && result.stat.size > params.maxBytes) {
-    throw regularFileTooLargeError(params.filePath, params.maxBytes);
+  if (maxBytes !== undefined && result.stat.size > maxBytes) {
+    throw regularFileTooLargeError(params.filePath, maxBytes);
   }
 
   let handle: FileHandle;
@@ -122,20 +124,20 @@ export async function readRegularFile(params: {
       postOpenStat: stat,
       preOpenStat: result.stat,
     });
-    if (params.maxBytes !== undefined && stat.size > params.maxBytes) {
-      throw regularFileTooLargeError(params.filePath, params.maxBytes);
+    if (maxBytes !== undefined && stat.size > maxBytes) {
+      throw regularFileTooLargeError(params.filePath, maxBytes);
     }
     // With a byte cap, avoid readFile(): a raced file growth would allocate
     // the oversized content before the post-read check could reject it.
     let buffer: Buffer;
     try {
       buffer =
-        params.maxBytes === undefined
+        maxBytes === undefined
           ? await handle.readFile()
-          : await readFileHandleBounded(handle, params.maxBytes);
+          : await readFileHandleBounded(handle, maxBytes);
     } catch (error) {
-      if (params.maxBytes !== undefined) {
-        translateBoundedReadOverflow(error, params.filePath, params.maxBytes);
+      if (maxBytes !== undefined) {
+        translateBoundedReadOverflow(error, params.filePath, maxBytes);
       }
       throw error;
     }
@@ -208,13 +210,14 @@ export function readRegularFileSync(params: { filePath: string; maxBytes?: numbe
   buffer: Buffer;
   stat: Stats;
 } {
+  const maxBytes = normalizeMaxBytes(params.maxBytes);
   assertNoUnsafeDeviceReadPath(params.filePath);
   const result = statRegularFileSync(params.filePath);
   if (result.missing) {
     throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });
   }
-  if (params.maxBytes !== undefined && result.stat.size > params.maxBytes) {
-    throw regularFileTooLargeError(params.filePath, params.maxBytes);
+  if (maxBytes !== undefined && result.stat.size > maxBytes) {
+    throw regularFileTooLargeError(params.filePath, maxBytes);
   }
 
   let fd: number;
@@ -231,7 +234,7 @@ export function readRegularFileSync(params: { filePath: string; maxBytes?: numbe
       fd,
       filePath: params.filePath,
       preOpenStat: result.stat,
-      maxBytes: params.maxBytes,
+      maxBytes,
     });
   } finally {
     fsSync.closeSync(fd);

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -4,6 +4,7 @@ import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import type { ContainmentGuarantee } from "./containment.js";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard, createNearestExistingDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
@@ -429,8 +430,7 @@ class RootHandle implements Root {
   ): Promise<ReadResult> {
     return await readFileInRoot(this.context, {
       relativePath,
-      ...readDefaults(this.defaults),
-      ...options,
+      ...mergeReadOptions(this.defaults, options),
     });
   }
 
@@ -459,8 +459,7 @@ class RootHandle implements Root {
   ): Promise<ReadResult> {
     return await readPathInRoot(this.context, {
       filePath,
-      ...readDefaults(this.defaults),
-      ...options,
+      ...mergeReadOptions(this.defaults, options),
     });
   }
 
@@ -579,13 +578,14 @@ class RootHandle implements Root {
     options: RootCopyOptions = {},
   ): Promise<void> {
     assertValidRootDestinationPath(relativePath);
+    const { maxBytes, ...copyOptions } = this.mutationOptions(options);
     await copyFileInRoot(this.context, {
       sourcePath,
       relativePath,
-      maxBytes: this.defaults.maxBytes,
+      maxBytes: normalizeMaxBytes(maxBytes, { defaultValue: this.defaults.maxBytes }),
       mkdir: this.defaults.mkdir,
       mode: this.defaults.mode,
-      ...this.mutationOptions(options),
+      ...copyOptions,
     });
   }
 
@@ -647,16 +647,26 @@ class RootHandle implements Root {
 function readDefaults(defaults: RootDefaults): RootReadParams {
   return {
     hardlinks: defaults.hardlinks,
-    maxBytes: defaults.maxBytes ?? DEFAULT_ROOT_MAX_BYTES,
+    maxBytes: normalizeMaxBytes(defaults.maxBytes, { defaultValue: DEFAULT_ROOT_MAX_BYTES }),
     nonBlockingRead: defaults.nonBlockingRead,
     symlinks: defaults.symlinks,
   };
+}
+
+function mergeReadOptions(defaults: RootDefaults, options: RootReadOptions): RootReadParams {
+  const merged = readDefaults(defaults);
+  if (options.hardlinks !== undefined) merged.hardlinks = options.hardlinks;
+  merged.maxBytes = normalizeMaxBytes(options.maxBytes, { defaultValue: merged.maxBytes });
+  if (options.nonBlockingRead !== undefined) merged.nonBlockingRead = options.nonBlockingRead;
+  if (options.symlinks !== undefined) merged.symlinks = options.symlinks;
+  return merged;
 }
 
 export async function root(
   rootDir: string,
   defaults: RootDefaults = {},
 ): Promise<Root> {
+  normalizeMaxBytes(defaults.maxBytes);
   return new RootHandle(await resolveRootContext(rootDir), defaults);
 }
 
@@ -747,9 +757,10 @@ export async function readLocalFileSafely(params: {
   filePath: string;
   maxBytes?: number;
 }): Promise<ReadResult> {
+  const maxBytes = normalizeMaxBytes(params.maxBytes);
   const opened = await openLocalFileSafely({ filePath: params.filePath });
   try {
-    return await readOpenedFileSafely({ opened, maxBytes: params.maxBytes });
+    return await readOpenedFileSafely({ opened, maxBytes });
   } finally {
     await opened.handle.close().catch(() => {});
   }

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -3,6 +3,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { canonicalPathFromExistingAncestor } from "./absolute-path.js";
 import { readFileDescriptorBoundedSync } from "./bounded-read.js";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard, type AsyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity, type FileIdentityStat } from "./file-identity.js";
@@ -34,7 +35,9 @@ export function readSecretFileSync(
     throw new FsSafeError("invalid-path", `${label} file path is empty.`, { cause: undefined });
   }
 
-  const maxBytes = options.maxBytes ?? DEFAULT_SECRET_FILE_MAX_BYTES;
+  const maxBytes = normalizeMaxBytes(options.maxBytes, {
+    defaultValue: DEFAULT_SECRET_FILE_MAX_BYTES,
+  })!;
   function inspectInput(symlinkMessage: string): fs.BigIntStats {
     const stat = options.rejectSymlink
       ? fs.lstatSync(resolvedPath, { bigint: true })

--- a/src/secret-read-async.ts
+++ b/src/secret-read-async.ts
@@ -1,6 +1,7 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { readFileHandleBounded } from "./bounded-read.js";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { FsSafeError } from "./errors.js";
 import { resolveHomeRelativePath } from "./home-dir.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
@@ -23,7 +24,9 @@ export async function readSecretFile(
   if (!resolvedPath) {
     throw new FsSafeError("invalid-path", `${label} file path is empty.`, { cause: undefined });
   }
-  const maxBytes = options.maxBytes ?? DEFAULT_SECRET_FILE_MAX_BYTES;
+  const maxBytes = normalizeMaxBytes(options.maxBytes, {
+    defaultValue: DEFAULT_SECRET_FILE_MAX_BYTES,
+  })!;
   async function inspectInput(symlinkMessage: string): Promise<fsSync.BigIntStats> {
     const stat = options.rejectSymlink
       ? await fs.lstat(resolvedPath, { bigint: true })

--- a/src/secure-file.ts
+++ b/src/secure-file.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { readFileHandleBounded } from "./bounded-read.js";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { assertNoUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
 import { isWindowsDriveLetterPath, isWindowsNetworkPath } from "./local-file-access.js";
@@ -68,7 +69,7 @@ function label(options: SecureFileReadOptions): string {
   return options.label ?? "Secure file";
 }
 
-async function openSecureHandle(options: SecureFileReadOptions): Promise<{
+async function openSecureHandle(options: SecureFileReadOptions, maxBytes: number | undefined): Promise<{
   handle: FileHandle;
   pathStat: Stats;
   realPath: string;
@@ -123,8 +124,8 @@ async function openSecureHandle(options: SecureFileReadOptions): Promise<{
     }, openedIdentity);
     const realPath = await fs.realpath(options.filePath);
     await inspectFileIdentity(() => fs.stat(realPath, { bigint: true }), openedIdentity);
-    if (options.io?.maxBytes !== undefined && openedStat.size > options.io.maxBytes) {
-      throw new FsSafeError("too-large", `${label(options)} exceeded maxBytes (${options.io.maxBytes}).`);
+    if (maxBytes !== undefined && openedStat.size > maxBytes) {
+      throw new FsSafeError("too-large", `${label(options)} exceeded maxBytes (${maxBytes}).`);
     }
     return { handle, pathStat: openedStat, realPath };
   } catch (err) {
@@ -245,14 +246,15 @@ async function readHandleWithTimeout(
 export async function readSecureFile(
   options: SecureFileReadOptions,
 ): Promise<SecureFileReadResult> {
-  const opened = await openSecureHandle(options);
+  const maxBytes = normalizeMaxBytes(options.io?.maxBytes);
+  const opened = await openSecureHandle(options, maxBytes);
   try {
     await assertTrustedDirs(options, opened.realPath);
     const permissions = await assertSecurePermissions(options, opened.pathStat, opened.realPath);
     const buffer = await readHandleWithTimeout(
       opened.handle,
       options.io?.timeoutMs,
-      options.io?.maxBytes,
+      maxBytes,
     );
     return { buffer, realPath: opened.realPath, stat: opened.pathStat, permissions };
   } finally {

--- a/test/byte-budget-normalization.test.ts
+++ b/test/byte-budget-normalization.test.ts
@@ -1,0 +1,156 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { normalizeMaxBytes } from "../src/byte-budget.js";
+import { fileStore, fileStoreSync } from "../src/file-store.js";
+import { readJsonDurableQueueEntry } from "../src/json-durable-queue.js";
+import { writeExternalFileWithinRoot } from "../src/output.js";
+import { readRegularFile } from "../src/regular-file.js";
+import { root } from "../src/root.js";
+import { readSecureFile } from "../src/secure-file.js";
+import { readSecretFile } from "../src/secret-read-async.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+const invalidLimits = [Number.NaN, -1, Number.NEGATIVE_INFINITY, 1.5, Number.MAX_SAFE_INTEGER + 1];
+
+describe("byte budget normalization", () => {
+  it.each(invalidLimits)("rejects invalid maxBytes %s", (maxBytes) => {
+    expect(() => normalizeMaxBytes(maxBytes)).toThrow(
+      "maxBytes must be a non-negative safe integer or Infinity",
+    );
+  });
+
+  it("preserves undefined defaults, explicit zero, and positive Infinity", () => {
+    expect(normalizeMaxBytes(undefined)).toBeUndefined();
+    expect(normalizeMaxBytes(undefined, { defaultValue: 7 })).toBe(7);
+    expect(normalizeMaxBytes(0, { defaultValue: 7 })).toBe(0);
+    expect(normalizeMaxBytes(Number.POSITIVE_INFINITY, { defaultValue: 7 }))
+      .toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("preserves Root defaults when per-call maxBytes is explicitly undefined", async () => {
+    const rootDir = await tempRoot("fs-safe-root-budget-default-");
+    await fs.writeFile(path.join(rootDir, "value"), "ab");
+    const scoped = await root(rootDir, { maxBytes: 1 });
+
+    await expect(scoped.read("value", { maxBytes: undefined })).rejects.toMatchObject({
+      code: "too-large",
+    });
+    await expect(scoped.read("value", { maxBytes: Number.POSITIVE_INFINITY }))
+      .resolves.toMatchObject({ buffer: Buffer.from("ab") });
+  });
+
+  it("preserves Root copy defaults and explicit zero", async () => {
+    const rootDir = await tempRoot("fs-safe-root-budget-copy-");
+    const source = path.join(rootDir, "source");
+    await fs.writeFile(source, "ab");
+    const scoped = await root(rootDir, { maxBytes: 1 });
+
+    await expect(scoped.copyIn("too-large", source, { maxBytes: undefined }))
+      .rejects.toMatchObject({ code: "too-large" });
+    await expect(scoped.copyIn("unlimited", source, { maxBytes: Number.POSITIVE_INFINITY }))
+      .resolves.toBeUndefined();
+    await fs.writeFile(source, "");
+    await expect(scoped.copyIn("empty", source, { maxBytes: 0 })).resolves.toBeUndefined();
+  });
+
+  it("rejects invalid Root defaults and per-call limits before opening a file", async () => {
+    const parent = await tempRoot("fs-safe-root-budget-invalid-");
+    const missingRoot = path.join(parent, "missing");
+    await expect(root(missingRoot, { maxBytes: Number.NaN })).rejects.toBeInstanceOf(RangeError);
+    await expect(fs.lstat(missingRoot)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const filePath = path.join(parent, "value");
+    await fs.writeFile(filePath, "value");
+    const scoped = await root(parent);
+    const open = vi.spyOn(fs, "open");
+    await expect(scoped.read("value", { maxBytes: -1 })).rejects.toBeInstanceOf(RangeError);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it("normalizes FileStore buffer, stream, copy, and sync limits", async () => {
+    const rootDir = await tempRoot("fs-safe-store-budget-");
+    const source = path.join(rootDir, "source");
+    await fs.writeFile(source, "ab");
+    const store = fileStore({ rootDir: path.join(rootDir, "async"), maxBytes: 1 });
+
+    await expect(store.write("buffer", "ab", { maxBytes: undefined }))
+      .rejects.toMatchObject({ code: "too-large" });
+    await expect(store.write("unlimited", "ab", { maxBytes: Number.POSITIVE_INFINITY }))
+      .resolves.toBeDefined();
+    await expect(store.readText("unlimited", { maxBytes: undefined }))
+      .rejects.toMatchObject({ code: "too-large" });
+    await expect(store.readText("unlimited", { maxBytes: Number.POSITIVE_INFINITY }))
+      .resolves.toBe("ab");
+    await expect(store.writeStream("stream", Readable.from(["a", "b"]), { maxBytes: undefined }))
+      .rejects.toMatchObject({ code: "too-large" });
+    await expect(store.writeStream("stream-unlimited", Readable.from(["a", "b"]), {
+      maxBytes: Number.POSITIVE_INFINITY,
+    })).resolves.toBeDefined();
+    await expect(store.copyIn("copy", source, { maxBytes: undefined }))
+      .rejects.toMatchObject({ code: "too-large" });
+    await expect(store.copyIn("copy-unlimited", source, { maxBytes: Number.POSITIVE_INFINITY }))
+      .resolves.toBeDefined();
+    await expect(store.write("empty", "", { maxBytes: 0 })).resolves.toBeDefined();
+
+    const sync = fileStoreSync({ rootDir: path.join(rootDir, "sync"), maxBytes: 1 });
+    expect(() => sync.write("buffer", "ab", { maxBytes: undefined }))
+      .toThrow(expect.objectContaining({ code: "too-large" }));
+    expect(sync.write("unlimited", "ab", { maxBytes: Number.POSITIVE_INFINITY }))
+      .toBeDefined();
+    expect(() => sync.readTextIfExists("unlimited", { maxBytes: undefined }))
+      .toThrow(expect.objectContaining({ code: "too-large" }));
+    expect(sync.readTextIfExists("unlimited", { maxBytes: Number.POSITIVE_INFINITY }))
+      .toBe("ab");
+  });
+
+  it("rejects invalid FileStore stream and copy overrides before consuming input", async () => {
+    const rootDir = await tempRoot("fs-safe-store-budget-override-");
+    const source = path.join(rootDir, "source");
+    await fs.writeFile(source, "source");
+    const store = fileStore({ rootDir: path.join(rootDir, "store") });
+    let consumed = false;
+    const stream = Readable.from((async function* () {
+      consumed = true;
+      yield "value";
+    })());
+
+    await expect(store.writeStream("stream", stream, { maxBytes: Number.NaN }))
+      .rejects.toBeInstanceOf(RangeError);
+    expect(consumed).toBe(false);
+    await expect(store.copyIn("copy", source, { maxBytes: -1 }))
+      .rejects.toBeInstanceOf(RangeError);
+  });
+
+  it.each(invalidLimits)("rejects FileStore maxBytes %s before creating its root", async (maxBytes) => {
+    const parent = await tempRoot("fs-safe-store-budget-invalid-");
+    const rootDir = path.join(parent, "store");
+    expect(() => fileStore({ rootDir, maxBytes })).toThrow(RangeError);
+    expect(() => fileStoreSync({ rootDir, maxBytes })).toThrow(RangeError);
+    await expect(fs.lstat(rootDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects invalid related read and write limits before filesystem admission", async () => {
+    const rootDir = await tempRoot("fs-safe-related-budget-");
+    const filePath = path.join(rootDir, "value");
+    await fs.writeFile(filePath, "value", { mode: 0o600 });
+    const open = vi.spyOn(fs, "open");
+
+    await expect(readRegularFile({ filePath, maxBytes: Number.NaN })).rejects.toBeInstanceOf(RangeError);
+    await expect(readSecureFile({ filePath, io: { maxBytes: -1 } })).rejects.toBeInstanceOf(RangeError);
+    await expect(readSecretFile(filePath, "token", { maxBytes: 1.5 })).rejects.toBeInstanceOf(RangeError);
+    await expect(readJsonDurableQueueEntry(filePath, { maxBytes: Number.NaN }))
+      .rejects.toBeInstanceOf(RangeError);
+    await expect(writeExternalFileWithinRoot({
+      rootDir,
+      path: "output",
+      maxBytes: -1,
+      write: async () => undefined,
+    })).rejects.toBeInstanceOf(RangeError);
+    expect(open).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- centralize `maxBytes` normalization: accept non-negative safe integers and positive `Infinity`, preserve explicit zero, and reject `NaN`, negatives, fractions, negative infinity, and unsafe integers
- preserve configured Root/FileStore defaults when callers explicitly forward `maxBytes: undefined`; retain positive `Infinity` as the documented per-call opt-out
- apply the same contract before filesystem or stream admission across Root reads/copies, FileStore buffer/stream/copy/sync paths, secure/secret/regular reads, durable queue reads, local-root readers, pinned writes, and external output

## Root cause

Byte budgets were validated only in some low-level bounded readers. Several owners compared sizes directly against unchecked values, so `NaN` behaved like no limit, negatives could produce inconsistent `too-large` errors, and unsafe integers/fractions reached filesystem work. Root merged defaults with object spreads, so an explicit `maxBytes: undefined` property overwrote a configured cap. FileStore stream/copy paths repeated their own `??` chains, making zero, Infinity, private defaults, and caller forwarding diverge.

`normalizeMaxBytes()` now owns one rule and optional default selection. Root validates defaults before resolving the filesystem and merges only defined per-call policies. FileStore normalizes factory and per-call values before consuming streams, opening copy sources, or creating roots. Low-level bounded reads and pinned writes reuse the same validator, while each owner keeps its existing `too-large` error once a valid cap is exceeded.

## Live behavior proof

A fresh npm consumer installed the packed package and exercised public Root, FileStore, and secure-read surfaces:

```json
{"rootDefault":{"error":{"name":"FsSafeError","code":"too-large","message":"file exceeds limit of 1 bytes (got 2)"}},"rootInfinity":{"value":"ab"},"copyDefault":{"error":{"name":"FsSafeError","code":"too-large","message":"file exceeds limit of 1 bytes (got 2)"}},"copyInfinity":{"value":"ab"},"storeDefault":{"error":{"name":"FsSafeError","code":"too-large","message":"file exceeds maximum size of 1 bytes"}},"storeInfinity":{"value":"ab"},"storeZero":{"ok":true},"invalidStream":{"error":{"name":"RangeError","message":"maxBytes must be a non-negative safe integer or Infinity"},"consumed":false},"invalidRoot":{"error":{"name":"RangeError","message":"maxBytes must be a non-negative safe integer or Infinity"},"rootCreated":false},"invalidStore":{"error":{"name":"RangeError","message":"maxBytes must be a non-negative safe integer or Infinity"}},"invalidSecure":{"error":{"name":"RangeError","message":"maxBytes must be a non-negative safe integer or Infinity"}}}
```

Explicit `undefined` preserved the configured one-byte caps for Root read/copy and FileStore write. Infinity overrode those caps. Zero accepted an empty write. Invalid values rejected before stream consumption or root creation.

## Verification

- focused Root, FileStore, bounded-read, secure/secret/regular, output, and security suites: 13 files, 168 tests passed, 1 skipped
- complete `CI=1 pnpm check`: 144 files passed, 1 skipped; 2,375 tests passed, 25 skipped; package/API validation passed
- fresh packed npm consumer proof passed
- build, docs examples, pack, file-size, filesystem-boundary, and diff checks passed
- Codex autoreview at P1: clean
- exact-head hosted Linux/macOS/Windows checks and ClawSweeper review remain landing gates
