### PR TITLE
fix(read): verify file identities losslessly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Verify regular-file reads, root-file adapters, archive input staging, and `Root.copyIn()` source checks with exact bigint identities; reject rounded-equal replacements and unresolved Windows identities without changing numeric public `Stats` receipts.
 - Normalize public `maxBytes` budgets across Root, FileStore, secure/secret/regular reads, durable queues, and external output: reject invalid values, preserve explicit zero and positive `Infinity`, and keep configured defaults when callers forward `undefined`.
 - Bind `writeJsonSync()` best-effort file-mode tightening to the staged bigint identity and a reopened single-link regular descriptor, preserving swapped paths without chmodding them.
 - Open attacker-raceable secure, secret, archive, queue, publication, fallback, and lock-file read paths nonblocking on POSIX, rejecting FIFO substitutions before reads, deadlines, or cleanup verification can stall.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -72,6 +72,13 @@ Operational filesystem failures such as permissions or I/O errors are rethrown.
 | `assertNoSymlinkParents`, `assertNoSymlinkParentsSync`, `AssertNoSymlinkParentsOptions` | – | Reject paths whose ancestor chain contains symlinks. |
 | `assertNoHardlinkedFinalPath`, `assertNoPathAliasEscape`, `PATH_ALIAS_POLICIES`, `PathAliasPolicy` | – | Hardlink/alias defense building blocks. |
 
+`openRootFile()` and `openRootFileSync()` compare exact bigint identities before
+open, on the retained descriptor, and on the current resolved path. Their `stat`
+receipts remain numeric. Custom `ioFs` adapters must honor `{ bigint: true }` for
+`lstatSync` and `fstatSync`; numeric identity responses fail validation. Unknown
+Windows identities receive one re-inspection without reopening, then fail
+validation if still unknown.
+
 The bounded descriptor helpers start at the descriptor's current offset and
 leave ownership with the caller. They are intended for the second half of a
 safe read: first open and validate the path using the boundary appropriate to

