### PR TITLE
fix: guard lock handoffs and ZIP read integrity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
           NODE_ENV: test
         run: node scripts/sidecar-unlinked-snapshot-proof.mjs
 
+      - name: Prove sidecar contention with JavaScript fallback
+        if: matrix.node == 24
+        run: node scripts/sidecar-contention-proof.mjs off
+
       - name: Prove regular append identity on Windows
         if: matrix.os == 'windows-latest'
         env:
@@ -125,6 +129,9 @@ jobs:
       - name: Test native mode off
         run: node scripts/native-mode-smoke.mjs off
 
+      - name: Prove sidecar contention with required native binding
+        run: node scripts/sidecar-contention-proof.mjs require
+
       - name: Test native security and path equivalence
         env:
           FS_SAFE_PAX_REQUIRE_NATIVE: "1"
@@ -135,6 +142,11 @@ jobs:
           FS_SAFE_NATIVE_MODE: require
         run: pnpm test test/root-write-mode.test.ts test/root-write-verification.test.ts test/root-write-lifetime.test.ts test/root-write-exact-identity.test.ts
 
+      - name: Test Root sidecar admission with required native binding
+        env:
+          FS_SAFE_NATIVE_MODE: require
+        run: pnpm test test/root-create-only-preflight.test.ts test/sidecar-lock-root-admission.test.ts test/sidecar-lock-root-ancestry.test.ts test/sidecar-lock-root-budget.test.ts test/sidecar-lock-root-resolver.test.ts test/sidecar-lock-root-unlink.test.ts test/sidecar-lock-unlink-siblings.test.ts test/file-lock-sync-stale.test.ts test/file-lock-sync-release.test.ts
+
       - name: Test canonical archive filter paths with required native binding
         env:
           FS_SAFE_PAX_REQUIRE_NATIVE: "1"
@@ -143,7 +155,7 @@ jobs:
       - name: Test ZIP admission with required native binding
         env:
           FS_SAFE_NATIVE_MODE: require
-        run: pnpm test test/archive-zip-admission.test.ts test/archive-zip-metadata.test.ts
+        run: pnpm test test/archive-zip-admission.test.ts test/archive-zip-metadata.test.ts test/archive-zip-integrity.test.ts
 
   native-musl:
     name: Native check (linux-x64-musl)
@@ -167,9 +179,11 @@ jobs:
             node scripts/native-mode-smoke.mjs auto
             node scripts/native-mode-smoke.mjs require
             node scripts/native-mode-smoke.mjs off
+            node scripts/sidecar-contention-proof.mjs require
+            FS_SAFE_NATIVE_MODE=require pnpm test test/root-create-only-preflight.test.ts test/sidecar-lock-root-admission.test.ts test/sidecar-lock-root-ancestry.test.ts test/sidecar-lock-root-budget.test.ts test/sidecar-lock-root-resolver.test.ts test/sidecar-lock-root-unlink.test.ts test/sidecar-lock-unlink-siblings.test.ts test/file-lock-sync-stale.test.ts test/file-lock-sync-release.test.ts
             FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm test test/native-owned-tree.test.ts test/native-write-containment.test.ts test/native-staging-regression.test.ts test/staged-file.test.ts test/staged-file-failures.test.ts test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts test/archive-pax.test.ts test/archive-pax-security.test.ts test/archive-pax-compressed.test.ts test/archive-tar-strip.test.ts test/archive-tar-framing.test.ts test/archive-tar-framing-compressed.test.ts test/archive-gzip-integrity.test.ts
             FS_SAFE_NATIVE_MODE=require pnpm test test/root-write-mode.test.ts test/root-write-verification.test.ts test/root-write-lifetime.test.ts test/root-write-exact-identity.test.ts
-            FS_SAFE_NATIVE_MODE=require pnpm test test/archive-zip-admission.test.ts test/archive-zip-metadata.test.ts
+            FS_SAFE_NATIVE_MODE=require pnpm test test/archive-zip-admission.test.ts test/archive-zip-metadata.test.ts test/archive-zip-integrity.test.ts
             FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm test test/archive-filter-paths.test.ts test/archive-filter-compressed.test.ts test/archive-tar-gnu.test.ts test/archive-tar-gnu-meter.test.ts test/archive-tar-ignored.test.ts test/archive-tar-ignored-meter.test.ts test/archive-tar-admission.test.ts test/archive-tar-manifest.test.ts
           '
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.7.1 - Unreleased
 
+- Retry Root-backed async lock handoffs with descriptor-proven, budgeted observation discard, including Windows unlink resolution failures; verify creator bytes before admission and preserve creator-token cleanup authority on failure.
+- Reject native selected ZIP entry reads whose decoded size differs from the declared uncompressed size, preserving byte caps and CRC verification.
+- Use the captured snapshot age for synchronous lock staleness and retain failed release cleanup for retry without double-decrementing references or re-closing a consumed descriptor.
+- Keep create-only Root writes from opening an existing target merely to inherit its mode, while preserving boundary, alias, hardlink, and type checks.
+- Clarify that invalid UTF-8 or NUL padding in fixed TAR path fields rejects with `ArchiveSecurityError("entry-path")`.
+
 ## 0.7.0 - 2026-08-31
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Retry Root-backed async lock handoffs with descriptor-proven, budgeted observation discard, including Windows unlink resolution failures; verify creator bytes before admission and preserve creator-token cleanup authority on failure.
 - Reject native selected ZIP entry reads whose decoded size differs from the declared uncompressed size, preserving byte caps and CRC verification.
-- Use the captured snapshot age for synchronous lock staleness and retain failed release cleanup for retry without double-decrementing references or re-closing a consumed descriptor.
+- Canonicalize Windows synchronous lock parents consistently with Root, bound lock-file open-denial and missing-snapshot retries, use captured snapshot age for staleness, and retain failed release cleanup for retry without double-decrementing references or re-closing a consumed descriptor.
 - Keep create-only Root writes from opening an existing target merely to inherit its mode, while preserving boundary, alias, hardlink, and type checks.
 - Clarify that invalid UTF-8 or NUL padding in fixed TAR path fields rejects with `ArchiveSecurityError("entry-path")`.
 

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -245,9 +245,13 @@ framing rules before parser normalization:
   padded sizes must fit `Number.MAX_SAFE_INTEGER`, even with PAX overrides,
   before member budgets are considered.
 
-Framing failures use `ArchiveFormatError("archive-header-invalid")`. PAX `x`
-and GNU long-name/long-link `L`/`K` payloads retain their existing support and
-metadata limits; the zero-body rule is not applied to all non-regular types.
+Framing failures use `ArchiveFormatError("archive-header-invalid")`, except
+invalid UTF-8 or nonzero bytes after the first NUL in fixed name, linkname,
+and USTAR prefix fields, which use `ArchiveSecurityError("entry-path")`.
+Missing linknames on links and nonempty linknames on non-links still use the
+format error. PAX `x` and GNU long-name/long-link `L`/`K` payloads retain their
+existing support and metadata limits; the zero-body rule is not applied to all
+non-regular types.
 PAX effective sizes still determine regular-member framing. Admission preserves
 the input bytes, and all entry/path/byte limits and extraction deadlines remain
 in force. Native inspection now completes this admission pass before parsing,
@@ -411,7 +415,11 @@ regular-file entry into a bounded `Buffer` without extracting a tree. It pins
 and privately stages the archive input, rejects link, directory, and duplicate
 entries, verifies ZIP CRC and declared size,
 and throws `ArchiveLimitError` if the requested entry's output exceeds
-`maxBytes`. For TAR, `maxBytes` applies only to that requested entry: a larger
+`maxBytes`. ZIP output within that cap must match the declared uncompressed
+size exactly; either a shorter or longer payload throws
+`ArchiveFormatError("archive-header-invalid")` before bytes are returned on
+both JavaScript and native backends.
+For TAR, `maxBytes` applies only to that requested entry: a larger
 unrequested member remains valid within the default archive admission limits.
 TAR traversal uses default entry-count, compressed-input, and metadata limits,
 plus the 768 MiB decoded ceiling derived from default extracted/archive byte

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -100,10 +100,12 @@ result is passed to `shouldReclaim` and `shouldRemoveStaleLock`, allowing PID,
 process-start, argv, or role schemas to remain application-owned.
 
 On Windows, a pathed `EPERM` from creating or opening the lock file can be a
-short teardown race after another holder unlinks it. The async lock retries that
-specific denial at most eight times. A parent-directory denial, a denial from a
-callback, or a ninth consecutive lock-file denial surfaces as the original
-`EPERM`; it is not converted to `file_lock_timeout`.
+short teardown race after another holder unlinks it. Both async and sync locks
+retry that specific open denial at most eight times per acquisition, within the
+caller's retry/deadline budget. A parent-directory denial, a callback/read/stat
+failure, or exhaustion of either budget surfaces the original error; a denied
+open is not converted to `file_lock_timeout`. Retrying always requires fresh
+exclusive creation and grants no ownership or removal authority.
 
 ## Owner-scoped reentrancy
 
@@ -209,6 +211,14 @@ the calling thread; use the async API in request-serving code. The sync
 compromise interval treats a thrown verification I/O error as a lost lock and
 invokes `onCompromised` once, matching the asynchronous `.catch(() => false)`
 contract. An explicit `verifyStillHeld()` call still propagates that I/O error.
+
+Windows synchronous lock parents use the same canonical path spelling as
+`root()`, including short-name expansion. With `lockRoot`, a failed parent
+canonicalization or an out-of-root parent still rejects. Missing-path observations from snapshot
+`lstat`/`open`, and identity-mismatched snapshots, consume the normal retry and
+deadline budget. Errors from descriptor reads/stats or parsing are not treated
+as missing snapshots, even when their code is `ENOENT`. Held verification,
+release, and reclaim do not retry open denials.
 
 Both synchronous helpers consume the [process-wide lock defaults](config.md#configurefssafelocks-config).
 A synchronous retry sleep is clamped to the remaining finite deadline, so a long or jittered backoff cannot extend the configured timeout or block forever.

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -155,6 +155,32 @@ an existing `Root` capability. `lockPath` must resolve inside that root.
 Identity-conditioned removal remains the only release and reclaim deletion
 path.
 
+An owner can finish releasing while another async acquirer inspects its record.
+Create-only Root writes do not open an existing record merely to inherit its
+mode. During acquisition, a failed snapshot can be discarded only when the
+original descriptor has exact identity, was not observed with multiple links,
+and proves it was unlinked (`nlink === 0`). This includes Windows resolver
+`EPERM`/`EBADF` failures, with evidence captured at the failing operation before
+closing the descriptor. The canonical in-root ancestor chain and Root are
+rechecked; permitted in-root parent symlinks are resolved before those checks.
+
+Discarding an acquisition observation is not proof that the pathname is absent:
+another owner may already have created the next record. Every discarded
+observation consumes the normal retry/deadline budget and requires fresh
+exclusive creation. It supplies no release, reclaim, or held-lock authority.
+Generic `Root.open()` and held-owner/reclaim reads still reject failed opens.
+Moved but linked records, unknown or inexact identities, retargeted ancestors,
+and unrelated filesystem or caller errors fail closed.
+
+After creating a record, the async Root-backed acquirer checks the reopened
+bytes against its exact serialized payload and ownership token. A replacement
+is never adopted; a descriptor observed unlinked at the end of admission is
+never registered as held. Failed admission cleanup retains the original creator
+receipt, so it cannot remove a replacement using a later stat alone. Native
+mode changes the create mechanism, not these Root-backed admission checks.
+Non-Root and synchronous snapshots retain their descriptor/read/path checks
+and do not use the Root opened-path resolver.
+
 ## Release handle
 
 ```ts

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -86,6 +86,9 @@ alone is never proof that the name still refers to the expected file.
 ### `fs.create(rel, data, options?)`
 
 Don't-clobber variant of `write()`. Throws `already-exists` if the target is there.
+Create-only preflight preserves boundary, alias, hardlink, and type checks without
+opening an existing target to inherit its mode; a fresh file uses the requested
+mode or the normal new-file default.
 
 ```ts
 try {

--- a/native/src/archive.rs
+++ b/native/src/archive.rs
@@ -801,7 +801,15 @@ fn read_zip_entry(
             format!("archive entry is not a file: {requested}"),
         ));
     }
-    read_bounded(&mut entry, max_bytes, cancelled)
+    let expected_size = entry.size();
+    let output = read_bounded(&mut entry, max_bytes, cancelled)?;
+    if output.len() as u64 != expected_size {
+        return Err(Error::new(
+            Status::InvalidArg,
+            "archive-header-invalid: ZIP entry size does not match declared uncompressed size",
+        ));
+    }
+    Ok(output)
 }
 
 fn read_bounded(

--- a/scripts/sidecar-contention-proof.mjs
+++ b/scripts/sidecar-contention-proof.mjs
@@ -1,0 +1,321 @@
+// Built public API proof: pnpm build, then node scripts/sidecar-contention-proof.mjs off|auto|require
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as pause } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+const mode = process.argv[2] ?? "auto";
+const worker = process.argv[3] === "--worker";
+const processes = 4;
+const acquisitionsPerProcess = 25;
+const childDeadlineMs = 60_000;
+const cases = [
+  { name: "pathname-async", rooted: false, sync: false },
+  { name: "pathname-sync", rooted: false, sync: true },
+  { name: "root-async", rooted: true, sync: false },
+  { name: "root-sync", rooted: true, sync: true },
+];
+const runtime = {
+  platform: process.platform, arch: process.arch, node: process.version,
+  nativeMode: ["off", "auto", "require"].includes(mode) ? mode : "invalid",
+};
+const emit = (value) => console.log(JSON.stringify({ proof: "sidecar-contention", ...runtime, ...value }));
+const safeLabel = (value) => typeof value === "string" && /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/.test(value)
+  ? value : undefined;
+// Never forward error messages, paths, stacks, sidecar bytes, or child output.
+const errorShape = (error) => ({ name: safeLabel(error?.name), code: safeLabel(error?.code) });
+const absent = (file) => assert.throws(() => fs.lstatSync(file), { code: "ENOENT" });
+const lockOptions = () => ({
+  staleMs: 60_000,
+  timeoutMs: 15_000,
+  retry: { retries: 15_000, factor: 1, minTimeout: 1, maxTimeout: 5, randomize: true },
+  staleRecovery: "fail-closed",
+  // Deliberately omit createdAt: contention must use the snapshot-mtime fallback.
+  payload: () => ({ pid: process.pid }),
+});
+let root, acquireFileLock, acquireFileLockSync;
+let phase = "setup";
+let completed = 0;
+
+function parentBarrier(notification, command) {
+  return new Promise((resolve, reject) => {
+    process.once("message", (message) => message === command ? resolve() : reject(new Error()));
+    process.send(notification, (error) => { if (error) reject(error); });
+  });
+}
+
+async function runWorker(test, directory) {
+  directory = fs.realpathSync(directory);
+  const target = path.join(directory, "state");
+  const marker = path.join(directory, "critical");
+  // Both APIs accept the documented Root capability; there is no RootSync API.
+  const lockRoot = test.rooted ? await root(directory) : undefined;
+  const options = { ...lockOptions(), lockRoot };
+  phase = "start-barrier";
+  await parentBarrier("ready", "start");
+  const waitWord = new Int32Array(new SharedArrayBuffer(4));
+  for (let index = 0; index < acquisitionsPerProcess; index += 1) {
+    phase = "acquire";
+    const handle = test.sync ? acquireFileLockSync(target, options) : await acquireFileLock(target, options);
+    let descriptor;
+    try {
+      phase = "verify-fresh";
+      assert.equal(await handle.verifyStillHeld(), true);
+      assert.deepEqual(JSON.parse(fs.readFileSync(handle.lockPath, "utf8")), { pid: process.pid });
+      phase = "exclusive-marker";
+      descriptor = fs.openSync(marker, "wx", 0o600);
+      phase = "counter-read";
+      const previous = JSON.parse(fs.readFileSync(target, "utf8"));
+      assert.ok(Number.isSafeInteger(previous) && previous >= 0 && previous < processes * acquisitionsPerProcess);
+      if (test.sync) Atomics.wait(waitWord, 0, 0, 2);
+      else await pause(2);
+      phase = "verify-critical-section";
+      assert.equal(await handle.verifyStillHeld(), true);
+      phase = "counter-write";
+      fs.writeFileSync(target, `${previous + 1}\n`);
+    } finally {
+      // A failed exclusive open must never unlink another holder's marker.
+      try {
+        if (descriptor !== undefined) {
+          try { fs.closeSync(descriptor); }
+          finally { fs.unlinkSync(marker); }
+        }
+      } finally {
+        const workPhase = phase;
+        phase = "release";
+        if (test.sync) handle.release();
+        else await handle.release();
+        phase = workPhase;
+      }
+    }
+    completed += 1;
+  }
+  // Keep exit cleanup from hiding a release that returned without removing its sidecar.
+  phase = "release-barrier";
+  await parentBarrier("released", "finish");
+}
+
+function launchWorker(test, directory, index) {
+  const child = spawn(process.execPath, [fileURLToPath(import.meta.url), mode, "--worker", test.name, directory], {
+    stdio: ["ignore", "pipe", "pipe", "ipc"], shell: false,
+  });
+  let stdout = "", stderrSeen = false, outputOverflow = false, timedOut = false, closed = false, childError;
+  let readyResolve, releasedResolve, releasedSeen = false;
+  const ready = new Promise((resolve) => { readyResolve = resolve; });
+  const released = new Promise((resolve) => { releasedResolve = resolve; });
+  const stop = () => {
+    if (!closed) {
+      try { child.kill("SIGKILL"); }
+      catch (error) { childError = errorShape(error); }
+    }
+  };
+  const deadline = setTimeout(() => { timedOut = true; stop(); }, childDeadlineMs);
+  child.stdout.on("data", (chunk) => {
+    if (stdout.length + chunk.length > 4_096) outputOverflow = true;
+    else stdout += chunk.toString();
+  });
+  child.stderr.on("data", () => { stderrSeen = true; });
+  child.on("message", (message) => {
+    if (message === "ready") readyResolve(true);
+    if (message === "released") { releasedSeen = true; releasedResolve(true); }
+  });
+  child.on("error", (error) => { childError = errorShape(error); stop(); });
+  const done = new Promise((resolve) => {
+    child.once("close", (exitCode, signal) => {
+      closed = true;
+      clearTimeout(deadline);
+      readyResolve(false);
+      releasedResolve(false);
+      let report;
+      try { report = JSON.parse(stdout); } catch { /* Raw output stays private. */ }
+      const count = Number.isSafeInteger(report?.completed) && report.completed >= 0
+        && report.completed <= acquisitionsPerProcess ? report.completed : releasedSeen ? acquisitionsPerProcess : 0;
+      const passed = exitCode === 0 && !signal && !timedOut && !childError && !outputOverflow
+        && report?.outcome === "passed" && count === acquisitionsPerProcess;
+      resolve({
+        worker: index, outcome: passed ? "passed" : "failed", completed: count,
+        ...(passed ? {} : {
+          exitCode, signal: safeLabel(signal), timedOut, stderrSeen, outputOverflow,
+          phase: safeLabel(report?.phase), error: childError ?? errorShape(report?.error),
+        }),
+      });
+    });
+  });
+  return {
+    ready, released, done, stop,
+    send(command) {
+      child.send(command, (error) => {
+        if (error) { childError = errorShape(error); stop(); }
+      });
+    },
+  };
+}
+
+async function runContentionCase(test, directory) {
+  const children = [];
+  let results = [];
+  const result = {
+    case: test.name, processes, acquisitionsPerProcess, expectedAcquisitions: processes * acquisitionsPerProcess,
+    completedAcquisitions: 0, outcome: "failed",
+  };
+  let casePhase = "setup";
+  try {
+    fs.mkdirSync(directory, { mode: 0o700 });
+    const target = path.join(directory, "state");
+    fs.writeFileSync(target, "0\n", { flag: "wx", mode: 0o600 });
+    for (let index = 0; index < processes; index += 1) children.push(launchWorker(test, directory, index));
+    casePhase = "start-barrier";
+    const ready = await Promise.all(children.map((child) => child.ready));
+    assert.ok(ready.every(Boolean));
+    for (const child of children) child.send("start");
+    casePhase = "release-barrier";
+    const released = await Promise.all(children.map((child) => child.released));
+    assert.ok(released.every(Boolean));
+    casePhase = "counter-final";
+    const counter = JSON.parse(fs.readFileSync(target, "utf8"));
+    assert.equal(counter, processes * acquisitionsPerProcess);
+    result.counter = counter;
+    casePhase = "marker-absent";
+    absent(path.join(directory, "critical"));
+    casePhase = "sidecar-absent";
+    absent(`${target}.lock`);
+    absent(`${target}.lock.reclaim`);
+    casePhase = "children";
+    for (const child of children) child.send("finish");
+    results = await Promise.all(children.map((child) => child.done));
+    assert.ok(results.every((child) => child.outcome === "passed"));
+    Object.assign(result, { outcome: "passed", markerAbsent: true, sidecarAbsent: true });
+  } catch (error) {
+    Object.assign(result, { phase: casePhase, error: errorShape(error) });
+  } finally {
+    // Also covers partial spawn/start failures: reap every sibling before scratch cleanup.
+    for (const child of children) child.stop();
+    const settled = await Promise.allSettled(children.map((child) => child.done));
+    results = settled.filter((entry) => entry.status === "fulfilled").map((entry) => entry.value);
+    result.launchedProcesses = children.length;
+    result.completedAcquisitions = results.reduce((total, child) => total + child.completed, 0);
+    if (result.outcome === "failed") result.workers = results;
+  }
+  return result;
+}
+
+function runPermissionCase(directory) {
+  const result = { case: "posix-release-retry", processes: 1, completedAcquisitions: 0, outcome: "failed" };
+  const skip = process.platform === "win32" ? "windows" :
+    process.getuid?.() === 0 || process.geteuid?.() === 0 ? "root-user" : undefined;
+  if (skip) return { ...result, processes: 0, outcome: "skipped", reason: skip };
+  let oldHandle;
+  let casePhase = "setup";
+  try {
+    fs.mkdirSync(directory, { mode: 0o700 });
+    const target = path.join(directory, "state");
+    casePhase = "acquire-original";
+    oldHandle = acquireFileLockSync(target, lockOptions());
+    assert.equal(oldHandle.verifyStillHeld(), true);
+    try {
+      casePhase = "permission-denial";
+      fs.chmodSync(directory, 0o500);
+      let releaseError;
+      try { oldHandle.release(); } catch (error) { releaseError = error; }
+      result.firstReleaseError = safeLabel(releaseError?.code) ?? "none";
+      assert.equal(releaseError?.code, "EACCES");
+    } finally {
+      fs.chmodSync(directory, 0o700);
+    }
+    casePhase = "retained-ownership";
+    assert.equal(fs.lstatSync(oldHandle.lockPath).isFile(), true);
+    assert.equal(oldHandle.verifyStillHeld(), true);
+    casePhase = "release-retry";
+    oldHandle.release();
+    absent(oldHandle.lockPath);
+    result.completedAcquisitions += 1;
+    casePhase = "acquire-fresh";
+    const fresh = acquireFileLockSync(target, lockOptions());
+    try {
+      assert.equal(fresh.verifyStillHeld(), true);
+      const bytes = fs.readFileSync(fresh.lockPath);
+      casePhase = "old-handle-repeated-release";
+      oldHandle.release();
+      oldHandle.release();
+      assert.equal(fresh.verifyStillHeld(), true);
+      assert.deepEqual(fs.readFileSync(fresh.lockPath), bytes);
+    } finally {
+      fresh.release();
+    }
+    casePhase = "sidecar-absent";
+    absent(fresh.lockPath);
+    result.completedAcquisitions += 1;
+    Object.assign(result, { outcome: "passed", firstReleaseError: "EACCES", retryRemoved: true, freshHolderPreserved: true });
+  } catch (error) {
+    Object.assign(result, { phase: casePhase, error: errorShape(error) });
+  } finally {
+    try { oldHandle?.release(); }
+    catch (error) { Object.assign(result, { outcome: "failed", cleanupError: errorShape(error) }); }
+  }
+  return result;
+}
+
+async function runSuite() {
+  const results = [];
+  let directory;
+  let failure;
+  try {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), "fs-safe-sidecar-contention-"));
+    for (const test of cases) {
+      const result = await runContentionCase(test, path.join(directory, test.name));
+      results.push(result);
+      emit(result);
+    }
+    const permission = runPermissionCase(path.join(directory, "permissions"));
+    results.push(permission);
+    emit(permission);
+  } catch (error) {
+    failure = errorShape(error);
+  } finally {
+    // runContentionCase never returns while any child can still mutate this root.
+    try { if (directory) fs.rmSync(directory, { recursive: true, force: true }); }
+    catch (error) { failure = errorShape(error); }
+  }
+  const permission = results.find((result) => result.case === "posix-release-retry");
+  const failed = Boolean(failure) || results.length !== 5 || results.some((result) => result.outcome === "failed");
+  emit({
+    case: "summary", outcome: failed ? "failed" : permission.outcome === "skipped" ? "passed-with-skip" : "passed",
+    contentionCases: cases.length, processesPerCase: processes,
+    expectedContentionProcesses: cases.length * processes,
+    launchedContentionProcesses: results.reduce((total, result) => total + (result.launchedProcesses ?? 0), 0),
+    acquisitionsPerProcess, expectedContentionAcquisitions: cases.length * processes * acquisitionsPerProcess,
+    completedContentionAcquisitions: results.filter((result) => result.case !== "posix-release-retry")
+      .reduce((total, result) => total + result.completedAcquisitions, 0),
+    permissionCase: { outcome: permission?.outcome ?? "not-run", reason: permission?.reason },
+    ...(failure ? { error: failure } : {}),
+  });
+  if (failed) process.exitCode = 1;
+}
+
+try {
+  assert.ok(["off", "auto", "require"].includes(mode));
+  assert.ok(worker ? process.argv.length === 6 && process.send : process.argv.length <= 3);
+  // Self-package resolution exercises dist through the same exports as an installed consumer.
+  ({ root } = await import("@openclaw/fs-safe"));
+  const { configureFsSafeNative } = await import("@openclaw/fs-safe/config");
+  ({ acquireFileLock, acquireFileLockSync } = await import("@openclaw/fs-safe/file-lock"));
+  configureFsSafeNative({ mode });
+  if (worker) {
+    const test = cases.find((candidate) => candidate.name === process.argv[4]);
+    assert.ok(test);
+    await runWorker(test, process.argv[5]);
+    console.log(JSON.stringify({ outcome: "passed", completed }));
+  } else {
+    await runSuite();
+  }
+} catch (error) {
+  const report = { outcome: "failed", phase, completed, error: errorShape(error) };
+  if (worker) console.log(JSON.stringify(report));
+  else emit({ case: "summary", ...report, usage: "node scripts/sidecar-contention-proof.mjs off|auto|require" });
+  process.exitCode = 1;
+} finally {
+  if (worker && process.connected) process.disconnect();
+}

