### PR TITLE
fix(archive): align gzip ratio policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Disable node-tar's hidden 1000x decompression threshold after complete fs-safe decoded-byte admission, allowing highly compressible gzip TARs within explicit archive, decoded, entry, output, and deadline limits to behave consistently across JavaScript and native backends.
 - Match archive entry reads to extraction's validated canonical pre-strip paths across JavaScript/native ZIP, TAR, gzip, zstd, and bzip2; resolve separator/dot aliases and effective metadata names while retaining directory, link, collision, integrity, and byte-limit checks.
 - Bound TAR manifests with one shared 64 MiB-capped admission budget independent of compressed size; validate checksums, strict fixed-field UTF-8, NFC/NFD component lengths, and GNU effective trailing separators across JavaScript/native TAR and supported codecs; require raw linknames on links and forbid them on every other header, including metadata, before metadata handling or policy.
 - Admit ignored TAR records (`V`, `A`, `I`, `M`, and unknown typeflags) through ordered path, count, strip, depth, collision, and filter policy before parser suppression; omit accepted unsupported records safely, validate raw names hidden by metadata or NUL terminators, and preserve JavaScript/native TAR/gzip/zstd/bzip2 parity.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -289,6 +289,9 @@ archive overhead with safe addition. Ordinary limits, including
 zero and the existing defaulting/rounding rules, retain their behavior.
 There is no new public option. This is an absolute decoded admission
 cap, not a decompression-ratio policy; bounded stream/codec read-ahead remains.
+After this complete preflight, the JavaScript backend disables node-tar's
+independent ratio threshold so it cannot reject data that the native backend
+accepts within the same absolute limits.
 
 ### Bounded local PAX support
 

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -21,7 +21,7 @@ import {
 } from "./archive-limits.js";
 import { readTarEntryInfo } from "./archive-tar.js";
 import { preflightTarMetadata } from "./archive-tar-meta.js";
