### PR TITLE
fix(lock): retry unlinked sidecar snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
       - name: Check JavaScript fallback
         run: pnpm check
 
+      - name: Prove Root sidecar unlinked snapshot handoff and replacement rejection
+        if: matrix.node == 24 && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15')
+        env:
+          NODE_ENV: test
+        run: node scripts/sidecar-unlinked-snapshot-proof.mjs
+
       - name: Prove regular append identity on Windows
         if: matrix.os == 'windows-latest'
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Security and Correctness
 
+- Treat Root-backed sidecar ownership records unlinked after open as absent for retry only after capability-backed absence proof; keep replacements fail-closed.
 - Update native gzip/DEFLATE decoding to flate2 1.1.10 and miniz_oxide 0.9.1, including upstream incomplete-stream rejection fixes; verify corrupted and truncated gzip archives fail before extraction publication or entry-read success.
 - Disable node-tar's hidden 1000x decompression threshold after complete fs-safe decoded-byte admission, allowing highly compressible gzip TARs within explicit archive, decoded, entry, output, and deadline limits to behave consistently across JavaScript and native backends.
 - Match archive entry reads to extraction's validated canonical pre-strip paths across JavaScript/native ZIP, TAR, gzip, zstd, and bzip2; resolve separator/dot aliases and effective metadata names while retaining directory, link, collision, integrity, and byte-limit checks.

