### PR TITLE
chore(release): prepare 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.7.0 - 2026-08-31
 
 ### Highlights
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "fs-safe-native"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bzip2",
  "flate2",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fs-safe-native"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/openclaw/fs-safe"

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-native-build",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Private build workspace for the native bindings bundled by @openclaw/fs-safe.",
   "private": true,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Capability-style filesystem roots for Node.js apps that handle untrusted relative paths.",
   "keywords": [
     "filesystem",
@@ -149,13 +149,13 @@
     "crabbox:warmup": "crabbox warmup"
   },
   "optionalDependencies": {
-    "@openclaw/fs-safe-darwin-arm64": "0.6.0",
-    "@openclaw/fs-safe-darwin-x64": "0.6.0",
-    "@openclaw/fs-safe-linux-arm64-gnu": "0.6.0",
-    "@openclaw/fs-safe-linux-arm64-musl": "0.6.0",
-    "@openclaw/fs-safe-linux-x64-gnu": "0.6.0",
-    "@openclaw/fs-safe-linux-x64-musl": "0.6.0",
-    "@openclaw/fs-safe-win32-x64-msvc": "0.6.0",
+    "@openclaw/fs-safe-darwin-arm64": "0.7.0",
+    "@openclaw/fs-safe-darwin-x64": "0.7.0",
+    "@openclaw/fs-safe-linux-arm64-gnu": "0.7.0",
+    "@openclaw/fs-safe-linux-arm64-musl": "0.7.0",
+    "@openclaw/fs-safe-linux-x64-gnu": "0.7.0",
+    "@openclaw/fs-safe-linux-x64-musl": "0.7.0",
+    "@openclaw/fs-safe-win32-x64-msvc": "0.7.0",
     "jszip": "^3.10.1",
     "tar": "7.5.22"
   },

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-darwin-arm64",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "macOS arm64 native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-darwin-x64",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "macOS x64 native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-arm64-gnu",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Linux arm64 glibc native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-musl/package.json
+++ b/packages/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-arm64-musl",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Linux arm64 musl native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-x64-gnu",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Linux x64 glibc native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-x64-musl/package.json
+++ b/packages/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-x64-musl",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Linux x64 musl native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/win32-x64-msvc/package.json
+++ b/packages/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-win32-x64-msvc",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Windows x64 MSVC native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,25 +46,25 @@ importers:
         version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1))
     optionalDependencies:
       '@openclaw/fs-safe-darwin-arm64':
-        specifier: 0.6.0
+        specifier: 0.7.0
         version: link:packages/darwin-arm64
       '@openclaw/fs-safe-darwin-x64':
-        specifier: 0.6.0
+        specifier: 0.7.0
         version: link:packages/darwin-x64
       '@openclaw/fs-safe-linux-arm64-gnu':
-        specifier: 0.6.0
+        specifier: 0.7.0
         version: link:packages/linux-arm64-gnu
       '@openclaw/fs-safe-linux-arm64-musl':
-        specifier: 0.6.0
+        specifier: 0.7.0
         version: link:packages/linux-arm64-musl
       '@openclaw/fs-safe-linux-x64-gnu':
-        specifier: 0.6.0
+        specifier: 0.7.0
         version: link:packages/linux-x64-gnu
       '@openclaw/fs-safe-linux-x64-musl':
-        specifier: 0.6.0
+        specifier: 0.7.0
         version: link:packages/linux-x64-musl
       '@openclaw/fs-safe-win32-x64-msvc':
-        specifier: 0.6.0
+        specifier: 0.7.0
         version: link:packages/win32-x64-msvc
       jszip:
         specifier: ^3.10.1


### PR DESCRIPTION
## Summary

Prepare the user-requested 0.7.0 release. Update the root package, all seven platform packages, private native build workspace, Rust crate, exact optional-dependency pins, and generated locks together. Date the approved Highlights/upgrade notes as 0.7.0 — 2026-08-31, preserving their complete content and all historical notes.

This is release metadata only: no runtime changes or dependency upgrades. After this PR lands and its exact-head gates pass, the maintainer will push an annotated protected v0.7.0 tag on main. The existing release workflow will build all seven bindings, publish the eight packages through npm trusted publishing, verify artifacts/provenance, and promote the GitHub Release. Do not publish locally.

## Executed candidate proof

On the candidate version, `pnpm native:build`, `pnpm check`, `pnpm test:security`, and `pnpm package:smoke` passed: 6,086 TypeScript tests, 65 Rust tests, and 78 security tests. The package smoke installed only the packed root into isolated npm/pnpm consumers; native require/auto/off produced the same SHA-256, omitted optionals retained the documented fallback, and missing binaries failed require with helper-unavailable. The local native target was macOS arm64; foreign fixtures proved installer filtering, not foreign execution. Hosted CI supplies the other execution lanes.

Version and approved-note verification emitted:

```json
{"rootVersion":"0.7.0","platformPackages":7,"nativeVersion":"0.7.0","exactOptionalPins":true,"releaseNotesMatchApprovedHighlights":true,"releaseNoteBytes":9335}
```

The real compiled sidecar proof emitted:

```json
{"proof":"sidecar-unlinked-snapshot","platform":"darwin","handoff":{"hookCalls":1,"waiterOwner":"waiter","payload":{"owner":"waiter","scenario":"handoff"},"verified":true,"openedHandleClosed":true,"finalMissing":true},"replacement":{"hookCalls":1,"error":{"name":"FsSafeError","code":"path-mismatch"},"openedHandleClosed":true,"replacementPreserved":true,"originalPreserved":true}}
```

Compiled temp quarantine/reparse-root proof preserved replacements and outside bytes with stable indeterminate results, and the append proof rejected raced async/sync targets while stable appends returned `ab`.

Codex autoreview is scoped-clean with no actionable findings. `git diff --check` passes. Lockfile diffs contain only seven platform version specifiers and the workspace crate version. The real release-note generator matches the previously approved Unreleased body byte-for-byte.