-import { importOptionalTar, normalizeTarParserError } from "./archive-tar-runtime.js";
+import { importOptionalTar, NODE_TAR_RATIO_DISABLED, normalizeTarParserError } from "./archive-tar-runtime.js";
 import { loadZipArchiveWithPreflight } from "./archive-zip-preflight.js";
 import {
   createZipIntegrityTransform,
@@ -191,6 +191,7 @@ async function readTarEntry(archivePath: string, entryPath: string, maxBytes: nu
       file: archivePath,
       strict: true,
       maxMetaEntrySize: DEFAULT_MAX_META_ENTRY_BYTES,
+      maxDecompressionRatio: NODE_TAR_RATIO_DISABLED,
       onReadEntry(entry) {
         const info = readTarEntryInfo(entry);
         let normalized: string;

--- a/src/archive-tar-runtime.ts
+++ b/src/archive-tar-runtime.ts
@@ -16,6 +16,10 @@ export type TarParser = NodeJS.WritableStream & {
   on(event: "end", listener: () => void): TarParser;
 };
 
+// Both callers parse an immutable staged stream only after fs-safe's complete
+// decoded-byte admission, so node-tar must not add backend-specific policy.
+export const NODE_TAR_RATIO_DISABLED = Number.POSITIVE_INFINITY;
+
 export type TarModule = {
   Parser: new (options: { strict: true; maxMetaEntrySize: number }) => TarParser;
   x(options: {
@@ -29,6 +33,7 @@ export type TarModule = {
     noMtime: true;
     strict: true;
     maxMetaEntrySize: number;
+    maxDecompressionRatio: number;
     filter?(this: TarParser, entryPath: string, entry: unknown): boolean;
     onReadEntry(this: unknown, entry: unknown): void;
   }): TarParser;
@@ -36,6 +41,7 @@ export type TarModule = {
     file: string;
     strict: true;
     maxMetaEntrySize: number;
+    maxDecompressionRatio: number;
     onReadEntry(entry: AsyncIterable<unknown> & { resume(): void }): void;
   }): Promise<unknown>;
 };

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -58,7 +58,7 @@ import {
   resolveArchiveFilteredEntryPolicy,
   shouldExtractArchiveEntry,
 } from "./archive-policy.js";
-import { importOptionalTar, normalizeTarParserError } from "./archive-tar-runtime.js";
+import { importOptionalTar, NODE_TAR_RATIO_DISABLED, normalizeTarParserError } from "./archive-tar-runtime.js";
 import { preflightTarMetadata } from "./archive-tar-meta.js";
 import { createTarAdmissionPlan } from "./archive-tar-admission.js";
 import type { ExtractArchiveOptions } from "./archive-options.js";
@@ -408,6 +408,7 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
               noMtime: true,
               strict: true,
               maxMetaEntrySize: tarLimits.maxMetaEntryBytes,
+              maxDecompressionRatio: NODE_TAR_RATIO_DISABLED,
               filter(this: { abort(error: Error): void }, _entryPath, entry) {
                 try {
                   const info = readTarEntryInfo(entry);

--- a/test/archive-tar-gzip-ratio.test.ts
+++ b/test/archive-tar-gzip-ratio.test.ts
@@ -1,0 +1,106 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extractArchive, readArchiveEntry } from "../src/archive.js";
+import { resolveTarMeterLimits } from "../src/archive-limits.js";
+import {
+  __resetFsSafeNativeConfigForTest,
+  configureFsSafeNative,
+} from "../src/native-config.js";
+import {
+  __resetNativeLoaderForTest,
+  __setNativeLoaderForTest,
+} from "../src/native.js";
+import { tarFixture } from "./helpers/archive-fuzz.js";
+import { paxNative } from "./helpers/archive-pax-native.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const payload = Buffer.alloc(8 * 1024 * 1024);
+const decoded = tarFixture([{ path: "payload.bin", body: payload }]);
+const compressed = gzipSync(decoded);
+const limits = {
+  maxArchiveBytes: compressed.byteLength,
+  maxEntryBytes: payload.byteLength,
+  maxExtractedBytes: payload.byteLength,
+};
+
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+for (const backend of ["off", "auto-missing", "auto", "require"] as const) {
+  describe.skipIf((backend === "auto" || backend === "require") && !paxNative)(
+    `TAR gzip ratio policy ${backend}`,
+    () => {
+      let inspect: ReturnType<typeof vi.fn> | undefined;
+      let extract: ReturnType<typeof vi.fn> | undefined;
+      let read: ReturnType<typeof vi.fn> | undefined;
+
+      beforeEach(() => {
+        configureFsSafeNative({ mode: backend === "auto-missing" ? "auto" : backend });
+        if (backend === "auto-missing") {
+          __setNativeLoaderForTest(() => {
+            throw new Error("fixture: no native binding");
+          });
+        }
+        if (backend === "auto" || backend === "require") {
+          const native = paxNative!;
+          inspect = vi.fn(native.inspectArchiveNative.bind(native));
+          extract = vi.fn(native.extractArchiveNative.bind(native));
+          read = vi.fn(native.readArchiveEntryNative.bind(native));
+          __setNativeLoaderForTest(() => ({
+            ...native,
+            inspectArchiveNative: inspect!,
+            extractArchiveNative: extract!,
+            readArchiveEntryNative: read!,
+          }));
+        }
+      });
+
+      it("accepts expansion above 1000x when absolute budgets admit the complete stream", async () => {
+        expect(decoded.byteLength / compressed.byteLength).toBeGreaterThan(1000);
+        expect(compressed.byteLength).toBeLessThanOrEqual(limits.maxArchiveBytes);
+        expect(payload.byteLength).toBeLessThanOrEqual(limits.maxEntryBytes);
+        expect(payload.byteLength).toBeLessThanOrEqual(limits.maxExtractedBytes);
+        expect(decoded.byteLength).toBeLessThanOrEqual(
+          resolveTarMeterLimits(limits).maxDecodedBytes,
+        );
+
+        const root = await tempRoot("fs-safe-tar-gzip-ratio-");
+        const archivePath = path.join(root, "fixture.tar.gz");
+        const destDir = path.join(root, "out");
+        await fs.writeFile(archivePath, compressed);
+        await fs.mkdir(destDir);
+        await fs.writeFile(path.join(destDir, "sentinel"), "unchanged");
+
+        await extractArchive({
+          archivePath,
+          destDir,
+          kind: "tar",
+          tarGzip: true,
+          timeoutMs: 30_000,
+          limits,
+        });
+        expect(await fs.stat(path.join(destDir, "payload.bin"))).toMatchObject({
+          size: payload.byteLength,
+        });
+        expect(await fs.readFile(path.join(destDir, "sentinel"), "utf8")).toBe("unchanged");
+
+        const selected = await readArchiveEntry(archivePath, "payload.bin", {
+          kind: "tar",
+          maxBytes: payload.byteLength,
+        });
+        expect(selected.equals(payload)).toBe(true);
+
+        if (backend === "auto" || backend === "require") {
+          expect(inspect).toHaveBeenCalledTimes(2);
+          expect(extract).toHaveBeenCalledTimes(1);
+          expect(read).toHaveBeenCalledTimes(1);
+        }
+      }, 30_000);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- disable node-tar's implicit 1000x decompression-ratio policy only after fs-safe has completely admitted the immutable staged TAR stream under its explicit decoded-byte ceiling
- apply the same owner boundary to JavaScript extraction and bounded entry reads, preserving parity with the native backend
- add a deterministic greater-than-1000x public-API regression across JavaScript, missing-native fallback, native auto, and native require modes, plus documentation and changelog coverage

## Root cause

fs-safe already meters the complete decoded TAR before parser policy, including headers, bodies, metadata, padding, EOF blocks, and trailing zero padding. The JavaScript backend then passed the same private staged gzip stream to node-tar without overriding node-tar 7.5.22's independent default ratio of 1000. A valid archive could therefore pass every fs-safe archive, decoded, entry, output, and deadline limit but fail only in JavaScript mode as `ArchiveFormatError("archive-header-invalid")`; native mode had no equivalent ratio rule.

The fix passes node-tar's documented disabling value, `Infinity`, at both preflighted parser call sites. It does not add a public option or weaken fs-safe's absolute byte budgets, framing checks, output policy, or deadline.

## Proof

- Before the fix, the new public regression failed in `off` and missing-native `auto` with `max decompression ratio exceeded: 1000.75 > 1000`; real native `auto` and `require` accepted the same archive.
- Focused parity test: 1 file, 4 tests passed.
- Neighboring TAR framing and canonical-read suites: 2 files, 658 tests passed, 48 intentional skips.
- `CI=1 pnpm check`: 162 files passed, 5,935 tests passed, 73 skipped; build, docs examples, filesystem-boundary lint, file-size budget, and package checks passed.
- `CI=1 pnpm test:security`: 5 files, 78 tests passed.
- Fresh packed consumer in native mode `off`: 8,235 compressed bytes, 8,390,144 decoded TAR bytes (1018.84x), 8,388,608 extracted and selected bytes, exact zero-filled content preserved.
- Codex autoreview at P1 scope: no accepted/actionable findings.