--- a/scripts/sidecar-unlinked-snapshot-proof.mjs
+++ b/scripts/sidecar-unlinked-snapshot-proof.mjs
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+process.env.NODE_ENV = "test";
+const { createFileLockManager } = await import("../dist/file-lock.js");
+const { root } = await import("../dist/root.js");
+const { __setFsSafeTestHooksForTest } = await import("../dist/test-hooks.js");
+
+const proof = "sidecar-unlinked-snapshot";
+if (process.platform === "win32") {
+  console.log(JSON.stringify({ proof, platform: process.platform, skipped: "POSIX unlink semantics required" }));
+  process.exit(0);
+}
+
+const mismatch = { name: "FsSafeError", code: "path-mismatch" };
+const errorShape = (error) => ({ name: error?.name, code: error?.code });
+const retry = { retries: 3, minTimeout: 1, maxTimeout: 1 };
+
+// Forward every call to this same real Root. Create's existing-file inspection
+// opens internally, so arm only at the public snapshot open after its collision.
+function observeSnapshot(capability, relative, hookName, mutate) {
+  const original = { create: capability.create, open: capability.open, stat: capability.stat };
+  const lockPath = path.join(capability.rootReal, relative);
+  const trace = { hookCalls: 0, creates: [], probes: [], opened: undefined, error: undefined };
+  let armed = false;
+  capability.create = async function (candidate, raw, ...args) {
+    const call = { raw, outcome: undefined };
+    if (candidate === relative) trace.creates.push(call);
+    try {
+      const result = await original.create.call(this, candidate, raw, ...args);
+      call.outcome = "created";
+      return result;
+    } catch (error) {
+      call.outcome = error.code;
+      throw error;
+    }
+  };
+  capability.open = async function (candidate, ...args) {
+    if (candidate !== relative || armed) return await original.open.call(this, candidate, ...args);
+    armed = true;
+    assert.deepEqual(trace.creates.map((call) => call.outcome), ["already-exists"]);
+    __setFsSafeTestHooksForTest({
+      async [hookName](candidatePath, handle) {
+        if (candidatePath !== lockPath) return;
+        __setFsSafeTestHooksForTest();
+        trace.hookCalls += 1;
+        trace.opened = handle;
+        assert.equal(trace.hookCalls, 1);
+        assert.ok(handle.fd >= 0);
+        await mutate(handle);
+      },
+    });
+    try {
+      return await original.open.call(this, candidate, ...args);
+    } catch (error) {
+      trace.error = errorShape(error);
+      throw error;
+    } finally {
+      __setFsSafeTestHooksForTest();
+    }
+  };
+  capability.stat = async function (candidate, ...args) {
+    try {
+      const result = await original.stat.call(this, candidate, ...args);
+      if (candidate === relative) trace.probes.push("present");
+      return result;
+    } catch (error) {
+      if (candidate === relative) trace.probes.push(error.code);
+      throw error;
+    }
+  };
+  trace.restore = () => {
+    __setFsSafeTestHooksForTest();
+    Object.assign(capability, original);
+  };
+  return trace;
+}
+
+async function proveHandoff(capability, ownerManager, waiterManager) {
+  const relative = "handoff.lock";
+  const lockPath = path.join(capability.rootReal, relative);
+  const targetPath = path.join(capability.rootReal, "handoff.json");
+  const options = { lockPath, lockRoot: capability, retry, timeoutMs: 5_000 };
+  const ownerPayload = { owner: "original", scenario: "handoff" };
+  const waiterPayload = { owner: "waiter", scenario: "handoff" };
+  const owner = await ownerManager.acquire(targetPath, { ...options, payload: () => ownerPayload });
+  const ownerBytes = await fs.readFile(lockPath);
+  assert.deepEqual(JSON.parse(ownerBytes.toString("utf8")), ownerPayload);
+
+  const trace = observeSnapshot(capability, relative, "afterOpenedPathIdentityCheck", async () => {
+    await owner.release();
+    await assert.rejects(fs.lstat(lockPath), { code: "ENOENT" });
+  });
+  let waiter;
+  try {
+    waiter = await waiterManager.acquire(targetPath, { ...options, payload: () => waiterPayload });
+  } finally {
+    trace.restore();
+  }
+  assert.equal(trace.hookCalls, 1);
+  assert.equal(trace.opened?.fd, -1);
+  assert.deepEqual(trace.error, mismatch);
+  assert.deepEqual(trace.probes, ["not-found"]);
+  assert.deepEqual(trace.creates.map((call) => call.outcome), ["already-exists", "created"]);
+  const waiterBytes = await fs.readFile(lockPath);
+  assert.deepEqual(waiterBytes, Buffer.from(trace.creates[1].raw, "utf8"));
+  const payload = JSON.parse(waiterBytes.toString("utf8"));
+  assert.deepEqual(payload, waiterPayload);
+  assert.notDeepEqual(waiterBytes, ownerBytes);
+  const verified = await waiter.verifyStillHeld();
+  assert.equal(verified, true);
+  assert.equal(waiterManager.heldEntries().length, 1);
+  await waiter.release();
+  await assert.rejects(capability.stat(relative), { name: "FsSafeError", code: "not-found" });
+  await assert.rejects(fs.lstat(lockPath), { code: "ENOENT" });
+  assert.equal(ownerManager.heldEntries().length, 0);
+  assert.equal(waiterManager.heldEntries().length, 0);
+  return {
+    hookCalls: trace.hookCalls,
+    waiterOwner: payload.owner,
+    payload,
+    verified,
+    openedHandleClosed: trace.opened.fd === -1,
+    finalMissing: true,
+  };
+}
+
+async function proveReplacement(capability, ownerManager, waiterManager) {
+  const relative = "replacement.lock";
+  const lockPath = path.join(capability.rootReal, relative);
+  const displacedPath = `${lockPath}.displaced`;
+  const targetPath = path.join(capability.rootReal, "replacement.json");
+  const options = { lockPath, lockRoot: capability, retry, timeoutMs: 5_000 };
+  const ownerPayload = { owner: "original", scenario: "replacement" };
+  const owner = await ownerManager.acquire(targetPath, { ...options, payload: () => ownerPayload });
+  const originalBytes = await fs.readFile(lockPath);
+  assert.deepEqual(JSON.parse(originalBytes.toString("utf8")), ownerPayload);
+  const replacementBytes = Buffer.from('{"owner":"replacement","preserve":true}\n');
+  assert.notDeepEqual(replacementBytes, originalBytes);
+
+  const trace = observeSnapshot(capability, relative, "afterOpen", async () => {
+    await fs.rename(lockPath, displacedPath);
+    await fs.writeFile(lockPath, replacementBytes, { flag: "wx", mode: 0o600 });
+  });
+  let rejected;
+  try {
+    await assert.rejects(
+      waiterManager.acquire(targetPath, {
+        ...options,
+        payload: () => ({ owner: "waiter", scenario: "replacement" }),
+      }),
+      (error) => {
+        rejected = errorShape(error);
+        assert.deepEqual(rejected, mismatch);
+        return true;
+      },
+    );
+  } finally {
+    trace.restore();
+  }
+  assert.equal(trace.hookCalls, 1);
+  assert.equal(trace.opened?.fd, -1);
+  assert.deepEqual(trace.error, mismatch);
+  assert.deepEqual(trace.probes, ["present"]);
+  assert.deepEqual(trace.creates.map((call) => call.outcome), ["already-exists"]);
+  assert.equal(waiterManager.heldEntries().length, 0);
+  assert.equal((await fs.lstat(lockPath)).isFile(), true);
+  assert.deepEqual(await fs.readFile(lockPath), replacementBytes);
+  assert.deepEqual(await fs.readFile(displacedPath), originalBytes);
+  assert.equal(await owner.verifyStillHeld(), false);
+  await owner.release();
+  await ownerManager.drain();
+  await waiterManager.drain();
+  ownerManager.reset();
+  waiterManager.reset();
+  assert.equal(ownerManager.heldEntries().length, 0);
+  assert.equal(waiterManager.heldEntries().length, 0);
+  assert.deepEqual(await fs.readFile(lockPath), replacementBytes);
+  assert.deepEqual(await fs.readFile(displacedPath), originalBytes);
+  return {
+    hookCalls: trace.hookCalls,
+    error: rejected,
+    openedHandleClosed: trace.opened.fd === -1,
+    replacementPreserved: true,
+    originalPreserved: true,
+  };
+}
+
+let phase = "setup";
+let directory;
+const ownerManager = createFileLockManager(`${proof}:owner`);
+const waiterManager = createFileLockManager(`${proof}:waiter`);
+try {
+  let result;
+  try {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-sidecar-proof-"));
+    const capability = await root(directory);
+    phase = "handoff";
+    const handoff = await proveHandoff(capability, ownerManager, waiterManager);
+    phase = "replacement";
+    const replacement = await proveReplacement(capability, ownerManager, waiterManager);
+    result = { proof, platform: process.platform, handoff, replacement };
+    phase = "cleanup";
+  } finally {
+    __setFsSafeTestHooksForTest();
+    try {
+      await ownerManager.drain();
+      await waiterManager.drain();
+      ownerManager.reset();
+      waiterManager.reset();
+    } finally {
+      if (directory) await fs.rm(directory, { recursive: true, force: true });
+    }
+  }
+  console.log(JSON.stringify(result));
+} catch (error) {
+  // Error messages/stacks can contain private absolute paths; expose only shape.
+  console.error(JSON.stringify({ proof, platform: process.platform, phase, failed: true, error: errorShape(error) }));
+  process.exitCode = 1;
+}

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -288,6 +288,7 @@ async function openVerifiedLocalFile(
       return pathStat;
     }, identity);
 