--- a/docs/regular-file.md
+++ b/docs/regular-file.md
@@ -64,7 +64,11 @@ processLog(result.buffer);
 ```
 
 The result is `{ buffer, stat }`. Missing files preserve the normal `ENOENT`
-shape; non-regular targets throw.
+shape; non-regular targets throw. Reads compare exact bigint identities from the
+preview, opened descriptor, and current path before consuming bytes; the returned
+`stat` remains numeric Node `Stats`. Unknown Windows identities receive one
+re-inspection without reopening; persistent unknowns or replacements throw
+`FsSafeError("path-mismatch")`.
 
 Throws `FsSafeError` with code `too-large` if the file exceeds `maxBytes`. Other I/O errors propagate as `NodeJS.ErrnoException`.
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -58,6 +58,9 @@ descriptor, the input path, and the canonical target; numeric public `Stats`
 receipts are not used as identity evidence. Unknown Windows device/inode values
 receive one re-inspection without reopening the file. A definite mismatch or
 persistent unknown identity rejects with `path-mismatch` before reading bytes.
+Regular-file readers, root-file adapters, and archive input staging use the same
+exact admission policy. `copyIn()` retains the admitted source identity for its
+checks before and after copying, independently of its numeric metadata receipt.
 
 ### Symlinks (write side)
 

--- a/src/archive-input.ts
+++ b/src/archive-input.ts
@@ -8,7 +8,8 @@ import {
   ArchiveLimitError,
   type ResolvedArchiveExtractLimits,
 } from "./archive-limits.js";
-import { sameFileIdentity } from "./file-identity.js";
+import { FsSafeError } from "./errors.js";
+import { inspectFileIdentity } from "./strict-file-identity.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { tempFile } from "./temp-target.js";
 
@@ -46,10 +47,13 @@ export async function stageArchiveFileForExtraction(params: {
 }): Promise<StagedArchiveFile> {
   params.deadline.check();
   const sourcePath = path.resolve(params.archivePath);
-  const initialStat = await fs.lstat(sourcePath);
-  if (initialStat.isSymbolicLink() || !initialStat.isFile()) {
-    throw new Error(`archive is not a regular file: ${params.archivePath}`);
-  }
+  const initialStat = await inspectFileIdentity(async () => {
+    const stat = await fs.lstat(sourcePath, { bigint: true });
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      throw new Error(`archive is not a regular file: ${params.archivePath}`);
+    }
+    return stat;
+  });
   if (initialStat.size > params.limits.maxArchiveBytes) {
     throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ARCHIVE_SIZE_EXCEEDS_LIMIT);
   }
@@ -61,17 +65,16 @@ export async function stageArchiveFileForExtraction(params: {
       prefix: "fs-safe-archive-input",
       fileName: path.basename(sourcePath),
     });
-    const openedStat = await handle.stat();
-    const pathStat = await fs.lstat(sourcePath);
-    if (
-      !openedStat.isFile() ||
-      pathStat.isSymbolicLink() ||
-      !pathStat.isFile() ||
-      !sameFileIdentity(initialStat, openedStat) ||
-      !sameFileIdentity(pathStat, openedStat)
-    ) {
-      throw new Error("archive changed during validation");
-    }
+    const opened = await inspectFileIdentity(async () => {
+      const stat = await handle.stat({ bigint: true });
+      if (!stat.isFile()) throw new Error("archive changed during validation");
+      return stat;
+    }, initialStat);
+    await inspectFileIdentity(async () => {
+      const stat = await fs.lstat(sourcePath, { bigint: true });
+      if (stat.isSymbolicLink() || !stat.isFile()) throw new Error("archive changed during validation");
+      return stat;
+    }, opened);
 
     const flags =
       fsConstants.O_WRONLY |
@@ -99,6 +102,9 @@ export async function stageArchiveFileForExtraction(params: {
   } catch (error) {
     await closeFileHandle(output);
     await staged?.cleanup().catch(() => undefined);
+    if (error instanceof FsSafeError && error.code === "path-mismatch") {
+      throw new FsSafeError("path-mismatch", "archive changed during validation", { cause: error });
+    }
     throw error;
   } finally {
     await closeFileHandle(handle);

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -29,7 +29,7 @@ import {
 } from "./archive-zip-integrity.js";
 import type { ZipEntry } from "./archive-zip-entry.js";
 import { FsSafeError } from "./errors.js";
-import { sameFileIdentity } from "./file-identity.js";
+import { inspectFileIdentity } from "./strict-file-identity.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { getNativeBinding } from "./native.js";
 import { admitZipBuffer } from "./archive-zip-admission.js";
@@ -94,28 +94,35 @@ async function stageArchiveInput(archivePath: string): Promise<{
   cleanup(): Promise<void>;
 }> {
   const resolved = await fs.realpath(archivePath);
-  const before = await fs.lstat(archivePath);
-  if (before.isSymbolicLink() || !before.isFile()) {
-    throw new Error(`archive is not a regular file: ${archivePath}`);
-  }
+  const before = await inspectFileIdentity(async () => {
+    const stat = await fs.lstat(archivePath, { bigint: true });
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      throw new Error(`archive is not a regular file: ${archivePath}`);
+    }
+    return stat;
+  });
   const handle = await fs.open(resolved, resolveReadOpenFlags());
   const staged = await tempFile({ prefix: "fs-safe-archive-read", fileName: "archive.bin" });
   try {
-    const opened = await handle.stat();
-    const current = await fs.lstat(resolved);
-    if (
-      !opened.isFile() ||
-      !current.isFile() ||
-      !sameFileIdentity(before, opened) ||
-      !sameFileIdentity(current, opened)
-    ) {
-      throw new Error("archive changed during validation");
-    }
+    const opened = await inspectFileIdentity(async () => {
+      const stat = await handle.stat({ bigint: true });
+      if (!stat.isFile()) throw new Error("archive changed during validation");
+      return stat;
+    }, before);
+    await inspectFileIdentity(async () => {
+      const stat = await fs.lstat(resolved, { bigint: true });
+      if (stat.isSymbolicLink() || !stat.isFile()) throw new Error("archive changed during validation");
+      return stat;
+    }, opened);
+
     const buffer = await readFileHandleBounded(handle, DEFAULT_MAX_ARCHIVE_BYTES_ZIP);
     await fs.writeFile(staged.path, buffer, { flag: "wx", mode: 0o600 });
     return { path: staged.path, buffer, cleanup: staged.cleanup };
   } catch (error) {
     await staged.cleanup().catch(() => undefined);
+    if (error instanceof FsSafeError && error.code === "path-mismatch") {
+      throw new FsSafeError("path-mismatch", "archive changed during validation", { cause: error });
+    }
     throw error;
   } finally {
     await handle.close().catch(() => undefined);

--- a/src/pinned-open.ts
+++ b/src/pinned-open.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { isUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
-import { sameFileIdentity as hasSameFileIdentity } from "./file-identity.js";
+import { inspectFileIdentitySync } from "./strict-file-identity.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 
 export type PinnedOpenSyncFailureReason = "path" | "validation" | "io";
@@ -21,10 +21,6 @@ function isExpectedPathError(error: unknown): boolean {
   const code =
     typeof error === "object" && error !== null && "code" in error ? String(error.code) : "";
   return code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP";
-}
-
-function sameFileIdentity(left: fs.Stats, right: fs.Stats): boolean {
-  return hasSameFileIdentity(left, right);
 }
 
 export function openPinnedFileSync(params: {
@@ -55,56 +51,29 @@ export function openPinnedFileSync(params: {
     if (isUnsafeDeviceReadPath(realPath)) {
       return { ok: false, reason: "validation" };
     }
-    const preOpenStat = ioFs.lstatSync(realPath);
-    if (!isAllowedType(preOpenStat, allowedType)) {
-      return {
-        ok: false,
-        reason: "validation",
-        error: new FsSafeError("not-file", "path does not have the required file type"),
-      };
-    }
-    if (params.rejectHardlinks && preOpenStat.isFile() && preOpenStat.nlink > 1) {
-      return {
-        ok: false,
-        reason: "validation",
-        error: new FsSafeError("hardlink", "path must not be hardlinked"),
-      };
-    }
-    if (
-      params.maxBytes !== undefined &&
-      preOpenStat.isFile() &&
-      preOpenStat.size > params.maxBytes
-    ) {
-      return { ok: false, reason: "validation" };
-    }
-
+    const preOpenStat = inspectFileIdentitySync(() => {
+      const stat = ioFs.lstatSync(realPath, { bigint: true });
+      assertAllowedStat(stat, allowedType, params);
+      return stat;
+    });
     fd = ioFs.openSync(realPath, openReadFlags);
     const openedStat = ioFs.fstatSync(fd);
-    if (!isAllowedType(openedStat, allowedType)) {
-      return {
-        ok: false,
-        reason: "validation",
-        error: new FsSafeError("not-file", "path does not have the required file type"),
-      };
-    }
-    if (params.rejectHardlinks && openedStat.isFile() && openedStat.nlink > 1) {
-      return {
-        ok: false,
-        reason: "validation",
-        error: new FsSafeError("hardlink", "path must not be hardlinked"),
-      };
-    }
-    if (params.maxBytes !== undefined && openedStat.isFile() && openedStat.size > params.maxBytes) {
-      return { ok: false, reason: "validation" };
-    }
-    if (!sameFileIdentity(preOpenStat, openedStat)) {
-      return { ok: false, reason: "validation" };
-    }
+    const identity = inspectFileIdentitySync(() => {
+      const stat = ioFs.fstatSync(fd!, { bigint: true });
+      assertAllowedStat(stat, allowedType, params);
+      return stat;
+    }, preOpenStat);
+    inspectFileIdentitySync(() => {
+      const stat = ioFs.lstatSync(realPath, { bigint: true });
+      assertAllowedStat(stat, allowedType, params);
+      return stat;
+    }, identity);
 
     const opened = { ok: true as const, path: realPath, fd, stat: openedStat };
     fd = null;
     return opened;
   } catch (error) {
+    if (error instanceof FsSafeError) return { ok: false, reason: "validation", error };
     if (isExpectedPathError(error)) {
       return { ok: false, reason: "path", error };
     }
@@ -116,9 +85,18 @@ export function openPinnedFileSync(params: {
   }
 }
 
-function isAllowedType(stat: fs.Stats, allowedType: PinnedOpenSyncAllowedType): boolean {
-  if (allowedType === "directory") {
-    return stat.isDirectory();
+function assertAllowedStat(
+  stat: fs.BigIntStats,
+  allowedType: PinnedOpenSyncAllowedType,
+  params: { rejectHardlinks?: boolean; maxBytes?: number },
+): void {
+  if (stat.isSymbolicLink() || !(allowedType === "directory" ? stat.isDirectory() : stat.isFile())) {
+    throw new FsSafeError("not-file", "path does not have the required file type");
   }
-  return stat.isFile();
+  if (params.rejectHardlinks && stat.isFile() && stat.nlink > 1n) {
+    throw new FsSafeError("hardlink", "path must not be hardlinked");
+  }
+  if (params.maxBytes !== undefined && stat.isFile() && stat.size > params.maxBytes) {
+    throw new FsSafeError("too-large", "file exceeds byte limit");
+  }
 }

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -1,4 +1,4 @@
-import type { Stats } from "node:fs";
+import type { BigIntStats, Stats } from "node:fs";
 import fsSync from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
@@ -7,7 +7,7 @@ import { readFileDescriptorBoundedSync, readFileHandleBounded } from "./bounded-
 import { normalizeMaxBytes } from "./byte-budget.js";
 import { assertNoUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
-import { sameFileIdentity } from "./file-identity.js";
+import { inspectFileIdentity, inspectFileIdentitySync } from "./strict-file-identity.js";
 import { isNotFoundPathError } from "./path.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { assertNoSymlinkParents, assertNoSymlinkParentsSync } from "./symlink-parents.js";
@@ -90,11 +90,12 @@ export async function readRegularFile(params: {
 }): Promise<{ buffer: Buffer; stat: Stats }> {
   const maxBytes = normalizeMaxBytes(params.maxBytes);
   assertNoUnsafeDeviceReadPath(params.filePath);
-  const result = await statRegularFile(params.filePath);
-  if (result.missing) {
-    throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });
-  }
-  if (maxBytes !== undefined && result.stat.size > maxBytes) {
+  const before = await inspectFileIdentity(async () => {
+    const stat = await fs.lstat(params.filePath, { bigint: true });
+    assertRegularReadStat(stat, params.filePath, true);
+    return stat;
+  }).catch((error) => throwReadPreviewError(error, params.filePath));
+  if (maxBytes !== undefined && before.size > maxBytes) {
     throw regularFileTooLargeError(params.filePath, maxBytes);
   }
 
@@ -109,21 +110,23 @@ export async function readRegularFile(params: {
   }
   try {
     const stat = await handle.stat();
-    let pathStat: Stats;
+    const identity = await inspectFileIdentity(async () => {
+      const exact = await handle.stat({ bigint: true });
+      assertRegularReadStat(exact, params.filePath);
+      return exact;
+    }, before);
     try {
-      pathStat = await fs.lstat(params.filePath);
+      await inspectFileIdentity(async () => {
+        const current = await fs.lstat(params.filePath, { bigint: true });
+        assertRegularReadStat(current, params.filePath);
+        return current;
+      }, identity);
     } catch (err) {
       if (isNotFoundPathError(err)) {
         throw new FsSafeError("path-mismatch", `File changed during read: ${params.filePath}`);
       }
       throw err;
     }
-    verifyStableReadTarget({
-      filePath: params.filePath,
-      pathStat,
-      postOpenStat: stat,
-      preOpenStat: result.stat,
-    });
     if (maxBytes !== undefined && stat.size > maxBytes) {
       throw regularFileTooLargeError(params.filePath, maxBytes);
     }
@@ -147,45 +150,43 @@ export async function readRegularFile(params: {
   }
 }
 
-function verifyStableReadTarget(params: {
-  preOpenStat: Stats;
-  postOpenStat: Stats;
-  pathStat: Stats;
-  filePath: string;
-}): void {
-  if (!params.postOpenStat.isFile() || params.pathStat.isSymbolicLink() || !params.pathStat.isFile()) {
-    throw new Error(`File is not a regular file: ${params.filePath}`);
+function throwReadPreviewError(error: unknown, filePath: string): never {
+  if (isNotFoundPathError(error)) {
+    throw Object.assign(new Error(`File not found: ${filePath}`), { code: "ENOENT" });
   }
-  if (
-    !sameFileIdentity(params.preOpenStat, params.postOpenStat) ||
-    !sameFileIdentity(params.pathStat, params.postOpenStat)
-  ) {
-    throw new FsSafeError("path-mismatch", `File changed during read: ${params.filePath}`);
+  throw error;
+}
+
+function assertRegularReadStat(stat: BigIntStats, filePath: string, preview = false): void {
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error(preview ? "path must be a regular file" : `File is not a regular file: ${filePath}`);
   }
 }
 
 function readOpenedRegularFileSync(params: {
   fd: number;
   filePath: string;
-  preOpenStat: Stats;
+  preOpenStat: BigIntStats;
   maxBytes?: number;
 }): { buffer: Buffer; stat: Stats } {
   const stat = fsSync.fstatSync(params.fd);
-  let pathStat: Stats;
+  const identity = inspectFileIdentitySync(() => {
+    const exact = fsSync.fstatSync(params.fd, { bigint: true });
+    assertRegularReadStat(exact, params.filePath);
+    return exact;
+  }, params.preOpenStat);
   try {
-    pathStat = fsSync.lstatSync(params.filePath);
+    inspectFileIdentitySync(() => {
+      const current = fsSync.lstatSync(params.filePath, { bigint: true });
+      assertRegularReadStat(current, params.filePath);
+      return current;
+    }, identity);
   } catch (error) {
     if (isNotFoundPathError(error)) {
       throw new FsSafeError("path-mismatch", `File changed during read: ${params.filePath}`);
     }
     throw error;
   }
-  verifyStableReadTarget({
-    filePath: params.filePath,
-    pathStat,
-    postOpenStat: stat,
-    preOpenStat: params.preOpenStat,
-  });
   if (params.maxBytes !== undefined && stat.size > params.maxBytes) {
     throw regularFileTooLargeError(params.filePath, params.maxBytes);
   }
@@ -212,11 +213,17 @@ export function readRegularFileSync(params: { filePath: string; maxBytes?: numbe
 } {
   const maxBytes = normalizeMaxBytes(params.maxBytes);
   assertNoUnsafeDeviceReadPath(params.filePath);
-  const result = statRegularFileSync(params.filePath);
-  if (result.missing) {
-    throw Object.assign(new Error(`File not found: ${params.filePath}`), { code: "ENOENT" });
+  let before: BigIntStats;
+  try {
+    before = inspectFileIdentitySync(() => {
+      const stat = fsSync.lstatSync(params.filePath, { bigint: true });
+      assertRegularReadStat(stat, params.filePath, true);
+      return stat;
+    });
+  } catch (error) {
+    throwReadPreviewError(error, params.filePath);
   }
-  if (maxBytes !== undefined && result.stat.size > maxBytes) {
+  if (maxBytes !== undefined && before.size > maxBytes) {
     throw regularFileTooLargeError(params.filePath, maxBytes);
   }
 
@@ -233,7 +240,7 @@ export function readRegularFileSync(params: { filePath: string; maxBytes?: numbe
     return readOpenedRegularFileSync({
       fd,
       filePath: params.filePath,
-      preOpenStat: result.stat,
+      preOpenStat: before,
       maxBytes,
     });
   } finally {

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -208,7 +208,7 @@ async function openVerifiedLocalFile(
     nonBlockingRead?: boolean;
     symlinks?: SymlinkPolicy;
   },
-): Promise<OpenResult> {
+): Promise<{ opened: OpenResult; identity: BigIntStats }> {
   assertNoUnsafeDeviceReadPath(filePath);
   const fsSafeTestHooks = getFsSafeTestHooks();
   let preOpenStat: BigIntStats | undefined;
@@ -297,7 +297,7 @@ async function openVerifiedLocalFile(
       return realStat;
     }, identity);
 
-    return openResult({ handle, realPath, stat });
+    return { opened: openResult({ handle, realPath, stat }), identity };
   } catch (err) {
     await handle.close().catch(() => {});
     if (err instanceof FsSafeError) {
@@ -687,10 +687,10 @@ async function openFileInRoot(
 
   let opened: OpenResult;
   try {
-    opened = await openVerifiedLocalFile(resolved, {
+    ({ opened } = await openVerifiedLocalFile(resolved, {
       nonBlockingRead: params.nonBlockingRead,
       symlinks: params.symlinks,
-    });
+    }));
   } catch (err) {
     if (err instanceof FsSafeError) {
       throw err;
@@ -768,7 +768,7 @@ export async function readLocalFileSafely(params: {
 
 export async function openLocalFileSafely(params: { filePath: string }): Promise<OpenResult> {
   assertNoNulPathInput(params.filePath, "file path contains a NUL byte");
-  return await openVerifiedLocalFile(params.filePath);
+  return (await openVerifiedLocalFile(params.filePath)).opened;
 }
 
 export type WritableOpenResult = {
@@ -1171,7 +1171,7 @@ async function copyFileInRoot(
 ): Promise<void> {
   assertValidRootRelativePath(params.relativePath);
   assertNoNulPathInput(params.sourcePath, "source path contains a NUL byte");
-  const source = await openVerifiedLocalFile(params.sourcePath, {
+  const { opened: source, identity: sourceIdentity } = await openVerifiedLocalFile(params.sourcePath, {
     hardlinks: params.sourceHardlinks,
   });
   if (params.maxBytes !== undefined && source.stat.size > params.maxBytes) {
@@ -1191,7 +1191,7 @@ async function copyFileInRoot(
         params.denyMutations,
       );
       await serializePathWrite(pinned.targetPath, async () => {
-        await assertCopySourceCurrent(source);
+        await assertCopySourceCurrent(source, sourceIdentity);
         let identity: FileIdentityStat;
         try {
           identity = await runPinnedWriteHelper({
@@ -1209,7 +1209,7 @@ async function copyFileInRoot(
           throw normalizePinnedWriteError(error);
         }
         try {
-          await assertCopySourcePathCurrent(source);
+          await assertCopySourcePathCurrent(source, sourceIdentity);
         } catch (error) {
           await removePathIfIdentityUnchanged(pinned.targetPath, identity).catch(() => undefined);
           throw error;
@@ -1221,19 +1221,19 @@ async function copyFileInRoot(
   }
 }
 
-async function assertCopySourceCurrent(source: OpenResult): Promise<void> {
-  const opened = await source.handle.stat();
-  if (!sameFileIdentity(opened, source.stat)) {
-    throw new FsSafeError("path-mismatch", "copy source descriptor changed");
-  }
-  await assertCopySourcePathCurrent(source);
+async function assertCopySourceCurrent(source: OpenResult, identity: BigIntStats): Promise<void> {
+  await inspectFileIdentity(() => source.handle.stat({ bigint: true }), identity);
+  await assertCopySourcePathCurrent(source, identity);
 }
 
-async function assertCopySourcePathCurrent(source: OpenResult): Promise<void> {
-  const current = await fs.lstat(source.realPath);
-  if (current.isSymbolicLink() || !current.isFile() || !sameFileIdentity(current, source.stat)) {
-    throw new FsSafeError("path-mismatch", "copy source path changed");
-  }
+async function assertCopySourcePathCurrent(source: OpenResult, identity: BigIntStats): Promise<void> {
+  await inspectFileIdentity(async () => {
+    const current = await fs.lstat(source.realPath, { bigint: true });
+    if (current.isSymbolicLink() || !current.isFile()) {
+      throw new FsSafeError("path-mismatch", "copy source path changed");
+    }
+    return current;
+  }, identity);
 }
 
 async function removePathIfIdentityUnchanged(

--- a/test/archive-adjacent-errors.test.ts
+++ b/test/archive-adjacent-errors.test.ts
@@ -141,7 +141,7 @@ describe("archive input staging failures", () => {
     const archivePath = path.join(root, "archive");
     await fs.writeFile(archivePath, "archive");
     const realLstat = fs.lstat.bind(fs);
-    const originalStat = await realLstat(archivePath);
+    const originalStat = await realLstat(archivePath, { bigint: true });
     const changedStat = new Proxy(originalStat, {
       get(target, property) {
         if (property === "ino") {
@@ -154,9 +154,9 @@ describe("archive input staging failures", () => {
       },
     });
     let archiveLstats = 0;
-    vi.spyOn(fs, "lstat").mockImplementation(async (candidate) => {
-      if (String(candidate) === archivePath && ++archiveLstats === 2) return changedStat;
-      return await realLstat(candidate);
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      if (String(args[0]) === archivePath && ++archiveLstats === 2) return changedStat;
+      return await realLstat(...args);
     });
 
     await expect(stageArchiveFileForExtraction({

--- a/test/archive-input-identity.test.ts
+++ b/test/archive-input-identity.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import JSZip from "jszip";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extractArchive, readArchiveEntry } from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { observeReadAdmission, readIdentity, type ReadBoundary } from "./helpers/read-admission-identity.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+beforeEach(() => configureFsSafeNative({ mode: "off" }));
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+  __resetFsSafeNativeConfigForTest();
+});
+
+describe.each(["read", "extract"] as const)("archive %s input identity", (route) => {
+  async function fixture(options: Parameters<typeof observeReadAdmission>[1] = {}) {
+    const directory = await fs.realpath(await tempRoot("fs-safe-archive-identity-"));
+    const filePath = path.join(directory, "input.zip");
+    const destination = path.join(directory, "output");
+    await fs.mkdir(destination);
+    for (const [target, value] of [[filePath, "original"], [`${filePath}.replacement`, "replacement"]]) {
+      await fs.writeFile(target!, await new JSZip().file("value", value!).generateAsync({ type: "nodebuffer" }));
+    }
+    const observed = observeReadAdmission(filePath, options);
+    return {
+      ...observed, destination,
+      run: () => route === "read"
+        ? readArchiveEntry(filePath, "value", { maxBytes: 100 })
+        : extractArchive({ archivePath: filePath, destDir: destination }),
+    };
+  }
+
+  it.each(["before-open", "after-open"] as const)("rejects a rounded-equal source swap %s", async (swap) => {
+    const subject = await fixture({ swap });
+    await expect(subject.run()).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(subject.read).not.toHaveBeenCalled();
+    expect(subject.close).toHaveBeenCalledTimes(1);
+    expect(await fs.readdir(subject.destination)).toEqual([]);
+  });
+
+  for (const boundary of ["preview", "descriptor", "current"] as ReadBoundary[]) {
+    it(`retries transient unknown Windows ${boundary} without reopening`, async () => {
+      const subject = await fixture({ samples: { [boundary]: [{ ino: 0n }, {}] } });
+      Object.defineProperty(process, "platform", { value: "win32" });
+      await subject.run();
+      expect(subject.counts[boundary]).toBe(2);
+      expect(subject.open).toHaveBeenCalledTimes(1);
+      expect(subject.close).toHaveBeenCalledTimes(1);
+    });
+    it(`rejects conflicting known bits during Windows ${boundary} retry`, async () => {
+      const subject = await fixture({ samples: {
+        [boundary]: [{ ino: 0n }, { dev: readIdentity.dev + 1n }],
+      } });
+      Object.defineProperty(process, "platform", { value: "win32" });
+      await expect(subject.run()).rejects.toMatchObject({ code: "path-mismatch" });
+      expect(subject.read).not.toHaveBeenCalled();
+      expect(subject.close).toHaveBeenCalledTimes(boundary === "preview" ? 0 : 1);
+    });
+    it(`rejects persistent unknown Windows ${boundary}`, async () => {
+      const subject = await fixture({ samples: { [boundary]: [{ ino: 0n }] } });
+      Object.defineProperty(process, "platform", { value: "win32" });
+      await expect(subject.run()).rejects.toMatchObject({ code: "path-mismatch" });
+      expect(subject.read).not.toHaveBeenCalled();
+      expect(subject.close).toHaveBeenCalledTimes(boundary === "preview" ? 0 : 1);
+      expect(await fs.readdir(subject.destination)).toEqual([]);
+    });
+  }
+});

--- a/test/helpers/read-admission-identity.ts
+++ b/test/helpers/read-admission-identity.ts
@@ -1,0 +1,117 @@
+import fsSync, { type BigIntStats, type Stats } from "node:fs";
+import fs from "node:fs/promises";
+import { vi } from "vitest";
+
+export const readIdentity = { dev: 9007199254740992n, ino: 9007199254740992n };
+export type ReadBoundary = "preview" | "descriptor" | "current";
+type Sample = (Partial<typeof readIdentity> & { kind?: "symlink" | "directory"; nlink?: bigint }) | Error;
+export type ReadSamples = Partial<Record<ReadBoundary, Sample[]>>;
+
+// Model exact filesystem identities over real I/O, projecting to Number only
+// when the caller requests numeric Stats. Windows cases are not kernel proof.
+export function observeReadAdmission(filePath: string, options: {
+  samples?: ReadSamples;
+  swap?: "before-open" | "after-open";
+  numericAdapter?: ReadBoundary;
+} = {}) {
+  let opened = false;
+  let swapped = false;
+  const counts = { preview: 0, descriptor: 0, current: 0 };
+  const open = vi.fn();
+  const read = vi.fn();
+  const close = vi.fn();
+  const handles: fs.FileHandle[] = [];
+  const descriptors = new Set<number>();
+  const displaced = `${filePath}.displaced`;
+  const replacement = `${filePath}.replacement`;
+  const rename = fsSync.renameSync.bind(fsSync);
+  function swap() {
+    rename(filePath, displaced);
+    rename(replacement, filePath);
+    swapped = true;
+  }
+  function observe(boundary: ReadBoundary, stat: Stats | BigIntStats, bigint: boolean) {
+    const sequence = options.samples?.[boundary];
+    const attempt = bigint ? counts[boundary]++ : 0;
+    const sample = sequence?.[Math.min(attempt, sequence.length - 1)] ?? {};
+    if (sample instanceof Error) throw sample;
+    const replaced = boundary === "current" ? swapped
+      : boundary === "descriptor" && options.swap === "before-open";
+    const identity = { ...readIdentity, ino: readIdentity.ino + (replaced ? 1n : 0n), ...sample };
+    for (const field of ["dev", "ino"] as const) {
+      stat[field] = bigint && options.numericAdapter !== boundary ? identity[field] : Number(identity[field]);
+    }
+    if (sample.kind) {
+      stat.isSymbolicLink = () => sample.kind === "symlink";
+      stat.isFile = () => false;
+      stat.isDirectory = () => sample.kind === "directory";
+    }
+    if (sample.nlink !== undefined) stat.nlink = bigint ? sample.nlink : Number(sample.nlink);
+    return stat;
+  }
+  const lstat = fs.lstat.bind(fs);
+  vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    const stat = await lstat(...args);
+    return String(args[0]) === filePath
+      ? observe(opened ? "current" : "preview", stat, args[1]?.bigint === true) : stat;
+  });
+  const lstatSync = fsSync.lstatSync.bind(fsSync);
+  vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+    const stat = lstatSync(...args);
+    return String(args[0]) === filePath
+      ? observe(opened ? "current" : "preview", stat, args[1]?.bigint === true) : stat;
+  });
+  const actualOpen = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    if (String(args[0]) !== filePath) return await actualOpen(...args);
+    if (options.swap === "before-open") swap();
+    const handle = await actualOpen(...args);
+    opened = true;
+    open();
+    handles.push(handle);
+    if (options.swap === "after-open") swap();
+    const stat = handle.stat.bind(handle);
+    vi.spyOn(handle, "stat").mockImplementation(async (options) =>
+      observe("descriptor", await stat(options), options?.bigint === true));
+    for (const method of ["read", "readFile"] as const) {
+      const actual = handle[method].bind(handle);
+      vi.spyOn(handle, method).mockImplementation((...args: never[]) => {
+        read();
+        return actual(...args);
+      });
+    }
+    const actualClose = handle.close.bind(handle);
+    vi.spyOn(handle, "close").mockImplementation(async () => {
+      close();
+      await actualClose();
+    });
+    return handle;
+  });
+  const openSync = fsSync.openSync.bind(fsSync);
+  vi.spyOn(fsSync, "openSync").mockImplementation((...args) => {
+    if (String(args[0]) !== filePath) return openSync(...args);
+    if (options.swap === "before-open") swap();
+    const fd = openSync(...args);
+    opened = true;
+    open();
+    descriptors.add(fd);
+    if (options.swap === "after-open") swap();
+    return fd;
+  });
+  const fstat = fsSync.fstatSync.bind(fsSync);
+  vi.spyOn(fsSync, "fstatSync").mockImplementation((...args) => {
+    const stat = fstat(...args);
+    return descriptors.has(args[0]) ? observe("descriptor", stat, args[1]?.bigint === true) : stat;
+  });
+  const readFile = fsSync.readFileSync.bind(fsSync);
+  vi.spyOn(fsSync, "readFileSync").mockImplementation((...args) => {
+    if (typeof args[0] === "number" && descriptors.has(args[0])) read();
+    return readFile(...args);
+  });
+  const actualClose = fsSync.closeSync.bind(fsSync);
+  vi.spyOn(fsSync, "closeSync").mockImplementation((fd) => {
+    if (descriptors.has(fd)) { close(); descriptors.delete(fd); }
+    actualClose(fd);
+  });
+  return { counts, open, read, close, handles, displaced, replacement };
+}

--- a/test/pinned-open.test.ts
+++ b/test/pinned-open.test.ts
@@ -50,11 +50,19 @@ function mockRealpathSync(result: string): PinnedOpenSyncRealpathSync {
 }
 
 function mockLstatSync(read: (filePath: fs.PathLike) => fs.Stats): PinnedOpenSyncLstatSync {
-  return ((filePath: fs.PathLike) => read(filePath)) as unknown as PinnedOpenSyncLstatSync;
+  return ((filePath: fs.PathLike, options?: { bigint?: boolean }) =>
+    projectStat(read(filePath), options?.bigint)) as PinnedOpenSyncLstatSync;
 }
 
 function mockFstatSync(stat: fs.Stats): PinnedOpenSyncFstatSync {
-  return ((_: number) => stat) as unknown as PinnedOpenSyncFstatSync;
+  return ((_: number, options?: { bigint?: boolean }) =>
+    projectStat(stat, options?.bigint)) as PinnedOpenSyncFstatSync;
+}
+
+function projectStat(stat: fs.Stats, bigint = false): fs.Stats | fs.BigIntStats {
+  if (!bigint) return stat;
+  return { ...stat, dev: BigInt(stat.dev), ino: BigInt(stat.ino),
+    nlink: BigInt(stat.nlink), size: BigInt(stat.size) } as fs.BigIntStats;
 }
 
 async function expectOpenFailure(params: {

--- a/test/read-admission-identity.test.ts
+++ b/test/read-admission-identity.test.ts
@@ -1,0 +1,115 @@
+import fsSync, { Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readRegularFile, readRegularFileSync } from "../src/regular-file.js";
+import { openRootFile, openRootFileSync } from "../src/root-file.js";
+import { observeReadAdmission, readIdentity, type ReadBoundary } from "./helpers/read-admission-identity.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+});
+
+for (const route of ["regular async", "regular sync", "root sync", "root async"] as const) {
+  describe(route, () => {
+    async function fixture(options: Parameters<typeof observeReadAdmission>[1] = {}) {
+      const directory = await fs.realpath(await tempRoot("fs-safe-read-admission-"));
+      const filePath = path.join(directory, "value");
+      await fs.writeFile(filePath, "original");
+      await fs.writeFile(`${filePath}.replacement`, "replacement");
+      const observation = observeReadAdmission(filePath, options);
+      const run = async () => {
+        if (route === "regular async") return await readRegularFile({ filePath });
+        if (route === "regular sync") return readRegularFileSync({ filePath });
+        const params = { absolutePath: filePath, rootPath: directory, boundaryLabel: "test", ioFs: fsSync };
+        const result = route === "root sync" ? openRootFileSync(params) : await openRootFile(params);
+        if (!result.ok) {
+          expect(result.reason).toBe("validation");
+          throw result.error;
+        }
+        try { return { stat: result.stat, buffer: fsSync.readFileSync(result.fd) }; }
+        finally { fsSync.closeSync(result.fd); }
+      };
+      return { ...observation, filePath, run };
+    }
+
+    it.each(["before-open", "after-open"] as const)("refuses a rounded-equal replacement %s", async (swap) => {
+      const subject = await fixture({ swap });
+      expect(Number(readIdentity.ino)).toBe(Number(readIdentity.ino + 1n));
+      await expect(subject.run()).rejects.toMatchObject({ code: "path-mismatch" });
+      expect(subject.read).not.toHaveBeenCalled();
+      expect(subject.close).toHaveBeenCalledTimes(1);
+      expect(await fs.readFile(subject.displaced, "utf8")).toBe("original");
+      expect(await fs.readFile(subject.filePath, "utf8")).toBe("replacement");
+    });
+
+    it("preserves numeric Stats on successful reads", async () => {
+      const subject = await fixture();
+      const result = await subject.run();
+      expect(result.stat).toBeInstanceOf(Stats);
+      expect(typeof result.stat.ino).toBe("number");
+      expect(result.buffer.toString()).toBe("original");
+      expect(subject.close).toHaveBeenCalledTimes(1);
+    });
+
+    for (const boundary of ["preview", "descriptor", "current"] as ReadBoundary[]) {
+      it(`retries a transient Windows ${boundary} once without reopening`, async () => {
+        const subject = await fixture({ samples: { [boundary]: [{ ino: 0n }, {}] } });
+        Object.defineProperty(process, "platform", { value: "win32" });
+        expect((await subject.run()).buffer.toString()).toBe("original");
+        expect(subject.counts[boundary]).toBe(2);
+        expect(subject.open).toHaveBeenCalledTimes(1);
+        expect(subject.close).toHaveBeenCalledTimes(1);
+      });
+      it(`retains a known component across a Windows ${boundary} retry`, async () => {
+        const subject = await fixture({ samples: {
+          [boundary]: [{ dev: readIdentity.dev, ino: 0n }, { dev: readIdentity.dev + 1n }],
+        } });
+        Object.defineProperty(process, "platform", { value: "win32" });
+        await expect(subject.run()).rejects.toMatchObject({ code: "path-mismatch" });
+        expect(subject.counts[boundary]).toBe(2);
+        expect(subject.read).not.toHaveBeenCalled();
+      });
+      it(`propagates a Windows ${boundary} retry I/O error`, async () => {
+        const failure = Object.assign(new Error("reinspection denied"), { code: "EACCES" });
+        const subject = await fixture({ samples: { [boundary]: [{ ino: 0n }, failure] } });
+        Object.defineProperty(process, "platform", { value: "win32" });
+        // Root adapters preserve the io/validation distinction in their result.
+        if (route.startsWith("root")) {
+          const params = { absolutePath: subject.filePath, rootPath: path.dirname(subject.filePath), boundaryLabel: "test" };
+          const result = route === "root sync" ? openRootFileSync(params) : await openRootFile(params);
+          expect(result).toMatchObject({ ok: false, reason: "io", error: failure });
+        } else {
+          await expect(subject.run()).rejects.toBe(failure);
+        }
+        expect(subject.counts[boundary]).toBe(2);
+        expect(subject.read).not.toHaveBeenCalled();
+        expect(subject.close).toHaveBeenCalledTimes(boundary === "preview" ? 0 : 1);
+      });
+      it(`rechecks file type on a Windows ${boundary} retry`, async () => {
+        const subject = await fixture({ samples: { [boundary]: [{ ino: 0n }, { kind: "symlink" }] } });
+        Object.defineProperty(process, "platform", { value: "win32" });
+        await expect(subject.run()).rejects.toThrow();
+        expect(subject.read).not.toHaveBeenCalled();
+        expect(subject.close).toHaveBeenCalledTimes(boundary === "preview" ? 0 : 1);
+      });
+      it(`rejects persistent unknown Windows ${boundary}`, async () => {
+        const subject = await fixture({ samples: { [boundary]: [{ ino: 0n }] } });
+        Object.defineProperty(process, "platform", { value: "win32" });
+        await expect(subject.run()).rejects.toMatchObject({ code: "path-mismatch" });
+        expect(subject.counts[boundary]).toBe(2);
+        expect(subject.read).not.toHaveBeenCalled();
+        expect(subject.close).toHaveBeenCalledTimes(boundary === "preview" ? 0 : 1);
+      });
+      it(`rejects an adapter returning numeric ${boundary} identity`, async () => {
+        const subject = await fixture({ numericAdapter: boundary });
+        await expect(subject.run()).rejects.toMatchObject({ code: "path-mismatch" });
+        expect(subject.read).not.toHaveBeenCalled();
+      });
+    }
+  });
+}

--- a/test/root-copy-read-identity.test.ts
+++ b/test/root-copy-read-identity.test.ts
@@ -1,0 +1,79 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { root } from "../src/root.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const ino = 9007199254740992n;
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+beforeEach(() => configureFsSafeNative({ mode: "off" }));
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+  __setFsSafeTestHooksForTest(undefined);
+  __resetFsSafeNativeConfigForTest();
+});
+
+describe("Root copy source lifetime", () => {
+  it.each(["before-copy", "after-copy", "unknown-after-copy"] as const)("rejects source identity drift %s", async (timing) => {
+    const directory = await fs.realpath(await tempRoot("fs-safe-copy-identity-"));
+    const source = path.join(directory, "source");
+    const displaced = path.join(directory, "displaced");
+    const replacement = path.join(directory, "replacement");
+    await fs.writeFile(source, "original");
+    await fs.writeFile(replacement, "replacement");
+    const scoped = await root(directory);
+    let swapped = false;
+    const read = vi.fn();
+    let close: ReturnType<typeof vi.spyOn> | undefined;
+    const swap = () => {
+      if (swapped) return;
+      fsSync.renameSync(source, displaced);
+      fsSync.renameSync(replacement, source);
+      swapped = true;
+    };
+    for (const method of ["lstat", "stat"] as const) {
+      const actual = fs[method].bind(fs);
+      vi.spyOn(fs, method).mockImplementation(async (...args) => {
+        const stat = await actual(...args);
+        if (String(args[0]) === source) {
+          const value = swapped ? (timing === "unknown-after-copy" ? 0n : ino + 1n) : ino;
+          stat.ino = args[1]?.bigint ? value : Number(value);
+        }
+        return stat;
+      });
+    }
+    __setFsSafeTestHooksForTest({
+      afterOpen(candidate, handle) {
+        if (candidate !== source) return;
+        close = vi.spyOn(handle, "close");
+        const actualStat = handle.stat.bind(handle);
+        let inspections = 0;
+        vi.spyOn(handle, "stat").mockImplementation(async (options) => {
+          if (++inspections === 3 && timing === "before-copy") swap();
+          const stat = await actualStat(options);
+          stat.ino = options?.bigint ? ino : Number(ino);
+          return stat;
+        });
+        const stream = handle.createReadStream.bind(handle);
+        vi.spyOn(handle, "createReadStream").mockImplementation((options) => {
+          read();
+          if (timing !== "before-copy") swap();
+          return stream(options);
+        });
+      },
+    });
+    if (timing === "unknown-after-copy") Object.defineProperty(process, "platform", { value: "win32" });
+    await expect(scoped.copyIn("target", source)).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(swapped).toBe(true);
+    expect(read).toHaveBeenCalledTimes(timing === "before-copy" ? 0 : 1);
+    expect(close).toHaveBeenCalled();
+    expect(await fs.readFile(source, "utf8")).toBe("replacement");
+    expect(await fs.readFile(displaced, "utf8")).toBe("original");
+    await expect(fs.access(path.join(directory, "target"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/test/secret-read-identity.test.ts
+++ b/test/secret-read-identity.test.ts
@@ -50,7 +50,8 @@ describe.each(["sync", "async"] as const)("%s secret identity", (kind) => {
     }
     await expect(read(filePath, rejectSymlink)).resolves.toBe("secret");
     const inputOperation = rejectSymlink ? "lstat" : "stat";
-    expect(inspections).toEqual([inputOperation, "fstat", "lstat", inputOperation]);
+    const pinnedInspections = kind === "sync" ? ["lstat", "fstat", "lstat"] : [];
+    expect(inspections).toEqual([inputOperation, ...pinnedInspections, "fstat", "lstat", inputOperation]);
   });
 
   it.each([false, true])("refuses a real replacement after opening (rejectSymlink=%s)", async (rejectSymlink) => {


### PR DESCRIPTION
## Summary

- verify regular-file reads, root-file adapters, archive input staging, and `Root.copyIn()` source checks with exact bigint `(dev, ino)` identities at preview, retained-descriptor, and current-path boundaries
- preserve numeric public `Stats` receipts while rejecting adapters that ignore `{ bigint: true }`
- retry transient unknown Windows identity components once on the same path or descriptor, retain known components across the retry, and fail closed if identity remains ambiguous

## Root cause

Several guarded read paths compared ordinary numeric Node `Stats`. JavaScript cannot distinguish adjacent integer identities above `Number.MAX_SAFE_INTEGER`: for example, `9007199254740992n` and `9007199254740993n` project to the same number. A path replacement with those identities could therefore pass preview/descriptor/current-path equality checks. The synchronous pinned opener also lacked a final current-path identity check, and `Root.copyIn()` reverted to its numeric public receipt for source checks after exact admission.

The affected owners now reuse the existing strict bigint inspector. Internal identity stays exact for the whole admission or copy lifetime; public metadata remains numeric. On Windows, only unknown zero components receive one bounded reinspection without reopening, and every known component remains binding across that retry.

## Live behavior proof

A fresh consumer installed the packed package and exercised only public exports. Its custom `openRootFileSync()` adapter supplied two distinct bigint identities that collapse to the same JavaScript number, a numeric-only adapter, transient and persistent Windows unknown identities, and a stable identity. It also exercised ordinary `readRegularFile()` and `Root.copyIn()` behavior:

```json
{"roundedEqual":{"numericCollision":true,"result":{"ok":false,"reason":"validation","code":"path-mismatch"},"calls":{"lstat":1,"fstat":2,"open":1,"close":1}},"stable":{"numericReceipt":true,"content":"original"},"numericAdapter":{"ok":false,"reason":"validation","code":"path-mismatch"},"transientWindows":{"ok":true,"calls":{"lstat":3,"fstat":2,"open":1,"close":0}},"persistentWindows":{"ok":false,"reason":"validation","code":"path-mismatch","calls":{"lstat":2,"fstat":0,"open":0,"close":0}},"regular":{"content":"original","numericReceipt":true},"copy":{"content":"original"}}
```

The rounded-equal replacement rejected and closed its descriptor. The numeric-only adapter failed validation. A transient Windows unknown was reinspected once without reopening; a persistent unknown failed before open. Successful public receipts remained numeric and ordinary reads/copies preserved content.

## Verification

- focused identity/archive/root/secret/regular regression set: 9 files, 177 tests passed
- complete test suite: 147 files passed, 1 skipped; 2,484 tests passed, 25 skipped
- complete `CI=1 pnpm check`: build, docs, file-size, filesystem-boundary, package/API checks, and the full test suite passed
- fresh packed-package consumer proof passed
- `git diff --check` passed
- independent adversarial review found no actionable correctness, security, compatibility, scope, or documentation issue
- Codex autoreview at P1: clean
- exact-head hosted Linux/macOS/Windows checks and ClawSweeper review remain landing gates