--- a/scripts/sidecar-unlinked-snapshot-proof.mjs
+++ b/scripts/sidecar-unlinked-snapshot-proof.mjs
@@ -18,8 +18,8 @@ const mismatch = { name: "FsSafeError", code: "path-mismatch" };
 const errorShape = (error) => ({ name: error?.name, code: error?.code });
 const retry = { retries: 3, minTimeout: 1, maxTimeout: 1 };
 
-// Forward every call to this same real Root. Create's existing-file inspection
-// opens internally, so arm only at the public snapshot open after its collision.
+// Forward every call to this same real Root and arm the snapshot open after
+// create-only preflight reports the collision without opening the existing file.
 function observeSnapshot(capability, relative, hookName, mutate) {
   const original = { create: capability.create, open: capability.open, stat: capability.stat };
   const lockPath = path.join(capability.rootReal, relative);
@@ -163,7 +163,7 @@ async function proveReplacement(capability, ownerManager, waiterManager) {
   assert.equal(trace.hookCalls, 1);
   assert.equal(trace.opened?.fd, -1);
   assert.deepEqual(trace.error, mismatch);
-  assert.deepEqual(trace.probes, ["present"]);
+  assert.deepEqual(trace.probes, []);
   assert.deepEqual(trace.creates.map((call) => call.outcome), ["already-exists"]);
   assert.equal(waiterManager.heldEntries().length, 0);
   assert.equal((await fs.lstat(lockPath)).isFile(), true);

--- a/src/directory-guard.ts
+++ b/src/directory-guard.ts
@@ -1,9 +1,10 @@
-import type { Stats } from "node:fs";
+import type { BigIntStats, Stats } from "node:fs";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
+import { inspectFileIdentity } from "./strict-file-identity.js";
 import { isNotFoundPathError } from "./path.js";
 import { directoryComponentNotDirectoryError } from "./root-errors.js";
 
@@ -91,4 +92,13 @@ export function createNearestExistingSyncDirectoryGuard(
     }
   }
   return createSyncDirectoryGuard(root);
+}
+
+// Recovery receipts must retain every identity bit, including on Windows.
+export async function inspectDirectoryIdentity(dir: string, expected?: BigIntStats): Promise<BigIntStats> {
+  return await inspectFileIdentity(async () => {
+    const stat = await fs.lstat(dir, { bigint: true });
+    if (stat.isSymbolicLink() || !stat.isDirectory()) throw directoryComponentNotDirectoryError();
+    return stat;
+  }, expected);
 }