+    await fsSafeTestHooks?.afterOpenedPathIdentityCheck?.(filePath, handle);
     const realPath = await resolveOpenedFileRealPathForFd(handle.fd, identity, filePath);
     await inspectFileIdentity(async () => {
       const realStat = await fs.stat(realPath, { bigint: true });

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -99,7 +99,23 @@ export async function readSidecarLockSnapshot(
   let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
     if (options.lockRoot) {
-      const opened = await options.lockRoot.open(relativeSidecarLockPath(options.lockRoot, lockPath));
+      const lockRoot = options.lockRoot;
+      const relative = relativeSidecarLockPath(lockRoot, lockPath);
+      const opened = await lockRoot.open(relative).catch(async (error: unknown) => {
+        if (error instanceof FsSafeError && error.code === "path-mismatch") {
+          // An owner can unlink after open. Prove absence through the same root;
+          // acquisition retries create-only, so a later replacement stays guarded.
+          try {
+            await lockRoot.stat(relative);
+          } catch (probeError) {
+            if (probeError instanceof FsSafeError && probeError.code === "not-found") {
+              return null;
+            }
+          }
+        }
+        throw error;
+      });
+      if (!opened) return null;
       try {
         const raw = (await readFileHandleBounded(opened.handle, MAX_LOCK_PAYLOAD_BYTES)).toString("utf8");
         return {

--- a/src/test-hooks.ts
+++ b/src/test-hooks.ts
@@ -5,6 +5,7 @@ export type FsSafeTestHooks = {
   afterPreOpenLstat?: (filePath: string) => Promise<void> | void;
   beforeOpen?: (filePath: string, flags: number) => Promise<void> | void;
   afterOpen?: (filePath: string, handle: FileHandle) => Promise<void> | void;
+  afterOpenedPathIdentityCheck?: (filePath: string, handle: FileHandle) => Promise<void> | void;
   beforeArchiveOutputMutation?: (
     operation: "mkdir" | "chmod",
     targetPath: string,

--- a/test/helpers/sidecar-snapshot.ts
+++ b/test/helpers/sidecar-snapshot.ts
@@ -1,31 +1,16 @@
-import fs, { type FileHandle } from "node:fs/promises";
-import { vi } from "vitest";
+import type { FileHandle } from "node:fs/promises";
 import { __setFsSafeTestHooksForTest } from "../../src/test-hooks.js";
 
 export function pauseSidecarSnapshotOpen(lockPath: string, afterIdentityCheck: boolean) {
   const opened = Promise.withResolvers<FileHandle>();
   const resumed = Promise.withResolvers<void>();
-  __setFsSafeTestHooksForTest({
-    async afterOpen(candidate, handle) {
-      if (candidate !== lockPath) return;
-      if (!afterIdentityCheck) {
-        opened.resolve(handle);
-        await resumed.promise;
-        return;
-      }
-      // Hold the successful pathname observation so unlink lands before
-      // opened-realpath resolution, rather than the earlier not-found path.
-      const lstat = fs.lstat.bind(fs);
-      const inspection = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-        const stat = await lstat(...args);
-        if (String(args[0]) === lockPath && args[1]?.bigint) {
-          inspection.mockRestore();
-          opened.resolve(handle);
-          await resumed.promise;
-        }
-        return stat;
-      });
-    },
-  });
+  const pause = async (candidate: string, handle: FileHandle) => {
+    if (candidate !== lockPath) return;
+    opened.resolve(handle);
+    await resumed.promise;
+  };
+  __setFsSafeTestHooksForTest(afterIdentityCheck
+    ? { afterOpenedPathIdentityCheck: pause }
+    : { afterOpen: pause });
   return { opened: opened.promise, resume: resumed.resolve };
 }

--- a/test/helpers/sidecar-snapshot.ts
+++ b/test/helpers/sidecar-snapshot.ts
@@ -1,0 +1,31 @@
+import fs, { type FileHandle } from "node:fs/promises";
+import { vi } from "vitest";
+import { __setFsSafeTestHooksForTest } from "../../src/test-hooks.js";
+
+export function pauseSidecarSnapshotOpen(lockPath: string, afterIdentityCheck: boolean) {
+  const opened = Promise.withResolvers<FileHandle>();
+  const resumed = Promise.withResolvers<void>();
+  __setFsSafeTestHooksForTest({
+    async afterOpen(candidate, handle) {
+      if (candidate !== lockPath) return;
+      if (!afterIdentityCheck) {
+        opened.resolve(handle);
+        await resumed.promise;
+        return;
+      }
+      // Hold the successful pathname observation so unlink lands before
+      // opened-realpath resolution, rather than the earlier not-found path.
+      const lstat = fs.lstat.bind(fs);
+      const inspection = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+        const stat = await lstat(...args);
+        if (String(args[0]) === lockPath && args[1]?.bigint) {
+          inspection.mockRestore();
+          opened.resolve(handle);
+          await resumed.promise;
+        }
+        return stat;
+      });
+    },
+  });
+  return { opened: opened.promise, resume: resumed.resolve };
+}

--- a/test/sidecar-lock-acquire-failure.test.ts
+++ b/test/sidecar-lock-acquire-failure.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useTempDirs } from "./helpers/vitest.js";
+import { pauseSidecarSnapshotOpen } from "./helpers/sidecar-snapshot.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { configureFsSafeNative } from "../src/native-config.js";
 import { root } from "../src/root.js";
 import { createSidecarLockManager, withSidecarLock } from "../src/sidecar-lock.js";
@@ -16,6 +17,67 @@ afterEach(() => {
 });
 
 describe("asynchronous sidecar lock acquisition failures", () => {
+  itPosix.each([false, true])(
+    "acquires after the owner unlinks a Root snapshot (after identity check: %s)",
+    async (afterIdentityCheck) => {
+      const capability = await root(await tempRoot("fs-safe-sidecar-root-contention-"));
+      const targetPath = path.join(capability.rootReal, "state.json");
+      const lockPath = path.join(capability.rootReal, "owner.json");
+      const ownerManager = createSidecarLockManager(`root-owner-${targetPath}`);
+      const waiterManager = createSidecarLockManager(`root-waiter-${targetPath}`);
+      const options = { targetPath, lockPath, lockRoot: capability };
+      const owner = await ownerManager.acquire({
+        ...options,
+        payload: () => ({ owner: "original" }),
+      });
+      const ownerRaw = await capability.readText("owner.json");
+      const payload = { owner: "waiter", createdAt: "2999-01-01T00:00:00.000Z" };
+      const create = vi.spyOn(capability, "create");
+      const reading = Promise.withResolvers<ReturnType<typeof pauseSidecarSnapshotOpen>>();
+      const rootOpen = capability.open.bind(capability);
+      // Arm only for the snapshot, after create's own existing-file checks.
+      const open = vi.spyOn(capability, "open").mockImplementationOnce((...args) => {
+        reading.resolve(pauseSidecarSnapshotOpen(lockPath, afterIdentityCheck));
+        return rootOpen(...args);
+      });
+      const acquiring = waiterManager.acquire({
+        ...options,
+        payload: () => payload,
+        retry: { retries: 3, minTimeout: 1, maxTimeout: 1 },
+      });
+      const acquired = expect(acquiring).resolves.toMatchObject({ lockPath });
+      const gate = await reading.promise;
+      const opened = await gate.opened;
+      try {
+        __setFsSafeTestHooksForTest();
+        await owner.release();
+        await expect(capability.stat("owner.json")).rejects.toMatchObject({ code: "not-found" });
+      } finally {
+        gate.resume();
+      }
+      try {
+        await acquired;
+        const waiter = await acquiring;
+        const raw = await capability.readText("owner.json");
+        expect(JSON.parse(raw)).toEqual(payload);
+        expect(raw).not.toBe(ownerRaw);
+        expect(create.mock.calls.at(-1)?.[1]).toBe(raw);
+        if (afterIdentityCheck) {
+          await expect(open.mock.results[0]?.value).rejects.toMatchObject({ code: "path-mismatch" });
+        }
+        expect(opened.fd).toBe(-1);
+        await expect(waiter.verifyStillHeld()).resolves.toBe(true);
+        await waiter.release();
+        await expect(capability.stat("owner.json")).rejects.toMatchObject({ code: "not-found" });
+        expect(ownerManager.heldEntries()).toEqual([]);
+        expect(waiterManager.heldEntries()).toEqual([]);
+      } finally {
+        await ownerManager.drain();
+        await waiterManager.drain();
+      }
+    },
+  );
+
   it("removes a partially-written lock when payload persistence fails", async () => {
     configureFsSafeNative({ mode: "off" });
     const directory = await tempRoot("fs-safe-sidecar-write-failure-");

--- a/test/sidecar-lock-helpers-failure.test.ts
+++ b/test/sidecar-lock-helpers-failure.test.ts
@@ -2,8 +2,11 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useTempDirs } from "./helpers/vitest.js";
+import { pauseSidecarSnapshotOpen } from "./helpers/sidecar-snapshot.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+import { FsSafeError } from "../src/errors.js";
 import { root } from "../src/root.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 import {
   parseSidecarLockPayload,
   readSidecarLockSnapshot,
@@ -28,6 +31,7 @@ import {
 const { tempRoot } = useTempDirs();
 
 afterEach(() => {
+  __setFsSafeTestHooksForTest();
   vi.restoreAllMocks();
 });
 
@@ -74,6 +78,101 @@ describe("sidecar lock helper failure handling", () => {
     const current = readSidecarLockSnapshotSync(lockPath);
     expect(removeSidecarLockIfUnchangedSync(lockPath, current!)).toBe(true);
     expect(fsSync.existsSync(lockPath)).toBe(false);
+  });
+
+  itPosix.each([false, true])(
+    "treats an unlinked Root snapshot as absent (after identity check: %s)",
+    async (afterIdentityCheck) => {
+      const capability = await root(await tempRoot("fs-safe-sidecar-root-unlinked-"));
+      const relative = "owner.json";
+      const lockPath = path.join(capability.rootReal, relative);
+      await capability.create(relative, '{"owner":"original"}');
+      const probe = vi.spyOn(capability, "stat");
+      const gate = pauseSidecarSnapshotOpen(lockPath, afterIdentityCheck);
+      const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability });
+      const result = expect(snapshot).resolves.toBeNull();
+      const handle = await gate.opened;
+      const close = vi.spyOn(handle, "close");
+      try {
+        __setFsSafeTestHooksForTest();
+        await capability.remove(relative);
+      } finally {
+        gate.resume();
+      }
+      await result;
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(handle.fd).toBe(-1);
+      if (afterIdentityCheck) expect(probe).toHaveBeenCalledExactlyOnceWith(relative);
+    },
+  );
+
+  itPosix("rejects a Root snapshot replacement without changing either file", async () => {
+    const capability = await root(await tempRoot("fs-safe-sidecar-root-replaced-"));
+    const lockPath = path.join(capability.rootReal, "owner.json");
+    const displacedPath = `${lockPath}.old`;
+    const original = '{"owner":"original"}\n';
+    const replacement = '{"owner":"replacement"}\n';
+    await capability.create("owner.json", original);
+    const probe = vi.spyOn(capability, "stat");
+    const gate = pauseSidecarSnapshotOpen(lockPath, false);
+    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability });
+    const result = expect(snapshot).rejects.toMatchObject({ code: "path-mismatch" });
+    const handle = await gate.opened;
+    try {
+      __setFsSafeTestHooksForTest();
+      await fs.rename(lockPath, displacedPath);
+      await capability.create("owner.json", replacement);
+    } finally {
+      gate.resume();
+    }
+    await result;
+    expect(probe).toHaveBeenCalledExactlyOnceWith("owner.json");
+    expect(handle.fd).toBe(-1);
+    await expect(fs.readFile(displacedPath, "utf8")).resolves.toBe(original);
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe(replacement);
+  });
+
+  it.each([
+    new FsSafeError("path-mismatch", "root changed"),
+    new FsSafeError("symlink", "symlink blocked"),
+    new FsSafeError("not-file", "not a file"),
+    new FsSafeError("hardlink", "hardlink blocked"),
+    Object.assign(new Error("missing without capability proof"), { code: "ENOENT" }),
+    Object.assign(new Error("probe denied"), { code: "EACCES" }),
+  ])("preserves the original mismatch when the Root absence probe rejects with $code", async (failure) => {
+    const capability = await root(await tempRoot("fs-safe-sidecar-root-probe-"));
+    const mismatch = new FsSafeError("path-mismatch", "opened path changed");
+    vi.spyOn(capability, "open").mockRejectedValueOnce(mismatch);
+    const probe = vi.spyOn(capability, "stat").mockRejectedValueOnce(failure);
+    await expect(readSidecarLockSnapshot(path.join(capability.rootReal, "owner.json"), {
+      lockRoot: capability,
+    })).rejects.toBe(mismatch);
+    expect(probe).toHaveBeenCalledExactlyOnceWith("owner.json");
+  });
+
+  itPosix("rejects absence under a replaced Root after the ownership record is unlinked", async () => {
+    const base = await tempRoot("fs-safe-sidecar-root-swap-");
+    const rootPath = path.join(base, "locks");
+    await fs.mkdir(rootPath);
+    const capability = await root(rootPath);
+    const lockPath = path.join(capability.rootReal, "owner.json");
+    await capability.create("owner.json", '{"owner":"original"}');
+    const probe = vi.spyOn(capability, "stat");
+    const gate = pauseSidecarSnapshotOpen(lockPath, true);
+    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability });
+    const result = expect(snapshot).rejects.toMatchObject({ code: "path-mismatch" });
+    const handle = await gate.opened;
+    try {
+      __setFsSafeTestHooksForTest();
+      await capability.remove("owner.json");
+      await fs.rename(rootPath, `${rootPath}.old`);
+      await fs.mkdir(rootPath);
+    } finally {
+      gate.resume();
+    }
+    await result;
+    expect(probe).toHaveBeenCalledExactlyOnceWith("owner.json");
+    expect(handle.fd).toBe(-1);
   });
 
   it("covers identity, raw, token, and stat-only snapshot comparisons", async () => {


### PR DESCRIPTION
## Summary

- treat a Root-backed sidecar ownership record unlinked after open as absent so acquisition retries instead of surfacing `path-mismatch`
- require a second absence proof through the same Root capability before normalizing the error
- keep replacements, symlinks, hardlinks, root drift, and operational probe failures fail-closed
- add deterministic helper and two-manager contention regressions for unlink before and after identity admission

## Root cause

A waiter could open and identity-check an existing sidecar lock while its owner was releasing it. If the owner unlinked the pathname before `Root.open()` completed opened-path resolution, the still-valid descriptor had no resolvable name and `Root.open()` correctly threw `FsSafeError("path-mismatch")`. `readSidecarLockSnapshot()` propagated that generic Root policy error, so normal ownership turnover could abort acquisition instead of behaving like an absent lock and retrying create-only publication.

The ownership distinction belongs in the sidecar layer, not in `Root.open()`: generic Root callers must continue to reject unlinked or ambiguously named descriptors.

## Fix

For Root-backed snapshots, `readSidecarLockSnapshot()` now catches only `FsSafeError("path-mismatch")` from the initial open and calls `lockRoot.stat(relative)` through the same capability. It returns `null` only when that second operation proves `FsSafeError("not-found")` under the still-valid root. Any existing replacement, changed root, symlink/non-file/hardlink policy result, raw `ENOENT`, or operational failure preserves the original mismatch.

Returning `null` after an observed absence is safe even if the name is recreated immediately afterward: the acquisition loop retries exclusive create, which either creates the new ownership record or rejects the replacement as contention.

## Compiled runtime proof

A standalone proof now runs the compiled public file-lock and Root APIs against real filesystem operations. It pauses the waiter after pathname identity admission, releases the owner, verifies same-capability absence recovery and create-only reacquisition, then separately installs a replacement after open and verifies `path-mismatch` plus exact preservation:

```json
{"proof":"sidecar-unlinked-snapshot","platform":"darwin","handoff":{"hookCalls":1,"waiterOwner":"waiter","payload":{"owner":"waiter","scenario":"handoff"},"verified":true,"openedHandleClosed":true,"finalMissing":true},"replacement":{"hookCalls":1,"error":{"name":"FsSafeError","code":"path-mismatch"},"openedHandleClosed":true,"replacementPreserved":true,"originalPreserved":true}}
```

The same proof runs on exact-head Node 24 Linux and macOS CI.

## Verification

- deterministic Root-backed helper regressions cover unlink before and after identity admission, handle closure, regular-file replacement preservation, root replacement, and every non-absence probe failure
- deterministic POSIX two-manager contention proof: owner releases while waiter holds the opened descriptor; waiter resumes, retries, acquires, verifies ownership, and releases cleanly
- focused sidecar suites: 3 files, 49 tests passed
- security suite: 5 files, 78 tests passed
- complete `CI=1 pnpm check`: 6,086 tests passed, 76 skipped; build, docs, filesystem-boundary lint, file-size budget, package, and API checks passed
- Codex autoreview at P1: clean; no accepted/actionable findings
- `git diff --check`: passed

Exact-head hosted Linux, macOS, Windows, coverage, package, analysis, and ClawSweeper review remain the landing gates. No release or package publication is part of this PR.