--- a/src/file-lock-sync.ts
+++ b/src/file-lock-sync.ts
@@ -57,7 +57,7 @@ export type FileLockSyncHandle = {
 };
 
 type SyncHeldLock = {
-  fd: number;
+  fd: number | undefined;
   lockPath: string;
   normalizedTargetPath: string;
   parsePayload?: (raw: string) => unknown;
@@ -89,7 +89,7 @@ function releaseAllSyncHeldLocks(): void {
       held.timer = undefined;
     }
     try {
-      fs.closeSync(held.fd);
+      if (held.fd !== undefined) fs.closeSync(held.fd);
     } catch {
       // Best-effort process-exit cleanup.
     }
@@ -121,15 +121,23 @@ function verifySyncHeldLock(held: SyncHeldLock): boolean {
 function releaseSyncHeldLock(held: SyncHeldLock): boolean {
   const heldLocks = getSyncHeldLocks();
   if (heldLocks.get(held.normalizedTargetPath) !== held) return false;
-  held.refCount -= 1;
-  if (held.refCount > 0) return false;
-  heldLocks.delete(held.normalizedTargetPath);
+  if (held.refCount > 1) {
+    held.refCount -= 1;
+    return false;
+  }
+  // Keep the final reference and cleanup receipt until deletion succeeds.
   if (held.timer) {
     clearInterval(held.timer);
     held.timer = undefined;
   }
-  fs.closeSync(held.fd);
+  if (held.fd !== undefined) {
+    const fd = held.fd;
+    // A close error may still free the number; consume ownership before closing.
+    held.fd = undefined;
+    fs.closeSync(fd);
+  }
   removeSidecarLockIfUnchangedSync(held.lockPath, held.snapshot);
+  heldLocks.delete(held.normalizedTargetPath);
   return true;
 }
 
@@ -137,8 +145,8 @@ function createSyncHeldLockHandle(held: SyncHeldLock): FileLockSyncHandle {
   let released = false;
   const release = () => {
     if (released) return;
-    released = true;
     releaseSyncHeldLock(held);
+    released = true;
   };
   return {
     lockPath: held.lockPath,
@@ -172,14 +180,11 @@ function boundedLockPath(lockPath: string, lockRoot?: Root): string {
   return path.join(parentReal, path.basename(resolved));
 }
 
-function defaultShouldReclaim(payload: unknown, lockPath: string, staleMs: number, nowMs: number): boolean {
-  const createdAtMs = sidecarLockPayloadCreatedAtMs(payload);
+function defaultShouldReclaim(snapshot: SidecarLockSnapshot, staleMs: number, nowMs: number): boolean {
+  const createdAtMs = sidecarLockPayloadCreatedAtMs(snapshot.payload);
   if (createdAtMs !== null) return nowMs - createdAtMs > staleMs;
-  try {
-    return nowMs - fs.statSync(lockPath).mtimeMs > staleMs;
-  } catch {
-    return true;
-  }
+  // A cooperating holder can unlink after the snapshot; use its observed age.
+  return !snapshot.stat || nowMs - snapshot.stat.mtimeMs > staleMs;
 }
 
 function reclaimGuardExists(reclaimGuardPath: string): boolean {
@@ -321,7 +326,7 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
             nowMs,
             heldByThisProcess: false,
           })
-        : defaultShouldReclaim(snapshot.payload, lockPath, staleMs, nowMs);
+        : defaultShouldReclaim(snapshot, staleMs, nowMs);
       if (reclaim) {
         if (
           staleRecovery === "remove-if-unchanged" &&

--- a/src/file-lock-sync.ts
+++ b/src/file-lock-sync.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
+import { isFileOpenFailure, recordFileOpenFailure } from "./opened-file-failure.js";
 import type { Root } from "./root-impl.js";
 import {
   readSidecarLockSnapshotSync,
@@ -13,6 +14,8 @@ import {
 } from "./sidecar-lock-reclaim.js";
 import {
   computeSidecarLockDelayMs,
+  isTransientLockFileDenial,
+  maxTransientLockDenials,
   sidecarLockPayloadCreatedAtMs,
   validateSidecarLockRetryOptions,
   validateSidecarLockTimeoutMs,
@@ -157,11 +160,16 @@ function createSyncHeldLockHandle(held: SyncHeldLock): FileLockSyncHandle {
   };
 }
 
+function canonicalLockParentSync(parent: string): string {
+  // Match Root's async realpath, including Windows short-name expansion.
+  return process.platform === "win32" ? fs.realpathSync.native(parent) : fs.realpathSync(parent);
+}
+
 function normalizeTargetPath(targetPath: string): string {
   const resolved = path.resolve(targetPath);
   fs.mkdirSync(path.dirname(resolved), { recursive: true });
   try {
-    return path.join(fs.realpathSync(path.dirname(resolved)), path.basename(resolved));
+    return path.join(canonicalLockParentSync(path.dirname(resolved)), path.basename(resolved));
   } catch {
     return resolved;
   }
@@ -172,7 +180,7 @@ function boundedLockPath(lockPath: string, lockRoot?: Root): string {
   if (!lockRoot) return resolved;
   relativeSidecarLockPath(lockRoot, resolved);
   const parent = path.dirname(resolved);
-  const parentReal = fs.realpathSync(parent);
+  const parentReal = canonicalLockParentSync(parent);
   const parentRelative = path.relative(lockRoot.rootReal, parentReal);
   if (parentRelative === ".." || parentRelative.startsWith(`..${path.sep}`) || path.isAbsolute(parentRelative)) {
     throw new FsSafeError("outside-workspace", "sidecar lock parent is outside lockRoot");
@@ -225,6 +233,7 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
   const staleRecovery = options.staleRecovery ?? defaults.staleRecovery;
   const startedAt = Date.now();
   let attempt = 0;
+  let transientDenials = 0;
   const reclaimGuardPath = `${lockPath}.reclaim`;
   const waitForRetry = (): void => {
     const elapsed = Date.now() - startedAt;
@@ -243,6 +252,18 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
     sleepSync(Math.min(computeSidecarLockDelayMs(retry, attempt), remaining));
     attempt += 1;
   };
+  const retryLockFileDenial = (error: unknown): boolean => {
+    if (!isFileOpenFailure(error, lockPath) || !isTransientLockFileDenial(error, lockPath) ||
+      ++transientDenials > maxTransientLockDenials) return false;
+    try {
+      waitForRetry();
+    } catch (waitError) {
+      // Preserve the filesystem diagnosis when the caller's budget runs out.
+      if ((waitError as NodeJS.ErrnoException).code === "file_lock_timeout") throw error;
+      throw waitError;
+    }
+    return true;
+  };
 
   while (true) {
     if (reclaimGuardExists(reclaimGuardPath)) {
@@ -257,11 +278,15 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
         process.platform !== "win32" && typeof fs.constants.O_NOFOLLOW === "number"
           ? fs.constants.O_NOFOLLOW
           : 0;
-      fd = fs.openSync(
-        lockPath,
-        fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | noFollow,
-        0o600,
-      );
+      try {
+        fd = fs.openSync(
+          lockPath,
+          fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | noFollow,
+          0o600,
+        );
+      } catch (error) {
+        recordFileOpenFailure(error, lockPath);
+      }
       fs.writeFileSync(fd, raw, "utf8");
       fs.fsyncSync(fd);
       const snapshot: SidecarLockSnapshot = {
@@ -307,15 +332,23 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
         fd = undefined;
         removeSidecarLockIfUnchangedSync(lockPath, failed);
       }
+      if (retryLockFileDenial(error)) continue;
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       if (heldLocks.has(normalizedTargetPath)) {
         waitForRetry();
         continue;
       }
-      const snapshot = readSidecarLockSnapshotSync(lockPath, options.parsePayload, {
-        rejectNonFile: true,
-      });
-      if (!snapshot) continue;
+      let snapshot: SidecarLockSnapshot | null;
+      try {
+        snapshot = readSidecarLockSnapshotSync(lockPath, options.parsePayload, { rejectNonFile: true });
+      } catch (readError) {
+        if (retryLockFileDenial(readError)) continue;
+        throw readError;
+      }
+      if (!snapshot) {
+        waitForRetry();
+        continue;
+      }
       const nowMs = Date.now();
       const reclaim = options.shouldReclaim
         ? options.shouldReclaim({

--- a/src/opened-file-failure.ts
+++ b/src/opened-file-failure.ts
@@ -1,0 +1,44 @@
+import type { BigIntStats } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import { FsSafeError } from "./errors.js";
+import { inspectFileIdentity, isFileIdentityMismatch } from "./strict-file-identity.js";
+
+const resolutionFailures = new WeakSet<Error>();
+const openFailures = new WeakMap<Error, string>();
+const unlinkedFailures = new WeakMap<Error, string>();
+
+export function recordFileOpenFailure(error: unknown, filePath: string): never {
+  if (error instanceof Error) openFailures.set(error, filePath);
+  throw error;
+}
+
+export function isFileOpenFailure(error: unknown, filePath: string): boolean {
+  return error instanceof Error && openFailures.get(error) === filePath;
+}
+
+export function openedPathResolutionError(
+  error: Error = new FsSafeError("path-mismatch", "unable to resolve opened file path"),
+): Error {
+  resolutionFailures.add(error);
+  return error;
+}
+
+export async function recordOpenedFileFailure(
+  error: unknown,
+  handle: FileHandle,
+  filePath: string,
+  identity: BigIntStats,
+): Promise<void> {
+  if (!(error instanceof Error) || (!resolutionFailures.has(error) && !isFileIdentityMismatch(error)) ||
+    !identity.isFile() || identity.nlink > 1n) return;
+  try {
+    const current = await inspectFileIdentity(() => handle.stat({ bigint: true }), identity);
+    if (current.isFile() && current.nlink === 0n) unlinkedFailures.set(error, filePath);
+  } catch {
+    // A closed, changed, or unknown descriptor provides no retry evidence.
+  }
+}
+
+export function isUnlinkedFileFailure(error: unknown, filePath: string): boolean {
+  return error instanceof Error && unlinkedFailures.get(error) === filePath;
+}

--- a/src/opened-realpath.ts
+++ b/src/opened-realpath.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
-import { FsSafeError } from "./errors.js";
+import { openedPathResolutionError } from "./opened-file-failure.js";
 import { sameFileIdentity, type FileIdentityStat } from "./file-identity.js";
 import { isNotFoundPathError } from "./path.js";
 
@@ -46,6 +46,12 @@ export async function resolveOpenedFileRealPathForFd(
     }
   } catch (err) {
     if (!isNotFoundPathError(err)) {
+      // Windows can fail here on a deleted-but-open file. Brand only this
+      // resolver operation; the caller must still prove unlink on the same fd.
+      if (process.platform === "win32" && err instanceof Error &&
+        ["EPERM", "EBADF"].includes((err as NodeJS.ErrnoException).code ?? "")) {
+        throw openedPathResolutionError(err);
+      }
       throw err;
     }
   }
@@ -53,7 +59,7 @@ export async function resolveOpenedFileRealPathForFd(
   if (parentResolved) {
     return parentResolved;
   }
-  throw new FsSafeError("path-mismatch", "unable to resolve opened file path");
+  throw openedPathResolutionError();
 }
 
 async function resolveOpenedFileRealPathFromParent(

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -22,6 +22,7 @@ import {
   type DenyMutationPolicy,
 } from "./deny-mutations.js";
 import { resolveOpenedFileRealPathForFd, resolveOpenedFileRealPathForHandle } from "./opened-realpath.js";
+import { openedPathResolutionError, recordFileOpenFailure, recordOpenedFileFailure } from "./opened-file-failure.js";
 import {
   type RenameIdentityPolicy,
   runPinnedWriteHelper,
@@ -237,23 +238,15 @@ async function openVerifiedLocalFile(
     await fsSafeTestHooks?.afterPreOpenLstat?.(filePath);
   }
 
+  const openFlags = options?.symlinks === "follow-within-root"
+    ? OPEN_READ_FOLLOW_FLAGS
+    : OPEN_READ_FLAGS;
+  await fsSafeTestHooks?.beforeOpen?.(filePath, openFlags);
   let handle: FileHandle;
   try {
-    const openFlags = options?.symlinks === "follow-within-root"
-      ? OPEN_READ_FOLLOW_FLAGS
-      : OPEN_READ_FLAGS;
-    await fsSafeTestHooks?.beforeOpen?.(filePath, openFlags);
-    handle = await fs.open(filePath, openFlags);
-    try {
-      await fsSafeTestHooks?.afterOpen?.(filePath, handle);
-    } catch (err) {
-      await handle.close().catch(() => {});
-      throw err;
-    }
+    handle = await fs.open(filePath, openFlags).catch((error: unknown) =>
+      recordFileOpenFailure(isNotFoundPathError(error) ? fileNotFoundError() : error, filePath));
   } catch (err) {
-    if (isNotFoundPathError(err)) {
-      throw fileNotFoundError();
-    }
     if (isSymlinkOpenError(err)) {
       throw new FsSafeError("symlink", "symlink open blocked", { cause: err });
     }
@@ -265,6 +258,7 @@ async function openVerifiedLocalFile(
   }
 
   try {
+    await fsSafeTestHooks?.afterOpen?.(filePath, handle);
     const stat = await handle.stat();
     if (!stat.isFile()) {
       throw new FsSafeError("not-file", "not a file");
@@ -278,7 +272,18 @@ async function openVerifiedLocalFile(
       throw hardlinkedPathNotAllowedError();
     }
 
-    await inspectFileIdentity(async () => {
+    const inspectPathIdentity = async (inspect: () => Promise<BigIntStats>) => {
+      try {
+        return await inspectFileIdentity(inspect, identity);
+      } catch (error) {
+        const failure = isNotFoundPathError(error) ? openedPathResolutionError(fileNotFoundError()) : error;
+        if (stat.nlink <= 1 && (!preOpenStat || preOpenStat.nlink <= 1n)) {
+          await recordOpenedFileFailure(failure, handle, filePath, identity);
+        }
+        throw failure;
+      }
+    };
+    await inspectPathIdentity(async () => {
       const pathStat = options?.symlinks === "follow-within-root"
         ? await fs.stat(filePath, { bigint: true })
         : await fs.lstat(filePath, { bigint: true });
@@ -286,27 +291,27 @@ async function openVerifiedLocalFile(
         throw new FsSafeError("symlink", "symlink not allowed");
       }
       return pathStat;
-    }, identity);
+    });
 
     await fsSafeTestHooks?.afterOpenedPathIdentityCheck?.(filePath, handle);
-    const realPath = await resolveOpenedFileRealPathForFd(handle.fd, identity, filePath);
-    await inspectFileIdentity(async () => {
+    const realPath = await resolveOpenedFileRealPathForFd(handle.fd, identity, filePath)
+      .catch(async (error: unknown) => {
+        if (stat.nlink <= 1 && (!preOpenStat || preOpenStat.nlink <= 1n)) {
+          await recordOpenedFileFailure(error, handle, filePath, identity);
+        }
+        throw error;
+      });
+    await inspectPathIdentity(async () => {
       const realStat = await fs.stat(realPath, { bigint: true });
       if (options?.hardlinks === "reject" && realStat.nlink > 1n) {
         throw hardlinkedPathNotAllowedError();
       }
       return realStat;
-    }, identity);
+    });
 
     return { opened: openResult({ handle, realPath, stat }), identity };
   } catch (err) {
     await handle.close().catch(() => {});
-    if (err instanceof FsSafeError) {
-      throw err;
-    }
-    if (isNotFoundPathError(err)) {
-      throw fileNotFoundError();
-    }
     throw err;
   }
 }
@@ -686,18 +691,10 @@ async function openFileInRoot(
     rejectSymlinks: params.symlinks !== "follow-within-root",
   });
 
-  let opened: OpenResult;
-  try {
-    ({ opened } = await openVerifiedLocalFile(resolved, {
-      nonBlockingRead: params.nonBlockingRead,
-      symlinks: params.symlinks,
-    }));
-  } catch (err) {
-    if (err instanceof FsSafeError) {
-      throw err;
-    }
-    throw err;
-  }
+  const { opened } = await openVerifiedLocalFile(resolved, {
+    nonBlockingRead: params.nonBlockingRead,
+    symlinks: params.symlinks,
+  });
 
   if (params.hardlinks !== "allow" && opened.stat.nlink > 1) {
     await opened.handle.close().catch(() => {});
@@ -1101,6 +1098,7 @@ async function writeFileInRoot(
       params.relativePath,
       params.mode,
       params.denyMutations,
+      params.overwrite,
     );
 
     await serializePathWrite(pinned.targetPath, async () => {
@@ -1256,6 +1254,7 @@ async function resolvePinnedWriteTargetInRoot(
   relativePath: string,
   requestedMode?: number,
   denyMutations?: DenyMutationPolicy,
+  overwrite = true,
 ): Promise<PinnedWriteTarget> {
   const { rootReal, rootWithSep, resolved } = await resolveGuardedWritePathInRoot(root, {
     relativePath,
@@ -1275,21 +1274,35 @@ async function resolvePinnedWriteTargetInRoot(
   if (!basename || basename === "." || basename === "/") {
     throw new FsSafeError("invalid-path", "invalid target path");
   }
+  // Exclusive publication cannot inherit an existing file's mode. Keep type
+  // and alias checks, but never open a competing owner's record just to reject it.
+  if (!overwrite) {
+    try {
+      const existing = await fs.stat(resolved);
+      if (!existing.isFile()) throw new FsSafeError("not-file", "not a file");
+      if (existing.nlink > 1) throw hardlinkedPathNotAllowedError();
+      throw new FsSafeError("already-exists", "file already exists");
+    } catch (error) {
+      if (!isNotFoundPathError(error)) throw error;
+    }
+  }
   let mode = requestedMode ?? 0o600;
   try {
-    const opened = await openFileInRoot(root, {
-      relativePath,
-      hardlinks: "reject",
-      nonBlockingRead: true,
-      symlinks: "follow-within-root",
-    });
-    try {
-      mode = requestedMode ?? (opened.stat.mode & 0o777);
-      if (!isPathInside(rootWithSep, opened.realPath)) {
-        throw outsideWorkspaceError();
+    if (overwrite) {
+      const opened = await openFileInRoot(root, {
+        relativePath,
+        hardlinks: "reject",
+        nonBlockingRead: true,
+        symlinks: "follow-within-root",
+      });
+      try {
+        mode = requestedMode ?? (opened.stat.mode & 0o777);
+        if (!isPathInside(rootWithSep, opened.realPath)) {
+          throw outsideWorkspaceError();
+        }
+      } finally {
+        await opened.handle.close().catch(() => {});
       }
-    } finally {
-      await opened.handle.close().catch(() => {});
     }
   } catch (err) {
     if (!(err instanceof FsSafeError) || err.code !== "not-found") {

--- a/src/sidecar-lock-acquire.ts
+++ b/src/sidecar-lock-acquire.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isFileOpenFailure } from "./opened-file-failure.js";
 import { FsSafeError } from "./errors.js";
+import { readFileHandleBounded } from "./bounded-read.js";
+import { openSidecarRoot } from "./sidecar-lock-root.js";
 import { createNativeExclusiveFile, type NativeFileHandle } from "./native-operations.js";
 import type { Root } from "./root-impl.js";
 import {
@@ -156,9 +159,10 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
         const payload = await options.payload();
         const { raw, ownershipToken } = serializeSidecarLockPayload(payload);
         if (options.lockRoot) {
-          const relativeLockPath = relativeSidecarLockPath(options.lockRoot, lockPath);
+          const lockRoot = options.lockRoot;
+          const relativeLockPath = relativeSidecarLockPath(lockRoot, lockPath);
           try {
-            await options.lockRoot.create(relativeLockPath, raw, { mkdir: true, mode: 0o600 });
+            await lockRoot.create(relativeLockPath, raw, { mkdir: true, mode: 0o600 });
           } catch (error) {
             if (error instanceof FsSafeError && error.code === "already-exists") {
               throw Object.assign(new Error("sidecar lock exists"), { code: "EEXIST" });
@@ -166,7 +170,22 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
             throw error;
           }
           createdSnapshot = { raw, payload, ownershipToken };
-          handle = (await options.lockRoot.open(relativeLockPath)).handle;
+          const opened = await openSidecarRoot(lockRoot, relativeLockPath, true);
+          if (!opened) {
+            await waitForRetry();
+            continue;
+          }
+          try {
+            // Root.open admits the current file, not necessarily the one we created.
+            const currentRaw = await readFileHandleBounded(opened.handle, Buffer.byteLength(raw));
+            if (!currentRaw.equals(Buffer.from(raw))) {
+              throw new FsSafeError("path-mismatch", "created sidecar lock changed before admission");
+            }
+          } catch (error) {
+            await opened.handle.close().catch(() => undefined);
+            throw error;
+          }
+          handle = opened.handle;
         } else {
           try {
             handle =
@@ -179,6 +198,12 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
           await handle.writeFile(raw, "utf8");
         }
         const snapshot = { raw, payload, stat: await handle.stat(), ownershipToken };
+        if (snapshot.stat.nlink === 0) {
+          await handle.close();
+          handle = null;
+          await waitForRetry();
+          continue;
+        }
         const createdHeld: HeldSidecarLock = {
           refCount: 1,
           reentrantOwner: options.reentrantOwner,
@@ -221,7 +246,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
       } catch (err) {
         try {
           if (handle) {
-            const failedSnapshot: SidecarLockSnapshot = { payload: null };
+            const failedSnapshot: SidecarLockSnapshot = createdSnapshot ?? { payload: null };
             try {
               failedSnapshot.stat = await handle.stat();
             } catch {
@@ -232,8 +257,8 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
               context.held.delete(normalizedTargetPath);
             }
             await handle.close().catch(() => undefined);
-            // The file may be empty or partial JSON, so remove by the identity
-            // captured from our exclusive handle rather than by pathname alone.
+            // Root-created records retain the creator's byte/token receipt;
+            // partial direct writes use the exclusive descriptor's identity.
             await removeSidecarLockIfUnchanged(lockPath, failedSnapshot, {
               lockRoot: options.lockRoot,
               parsePayload: options.parsePayload,
@@ -261,6 +286,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
         if (ownsReclaimGuard) {
           await releaseSidecarReclaimGuard(context.reclaimGuards, reclaimGuardPath);
           ownsReclaimGuard = false;
+          await waitForRetry();
           continue;
         }
         const nowMs = Date.now();
@@ -270,13 +296,16 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
             lockRoot: options.lockRoot,
             parsePayload: options.parsePayload,
             rejectNonFile: true,
+            discardUnlinked: true,
           });
         } catch (readErr) {
-          if (!isTransientLockFileDenial(readErr, lockPath) || !withinDenialBudget()) throw readErr;
+          if (!isFileOpenFailure(readErr, lockPath) ||
+            !isTransientLockFileDenial(readErr, lockPath) || !withinDenialBudget()) throw readErr;
           await retryOrRethrowDenial(readErr);
           continue;
         }
         if (!snapshot) {
+          await waitForRetry();
           continue;
         }
         if (context.held.has(normalizedTargetPath)) {
@@ -300,6 +329,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
               parsePayload: options.parsePayload,
             }))
           ) {
+            await waitForRetry();
             continue;
           }
           const staleRecovery = options.staleRecovery ?? "fail-closed";
@@ -318,6 +348,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
               parsePayload: options.parsePayload,
             });
             if (removal === "removed" || removal === "changed") {
+              if (removal === "changed") await waitForRetry();
               continue;
             }
             await releaseSidecarReclaimGuard(context.reclaimGuards, reclaimGuardPath);

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -169,6 +169,14 @@ export async function readSidecarLockSnapshot(
   }
 }
 
+function lstatSidecarLockSync(lockPath: string): Stats | null {
+  try {
+    return fsSync.lstatSync(lockPath);
+  } catch (error) {
+    return missingSnapshotPath(error);
+  }
+}
+
 export function readSidecarLockSnapshotSync(
   lockPath: string,
   parsePayload?: (raw: string) => unknown,
@@ -176,14 +184,20 @@ export function readSidecarLockSnapshotSync(
 ): SidecarLockSnapshot | null {
   let fd: number | undefined;
   try {
-    const before = fsSync.lstatSync(lockPath);
+    const before = lstatSidecarLockSync(lockPath);
+    if (!before) return null;
     if (!before.isFile() || before.isSymbolicLink()) {
       if (options.rejectNonFile) {
         throw new FsSafeError("not-file", `sidecar lock is not a regular file: ${lockPath}`);
       }
       return null;
     }
-    fd = fsSync.openSync(lockPath, resolveReadOpenFlags());
+    try {
+      fd = fsSync.openSync(lockPath, resolveReadOpenFlags());
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      recordFileOpenFailure(error, lockPath);
+    }
     const opened = fsSync.fstatSync(fd);
     if (!opened.isFile()) {
       if (options.rejectNonFile) {
@@ -192,17 +206,14 @@ export function readSidecarLockSnapshotSync(
       return null;
     }
     const raw = readFileDescriptorBoundedSync(fd, MAX_LOCK_PAYLOAD_BYTES).toString("utf8");
-    const after = fsSync.lstatSync(lockPath);
-    if (!sameFileIdentity(before, opened) || !sameFileIdentity(opened, after)) return null;
+    const after = lstatSidecarLockSync(lockPath);
+    if (!after || !sameFileIdentity(before, opened) || !sameFileIdentity(opened, after)) return null;
     return {
       raw,
       payload: parseSidecarLockPayload(raw, parsePayload),
       stat: after,
       ownershipToken: readSidecarLockOwnershipToken(raw),
     };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-    throw error;
   } finally {
     if (fd !== undefined) fsSync.closeSync(fd);
   }

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -7,6 +7,8 @@ import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import type { Root } from "./root-impl.js";
+import { recordFileOpenFailure } from "./opened-file-failure.js";
+import { openSidecarRoot } from "./sidecar-lock-root.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
 
 const MAX_LOCK_PAYLOAD_BYTES = 1024 * 1024;
@@ -87,6 +89,11 @@ export function parseSidecarLockPayload(
   }
 }
 
+function missingSnapshotPath(error: unknown): null {
+  if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+  throw error;
+}
+
 export async function readSidecarLockSnapshot(
   lockPath: string,
   options: {
@@ -94,6 +101,8 @@ export async function readSidecarLockSnapshot(
     parsePayload?: (raw: string) => unknown;
     rejectNonFile?: boolean;
     allowDescriptorIdentityDrift?: boolean;
+    // Acquisition alone may discard a proven-unlinked observation, never delete from it.
+    discardUnlinked?: boolean;
   } = {},
 ): Promise<SidecarLockSnapshot | null> {
   let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
@@ -101,20 +110,7 @@ export async function readSidecarLockSnapshot(
     if (options.lockRoot) {
       const lockRoot = options.lockRoot;
       const relative = relativeSidecarLockPath(lockRoot, lockPath);
-      const opened = await lockRoot.open(relative).catch(async (error: unknown) => {
-        if (error instanceof FsSafeError && error.code === "path-mismatch") {
-          // An owner can unlink after open. Prove absence through the same root;
-          // acquisition retries create-only, so a later replacement stays guarded.
-          try {
-            await lockRoot.stat(relative);
-          } catch (probeError) {
-            if (probeError instanceof FsSafeError && probeError.code === "not-found") {
-              return null;
-            }
-          }
-        }
-        throw error;
-      });
+      const opened = await openSidecarRoot(lockRoot, relative, options.discardUnlinked);
       if (!opened) return null;
       try {
         const raw = (await readFileHandleBounded(opened.handle, MAX_LOCK_PAYLOAD_BYTES)).toString("utf8");
@@ -127,7 +123,8 @@ export async function readSidecarLockSnapshot(
         await opened.handle.close().catch(() => undefined);
       }
     }
-    const before = await fs.lstat(lockPath);
+    const before = await fs.lstat(lockPath).catch(missingSnapshotPath);
+    if (!before) return null;
     if (!before.isFile() || before.isSymbolicLink()) {
       if (options.rejectNonFile) {
         throw new FsSafeError("not-file", `sidecar lock is not a regular file: ${lockPath}`);
@@ -147,12 +144,13 @@ export async function readSidecarLockSnapshot(
           (typeof fsSync.constants.O_NONBLOCK === "number" ? fsSync.constants.O_NONBLOCK : 0),
       );
     } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
       if (options.rejectNonFile && (error as NodeJS.ErrnoException).code === "ELOOP") {
         throw new FsSafeError("not-file", `sidecar lock is not a regular file: ${lockPath}`, {
           cause: error,
         });
       }
-      throw error;
+      recordFileOpenFailure(error, lockPath);
     }
     const opened = await handle.stat();
     if (!opened.isFile()) {
@@ -163,17 +161,9 @@ export async function readSidecarLockSnapshot(
     }
     if (!options.allowDescriptorIdentityDrift && !sameFileIdentity(before, opened)) return null;
     const raw = (await readFileHandleBounded(handle, MAX_LOCK_PAYLOAD_BYTES)).toString("utf8");
-    const after = await fs.lstat(lockPath);
-    if (!after.isFile() || !sameFileIdentity(before, after)) return null;
+    const after = await fs.lstat(lockPath).catch(missingSnapshotPath);
+    if (!after || !after.isFile() || !sameFileIdentity(before, after)) return null;
     return { raw, payload: parseSidecarLockPayload(raw, options.parsePayload), stat: after };
-  } catch (err) {
-    if (
-      (err as NodeJS.ErrnoException).code === "ENOENT" ||
-      (err instanceof FsSafeError && err.code === "not-found")
-    ) {
-      return null;
-    }
-    throw err;
   } finally {
     await handle?.close().catch(() => undefined);
   }

--- a/src/sidecar-lock-root.ts
+++ b/src/sidecar-lock-root.ts
@@ -1,0 +1,63 @@
+import path from "node:path";
+import { inspectDirectoryIdentity } from "./directory-guard.js";
+import { FsSafeError } from "./errors.js";
+import { isFileOpenFailure, isUnlinkedFileFailure } from "./opened-file-failure.js";
+import { isNotFoundPathError } from "./path.js";
+import type { OpenResult, Root } from "./root-impl.js";
+import { resolveRootPath } from "./root-path.js";
+
+export async function openSidecarRoot(
+  lockRoot: Root,
+  relative: string,
+  discardUnlinked = false,
+): Promise<OpenResult | null> {
+  const resolved = await lockRoot.resolve(relative);
+  const canonicalPath = async () => (await resolveRootPath({
+    absolutePath: resolved,
+    rootPath: lockRoot.rootReal,
+    rootCanonicalPath: lockRoot.rootReal,
+    boundaryLabel: "sidecar lock root",
+  })).canonicalPath;
+  const expectedRealPath = await canonicalPath();
+  if (expectedRealPath === lockRoot.rootReal) throw new FsSafeError("not-file", "sidecar lock is a directory");
+  const parents = [];
+  let completeParents = true;
+  if (discardUnlinked) {
+    // Follow permitted in-root aliases first; receipts cover canonical ancestry.
+    for (let dir = path.dirname(expectedRealPath); ; dir = path.dirname(dir)) {
+      try {
+        parents.push({ dir, stat: await inspectDirectoryIdentity(dir) });
+      } catch (error) {
+        if (!isNotFoundPathError(error)) throw error;
+        completeParents = false;
+      }
+      if (dir === lockRoot.rootReal) break;
+    }
+  }
+  try {
+    const opened = await lockRoot.open(relative);
+    if (opened.realPath !== expectedRealPath) {
+      await opened.handle.close().catch(() => undefined);
+      throw new FsSafeError("path-mismatch", "sidecar lock path changed during open");
+    }
+    return opened;
+  } catch (error) {
+    const missing = isFileOpenFailure(error, resolved) && error instanceof FsSafeError && error.code === "not-found";
+    if (missing && !discardUnlinked) return null;
+    if (!discardUnlinked || (!missing && (!completeParents || !isUnlinkedFileFailure(error, resolved)))) throw error;
+    try {
+      try {
+        const current = await lockRoot.stat(relative);
+        if (!current.isFile || current.isSymbolicLink || current.nlink !== 1) throw error;
+      } catch (probeError) {
+        if (!(probeError instanceof FsSafeError && probeError.code === "not-found")) throw probeError;
+      }
+      for (const { dir, stat } of parents) await inspectDirectoryIdentity(dir, stat);
+      await lockRoot.resolve(relative);
+      if (await canonicalPath() === expectedRealPath) return null;
+    } catch {
+      // Keep the original failure when directory or confinement proof fails.
+    }
+    throw error;
+  }
+}

--- a/src/strict-file-identity.ts
+++ b/src/strict-file-identity.ts
@@ -3,8 +3,16 @@ import { FsSafeError } from "./errors.js";
 
 type ExactFileIdentity = Pick<BigIntStats, "dev" | "ino">;
 
+const identityMismatches = new WeakSet<Error>();
+
+export function isFileIdentityMismatch(error: unknown): error is Error {
+  return error instanceof Error && identityMismatches.has(error);
+}
+
 function identityMismatch(): FsSafeError {
-  return new FsSafeError("path-mismatch", "file identity changed or could not be verified");
+  const error = new FsSafeError("path-mismatch", "file identity changed or could not be verified");
+  identityMismatches.add(error);
+  return error;
 }
 
 function identityCheck(expected: ExactFileIdentity | undefined, platform: NodeJS.Platform) {

--- a/test/archive-zip-integrity.test.ts
+++ b/test/archive-zip-integrity.test.ts
@@ -1,0 +1,163 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { crc32, deflateRawSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ARCHIVE_LIMIT_ERROR_CODE,
+  ArchiveFormatError,
+  ArchiveLimitError,
+  extractArchive,
+  readArchiveEntry,
+} from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __resetNativeLoaderForTest, __setNativeLoaderForTest } from "../src/native.js";
+import { paxNative as native } from "./helpers/archive-pax-native.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const payload = Buffer.from("0123456789ABCDEF");
+const payloadCrc = 0x983c37b5;
+const { tempRoot } = useTempDirs();
+
+// Standalone physical records with matching local/central metadata; only the
+// declared output size or CRC differs from the actual payload in corrupt cases.
+function zipFixture(method: 0 | 8, declaredSize = payload.length, checksum = payloadCrc, body = payload): Buffer {
+  const name = Buffer.from("selected");
+  const compressed = method === 8 ? deflateRawSync(body) : body;
+  const local = Buffer.alloc(30);
+  local.writeUInt32LE(0x04034b50);
+  local.writeUInt16LE(20, 4);
+  local.writeUInt16LE(0x800, 6);
+  local.writeUInt16LE(method, 8);
+  local.writeUInt32LE(checksum, 14);
+  local.writeUInt32LE(compressed.length, 18);
+  local.writeUInt32LE(declaredSize, 22);
+  local.writeUInt16LE(name.length, 26);
+  const central = Buffer.alloc(46);
+  central.writeUInt32LE(0x02014b50);
+  central.writeUInt16LE(20, 4);
+  central.writeUInt16LE(20, 6);
+  central.writeUInt16LE(0x800, 8);
+  central.writeUInt16LE(method, 10);
+  central.writeUInt32LE(checksum, 16);
+  central.writeUInt32LE(compressed.length, 20);
+  central.writeUInt32LE(declaredSize, 24);
+  central.writeUInt16LE(name.length, 28);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50);
+  end.writeUInt16LE(1, 8);
+  end.writeUInt16LE(1, 10);
+  end.writeUInt32LE(central.length + name.length, 12);
+  end.writeUInt32LE(local.length + name.length + compressed.length, 16);
+  return Buffer.concat([local, name, compressed, central, name, end]);
+}
+
+async function expectFormatError(operation: Promise<unknown>) {
+  await expect(operation).rejects.toBeInstanceOf(ArchiveFormatError);
+  await expect(operation).rejects.toMatchObject({ code: "archive-header-invalid" });
+}
+
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+for (const mode of ["off", "auto", "require"] as const) {
+  describe.skipIf(mode !== "off" && !native)(`ZIP payload integrity ${mode}`, () => {
+    let read: ReturnType<typeof vi.fn>;
+    let extract: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+      configureFsSafeNative({ mode });
+      if (mode !== "off") {
+        // The shared loader uses native/<host artifact>, never a registry binary.
+        // FS_SAFE_NATIVE_MODE=require makes a missing local build fail the suite.
+        read = vi.fn(native!.readArchiveEntryNative.bind(native));
+        extract = vi.fn(native!.extractArchiveNative.bind(native));
+        __setNativeLoaderForTest(() => ({
+          ...native!, readArchiveEntryNative: read, extractArchiveNative: extract,
+        }));
+      }
+    });
+
+    async function fixture(bytes: Buffer) {
+      const root = await tempRoot("fs-safe-zip-integrity-");
+      const archivePath = path.join(root, "fixture.zip");
+      const destDir = path.join(root, "output");
+      await fs.writeFile(archivePath, bytes);
+      await fs.mkdir(destDir);
+      await fs.writeFile(path.join(destDir, "sentinel"), "unchanged");
+      return { archivePath, destDir, kind: "zip" as const, timeoutMs: 10_000 };
+    }
+
+    async function expectUnpublished(destDir: string) {
+      expect(await fs.readdir(destDir)).toEqual(["sentinel"]);
+      expect(await fs.readFile(path.join(destDir, "sentinel"), "utf8")).toBe("unchanged");
+      if (mode !== "off") expect(extract).toHaveBeenCalledTimes(1);
+    }
+
+    describe.each([0, 8] as const)("method %s", (method) => {
+      it.each([1, 100])("rejects selected reads declaring %s bytes with a generous cap", async (declaredSize) => {
+        const { archivePath } = await fixture(zipFixture(method, declaredSize));
+        const operation = readArchiveEntry(archivePath, "selected", { maxBytes: 128 });
+        await expectFormatError(operation);
+        if (mode !== "off") expect(read).toHaveBeenCalledTimes(1);
+      });
+
+      it.each([1, 100])("rejects extraction declaring %s bytes without publishing", async (declaredSize) => {
+        const input = await fixture(zipFixture(method, declaredSize));
+        await expectFormatError(extractArchive(input));
+        await expectUnpublished(input.destDir);
+      });
+
+      it.each([1, 16, 100])("enforces maxBytes=1 with declared size %s", async (declaredSize) => {
+        const { archivePath } = await fixture(zipFixture(method, declaredSize));
+        const operation = readArchiveEntry(archivePath, "selected", { maxBytes: 1 });
+        await expect(operation).rejects.toBeInstanceOf(ArchiveLimitError);
+        await expect(operation).rejects.toMatchObject({
+          code: ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT,
+        });
+        if (mode !== "off") expect(read).toHaveBeenCalledTimes(1);
+      });
+
+      it("reads and extracts a correctly sized payload", async () => {
+        expect(payload.length).toBe(16);
+        expect(crc32(payload)).toBe(payloadCrc);
+        const input = await fixture(zipFixture(method));
+        for (const maxBytes of [16, 128]) {
+          expect(await readArchiveEntry(input.archivePath, "selected", { maxBytes })).toEqual(payload);
+        }
+        await extractArchive(input);
+        expect(await fs.readFile(path.join(input.destDir, "selected"))).toEqual(payload);
+        if (mode !== "off") {
+          expect(read).toHaveBeenCalledTimes(2);
+          expect(extract).toHaveBeenCalledTimes(1);
+        }
+      });
+
+      it("rejects a bad CRC even with the correct declared size", async () => {
+        const { archivePath } = await fixture(zipFixture(method, 16, (payloadCrc ^ 1) >>> 0));
+        for (const maxBytes of [16, 128]) {
+          await expect(readArchiveEntry(archivePath, "selected", { maxBytes })).rejects.toThrow();
+        }
+        if (mode !== "off") expect(read).toHaveBeenCalledTimes(2);
+      });
+
+      it("rejects bad-CRC extraction without publishing", async () => {
+        const input = await fixture(zipFixture(method, 16, (payloadCrc ^ 1) >>> 0));
+        await expect(extractArchive(input)).rejects.toThrow();
+        await expectUnpublished(input.destDir);
+      });
+
+      it("reads a valid empty entry at maxBytes=0 and extracts it", async () => {
+        const empty = Buffer.alloc(0);
+        const input = await fixture(zipFixture(method, 0, 0, empty));
+        expect(await readArchiveEntry(input.archivePath, "selected", { maxBytes: 0 })).toEqual(empty);
+        await extractArchive(input);
+        expect(await fs.readFile(path.join(input.destDir, "selected"))).toEqual(empty);
+        if (mode !== "off") {
+          expect(read).toHaveBeenCalledTimes(1);
+          expect(extract).toHaveBeenCalledTimes(1);
+        }
+      });
+    });
+  });
+}

--- a/test/file-lock-sync-failure.test.ts
+++ b/test/file-lock-sync-failure.test.ts
@@ -94,17 +94,17 @@ describe("synchronous file-lock failure handling", () => {
     const targetPath = path.join(await fs.realpath(root), "state.json");
     const lockPath = `${targetPath}.lock`;
     await fs.writeFile(lockPath, "{}");
-    const realStat = fsSync.statSync.bind(fsSync);
-    vi.spyOn(fsSync, "statSync").mockImplementation((filePath, options) => {
+    const realLstat = fsSync.lstatSync.bind(fsSync);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((filePath, options) => {
       if (String(filePath) === lockPath) {
         throw Object.assign(new Error("inspection denied"), { code: "EACCES" });
       }
-      return realStat(filePath, options as never);
+      return realLstat(filePath, options as never);
     });
 
     expect(() =>
       acquireFileLockSync(targetPath, { ...lockOptions(), staleMs: 60_000 }),
-    ).toThrow(expect.objectContaining({ code: "file_lock_stale" }));
+    ).toThrow(expect.objectContaining({ code: "EACCES" }));
     await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("{}");
   });
 

--- a/test/file-lock-sync-failure.test.ts
+++ b/test/file-lock-sync-failure.test.ts
@@ -2,7 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { itPosix, itWin32, useTempDirs } from "./helpers/vitest.js";
+import { itWin32, useTempDirs } from "./helpers/vitest.js";
 import { acquireFileLockSync } from "../src/file-lock.js";
 import { root } from "../src/root.js";
 
@@ -203,7 +203,9 @@ describe("synchronous file-lock failure handling", () => {
   it("falls back to the resolved target when parent realpath lookup fails", async () => {
     const root = await tempRoot("fs-safe-sync-lock-realpath-failure-");
     const targetPath = path.join(root, "state.json");
-    vi.spyOn(fsSync, "realpathSync").mockImplementationOnce(() => {
+    const realpath = process.platform === "win32"
+      ? vi.spyOn(fsSync.realpathSync, "native") : vi.spyOn(fsSync, "realpathSync");
+    realpath.mockImplementationOnce(() => {
       throw Object.assign(new Error("realpath unavailable"), { code: "EIO" });
     });
 
@@ -221,7 +223,7 @@ describe("synchronous file-lock failure handling", () => {
     expect(fsSync.existsSync(lock.lockPath)).toBe(false);
   });
 
-  itPosix("bounds synchronous lock paths through a Root capability", async () => {
+  it("bounds synchronous lock paths through a Root capability", async () => {
     const directory = await tempRoot("fs-safe-sync-lock-root-");
     const lockDirectory = path.join(directory, "locks");
     await fs.mkdir(lockDirectory);
@@ -240,19 +242,48 @@ describe("synchronous file-lock failure handling", () => {
     })).toThrow(expect.objectContaining({ code: "outside-workspace" }));
   });
 
-  itWin32("fails closed when a synchronous lock parent cannot match the Root canonical path", async () => {
+  itWin32.each([false, true])("canonicalizes Windows Root sync locks (explicit path: %s)", async (explicit) => {
     const directory = await tempRoot("fs-safe-sync-lock-root-win32-");
-    const lockDirectory = path.join(directory, "locks");
-    const lockPath = path.join(lockDirectory, "state.lock");
-    await fs.mkdir(lockDirectory);
-    const lockRoot = await root(lockDirectory);
+    const lockRoot = await root(directory);
+    const canonicalTarget = path.join(lockRoot.rootReal, "state.json");
+    const options = {
+      ...lockOptions(), lockRoot, reentrantOwner: "canonical-owner",
+      ...(explicit ? { lockPath: path.join(directory, "custom.lock") } : {}),
+    };
+    const realpath = vi.spyOn(fsSync.realpathSync, "native");
+    const first = acquireFileLockSync(path.join(directory, "state.json"), options);
+    let second: ReturnType<typeof acquireFileLockSync> | undefined;
+    try {
+      second = acquireFileLockSync(canonicalTarget, options);
+      expect(realpath).toHaveBeenCalledTimes(4);
+      expect(first.normalizedTargetPath).toBe(canonicalTarget);
+      expect(second.normalizedTargetPath).toBe(canonicalTarget);
+      expect(first.lockPath).toBe(path.join(lockRoot.rootReal, explicit ? "custom.lock" : "state.json.lock"));
+      expect(second.lockPath).toBe(first.lockPath);
+      expect(first.verifyStillHeld()).toBe(true);
+      expect(() => acquireFileLockSync(canonicalTarget, { ...options, reentrantOwner: "other-owner" }))
+        .toThrow(expect.objectContaining({ code: "file_lock_timeout" }));
+      first.release();
+      expect(second.verifyStillHeld()).toBe(true);
+    } finally {
+      first.release();
+      second?.release();
+    }
+    expect(fsSync.existsSync(first.lockPath)).toBe(false);
+  });
 
-    expect(() => acquireFileLockSync(path.join(directory, "state.json"), {
-      ...lockOptions(),
-      lockPath,
-      lockRoot,
-    })).toThrow(expect.objectContaining({ code: "outside-workspace" }));
-    expect(fsSync.existsSync(lockPath)).toBe(false);
+  it.each(["EPERM", "ENOENT", "EIO"])("does not bypass a Root parent realpath %s", async (code) => {
+    const directory = await tempRoot("fs-safe-sync-lock-root-realpath-");
+    const lockRoot = await root(directory);
+    const target = path.join(directory, "state.json");
+    const failure = Object.assign(new Error("canonical parent unavailable"), { code, path: `${target}.lock` });
+    const realpath = process.platform === "win32"
+      ? vi.spyOn(fsSync.realpathSync, "native") : vi.spyOn(fsSync, "realpathSync");
+    realpath.mockImplementation(() => { throw failure; });
+    const open = vi.spyOn(fsSync, "openSync");
+    expect(() => acquireFileLockSync(target, { ...lockOptions(), lockRoot })).toThrow(failure);
+    expect(open).not.toHaveBeenCalled();
+    expect(fsSync.existsSync(`${target}.lock`)).toBe(false);
   });
 
   it("sleeps for a bounded retry before timing out on an in-process holder", async () => {
@@ -282,14 +313,14 @@ describe("synchronous file-lock failure handling", () => {
     );
   });
 
-  itPosix("rejects a lexically-contained lock parent that resolves outside lockRoot", async () => {
+  it("rejects a lexically-contained lock parent that resolves outside lockRoot", async () => {
     const directory = await tempRoot("fs-safe-sync-lock-root-parent-swap-");
     const lockDirectory = path.join(directory, "locks");
     const outside = path.join(directory, "outside");
     const linkedParent = path.join(lockDirectory, "linked");
     await fs.mkdir(lockDirectory);
     await fs.mkdir(outside);
-    await fs.symlink(outside, linkedParent);
+    await fs.symlink(outside, linkedParent, process.platform === "win32" ? "junction" : "dir");
     const lockRoot = await root(lockDirectory);
 
     expect(() => acquireFileLockSync(path.join(directory, "state.json"), {

--- a/test/file-lock-sync-release.test.ts
+++ b/test/file-lock-sync-release.test.ts
@@ -1,0 +1,217 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { acquireFileLockSync } from "../src/file-lock.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const options = { payload: () => ({ pid: process.pid }), retry: { retries: 0 } };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function denyRemoval(lockPath: string) {
+  const failure = Object.assign(new Error("sidecar deletion denied"), { code: "EACCES" });
+  const realRm = fs.rmSync.bind(fs);
+  const remove = vi.spyOn(fs, "rmSync").mockImplementation((target, ...args) => {
+    if (String(target) === lockPath) throw failure;
+    return realRm(target, ...args);
+  });
+  return { failure, remove };
+}
+
+describe("synchronous file-lock release retries", () => {
+  it.each(["release", "reentrant release", "exit"])(
+    "does not close a reused descriptor after close reports EIO (%s)",
+    async (cleanupKind) => {
+      const targetPath = path.join(await tempRoot("fs-safe-sync-close-reuse-"), "state.json");
+      const unrelatedPath = `${targetPath}.unrelated`;
+      fs.writeFileSync(unrelatedPath, "unrelated descriptor");
+      const reentrant = { ...options, reentrantOwner: "operation" };
+      const lock = acquireFileLockSync(targetPath, reentrant);
+      const failure = Object.assign(new Error("close failed after freeing the descriptor"), { code: "EIO" });
+      const realClose = fs.closeSync.bind(fs);
+      let closedFd: number | undefined;
+      let unrelatedFd: number | undefined;
+      let unrelatedOpen = false;
+      const close = vi.spyOn(fs, "closeSync").mockImplementation((fd) => {
+        realClose(fd);
+        // Track accidental closes so fixture cleanup cannot mask the failure.
+        if (fd === unrelatedFd) unrelatedOpen = false;
+        if (closedFd === undefined) {
+          closedFd = fd;
+          unrelatedFd = fs.openSync(unrelatedPath, "r");
+          unrelatedOpen = true;
+          throw failure;
+        }
+      });
+      let nested: ReturnType<typeof acquireFileLockSync> | undefined;
+      try {
+        let error: unknown;
+        try {
+          lock.release();
+        } catch (caught) {
+          error = caught;
+        }
+        expect(error).toBe(failure);
+        expect(closedFd).toBeDefined();
+        expect(unrelatedFd).toBe(closedFd);
+        expect(unrelatedOpen).toBe(true);
+        expect(lock.verifyStillHeld()).toBe(true);
+
+        if (cleanupKind === "reentrant release") {
+          nested = acquireFileLockSync(targetPath, reentrant);
+          lock.release();
+          expect(nested.verifyStillHeld()).toBe(true);
+          nested.release();
+        } else if (cleanupKind === "exit") {
+          const cleanup = Reflect.get(globalThis, Symbol.for("fsSafe.syncSidecarLockCleanupHandler")) as () => void;
+          cleanup();
+        }
+        lock.release();
+        expect(fs.existsSync(lock.lockPath)).toBe(false);
+        expect(fs.readFileSync(unrelatedFd!, "utf8")).toBe("unrelated descriptor");
+        expect(close.mock.calls.filter(([fd]) => fd === closedFd)).toHaveLength(1);
+      } finally {
+        try {
+          lock.release();
+          nested?.release();
+        } finally {
+          close.mockRestore();
+          if (unrelatedOpen && unrelatedFd !== undefined) realClose(unrelatedFd);
+        }
+      }
+    },
+  );
+
+  it("retains cleanup through repeated deletion failures and releases idempotently", async () => {
+    const targetPath = path.join(await tempRoot("fs-safe-sync-release-retry-"), "state.json");
+    const lock = acquireFileLockSync(targetPath, options);
+    const raw = fs.readFileSync(lock.lockPath, "utf8");
+    const { failure, remove } = denyRemoval(lock.lockPath);
+    try {
+      expect(() => lock.release()).toThrow(failure);
+      expect(() => lock[Symbol.dispose]()).toThrow(failure);
+      expect(remove).toHaveBeenCalledTimes(2);
+      expect(fs.readFileSync(lock.lockPath, "utf8")).toBe(raw);
+      expect(lock.verifyStillHeld()).toBe(true);
+    } finally {
+      remove.mockRestore();
+      lock.release();
+    }
+    expect(fs.existsSync(lock.lockPath)).toBe(false);
+    const next = acquireFileLockSync(targetPath, options);
+    try {
+      lock.release();
+      lock[Symbol.dispose]();
+      expect(next.verifyStillHeld()).toBe(true);
+    } finally {
+      next.release();
+    }
+  });
+
+  it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+    "retries after the owned parent regains write permission",
+    async () => {
+      const directory = await tempRoot("fs-safe-sync-release-permission-");
+      const lock = acquireFileLockSync(path.join(directory, "state.json"), options);
+      try {
+        fs.chmodSync(directory, 0o500);
+        expect(() => lock.release()).toThrow(expect.objectContaining({ code: "EACCES" }));
+        expect(fs.existsSync(lock.lockPath)).toBe(true);
+      } finally {
+        fs.chmodSync(directory, 0o700);
+        lock.release();
+      }
+      expect(fs.existsSync(lock.lockPath)).toBe(false);
+    },
+  );
+
+  it.each(["failed handle", "new handle"])(
+    "preserves reentrant references when the %s releases first after a failure",
+    async (releaseFirst) => {
+      const targetPath = path.join(await tempRoot("fs-safe-sync-release-refs-"), "state.json");
+      const reentrant = { ...options, reentrantOwner: "operation" };
+      const first = acquireFileLockSync(targetPath, reentrant);
+      const second = acquireFileLockSync(targetPath, reentrant);
+      first.release();
+      first.release();
+      const { failure, remove } = denyRemoval(second.lockPath);
+      let third: ReturnType<typeof acquireFileLockSync> | undefined;
+      try {
+        expect(() => second.release()).toThrow(failure);
+        expect(() => acquireFileLockSync(targetPath, { ...options, shouldReclaim: () => true }))
+          .toThrow(expect.objectContaining({ code: "file_lock_timeout" }));
+        expect(() => acquireFileLockSync(targetPath, { ...reentrant, reentrantOwner: "other" }))
+          .toThrow(expect.objectContaining({ code: "file_lock_timeout" }));
+        third = acquireFileLockSync(targetPath, reentrant);
+        remove.mockRestore();
+        const early = releaseFirst === "failed handle" ? second : third;
+        const final = releaseFirst === "failed handle" ? third : second;
+        early.release();
+        early[Symbol.dispose]();
+        expect(final.verifyStillHeld()).toBe(true);
+        final.release();
+        expect(fs.existsSync(final.lockPath)).toBe(false);
+      } finally {
+        remove.mockRestore();
+        first.release();
+        second.release();
+        third?.release();
+      }
+    },
+  );
+
+  it.each(["rewritten payload", "new owner token"])(
+    "preserves a replacement after failed release (%s)",
+    async (replacementKind) => {
+      const targetPath = path.join(await tempRoot("fs-safe-sync-release-replaced-"), "state.json");
+      const lock = acquireFileLockSync(targetPath, options);
+      const donor = acquireFileLockSync(`${targetPath}.donor`, options);
+      const replacement = replacementKind === "new owner token"
+        ? fs.readFileSync(donor.lockPath, "utf8")
+        : "replacement";
+      donor.release();
+      const { failure, remove } = denyRemoval(lock.lockPath);
+      try {
+        expect(() => lock.release()).toThrow(failure);
+        fs.unlinkSync(lock.lockPath);
+        fs.writeFileSync(lock.lockPath, replacement);
+      } finally {
+        remove.mockRestore();
+        lock.release();
+      }
+      lock.release();
+      expect(fs.readFileSync(lock.lockPath, "utf8")).toBe(replacement);
+      fs.unlinkSync(lock.lockPath);
+      const next = acquireFileLockSync(targetPath, options);
+      next.release();
+      expect(fs.existsSync(lock.lockPath)).toBe(false);
+    },
+  );
+
+  it.each([false, true])("retains exit cleanup after failed deletion (replacement=%s)", async (replace) => {
+    const targetPath = path.join(await tempRoot("fs-safe-sync-release-exit-"), "state.json");
+    const lock = acquireFileLockSync(targetPath, options);
+    const { failure, remove } = denyRemoval(lock.lockPath);
+    try {
+      expect(() => lock.release()).toThrow(failure);
+      if (replace) fs.writeFileSync(lock.lockPath, "replacement");
+    } finally {
+      remove.mockRestore();
+    }
+    fs.writeFileSync(`${targetPath}.unrelated`, "unrelated descriptor");
+    const unrelated = fs.openSync(`${targetPath}.unrelated`, "r");
+    const cleanup = Reflect.get(globalThis, Symbol.for("fsSafe.syncSidecarLockCleanupHandler")) as () => void;
+    try {
+      cleanup();
+      lock.release();
+      expect(fs.readFileSync(unrelated, "utf8")).toBe("unrelated descriptor");
+    } finally {
+      fs.closeSync(unrelated);
+    }
+    if (replace) expect(fs.readFileSync(lock.lockPath, "utf8")).toBe("replacement");
+    else expect(fs.existsSync(lock.lockPath)).toBe(false);
+  });
+});

--- a/test/file-lock-sync-stale.test.ts
+++ b/test/file-lock-sync-stale.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { acquireFileLockSync } from "../src/file-lock.js";
 import { root } from "../src/root.js";
-import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
 
 const { tempRoot } = useRealTempDirs();
 const now = Date.parse("2026-01-01T00:00:00.000Z");
@@ -44,7 +44,7 @@ describe("synchronous file-lock snapshot age", () => {
     },
   );
 
-  itPosix("retries the same snapshot/unlink handoff with lockRoot", async () => {
+  it("retries the same snapshot/unlink handoff with lockRoot", async () => {
     const directory = await tempRoot("fs-safe-sync-age-root-");
     const lockRoot = await root(directory);
     const targetPath = path.join(directory, "state.json");

--- a/test/file-lock-sync-stale.test.ts
+++ b/test/file-lock-sync-stale.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { acquireFileLockSync } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const now = Date.parse("2026-01-01T00:00:00.000Z");
+const payload = () => ({ pid: process.pid });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("synchronous file-lock snapshot age", () => {
+  it.each(["missing", "malformed"])(
+    "retries a holder's unlink after reading a snapshot with %s createdAt",
+    async (timestamp) => {
+      const targetPath = path.join(await tempRoot("fs-safe-sync-age-unlink-"), "state.json");
+      const lockPath = `${targetPath}.lock`;
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, ...(timestamp === "malformed" ? { createdAt: "invalid" } : {}) }));
+      fs.utimesSync(lockPath, now / 1000, now / 1000);
+      vi.spyOn(Date, "now").mockReturnValue(now);
+      const parsePayload = vi.fn((raw: string) => {
+        // Parsing runs after the snapshot's final identity/mtime observation.
+        fs.unlinkSync(lockPath);
+        return JSON.parse(raw);
+      });
+      const lock = acquireFileLockSync(targetPath, {
+        payload,
+        parsePayload,
+        staleMs: 60_000,
+        timeoutMs: 5_000,
+        retry: { retries: 1, minTimeout: 0, maxTimeout: 0 },
+      });
+      try {
+        expect(parsePayload).toHaveBeenCalledTimes(1);
+        expect(JSON.parse(fs.readFileSync(lockPath, "utf8"))).toEqual(payload());
+      } finally {
+        lock.release();
+      }
+      expect(fs.existsSync(lockPath)).toBe(false);
+    },
+  );
+
+  itPosix("retries the same snapshot/unlink handoff with lockRoot", async () => {
+    const directory = await tempRoot("fs-safe-sync-age-root-");
+    const lockRoot = await root(directory);
+    const targetPath = path.join(directory, "state.json");
+    const lockPath = `${targetPath}.lock`;
+    fs.writeFileSync(lockPath, JSON.stringify(payload()));
+    fs.utimesSync(lockPath, now / 1000, now / 1000);
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const lock = acquireFileLockSync(targetPath, {
+      lockRoot,
+      payload,
+      staleMs: 60_000,
+      retry: { retries: 1, minTimeout: 0, maxTimeout: 0 },
+      parsePayload: (raw) => {
+        fs.unlinkSync(lockPath);
+        return JSON.parse(raw);
+      },
+    });
+    lock.release();
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("does not combine a fresh snapshot with a replacement's older mtime", async () => {
+    const targetPath = path.join(await tempRoot("fs-safe-sync-age-replace-"), "state.json");
+    const lockPath = `${targetPath}.lock`;
+    fs.writeFileSync(lockPath, JSON.stringify(payload()));
+    fs.utimesSync(lockPath, now / 1000, now / 1000);
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    expect(() => acquireFileLockSync(targetPath, {
+      payload,
+      staleMs: 60_000,
+      retry: { retries: 0 },
+      parsePayload: (raw) => {
+        fs.unlinkSync(lockPath);
+        fs.writeFileSync(lockPath, "replacement");
+        fs.utimesSync(lockPath, 0, 0);
+        return JSON.parse(raw);
+      },
+    })).toThrow(expect.objectContaining({ code: "file_lock_timeout" }));
+    expect(fs.readFileSync(lockPath, "utf8")).toBe("replacement");
+  });
+
+  it.each(["missing", "malformed"])("recovers an approved old mtime with %s createdAt", async (timestamp) => {
+    const targetPath = path.join(await tempRoot("fs-safe-sync-age-recover-"), "state.json");
+    const lockPath = `${targetPath}.lock`;
+    const raw = JSON.stringify({ pid: process.pid, ...(timestamp === "malformed" ? { createdAt: "invalid" } : {}) });
+    fs.writeFileSync(lockPath, raw);
+    fs.utimesSync(lockPath, 0, 0);
+    const options = { payload, staleMs: 60_000, retry: { retries: 0 } };
+    expect(() => acquireFileLockSync(targetPath, options))
+      .toThrow(expect.objectContaining({ code: "file_lock_stale" }));
+    const approve = vi.fn((snapshot: { raw: string }) => snapshot.raw === raw);
+    const lock = acquireFileLockSync(targetPath, {
+      ...options,
+      staleRecovery: "remove-if-unchanged",
+      shouldRemoveStaleLock: approve,
+    });
+    try {
+      expect(approve).toHaveBeenCalledTimes(1);
+      expect(lock.verifyStillHeld()).toBe(true);
+    } finally {
+      lock.release();
+    }
+    expect(fs.existsSync(`${lockPath}.reclaim`)).toBe(false);
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+});

--- a/test/file-lock-sync-windows-denial.test.ts
+++ b/test/file-lock-sync-windows-denial.test.ts
@@ -1,0 +1,259 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { acquireFileLockSync } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+const defaults = {
+  payload: () => ({ pid: process.pid }),
+  staleMs: 60_000,
+  timeoutMs: 1_000,
+  retry: { retries: 20, minTimeout: 0, maxTimeout: 0 },
+};
+const failure = (pathname: string, code = "EPERM") =>
+  Object.assign(new Error("injected filesystem failure"), { code, path: pathname, syscall: "open" });
+const exclusive = (flags: string | number) => typeof flags === "number" && (flags & fs.constants.O_EXCL) !== 0;
+
+async function fixture(rooted = false) {
+  const directory = await tempRoot("fs-safe-sync-denial-");
+  const lockRoot = rooted ? await root(directory) : undefined;
+  const target = path.join(directory, "state");
+  // Exercise Windows classification on every host, using real local descriptors.
+  Object.defineProperty(process, "platform", { value: "win32" });
+  return { directory, target, lockPath: `${target}.lock`, options: { ...defaults, lockRoot } };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+});
+
+describe("synchronous Windows lock-file open denials", () => {
+  it.each([
+    [false, "create"], [true, "create"], [false, "snapshot"], [true, "snapshot"],
+  ] as const)("retries only fresh exclusive creation after a denial (Root: %s, %s)", async (rooted, stage) => {
+    const { target, lockPath, options } = await fixture(rooted);
+    if (stage === "snapshot") fs.writeFileSync(lockPath, "{}");
+    const open = fs.openSync.bind(fs);
+    const parsePayload = vi.fn(JSON.parse);
+    let creates = 0, denials = 0;
+    vi.spyOn(fs, "openSync").mockImplementation((file, flags, mode) => {
+      if (file === lockPath) {
+        if (exclusive(flags)) creates += 1;
+        if (!denials && exclusive(flags) === (stage === "create")) {
+          denials += 1;
+          if (stage === "snapshot") fs.unlinkSync(lockPath);
+          throw failure(lockPath);
+        }
+      }
+      return open(file, flags, mode);
+    });
+    const lock = acquireFileLockSync(target, { ...options, parsePayload });
+    try {
+      expect(creates).toBe(2);
+      expect(denials).toBe(1);
+      expect(parsePayload).not.toHaveBeenCalled();
+      expect(lock.verifyStillHeld()).toBe(true);
+    } finally {
+      lock.release();
+    }
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  for (const stage of ["create", "snapshot"] as const) {
+    it.each([
+      { name: "internal cap", retries: undefined, timeoutMs: Infinity, attempts: 9 },
+      { name: "zero retries", retries: 0, timeoutMs: Infinity, attempts: 1 },
+      { name: "caller retry cap", retries: 2, timeoutMs: Infinity, attempts: 3 },
+      { name: "caller deadline", retries: 20, timeoutMs: 0, attempts: 1 },
+    ])(`preserves the last ${stage} denial at $name`, async ({ retries, timeoutMs, attempts }) => {
+      const { target, lockPath, options } = await fixture();
+      if (stage === "snapshot") fs.writeFileSync(lockPath, "{}");
+      const open = fs.openSync.bind(fs);
+      let denied = 0, lastError: Error | undefined;
+      vi.spyOn(fs, "openSync").mockImplementation((file, flags, mode) => {
+        if (file === lockPath && exclusive(flags) === (stage === "create")) {
+          denied += 1;
+          lastError = failure(lockPath);
+          throw lastError;
+        }
+        return open(file, flags, mode);
+      });
+      const payload = vi.fn(options.payload), shouldReclaim = vi.fn(() => false);
+      let caught: unknown;
+      try {
+        acquireFileLockSync(target, {
+          ...options, payload, shouldReclaim, timeoutMs,
+          retry: { retries, minTimeout: 0, maxTimeout: 0 },
+        });
+      } catch (error) { caught = error; }
+      expect(caught).toBe(lastError);
+      expect(denied).toBe(attempts);
+      expect(payload).toHaveBeenCalledTimes(attempts);
+      expect(shouldReclaim).not.toHaveBeenCalled();
+      expect(fs.existsSync(lockPath)).toBe(stage === "snapshot");
+    });
+  }
+
+  it("shares the denial cap across create and snapshot opens", async () => {
+    const { target, lockPath, options } = await fixture();
+    const open = fs.openSync.bind(fs);
+    let denials = 0;
+    vi.spyOn(fs, "openSync").mockImplementation((file, flags, mode) => {
+      if (file === lockPath && (denials < 4 || !exclusive(flags))) {
+        denials += 1;
+        if (denials === 4) fs.writeFileSync(lockPath, "{}");
+        throw failure(lockPath);
+      }
+      return open(file, flags, mode);
+    });
+    expect(() => acquireFileLockSync(target, options)).toThrow(expect.objectContaining({ code: "EPERM" }));
+    expect(denials).toBe(9);
+    expect(fs.readFileSync(lockPath, "utf8")).toBe("{}");
+  });
+
+  it.each(["create", "snapshot"])("does not retry POSIX %s denials or denials without the exact lock path", async (stage) => {
+    const { directory, target, lockPath, options } = await fixture();
+    if (stage === "snapshot") fs.writeFileSync(lockPath, "{}");
+    const open = fs.openSync.bind(fs);
+    for (const [system, pathname, code] of [
+      ["linux", lockPath, "EPERM"], ["win32", directory, "EPERM"],
+      ["win32", undefined, "EPERM"], ["win32", lockPath, "EACCES"],
+    ] as const) {
+      Object.defineProperty(process, "platform", { value: system });
+      const error = Object.assign(failure(lockPath, code), { path: pathname });
+      let calls = 0;
+      const spy = vi.spyOn(fs, "openSync").mockImplementation((file, flags, mode) => {
+        if (file === lockPath && exclusive(flags) === (stage === "create")) {
+          calls += 1;
+          throw error;
+        }
+        return open(file, flags, mode);
+      });
+      expect(() => acquireFileLockSync(target, options)).toThrow(error);
+      expect(calls).toBe(1);
+      spy.mockRestore();
+    }
+  });
+
+  it.each(["payload", "parser", "read", "fstat", "parent", "write", "fsync"])(
+    "propagates caller/read/stat errors without retry or ENOENT suppression (%s)", async (stage) => {
+      for (const code of ["EPERM", "ENOENT"]) {
+        const { target, lockPath, options } = await fixture();
+        if (["parser", "read", "fstat"].includes(stage)) fs.writeFileSync(lockPath, "{}");
+        const error = failure(lockPath, code);
+        const close = vi.spyOn(fs, "closeSync");
+        const fail = vi.fn((): never => { throw error; });
+        const payload = stage === "payload" ? fail : vi.fn(options.payload);
+        if (stage === "read") vi.spyOn(fs, "readSync").mockImplementationOnce(fail);
+        if (stage === "fstat") vi.spyOn(fs, "fstatSync").mockImplementationOnce(fail);
+        if (stage === "parent") vi.spyOn(fs, "mkdirSync").mockImplementationOnce(fail);
+        if (stage === "write") vi.spyOn(fs, "writeFileSync").mockImplementationOnce(fail);
+        if (stage === "fsync") vi.spyOn(fs, "fsyncSync").mockImplementationOnce(fail);
+        expect(() => acquireFileLockSync(target, {
+          ...options, payload, ...(stage === "parser" ? { parsePayload: fail } : {}),
+        })).toThrow(error);
+        expect(fail).toHaveBeenCalledTimes(1);
+        expect(payload).toHaveBeenCalledTimes(stage === "parent" ? 0 : 1);
+        if (["parser", "read", "fstat"].includes(stage)) expect(close).toHaveBeenCalledTimes(1);
+        vi.restoreAllMocks();
+        expect(fs.existsSync(lockPath)).toBe(["parser", "read", "fstat"].includes(stage));
+      }
+    },
+  );
+
+  it.each([1, 2])("does not classify snapshot lstat %s as an open denial", async (observation) => {
+    const { target, lockPath, options } = await fixture();
+    fs.writeFileSync(lockPath, "{}");
+    const error = failure(lockPath), lstat = fs.lstatSync.bind(fs);
+    let calls = 0;
+    vi.spyOn(fs, "lstatSync").mockImplementation((file, opts) => {
+      if (file === lockPath && ++calls === observation) throw error;
+      return lstat(file, opts as never);
+    });
+    const payload = vi.fn(options.payload);
+    expect(() => acquireFileLockSync(target, { ...options, payload })).toThrow(error);
+    expect(calls).toBe(observation);
+    expect(payload).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["verify", "release", "reclaim"])("keeps %s open-denial handling strict", async (stage) => {
+    const { target, lockPath, options } = await fixture();
+    const error = failure(lockPath), open = fs.openSync.bind(fs);
+    let reads = 0;
+    const denyReads = () => vi.spyOn(fs, "openSync").mockImplementation((file, flags, mode) => {
+      if (file === lockPath && !exclusive(flags)) { reads += 1; throw error; }
+      return open(file, flags, mode);
+    });
+    if (stage === "reclaim") {
+      fs.writeFileSync(lockPath, "{}");
+      expect(() => acquireFileLockSync(target, {
+        ...options, shouldReclaim: () => true, staleRecovery: "remove-if-unchanged",
+        shouldRemoveStaleLock: () => { denyReads(); return true; },
+      })).toThrow(error);
+      expect(fs.existsSync(`${lockPath}.reclaim`)).toBe(false);
+      expect(fs.readFileSync(lockPath, "utf8")).toBe("{}");
+    } else {
+      const lock = acquireFileLockSync(target, options);
+      const spy = denyReads();
+      try {
+        expect(() => stage === "verify" ? lock.verifyStillHeld() : lock.release()).toThrow(error);
+        expect(fs.existsSync(lockPath)).toBe(true);
+      } finally {
+        spy.mockRestore();
+        lock.release();
+      }
+      expect(fs.existsSync(lockPath)).toBe(false);
+    }
+    expect(reads).toBe(1);
+  });
+
+  for (const stage of ["before-lstat", "open", "after-lstat", "identity"] as const) {
+    it.each([
+      { retries: 0, timeoutMs: 1_000, attempts: 1 },
+      { retries: 2, timeoutMs: 1_000, attempts: 3 },
+      { retries: undefined, timeoutMs: 0, attempts: 1 },
+    ])(`charges null ${stage} snapshots to caller retries/deadlines ($retries, $timeoutMs)`, async (budget) => {
+      const { target, lockPath, options } = await fixture();
+      fs.writeFileSync(lockPath, "{}");
+      const missing = failure(lockPath, "ENOENT");
+      if (stage === "open") {
+        const open = fs.openSync.bind(fs);
+        vi.spyOn(fs, "openSync").mockImplementation((file, flags, mode) => {
+          if (file === lockPath && !exclusive(flags)) throw missing;
+          return open(file, flags, mode);
+        });
+      } else if (stage === "identity") {
+        const fstat = fs.fstatSync.bind(fs);
+        vi.spyOn(fs, "fstatSync").mockImplementation((fd) => {
+          const stat = fstat(fd);
+          return Object.assign(stat, { ino: stat.ino + 1 });
+        });
+      } else {
+        const lstat = fs.lstatSync.bind(fs);
+        let calls = 0;
+        vi.spyOn(fs, "lstatSync").mockImplementation((file, opts) => {
+          if (file === lockPath && (++calls % 2 === 0 || stage === "before-lstat")) throw missing;
+          return lstat(file, opts as never);
+        });
+      }
+      let attempts = 0;
+      const parsePayload = vi.fn(JSON.parse);
+      expect(() => acquireFileLockSync(target, {
+        ...options, parsePayload, timeoutMs: budget.timeoutMs,
+        retry: { retries: budget.retries, minTimeout: 0, maxTimeout: 0 },
+        payload: () => {
+          // Bound the regression itself: an unbudgeted sync loop blocks test timeouts.
+          if (++attempts > budget.attempts + 1) throw new Error("unbounded null-snapshot loop");
+          return {};
+        },
+      })).toThrow(expect.objectContaining({ code: "file_lock_timeout" }));
+      expect(attempts).toBe(budget.attempts);
+      expect(parsePayload).not.toHaveBeenCalled();
+      expect(fs.readFileSync(lockPath, "utf8")).toBe("{}");
+    });
+  }
+});

--- a/test/file-lock-sync-windows-denial.test.ts
+++ b/test/file-lock-sync-windows-denial.test.ts
@@ -227,11 +227,13 @@ describe("synchronous Windows lock-file open denials", () => {
           return open(file, flags, mode);
         });
       } else if (stage === "identity") {
-        const fstat = fs.fstatSync.bind(fs);
-        vi.spyOn(fs, "fstatSync").mockImplementation((fd) => {
-          const stat = fstat(fd);
-          return Object.assign(stat, { ino: stat.ino + 1 });
+        // Large Windows inode numbers can round away +1; use distinct known identities.
+        const lstat = fs.lstatSync.bind(fs), fstat = fs.fstatSync.bind(fs);
+        vi.spyOn(fs, "lstatSync").mockImplementation((file, opts) => {
+          const stat = lstat(file, opts as never);
+          return file === lockPath ? Object.assign(stat, { ino: 1 }) : stat;
         });
+        vi.spyOn(fs, "fstatSync").mockImplementation((fd) => Object.assign(fstat(fd), { ino: 2 }));
       } else {
         const lstat = fs.lstatSync.bind(fs);
         let calls = 0;

--- a/test/root-create-only-preflight.test.ts
+++ b/test/root-create-only-preflight.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { configureFsSafeNative, root } from "../src/index.js";
+import { getNativeBinding } from "../src/native.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+afterEach(() => { configureFsSafeNative({ mode: "auto" }); __setFsSafeTestHooksForTest(); vi.restoreAllMocks(); });
+
+it.each(["off", "auto"] as const)("create-only keeps type, alias, hardlink, and root guards (native %s)", async (mode) => {
+  configureFsSafeNative({ mode });
+  const directory = await tempRoot("root-create-only-"), capability = await root(directory);
+  const target = path.join(capability.rootReal, "target");
+  await fs.writeFile(target, "owner");
+  const afterOpen = vi.fn();
+  __setFsSafeTestHooksForTest({ afterOpen });
+  await expect(capability.create("target", "replacement")).rejects.toMatchObject({ code: "already-exists" });
+  await expect(capability.write("target", "replacement", { overwrite: false })).rejects.toMatchObject({ code: "already-exists" });
+  expect(afterOpen).not.toHaveBeenCalled();
+  await expect(fs.readFile(target, "utf8")).resolves.toBe("owner");
+  await fs.mkdir(path.join(capability.rootReal, "directory"));
+  await expect(capability.create("directory", "replacement")).rejects.toMatchObject({
+    code: process.platform === "win32" && !getNativeBinding() ? "already-exists" : "not-file",
+  });
+  await fs.link(target, `${target}.link`);
+  await expect(capability.create("target", "replacement")).rejects.toMatchObject({ code: "path-alias" });
+  await expect(capability.create("../escape", "replacement")).rejects.toMatchObject({ code: "outside-workspace" });
+  const denied = await root(directory, { denyMutations: { paths: [target] } });
+  await expect(denied.create("target", "replacement")).rejects.toMatchObject({ code: "denied-path" });
+  __setFsSafeTestHooksForTest();
+  await fs.rename(directory, `${directory}.old`);
+  try {
+    await fs.mkdir(directory);
+    await expect(capability.create("new", "replacement")).rejects.toMatchObject({ code: "path-mismatch" });
+  } finally { await fs.rm(`${directory}.old`, { recursive: true }); }
+});
+
+it.skipIf(process.platform === "win32")("create-only rejects an escaped alias and supports an in-root parent alias", async () => {
+  const capability = await root(await tempRoot("root-create-alias-"));
+  const outside = await tempRoot("root-create-outside-");
+  await fs.symlink(outside, path.join(capability.rootReal, "outside"));
+  await expect(capability.create("outside/file", "no")).rejects.toMatchObject({ code: "path-alias" });
+  await capability.mkdir("actual");
+  await fs.symlink("actual", path.join(capability.rootReal, "alias"));
+  await capability.create("alias/file", "yes");
+  await expect(fs.readFile(path.join(capability.rootReal, "actual/file"), "utf8")).resolves.toBe("yes");
+});

--- a/test/sidecar-lock-helpers-failure.test.ts
+++ b/test/sidecar-lock-helpers-failure.test.ts
@@ -89,7 +89,7 @@ describe("sidecar lock helper failure handling", () => {
       await capability.create(relative, '{"owner":"original"}');
       const probe = vi.spyOn(capability, "stat");
       const gate = pauseSidecarSnapshotOpen(lockPath, afterIdentityCheck);
-      const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability });
+      const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true });
       const result = expect(snapshot).resolves.toBeNull();
       const handle = await gate.opened;
       const close = vi.spyOn(handle, "close");
@@ -115,7 +115,7 @@ describe("sidecar lock helper failure handling", () => {
     await capability.create("owner.json", original);
     const probe = vi.spyOn(capability, "stat");
     const gate = pauseSidecarSnapshotOpen(lockPath, false);
-    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability });
+    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true });
     const result = expect(snapshot).rejects.toMatchObject({ code: "path-mismatch" });
     const handle = await gate.opened;
     try {
@@ -126,7 +126,7 @@ describe("sidecar lock helper failure handling", () => {
       gate.resume();
     }
     await result;
-    expect(probe).toHaveBeenCalledExactlyOnceWith("owner.json");
+    expect(probe).not.toHaveBeenCalled();
     expect(handle.fd).toBe(-1);
     await expect(fs.readFile(displacedPath, "utf8")).resolves.toBe(original);
     await expect(fs.readFile(lockPath, "utf8")).resolves.toBe(replacement);
@@ -139,7 +139,7 @@ describe("sidecar lock helper failure handling", () => {
     new FsSafeError("hardlink", "hardlink blocked"),
     Object.assign(new Error("missing without capability proof"), { code: "ENOENT" }),
     Object.assign(new Error("probe denied"), { code: "EACCES" }),
-  ])("preserves the original mismatch when the Root absence probe rejects with $code", async (failure) => {
+  ])("does not probe an unproven mismatch even when stat would reject with $code", async (failure) => {
     const capability = await root(await tempRoot("fs-safe-sidecar-root-probe-"));
     const mismatch = new FsSafeError("path-mismatch", "opened path changed");
     vi.spyOn(capability, "open").mockRejectedValueOnce(mismatch);
@@ -147,7 +147,7 @@ describe("sidecar lock helper failure handling", () => {
     await expect(readSidecarLockSnapshot(path.join(capability.rootReal, "owner.json"), {
       lockRoot: capability,
     })).rejects.toBe(mismatch);
-    expect(probe).toHaveBeenCalledExactlyOnceWith("owner.json");
+    expect(probe).not.toHaveBeenCalled();
   });
 
   itPosix("rejects absence under a replaced Root after the ownership record is unlinked", async () => {
@@ -159,7 +159,7 @@ describe("sidecar lock helper failure handling", () => {
     await capability.create("owner.json", '{"owner":"original"}');
     const probe = vi.spyOn(capability, "stat");
     const gate = pauseSidecarSnapshotOpen(lockPath, true);
-    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability });
+    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true });
     const result = expect(snapshot).rejects.toMatchObject({ code: "path-mismatch" });
     const handle = await gate.opened;
     try {
@@ -305,7 +305,7 @@ describe("sidecar lock helper failure handling", () => {
     const capability = await root(rootDir);
     const lockPath = path.join(rootDir, "state.lock");
     await capability.create("state.lock", "old");
-    const snapshot = await readSidecarLockSnapshot(lockPath, { lockRoot: capability });
+    const snapshot = await readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true });
     await expect(removeStaleSidecarLockIfAllowed({
       lockPath,
       normalizedTargetPath: path.join(rootDir, "state"),

--- a/test/sidecar-lock-root-admission.test.ts
+++ b/test/sidecar-lock-root-admission.test.ts
@@ -1,0 +1,335 @@
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createFileLockManager } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { readSidecarLockSnapshot } from "../src/sidecar-lock-reclaim.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+afterEach(() => {
+  __setFsSafeTestHooksForTest();
+  vi.restoreAllMocks();
+});
+const posix = it.skipIf(process.platform === "win32");
+
+function mutateOpened(lockPath: string, mutate: (handle: FileHandle) => Promise<void>, afterIdentity = true) {
+  let opened: FileHandle | undefined;
+  const hook = async (candidate: string, handle: FileHandle) => {
+    if (candidate !== lockPath || opened) return;
+    opened = handle;
+    __setFsSafeTestHooksForTest();
+    await mutate(handle);
+  };
+  __setFsSafeTestHooksForTest(afterIdentity
+    ? { afterOpenedPathIdentityCheck: hook } : { afterOpen: hook });
+  return () => opened;
+}
+
+posix.each(["unlink", "replacement"])("post-create admission handles %s without admitting the lost record", async (mutation) => {
+  const capability = await root(await tempRoot("sidecar-postcreate-"));
+  const relative = "state.lock";
+  const lockPath = path.join(capability.rootReal, relative);
+  const target = path.join(capability.rootReal, "state");
+  const manager = createFileLockManager(`postcreate:${target}`);
+  const realOpen = capability.open.bind(capability);
+  const create = vi.spyOn(capability, "create");
+  let opened: (() => FileHandle | undefined) | undefined;
+  const replacement = '{"owner":"replacement"}\n';
+  vi.spyOn(capability, "open").mockImplementationOnce(async (...args) => {
+    expect(create.mock.settledResults[0]?.type).toBe("fulfilled");
+    opened = mutateOpened(lockPath, async (handle) => {
+      if (mutation === "replacement") {
+        await fs.rename(lockPath, `${lockPath}.displaced`);
+        await fs.writeFile(lockPath, replacement, { flag: "wx" });
+      } else {
+        await fs.unlink(lockPath);
+        expect((await handle.stat({ bigint: true })).nlink).toBe(0n);
+      }
+    }, mutation === "unlink");
+    return await realOpen(...args);
+  });
+  const acquiring = manager.acquire(target, {
+    lockRoot: capability, lockPath, payload: () => ({ owner: "new" }),
+    retry: { retries: 1, minTimeout: 0, maxTimeout: 0 },
+  });
+  if (mutation === "replacement") {
+    await expect(acquiring).rejects.toMatchObject({ code: "path-mismatch" });
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe(replacement);
+  } else {
+    const held = await acquiring;
+    try {
+      expect(create).toHaveBeenCalledTimes(2);
+      expect(create.mock.calls[0]?.[1]).not.toBe(create.mock.calls[1]?.[1]);
+      await expect(held.verifyStillHeld()).resolves.toBe(true);
+    } finally {
+      await held.release();
+    }
+    await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  }
+  expect(opened?.()?.fd).toBe(-1);
+  expect(manager.heldEntries()).toEqual([]);
+});
+
+posix("generic Root.open remains strict after a direct test unlink", async () => {
+  const capability = await root(await tempRoot("sidecar-generic-"));
+  const lockPath = path.join(capability.rootReal, "file");
+  await capability.create("file", "content");
+  const opened = mutateOpened(lockPath, async (handle) => {
+    await fs.unlink(lockPath);
+    expect((await handle.stat({ bigint: true })).nlink).toBe(0n);
+  });
+  await expect(capability.open("file")).rejects.toMatchObject({ code: "path-mismatch" });
+  expect(opened()?.fd).toBe(-1);
+});
+
+posix("post-create admission refuses a replacement installed before reopening", async () => {
+  const capability = await root(await tempRoot("sidecar-before-reopen-"));
+  const target = path.join(capability.rootReal, "state");
+  const lockPath = `${target}.lock`;
+  const manager = createFileLockManager(`before-reopen:${target}`);
+  const realOpen = capability.open.bind(capability);
+  const replacement = '{"owner":"replacement"}\n';
+  vi.spyOn(capability, "open").mockImplementationOnce(async (...args) => {
+    await fs.rename(lockPath, `${lockPath}.displaced`);
+    await fs.writeFile(lockPath, replacement, { flag: "wx" });
+    return await realOpen(...args);
+  });
+  const result = await manager.acquire(target, {
+    lockRoot: capability, lockPath, payload: () => ({ owner: "new" }),
+  }).then((handle) => ({ handle, error: undefined }), (error: unknown) => ({ handle: undefined, error }));
+  try {
+    const verified = result.handle ? await result.handle.verifyStillHeld() : undefined;
+    console.log(JSON.stringify({ phase: "post-create-before-reopen", admitted: !!result.handle, verified }));
+    expect(result.handle).toBeUndefined();
+    expect(result.error).toBeDefined();
+  } finally {
+    await result.handle?.release();
+    await manager.drain();
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe(replacement);
+  }
+});
+
+posix.each([
+  "root-replaced", "parent-escape", "parent-retarget", "linked-stale-descriptor",
+  "unlinked-parent-retarget", "unlinked-parent-replaced",
+].flatMap((mutation) => [false, true].map((afterIdentity) => ({ mutation, afterIdentity }))))(
+  "refuses $mutation (after identity: $afterIdentity)",
+  async ({ mutation, afterIdentity }) => {
+    const base = await tempRoot("sidecar-retarget-");
+    const rootPath = path.join(base, "root");
+    await fs.mkdir(path.join(rootPath, "parent"), { recursive: true });
+    const capability = await root(rootPath);
+    const relative = "parent/state.lock";
+    const lockPath = path.join(capability.rootReal, relative);
+    await capability.create(relative, '{"owner":"original"}');
+    const probe = vi.spyOn(capability, "stat");
+    const opened = mutateOpened(lockPath, async (handle) => {
+      if (mutation === "root-replaced") {
+        await fs.unlink(lockPath);
+        await fs.rename(rootPath, `${rootPath}.old`);
+        await fs.mkdir(rootPath);
+      } else if (mutation === "linked-stale-descriptor") {
+        // Keep the real inode alive outside the root, with no forged metadata.
+        await fs.rename(lockPath, path.join(base, "displaced.lock"));
+        expect((await handle.stat({ bigint: true })).nlink).toBe(1n);
+      } else {
+        if (mutation.startsWith("unlinked-")) {
+          await fs.unlink(lockPath);
+          expect((await handle.stat({ bigint: true })).nlink).toBe(0n);
+        }
+        const parent = path.dirname(lockPath);
+        await fs.rename(parent, path.join(base, "displaced-parent"));
+        if (mutation === "unlinked-parent-replaced") {
+          await fs.mkdir(parent);
+        } else {
+          const destination = mutation === "parent-escape" ? path.join(base, "outside") : path.join(rootPath, "other");
+          await fs.mkdir(destination);
+          await fs.symlink(destination, parent);
+        }
+      }
+    }, afterIdentity);
+    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true });
+    const error = await snapshot.catch((caught: unknown) => caught);
+    expect(error).toMatchObject({ name: "FsSafeError" });
+    expect(["path-mismatch", "outside-workspace", "path-alias", "not-found"]).toContain((error as { code: string }).code);
+    expect(opened()?.fd).toBe(-1);
+    expect(probe.mock.calls.length).toBeLessThanOrEqual(1);
+    if (mutation !== "root-replaced") {
+      const preserved = mutation === "linked-stale-descriptor"
+        ? path.join(base, "displaced.lock") : path.join(base, "displaced-parent/state.lock");
+      if (mutation.startsWith("unlinked-")) {
+        await expect(fs.lstat(preserved)).rejects.toMatchObject({ code: "ENOENT" });
+      } else {
+        await expect(fs.readFile(preserved, "utf8")).resolves.toBe('{"owner":"original"}');
+      }
+    }
+  },
+);
+
+posix.each(["before-probe", "after-probe"])("replacement %s cannot be acquired or removed by the waiter", async (when) => {
+  const capability = await root(await tempRoot("sidecar-probe-replacement-"));
+  const relative = "state.lock";
+  const lockPath = path.join(capability.rootReal, relative);
+  const target = path.join(capability.rootReal, "state");
+  const ownerManager = createFileLockManager(`probe-owner:${target}`);
+  const waiterManager = createFileLockManager(`probe-waiter:${target}`);
+  const options = { lockRoot: capability, lockPath, retry: { retries: 0 }, shouldReclaim: () => false };
+  const owner = await ownerManager.acquire(target, { ...options, payload: () => ({ owner: "original" }) });
+  const realOpen = capability.open.bind(capability);
+  let opened: (() => FileHandle | undefined) | undefined;
+  vi.spyOn(capability, "open").mockImplementationOnce(async (...args) => {
+    opened = mutateOpened(lockPath, async () => { await owner.release(); });
+    return await realOpen(...args);
+  });
+  const replacement = '{"owner":"replacement"}\n';
+  const realStat = capability.stat.bind(capability);
+  const probe = vi.spyOn(capability, "stat").mockImplementationOnce(async (...args) => {
+    if (when === "before-probe") await fs.writeFile(lockPath, replacement, { flag: "wx" });
+    try {
+      return await realStat(...args);
+    } catch (error) {
+      expect(error).toMatchObject({ code: "not-found" });
+      await fs.writeFile(lockPath, replacement, { flag: "wx" });
+      throw error;
+    }
+  });
+  try {
+    await expect(waiterManager.acquire(target, { ...options, payload: () => ({ owner: "waiter" }) }))
+      .rejects.toMatchObject({ code: "file_lock_timeout" });
+    expect(probe).toHaveBeenCalledExactlyOnceWith(relative);
+    expect(opened?.()?.fd).toBe(-1);
+    expect(waiterManager.heldEntries()).toEqual([]);
+    await expect(fs.readFile(lockPath, "utf8")).resolves.toBe(replacement);
+  } finally {
+    __setFsSafeTestHooksForTest();
+    await owner.release();
+    await waiterManager.drain();
+  }
+});
+
+posix.each([false, true])("rejects a snapshot replacement (after identity: %s)", async (afterIdentity) => {
+  const capability = await root(await tempRoot("sidecar-snapshot-replaced-"));
+  const lockPath = path.join(capability.rootReal, "state.lock");
+  await capability.create("state.lock", '{"owner":"original"}');
+  const opened = mutateOpened(lockPath, async () => {
+    await fs.rename(lockPath, `${lockPath}.displaced`);
+    await fs.writeFile(lockPath, '{"owner":"replacement"}', { flag: "wx" });
+  }, afterIdentity);
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+    .rejects.toMatchObject({ code: "path-mismatch" });
+  expect(opened()?.fd).toBe(-1);
+  await expect(fs.readFile(lockPath, "utf8")).resolves.toBe('{"owner":"replacement"}');
+  await expect(fs.readFile(`${lockPath}.displaced`, "utf8")).resolves.toBe('{"owner":"original"}');
+});
+
+posix("rejects a Root replaced after its absence probe", async () => {
+  const base = await tempRoot("sidecar-probe-root-swap-");
+  const rootPath = path.join(base, "root");
+  await fs.mkdir(rootPath);
+  const capability = await root(rootPath);
+  const lockPath = path.join(capability.rootReal, "state.lock");
+  await capability.create("state.lock", "{}");
+  const opened = mutateOpened(lockPath, async () => { await fs.unlink(lockPath); });
+  const stat = capability.stat.bind(capability);
+  vi.spyOn(capability, "stat").mockImplementationOnce(async (...args) => {
+    try {
+      return await stat(...args);
+    } catch (error) {
+      expect(error).toMatchObject({ code: "not-found" });
+      await fs.rename(rootPath, `${rootPath}.old`);
+      await fs.mkdir(rootPath);
+      throw error;
+    }
+  });
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+    .rejects.toMatchObject({ code: "path-mismatch" });
+  expect(opened()?.fd).toBe(-1);
+});
+
+posix.each(["retry", "deadline"])("bounds repeated post-create loss by the %s policy", async (limit) => {
+  const capability = await root(await tempRoot("sidecar-lost-budget-"));
+  const target = path.join(capability.rootReal, "state");
+  const lockPath = `${target}.lock`;
+  const manager = createFileLockManager(`lost-budget:${target}`);
+  const create = vi.spyOn(capability, "create");
+  const originalOpen = capability.open.bind(capability);
+  const descriptors: FileHandle[] = [];
+  vi.spyOn(capability, "open").mockImplementation(async (...args) => {
+    mutateOpened(lockPath, async (handle) => {
+      descriptors.push(handle);
+      await fs.unlink(lockPath);
+      expect((await handle.stat({ bigint: true })).nlink).toBe(0n);
+    });
+    return await originalOpen(...args);
+  });
+  await expect(manager.acquire(target, {
+    lockRoot: capability, payload: () => ({}),
+    retry: { retries: 1, minTimeout: 0, maxTimeout: 0 },
+    ...(limit === "deadline" ? { timeoutMs: 0 } : {}),
+  })).rejects.toMatchObject({ code: "file_lock_timeout" });
+  expect(create).toHaveBeenCalledTimes(limit === "retry" ? 2 : 1);
+  expect(descriptors.every((handle) => handle.fd === -1)).toBe(true);
+  expect(manager.heldEntries()).toEqual([]);
+  await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+posix.each(["retry", "deadline", "replacement"])("does not register a record unlinked during admission read (%s)", async (kind) => {
+  const capability = await root(await tempRoot("sidecar-read-loss-"));
+  const target = path.join(capability.rootReal, "state"), lockPath = `${target}.lock`;
+  const manager = createFileLockManager(`read-loss:${target}`);
+  const open = capability.open.bind(capability);
+  let descriptor: FileHandle | undefined;
+  vi.spyOn(capability, "open").mockImplementationOnce(async (...args) => {
+    const opened = await open(...args);
+    descriptor = opened.handle;
+    const read = opened.handle.read.bind(opened.handle);
+    vi.spyOn(opened.handle, "read").mockImplementationOnce(async (...values: Parameters<typeof read>) => {
+      const result = await read(...values);
+      await fs.unlink(lockPath);
+      if (kind === "replacement") await fs.writeFile(lockPath, '{"owner":"replacement"}');
+      return result;
+    });
+    return opened;
+  });
+  const pending = manager.acquire(target, {
+    lockRoot: capability, payload: () => ({ owner: "creator" }),
+    retry: { retries: kind === "retry" ? 1 : 0, minTimeout: 0, maxTimeout: 0 },
+    ...(kind === "deadline" ? { timeoutMs: 0 } : {}),
+  });
+  if (kind === "retry") {
+    const held = await pending;
+    await expect(held.verifyStillHeld()).resolves.toBe(true);
+    await held.release();
+  } else await expect(pending).rejects.toMatchObject({ code: "file_lock_timeout" });
+  expect(descriptor?.fd).toBe(-1);
+  expect(manager.heldEntries()).toEqual([]);
+  if (kind === "replacement") await expect(fs.readFile(lockPath, "utf8")).resolves.toBe('{"owner":"replacement"}');
+  else await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+posix("creator cleanup retains its token when a later stat fails over a replacement", async () => {
+  const capability = await root(await tempRoot("sidecar-creator-cleanup-"));
+  const target = path.join(capability.rootReal, "state"), lockPath = `${target}.lock`;
+  const manager = createFileLockManager(`creator-cleanup:${target}`);
+  const open = capability.open.bind(capability);
+  const failure = Object.assign(new Error("admission stat failure"), { code: "EIO" });
+  let descriptor: FileHandle | undefined;
+  vi.spyOn(capability, "open").mockImplementationOnce(async (...args) => {
+    const opened = await open(...args);
+    descriptor = opened.handle;
+    const stat = opened.handle.stat.bind(opened.handle);
+    vi.spyOn(opened.handle, "stat").mockImplementationOnce(async () => {
+      await fs.rename(lockPath, `${lockPath}.displaced`);
+      await fs.writeFile(lockPath, '{"owner":"replacement"}');
+      throw failure;
+    }).mockImplementation(stat);
+    return opened;
+  });
+  await expect(manager.acquire(target, { lockRoot: capability, payload: () => ({ owner: "creator" }) })).rejects.toBe(failure);
+  expect(descriptor?.fd).toBe(-1);
+  expect(manager.heldEntries()).toEqual([]);
+  await expect(fs.readFile(lockPath, "utf8")).resolves.toBe('{"owner":"replacement"}');
+  expect(JSON.parse(await fs.readFile(`${lockPath}.displaced`, "utf8"))).toEqual({ owner: "creator" });
+});

--- a/test/sidecar-lock-root-ancestry.test.ts
+++ b/test/sidecar-lock-root-ancestry.test.ts
@@ -1,0 +1,99 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createFileLockManager } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { readSidecarLockSnapshot } from "../src/sidecar-lock-reclaim.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => {
+  __setFsSafeTestHooksForTest();
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+});
+
+it.skipIf(process.platform === "win32")("rechecks ancestors even when the immediate parent inode is preserved", async () => {
+  const capability = await root(await tempRoot("sidecar-ancestor-swap-"));
+  const relative = "ancestor/parent/state.lock", lockPath = path.join(capability.rootReal, relative);
+  await capability.create(relative, "{}");
+  __setFsSafeTestHooksForTest({ async afterOpenedPathIdentityCheck(candidate) {
+    if (candidate !== lockPath) return;
+    __setFsSafeTestHooksForTest();
+    await fs.unlink(lockPath);
+    const ancestor = path.join(capability.rootReal, "ancestor");
+    await fs.rename(ancestor, `${ancestor}.old`);
+    await fs.mkdir(ancestor);
+    await fs.rename(`${ancestor}.old/parent`, `${ancestor}/parent`);
+  } });
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+    .rejects.toMatchObject({ code: "path-mismatch" });
+});
+
+it.skipIf(process.platform === "win32")("permits an unchanged canonical parent reached through an in-root symlink", async () => {
+  const capability = await root(await tempRoot("sidecar-parent-alias-"), { symlinks: "follow-within-root" });
+  await capability.mkdir("actual");
+  await fs.symlink("actual", path.join(capability.rootReal, "alias"));
+  const lockPath = path.join(capability.rootReal, "alias/state.lock");
+  await capability.create("actual/state.lock", "{}");
+  __setFsSafeTestHooksForTest({ async afterOpenedPathIdentityCheck(candidate) {
+    if (candidate !== lockPath) return;
+    __setFsSafeTestHooksForTest();
+    await fs.unlink(lockPath);
+  } });
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true })).resolves.toBeNull();
+  const manager = createFileLockManager(`alias:${lockPath}`);
+  const held = await manager.acquire(path.join(capability.rootReal, "state"), {
+    lockRoot: capability, lockPath, payload: () => ({}),
+  });
+  await expect(held.verifyStillHeld()).resolves.toBe(true);
+  await held.release();
+});
+
+it.each(["numeric", "unknown", "changed", "EACCES", "EIO"])("rejects %s canonical directory reinspection", async (kind) => {
+  const capability = await root(await tempRoot("sidecar-directory-evidence-"));
+  const lockPath = path.join(capability.rootReal, "parent/state.lock"), parent = path.dirname(lockPath);
+  await capability.create("parent/state.lock", "{}");
+  __setFsSafeTestHooksForTest({ async afterOpenedPathIdentityCheck(candidate) {
+    if (candidate !== lockPath) return;
+    __setFsSafeTestHooksForTest();
+    await fs.unlink(lockPath);
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const lstat = fs.lstat.bind(fs);
+    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      const value = await lstat(...args);
+      if (String(args[0]) === parent && typeof args[1] === "object" && args[1]?.bigint) {
+        if (kind === "EACCES" || kind === "EIO") throw Object.assign(new Error("directory failure"), { code: kind });
+        Object.assign(value, { ino: kind === "numeric" ? Number(value.ino) : kind === "unknown" ? 0n : BigInt(value.ino) + 1n });
+      }
+      return value;
+    });
+  } });
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+    .rejects.toMatchObject({ code: "path-mismatch" });
+});
+
+it.each(["EACCES", "EIO"])("does not treat initial directory %s as missing-parent evidence", async (code) => {
+  const capability = await root(await tempRoot("sidecar-parent-denial-"));
+  const lockPath = path.join(capability.rootReal, "state.lock");
+  await capability.create("state.lock", "{}");
+  const failure = Object.assign(new Error("directory failure"), { code });
+  const lstat = fs.lstat.bind(fs), open = vi.spyOn(capability, "open");
+  vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    if (String(args[0]) === capability.rootReal && typeof args[1] === "object" && args[1]?.bigint) throw failure;
+    return await lstat(...args);
+  });
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true })).rejects.toBe(failure);
+  expect(open).not.toHaveBeenCalled();
+});
+
+it("creates missing parents without inventing an earlier directory receipt", async () => {
+  const capability = await root(await tempRoot("sidecar-missing-parent-"));
+  const target = path.join(capability.rootReal, "state"), lockPath = path.join(capability.rootReal, "new/parent/state.lock");
+  const manager = createFileLockManager(`missing:${target}`);
+  const held = await manager.acquire(target, { lockRoot: capability, lockPath, payload: () => ({}) });
+  await expect(held.verifyStillHeld()).resolves.toBe(true);
+  await held.release();
+});

--- a/test/sidecar-lock-root-budget.test.ts
+++ b/test/sidecar-lock-root-budget.test.ts
@@ -1,0 +1,50 @@
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createFileLockManager } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+afterEach(() => { __setFsSafeTestHooksForTest(); vi.restoreAllMocks(); });
+
+it.each(["missing", "unlinked", "replacement"])("charges every discarded %s snapshot to retry and deadline limits", async (kind) => {
+  for (const deadline of [false, true]) {
+    const capability = await root(await tempRoot("sidecar-snapshot-budget-"));
+    const target = path.join(capability.rootReal, "state"), lockPath = `${target}.lock`;
+    const manager = createFileLockManager(`snapshot-budget:${target}`);
+    const create = vi.spyOn(capability, "create");
+    const open = capability.open.bind(capability);
+    const descriptors: FileHandle[] = [];
+    let now = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    vi.spyOn(capability, "open").mockImplementation(async (...args) => {
+      if (kind === "missing") {
+        await fs.unlink(lockPath);
+        now += 10;
+      } else {
+        __setFsSafeTestHooksForTest({ async afterOpen(candidate, handle) {
+          if (candidate !== lockPath) return;
+          __setFsSafeTestHooksForTest();
+          descriptors.push(handle);
+          await fs.unlink(lockPath);
+          if (kind === "replacement") await fs.writeFile(lockPath, '{"owner":"replacement"}');
+          now += 10;
+        } });
+      }
+      return await open(...args);
+    });
+    await expect(manager.acquire(target, {
+      lockRoot: capability,
+      payload: async () => { await fs.writeFile(lockPath, '{"owner":"other"}'); return {}; },
+      retry: { retries: 2, minTimeout: 0, maxTimeout: 0 },
+      ...(deadline ? { timeoutMs: 10 } : {}),
+    })).rejects.toMatchObject({ code: "file_lock_timeout" });
+    expect(create).toHaveBeenCalledTimes(deadline ? 1 : 3);
+    expect(descriptors.every((handle) => handle.fd === -1)).toBe(true);
+    expect(manager.heldEntries()).toEqual([]);
+    if (kind === "replacement") await expect(fs.readFile(lockPath, "utf8")).resolves.toContain("replacement");
+    vi.restoreAllMocks();
+  }
+});

--- a/test/sidecar-lock-root-resolver.test.ts
+++ b/test/sidecar-lock-root-resolver.test.ts
@@ -1,0 +1,200 @@
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { FsSafeError } from "../src/errors.js";
+import { createFileLockManager } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { readSidecarLockSnapshot } from "../src/sidecar-lock-reclaim.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => {
+  __setFsSafeTestHooksForTest();
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+});
+
+it.each(["EPERM", "EBADF"])("retries the recorded Windows resolver %s only with inspectable unlink evidence", async (code) => {
+  const capability = await root(await tempRoot("sidecar-windows-resolver-"));
+  const target = path.join(capability.rootReal, "state"), lockPath = `${target}.lock`;
+  const ownerManager = createFileLockManager(`resolver-owner:${target}`);
+  const waiterManager = createFileLockManager(`resolver-waiter:${target}`);
+  const owner = await ownerManager.acquire(target, { lockRoot: capability, payload: () => ({ owner: 1 }) });
+  const failure = Object.assign(new Error("recorded resolver failure"), {
+    code, syscall: code === "EPERM" ? "stat" : "realpath", path: "C:\\$Extend\\$Deleted\\record",
+  });
+  const open = capability.open.bind(capability);
+  let descriptor: FileHandle | undefined;
+  const parsePayload = vi.fn(JSON.parse);
+  vi.spyOn(capability, "open").mockImplementationOnce(async (...args) => {
+    __setFsSafeTestHooksForTest({ async afterOpenedPathIdentityCheck(candidate, handle) {
+      if (candidate !== lockPath) return;
+      __setFsSafeTestHooksForTest();
+      descriptor = handle;
+      await owner.release();
+      expect((await handle.stat({ bigint: true })).nlink).toBe(0n);
+      Object.defineProperty(process, "platform", { value: "win32" });
+      const realpath = fs.realpath.bind(fs), stat = fs.stat.bind(fs);
+      vi.spyOn(fs, "realpath").mockImplementation(async (...values) => {
+        if (String(values[0]) === lockPath) {
+          if (code === "EBADF") throw failure;
+          return failure.path;
+        }
+        return await realpath(...values);
+      });
+      vi.spyOn(fs, "stat").mockImplementation(async (...values) => {
+        if (String(values[0]) === failure.path) throw failure;
+        return await stat(...values);
+      });
+    } });
+    try { return await open(...args); } finally {
+      Object.defineProperty(process, "platform", platform);
+      vi.mocked(fs.realpath).mockRestore();
+      vi.mocked(fs.stat).mockRestore();
+    }
+  });
+  const waiter = await waiterManager.acquire(target, {
+    lockRoot: capability, payload: () => ({ owner: 2 }), parsePayload,
+    retry: { retries: 1, minTimeout: 0, maxTimeout: 0 },
+  });
+  expect(parsePayload).not.toHaveBeenCalled();
+  expect(descriptor?.fd).toBe(-1);
+  await expect(waiter.verifyStillHeld()).resolves.toBe(true);
+  await waiter.release();
+  expect(waiterManager.heldEntries()).toEqual([]);
+});
+
+it.each(["numeric", "unknown", "closed", "changed", "linked", "multiple-links"])(
+  "rejects Windows resolver failures with %s descriptor evidence", async (control) => {
+    const capability = await root(await tempRoot("sidecar-resolver-control-"));
+    const lockPath = path.join(capability.rootReal, "state.lock");
+    await capability.create("state.lock", "{}");
+    const failure = Object.assign(new Error("resolver failed"), { code: "EBADF" });
+    let descriptor: FileHandle | undefined;
+    __setFsSafeTestHooksForTest({
+      async afterOpen(candidate) {
+        if (candidate === lockPath && control === "multiple-links") await fs.link(lockPath, `${lockPath}.link`);
+      },
+      async afterOpenedPathIdentityCheck(candidate, handle) {
+        if (candidate !== lockPath) return;
+        descriptor = handle;
+        __setFsSafeTestHooksForTest();
+        if (control === "linked") await fs.rename(lockPath, `${lockPath}.moved`);
+        else await fs.unlink(lockPath);
+        if (control === "multiple-links") await fs.unlink(`${lockPath}.link`);
+        if (control === "closed") await handle.close();
+        if (["numeric", "unknown", "changed"].includes(control)) {
+          const stat = handle.stat.bind(handle);
+          vi.spyOn(handle, "stat").mockImplementation(async (options) => {
+            const value = await stat(options);
+            if (options?.bigint) Object.assign(value, {
+              ino: control === "numeric" ? Number(value.ino) : control === "unknown" ? 0n : BigInt(value.ino) + 1n,
+            });
+            return value;
+          });
+        }
+        Object.defineProperty(process, "platform", { value: "win32" });
+        const realpath = fs.realpath.bind(fs);
+        vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+          if (String(args[0]) === lockPath) throw failure;
+          return await realpath(...args);
+        });
+      },
+    });
+    await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true })).rejects.toBe(failure);
+    expect(descriptor?.fd).toBe(-1);
+  },
+);
+
+it.each(["beforeOpen", "afterOpen", "afterOpenedPathIdentityCheck"] as const)(
+  "preserves %s hook exceptions even after unlink", async (hook) => {
+    for (const failure of [new FsSafeError("not-found", "caller failure"),
+      Object.assign(new Error("caller failure"), { code: "ENOENT" }),
+      Object.assign(new Error("caller failure"), { code: "EPERM" })]) {
+      const capability = await root(await tempRoot("sidecar-hook-error-"));
+      const lockPath = path.join(capability.rootReal, "state.lock");
+      await capability.create("state.lock", "{}");
+      let descriptor: FileHandle | undefined;
+      __setFsSafeTestHooksForTest({ [hook]: async (candidate: string, handle: FileHandle) => {
+        if (candidate !== lockPath) return;
+        descriptor = typeof handle === "object" ? handle : undefined;
+        __setFsSafeTestHooksForTest();
+        await fs.unlink(lockPath);
+        throw failure;
+      } });
+      await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+        .rejects.toBe(failure);
+      if (descriptor) expect(descriptor.fd).toBe(-1);
+    }
+  },
+);
+
+it.each(["parser", "read", "stat"])("does not retry a Windows %s exception shaped like an open denial", async (stage) => {
+  const capability = await root(await tempRoot("sidecar-read-error-"));
+  const lockPath = path.join(capability.rootReal, "state.lock");
+  await capability.create("state.lock", "{}");
+  const failure = Object.assign(new Error("caller failure"), { code: "EPERM", path: lockPath, syscall: "open" });
+  const create = vi.spyOn(capability, "create").mockRejectedValue(new FsSafeError("already-exists", "exists"));
+  const parsePayload = vi.fn(() => { throw failure; });
+  if (stage !== "parser") __setFsSafeTestHooksForTest({ afterOpen(candidate, handle) {
+    if (candidate === lockPath) vi.spyOn(handle, stage).mockRejectedValue(failure);
+  } });
+  Object.defineProperty(process, "platform", { value: "win32" });
+  const manager = createFileLockManager(`read-error:${lockPath}`);
+  await expect(manager.acquire(path.join(capability.rootReal, "state"), {
+    lockRoot: capability, payload: () => ({}), parsePayload,
+    retry: { retries: 20, minTimeout: 0, maxTimeout: 0 },
+  })).rejects.toBe(failure);
+  expect(create).toHaveBeenCalledTimes(1);
+  expect(parsePayload).toHaveBeenCalledTimes(stage === "parser" ? 1 : 0);
+});
+
+it.each([false, true])("parser ENOENT remains a caller error (Root: %s)", async (bounded) => {
+  const capability = await root(await tempRoot("sidecar-parser-missing-"));
+  const lockPath = path.join(capability.rootReal, "state.lock");
+  await capability.create("state.lock", "{}");
+  const failure = Object.assign(new Error("parser failure"), { code: "ENOENT" });
+  await expect(readSidecarLockSnapshot(lockPath, {
+    ...(bounded ? { lockRoot: capability } : {}),
+    discardUnlinked: true, parsePayload: () => { throw failure; },
+  })).rejects.toBe(failure);
+});
+
+it.each(["EPERM", "EBADF"])("generic Root.open preserves the Windows resolver %s and closes its unlinked fd", async (code) => {
+  const capability = await root(await tempRoot("root-resolver-strict-"));
+  const lockPath = path.join(capability.rootReal, "state.lock");
+  await capability.create("state.lock", "{}");
+  const failure = Object.assign(new Error("resolver failure"), { code });
+  let descriptor: FileHandle | undefined;
+  __setFsSafeTestHooksForTest({ async afterOpenedPathIdentityCheck(candidate, handle) {
+    if (candidate !== lockPath) return;
+    descriptor = handle;
+    __setFsSafeTestHooksForTest();
+    await fs.unlink(lockPath);
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const realpath = fs.realpath.bind(fs);
+    vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+      if (String(args[0]) === lockPath) throw failure;
+      return await realpath(...args);
+    });
+  } });
+  await expect(capability.open("state.lock")).rejects.toBe(failure);
+  expect(descriptor?.fd).toBe(-1);
+});
+
+it("ordinary snapshot reads do not discard failed descriptor observations", async () => {
+  const capability = await root(await tempRoot("sidecar-held-read-strict-"));
+  const lockPath = path.join(capability.rootReal, "state.lock");
+  await capability.create("state.lock", "{}");
+  const parsePayload = vi.fn(JSON.parse);
+  __setFsSafeTestHooksForTest({ async afterOpenedPathIdentityCheck(candidate) {
+    if (candidate !== lockPath) return;
+    __setFsSafeTestHooksForTest();
+    await fs.unlink(lockPath);
+  } });
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, parsePayload }))
+    .rejects.toMatchObject({ code: "path-mismatch" });
+  expect(parsePayload).not.toHaveBeenCalled();
+});

--- a/test/sidecar-lock-root-unlink.test.ts
+++ b/test/sidecar-lock-root-unlink.test.ts
@@ -1,0 +1,152 @@
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createFileLockManager } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+afterEach(() => {
+  __setFsSafeTestHooksForTest();
+  vi.restoreAllMocks();
+});
+
+// Intercept the actual descriptor resolver; all identities come from the filesystem.
+function atFdResolution(lockPath: string, mutate: (handle: FileHandle) => Promise<void>) {
+  let opened: FileHandle | undefined;
+  let fired = false;
+  let mutation: Promise<void> | undefined;
+  const realpath = fs.realpath.bind(fs);
+  const wrapper = vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+    const candidate = String(args[0]);
+    if (!fired && opened && (candidate === `/dev/fd/${opened.fd}` || candidate === `/proc/self/fd/${opened.fd}`)) {
+      fired = true;
+      __setFsSafeTestHooksForTest();
+      mutation = mutate(opened);
+      await mutation;
+    }
+    return await realpath(...args);
+  });
+  __setFsSafeTestHooksForTest({
+    afterOpen(candidate, handle) {
+      if (candidate === lockPath && !opened) opened = handle;
+    },
+  });
+  return {
+    get opened() { return opened; },
+    get fired() { return fired; },
+    async join() { await mutation; },
+    restore() { wrapper.mockRestore(); __setFsSafeTestHooksForTest(); },
+  };
+}
+
+it.skipIf(process.platform === "win32").each(["snapshot"] as const)(
+  "completed owner release permits successor at %s FD resolution",
+  async (phase) => {
+    const capability = await root(await tempRoot("sidecar-discovery-"));
+    const target = path.join(capability.rootReal, "state");
+    const relative = "state.lock";
+    const lockPath = path.join(capability.rootReal, relative);
+    const ownerManager = createFileLockManager(`discovery-owner:${target}`);
+    const waiterManager = createFileLockManager(`discovery-waiter:${target}`);
+    const shouldReclaim = vi.fn(() => false);
+    const options = { lockRoot: capability, lockPath, shouldReclaim, retry: { retries: 1, minTimeout: 0, maxTimeout: 0 } };
+    const owner = await ownerManager.acquire(target, { ...options, payload: () => ({ owner: "original" }) });
+    const ownerRaw = await fs.readFile(lockPath, "utf8");
+    const events: string[] = [];
+    let gate: ReturnType<typeof atFdResolution> | undefined;
+    const mutate = async (handle: FileHandle) => {
+      const descriptor = await handle.stat({ bigint: true });
+      const pathname = await fs.lstat(lockPath, { bigint: true });
+      expect([descriptor.dev, descriptor.ino]).toEqual([pathname.dev, pathname.ino]);
+      events.push("descriptor-and-path-match-at-fd-resolver");
+      await owner.release();
+      events.push("owner-release-joined");
+      await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+      expect((await handle.stat({ bigint: true })).nlink).toBe(0n);
+      expect(ownerManager.heldEntries()).toHaveLength(0);
+      events.push("pathname-absent-descriptor-nlink-zero");
+    };
+    const realCreate = capability.create.bind(capability);
+    vi.spyOn(capability, "create").mockImplementation(async (...args) => {
+      try {
+        await realCreate(...args);
+        events.push("create-succeeded");
+      } catch (error) {
+        events.push(`create:${(error as { code: string }).code}`);
+        throw error;
+      }
+    });
+    const realOpen = capability.open.bind(capability);
+    vi.spyOn(capability, "open").mockImplementation(async (...args) => {
+      if (phase === "snapshot" && !gate) {
+        expect(events).toEqual(["create:already-exists"]);
+        gate = atFdResolution(lockPath, mutate);
+      }
+      return await realOpen(...args);
+    });
+    const result = await waiterManager.acquire(target, { ...options, payload: () => ({ owner: "waiter" }) })
+      .then((handle) => ({ handle, error: undefined }), (error: unknown) => ({ handle: undefined, error }));
+    try {
+      await gate?.join();
+      expect(gate?.fired).toBe(true);
+      expect(gate?.opened?.fd).toBe(-1);
+      console.log(JSON.stringify({ phase, events, error: result.error && {
+        name: (result.error as Error).name,
+        code: (result.error as { code: string }).code,
+        message: (result.error as Error).message,
+      }, closed: gate?.opened?.fd === -1 }));
+      expect(result.error).toBeUndefined();
+      expect(result.handle).toBeDefined();
+      expect(shouldReclaim).not.toHaveBeenCalled();
+      const raw = await fs.readFile(lockPath, "utf8");
+      expect(JSON.parse(raw)).toEqual({ owner: "waiter" });
+      expect(raw).not.toBe(ownerRaw);
+      await expect(result.handle!.verifyStillHeld()).resolves.toBe(true);
+    } finally {
+      gate?.restore();
+      await result.handle?.release();
+      await owner.release();
+      await ownerManager.drain();
+      await waiterManager.drain();
+      expect(waiterManager.heldEntries()).toHaveLength(0);
+      await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  },
+);
+
+it("owner release during create-only preflight needs no existing-file descriptor", async () => {
+  const capability = await root(await tempRoot("sidecar-create-preflight-"));
+  const target = path.join(capability.rootReal, "state"), lockPath = `${target}.lock`;
+  const ownerManager = createFileLockManager(`preflight-owner:${target}`);
+  const waiterManager = createFileLockManager(`preflight-waiter:${target}`);
+  const owner = await ownerManager.acquire(target, { lockRoot: capability, payload: () => ({ owner: 1 }) });
+  let fired = false;
+  const open = vi.fn();
+  __setFsSafeTestHooksForTest({ afterOpen: open });
+  const stat = fs.stat.bind(fs);
+  vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
+    const result = await stat(...args);
+    if (String(args[0]) === lockPath && !fired) {
+      fired = true;
+      expect(open).not.toHaveBeenCalled();
+      __setFsSafeTestHooksForTest();
+      await owner.release();
+    }
+    return result;
+  });
+  const waiter = await waiterManager.acquire(target, {
+    lockRoot: capability, payload: () => ({ owner: 2 }), shouldReclaim: () => false,
+    retry: { retries: 1, minTimeout: 0, maxTimeout: 0 },
+  });
+  try {
+    expect(fired).toBe(true);
+    await expect(waiter.verifyStillHeld()).resolves.toBe(true);
+  } finally {
+    await waiter.release();
+    await owner.release();
+  }
+  expect(ownerManager.heldEntries()).toEqual([]);
+  expect(waiterManager.heldEntries()).toEqual([]);
+});

--- a/test/sidecar-lock-unlink-siblings.test.ts
+++ b/test/sidecar-lock-unlink-siblings.test.ts
@@ -1,0 +1,100 @@
+import fsSync from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { acquireFileLockSync, createFileLockManager } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const posix = it.skipIf(process.platform === "win32");
+afterEach(() => { vi.restoreAllMocks(); });
+
+posix("non-Root async snapshot hands off after the owner unlinks its opened record", async () => {
+  const directory = await fs.realpath(await tempRoot("sidecar-unlink-async-"));
+  const target = path.join(directory, "state");
+  const lockPath = `${target}.lock`;
+  const ownerManager = createFileLockManager(`sibling-owner:${target}`);
+  const waiterManager = createFileLockManager(`sibling-waiter:${target}`);
+  const shouldReclaim = vi.fn(() => false);
+  const owner = await ownerManager.acquire(target, { payload: () => ({ owner: "original" }) });
+  const realOpen = fs.open.bind(fs);
+  let opened: FileHandle | undefined;
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await realOpen(...args);
+    if (String(args[0]) === lockPath && !opened) {
+      opened = handle;
+      const before = await fs.lstat(lockPath, { bigint: true });
+      const descriptor = await handle.stat({ bigint: true });
+      expect([descriptor.dev, descriptor.ino]).toEqual([before.dev, before.ino]);
+      await owner.release();
+      expect(ownerManager.heldEntries()).toEqual([]);
+      await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+      expect((await handle.stat({ bigint: true })).nlink).toBe(0n);
+    }
+    return handle;
+  });
+  const waiter = await waiterManager.acquire(target, {
+    payload: () => ({ owner: "waiter" }), shouldReclaim,
+    retry: { retries: 1, minTimeout: 0, maxTimeout: 0 },
+  });
+  try {
+    expect(opened?.fd).toBe(-1);
+    expect(shouldReclaim).not.toHaveBeenCalled();
+    await expect(waiter.verifyStillHeld()).resolves.toBe(true);
+    expect(JSON.parse(await fs.readFile(lockPath, "utf8"))).toEqual({ owner: "waiter" });
+  } finally {
+    await waiter.release();
+    await owner.release();
+    await ownerManager.drain();
+    await waiterManager.drain();
+  }
+  await expect(fs.lstat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+posix.each([false, true])("sync snapshot hands off an unlinked descriptor (lockRoot: %s)", async (bounded) => {
+  const capability = await root(await tempRoot("sidecar-unlink-sync-"));
+  const target = path.join(capability.rootReal, "state");
+  const lockPath = `${target}.lock`;
+  const options = { lockPath, ...(bounded ? { lockRoot: capability } : {}) };
+  // Distinct logical targets sharing an explicit sidecar exercise filesystem
+  // arbitration, rather than the sync manager's known-live-holder short circuit.
+  const owner = acquireFileLockSync(`${target}.owner`, { ...options, payload: () => ({ owner: "original" }) });
+  const shouldReclaim = vi.fn(() => false);
+  let snapshotFd: number | undefined;
+  let snapshotClosed = false;
+  const realClose = fsSync.closeSync.bind(fsSync);
+  vi.spyOn(fsSync, "closeSync").mockImplementation((fd) => {
+    realClose(fd);
+    if (fd === snapshotFd) snapshotClosed = true;
+  });
+  const realOpen = fsSync.openSync.bind(fsSync);
+  vi.spyOn(fsSync, "openSync").mockImplementation((...args) => {
+    const fd = realOpen(...args);
+    if (String(args[0]) === lockPath && snapshotFd === undefined) {
+      snapshotFd = fd;
+      const before = fsSync.lstatSync(lockPath, { bigint: true });
+      const descriptor = fsSync.fstatSync(fd, { bigint: true });
+      expect([descriptor.dev, descriptor.ino]).toEqual([before.dev, before.ino]);
+      owner.release();
+      expect(() => fsSync.lstatSync(lockPath)).toThrow(expect.objectContaining({ code: "ENOENT" }));
+      expect(fsSync.fstatSync(fd, { bigint: true }).nlink).toBe(0n);
+    }
+    return fd;
+  });
+  const waiter = acquireFileLockSync(target, {
+    ...options, payload: () => ({ owner: "waiter" }), shouldReclaim,
+    retry: { retries: 1, minTimeout: 0, maxTimeout: 0 },
+  });
+  try {
+    expect(snapshotFd).toBeDefined();
+    expect(snapshotClosed).toBe(true);
+    expect(shouldReclaim).not.toHaveBeenCalled();
+    expect(waiter.verifyStillHeld()).toBe(true);
+    expect(JSON.parse(fsSync.readFileSync(lockPath, "utf8"))).toEqual({ owner: "waiter" });
+  } finally {
+    waiter.release();
+    owner.release();
+  }
+  expect(() => fsSync.lstatSync(lockPath)).toThrow(expect.objectContaining({ code: "ENOENT" }));
+});


### PR DESCRIPTION
## Summary

Fix the four failures found by fresh installed-consumer testing of published 0.7.0: Root-backed async lock handoffs, synchronous stale classification, synchronous failed-release retries, and native selected ZIP entry size verification. Also fix the Windows sync-lock canonicalization and open-denial gaps exposed by the new real-process proof, and clarify the TAR error-code wording found during validation.

Production source is **342 lines added / 120 deleted / net +222** across `src/` and `native/src/`. ZIP and sync fixes account for net +57; the remaining growth is the bounded async observation/ownership path. Most of the overall diff is deterministic regression coverage and a standalone cross-process proof. No new public API, dependency, version bump, or publication is included.

## Ownership and safety

Create-only Root preflight no longer opens an existing file merely to inherit a mode it cannot use. Boundary, alias, hardlink and type checks remain. Failed opened-file observations during async acquisition may be discarded only with operation-specific provenance, an inspectable exact-identity unlinked descriptor, and rechecked canonical ancestry. Discarding is not proof of pathname absence and provides no release/reclaim authority; a fresh exclusive creation is still required, and retry/deadline budgets apply. Generic Root reads, moved-but-linked/unknown descriptors, changed ancestry and caller errors remain strict.

Post-create admission compares the original serialized bytes/token before registering a holder. Cleanup retains that creator receipt rather than adopting a replacement's stat. Sync staleness uses the validated snapshot mtime, and failed sync release keeps its final reference and cleanup receipt. Descriptor ownership is consumed before close, since a failed close can already have freed the number; retry cannot close an unrelated reused descriptor.

Windows sync parent canonicalization now agrees with Root, including 8.3 short-name expansion. Open-denial retries reuse the existing eight-denial cap, are scoped to actual lock-file opens, consume caller budgets, and preserve the original error on exhaustion. Missing or changed snapshots also consume retry budgets; parser/read/stat errors are not disguised as missing paths. Held verification, release and reclaim remain strict. The previous test expecting an ordinary valid Windows Root-sync acquisition to fail was replaced with successful default/explicit path and reentrant-identity checks, retaining outside-root/junction/error controls.

The native ZIP reader verifies decoded length after its existing bounded, CRC-checking read. Both short and long declared-size mismatches reject; valid data, CRC rejection and byte caps remain unchanged.

## Executed before/after behavior

Published-package runs captured Root async `path-mismatch`/Windows resolver failures, false sync `file_lock_stale`, a sync release retry leaving its sidecar after `EACCES`, and native ZIP reads accepting 16 decoded bytes declared as 1 or 100. The first PR CI run exposed Windows Root-sync `outside-workspace`; a separate Windows VM also reproduced sync acquisition `EPERM`. These failures were corrected rather than skipped or hidden by longer timeouts.

The final candidate was built and packed, then installed into a fresh Linux consumer with its freshly built binding. Installed binding bytes were verified against the build; neither workspace links nor the old registry binding substituted for it. The unchanged public reproductions passed in separate `off`, `auto`, and `require` processes. Actual final output:

```json
{"proof":"fixed-installed-consumer","scenarios":18,"passed":true,"node":"v24.20.0","platform":"linux","arch":"x64"}
```

This gate asserts all four pathname/Root × async/sync lock combinations with four processes and 100 acquisitions per case, actual permission-failure release retry, stored/deflated ZIPs declaring 1/16/100 bytes, valid payload contents, CRC rejection, and enforced byte caps. A second built-public-API proof keeps children alive until final sidecar absence is checked, so process-exit cleanup cannot hide a broken release. Together the two final Linux proofs completed **2,400 contended acquisitions** across all three modes, plus release-retry controls.

The actual Windows short-path probe changed from:

```json
{"proof":"windows-root-canonicalization","shortDiffersFromLong":true,"legacyMatchesRoot":false,"nativeMatchesRoot":true,"acquired":false,"error":"outside-workspace"}
```

To:

```json
{"proof":"windows-root-canonicalization","shortDiffersFromLong":true,"legacyMatchesRoot":false,"nativeMatchesRoot":true,"defaultAndExplicitPassed":true,"reentrantAliasPassed":true}
```

Windows focused source tests passed **103 tests**, with one POSIX permission test skipped. The final built-source and fresh installed-consumer proofs passed **2,400 contended acquisitions** across `off`, `auto`, and `require`, plus the actual short-path/default-path/explicit-path/reentrant checks above. This dedicated Windows lane uses the published binding only for the unchanged lock ABI; it is not proof of the Rust ZIP change. Hosted native CI builds the new Windows binding for that coverage. An initial source-proof setup omitted the binding from the workspace package; installing it in the normal resolution location and verifying its bytes corrected the harness without changing source.

## Validation

- `pnpm check`: **6,274 passed, 81 skipped**; 178 test files passed, one skipped.
- `pnpm native:test`: **63 passed** on Linux x64.
- `pnpm test:security`: **78 passed**.
- New regression selection with `FS_SAFE_NATIVE_MODE=require`: **150 passed**.
- `node scripts/sidecar-contention-proof.mjs off`, `auto`, and `require`: final Linux runs passed.
- `pnpm package:smoke`: root-only npm 11.19.0 and pnpm 11.24.0 consumers passed native selection, missing-binary fallback and omitted-optionals cases. Foreign-platform filtering fixtures are explicitly synthetic; they are not foreign execution proof.
- Source size/boundary checks, documentation checks, build, and `git diff --check`: passed.
- Fresh complete-candidate Codex autoreview: scoped-clean at the configured P0 threshold, no accepted/actionable findings.

Production/package proof tree: `939dd9f6771449e6be7f60773a3b72580c612615`. Final PR head: `cce3a4059da04cdbc1c6e55f10fedec21e82da7c`, tree `6e8f6bd58f43eb3d6684b2e0051385dd3481bbdf`. The final commit changes only the test fixture: Windows inode numbers can round away `ino + 1`, so the regression now supplies explicit distinct nonzero identities. All production/package inputs remain byte-identical, verified by Git diff; the corrected Windows suite again passed 103 tests and fixture-only Codex autoreview is scoped-clean. The local host was heavily contended, so the authoritative combined gate ran on isolated Linux instead of raising test timeouts.

CI explicitly includes the ZIP integrity regression and Root admission tests in native selections, plus real contention proof on fallback Node 24 and native Linux/macOS/Windows/musl jobs. Hosted exact-head validation is required before merge; this body does not claim pending jobs have passed.

## Packaged Windows authority-chain proof

The final installed Windows consumer also exercised the precise forbidden effect requested by review, in separate `off`, `auto`, and `require` processes. A wrapper around the public Root `open()` method schedules a **real rename and exclusive replacement-file creation after creator publication but before admission**. No filesystem error is injected in this replacement case. The acquisition returns `path-mismatch`, the opened descriptor is closed, the manager has zero held entries, and both replacement and displaced original remain byte-identical after acquisition cleanup and manager drain. An outside canary is preserved.

Separate synchronous controls explicitly inject one `EPERM` at the Node lock-file open call (controlled fault injection, not a claim of a naturally timed denial). They prove that success requires another real exclusive create. When a foreign replacement occupies the path, retries exhaust without a handle, a subsequent same-owner reentrant request still contends rather than inheriting hidden ownership, and replacement bytes survive. These runtime controls supplement—not replace—the naturally contended multi-process runs. The installed artifact integrity is checked before execution; the final head differs from its frozen production/package tree only in a nonpackaged test fixture.

Actual complete redacted terminal output:

```jsonl
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"off","case":"root-async-replacement-before-admission","scheduling":"public-Root-open-wrapper","filesystemMutation":"real-rename-and-exclusive-create","injectedFilesystemErrors":false,"rejected":"path-mismatch","heldRegistrations":0,"openedDescriptorClosed":true,"replacementPreservedAfterCleanup":true,"displacedOriginalPreserved":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"off","case":"pathname-sync-open-denial","injectedOpenDenials":1,"exclusiveCreateAttempts":2,"grantedOnlyAfterFreshExclusiveCreate":true,"verified":true,"released":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"off","case":"pathname-sync-denial-replacement-preservation","injectedSnapshotOpenDenials":1,"exclusiveCreateAttempts":2,"rejected":"file_lock_timeout","noReentrantHeldAuthority":true,"replacementBytesPreserved":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"off","case":"root-sync-open-denial","injectedOpenDenials":1,"exclusiveCreateAttempts":2,"grantedOnlyAfterFreshExclusiveCreate":true,"verified":true,"released":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"off","case":"root-sync-denial-replacement-preservation","injectedSnapshotOpenDenials":1,"exclusiveCreateAttempts":2,"rejected":"file_lock_timeout","noReentrantHeldAuthority":true,"replacementBytesPreserved":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"off","case":"summary","passed":true,"outsideCanaryPreserved":true,"packageIntegrity":"sha512-qhTAnHU8V9rmYphO3En5EwNgQJrh0jDysVRiaYkzN2uRgp4K2CtjhYKgWHCvOlXpU3NZVHhUMNTRvuOBf3ymVA==","nativeBindingScope":"published-0.7.0-lock-ABI-only"}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"auto","case":"root-async-replacement-before-admission","scheduling":"public-Root-open-wrapper","filesystemMutation":"real-rename-and-exclusive-create","injectedFilesystemErrors":false,"rejected":"path-mismatch","heldRegistrations":0,"openedDescriptorClosed":true,"replacementPreservedAfterCleanup":true,"displacedOriginalPreserved":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"auto","case":"pathname-sync-open-denial","injectedOpenDenials":1,"exclusiveCreateAttempts":2,"grantedOnlyAfterFreshExclusiveCreate":true,"verified":true,"released":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"auto","case":"pathname-sync-denial-replacement-preservation","injectedSnapshotOpenDenials":1,"exclusiveCreateAttempts":2,"rejected":"file_lock_timeout","noReentrantHeldAuthority":true,"replacementBytesPreserved":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"auto","case":"root-sync-open-denial","injectedOpenDenials":1,"exclusiveCreateAttempts":2,"grantedOnlyAfterFreshExclusiveCreate":true,"verified":true,"released":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"auto","case":"root-sync-denial-replacement-preservation","injectedSnapshotOpenDenials":1,"exclusiveCreateAttempts":2,"rejected":"file_lock_timeout","noReentrantHeldAuthority":true,"replacementBytesPreserved":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"auto","case":"summary","passed":true,"outsideCanaryPreserved":true,"packageIntegrity":"sha512-qhTAnHU8V9rmYphO3En5EwNgQJrh0jDysVRiaYkzN2uRgp4K2CtjhYKgWHCvOlXpU3NZVHhUMNTRvuOBf3ymVA==","nativeBindingScope":"published-0.7.0-lock-ABI-only"}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"require","case":"root-async-replacement-before-admission","scheduling":"public-Root-open-wrapper","filesystemMutation":"real-rename-and-exclusive-create","injectedFilesystemErrors":false,"rejected":"path-mismatch","heldRegistrations":0,"openedDescriptorClosed":true,"replacementPreservedAfterCleanup":true,"displacedOriginalPreserved":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"require","case":"pathname-sync-open-denial","injectedOpenDenials":1,"exclusiveCreateAttempts":2,"grantedOnlyAfterFreshExclusiveCreate":true,"verified":true,"released":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"require","case":"pathname-sync-denial-replacement-preservation","injectedSnapshotOpenDenials":1,"exclusiveCreateAttempts":2,"rejected":"file_lock_timeout","noReentrantHeldAuthority":true,"replacementBytesPreserved":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"require","case":"root-sync-open-denial","injectedOpenDenials":1,"exclusiveCreateAttempts":2,"grantedOnlyAfterFreshExclusiveCreate":true,"verified":true,"released":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"require","case":"root-sync-denial-replacement-preservation","injectedSnapshotOpenDenials":1,"exclusiveCreateAttempts":2,"rejected":"file_lock_timeout","noReentrantHeldAuthority":true,"replacementBytesPreserved":true}
{"proof":"windows-packaged-lock-authority","head":"cce3a4059da04cdbc1c6e55f10fedec21e82da7c","productionTree":"939dd9f6771449e6be7f60773a3b72580c612615","mode":"require","case":"summary","passed":true,"outsideCanaryPreserved":true,"packageIntegrity":"sha512-qhTAnHU8V9rmYphO3En5EwNgQJrh0jDysVRiaYkzN2uRgp4K2CtjhYKgWHCvOlXpU3NZVHhUMNTRvuOBf3ymVA==","nativeBindingScope":"published-0.7.0-lock-ABI-only"}
```

## Release boundary

Only `0.7.1 - Unreleased` notes change. Package versions remain 0.7.0, the dated 0.7.0 changelog remains byte-identical, and existing tag/npm/GitHub Release artifacts are untouched. These fixes are not a new npm release.
