### PR TITLE
fix(lock): keep callback errors out of acquisition retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.1 - Unreleased
 
+- Keep lock payload, serialization, and parsing failures outside acquisition retry handling, and scope Root failure receipts to each observation so historical errors cannot replay retry authority.
 - Retry Root-backed async lock handoffs with descriptor-proven, budgeted observation discard, including Windows unlink resolution failures; verify creator bytes before admission and preserve creator-token cleanup authority on failure.
 - Reject native selected ZIP entry reads whose decoded size differs from the declared uncompressed size, preserving byte caps and CRC verification.
 - Canonicalize Windows synchronous lock parents consistently with Root, bound lock-file open-denial and missing-snapshot retries, use captured snapshot age for staleness, and retain failed release cleanup for retry without double-decrementing references or re-closing a consumed descriptor.

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -94,6 +94,9 @@ type FileLockRetryOptions = {
 ```
 
 `payload` is a function so you can re-evaluate it on each retry (e.g. timestamp, PID).
+Errors thrown by `payload`, its JSON serialization (including `toJSON`), or
+`parsePayload` propagate unchanged without retrying the callback. Rethrowing an
+error saved from an earlier filesystem operation does not grant retry authority.
 Retry counts must be non-negative safe integers. Retry factors and delays must be finite and non-negative, and when both delay bounds are provided `minTimeout` cannot exceed `maxTimeout`. `timeoutMs` accepts a finite non-negative deadline or positive infinity for an unbounded wait; invalid numeric values reject before filesystem acquisition starts.
 `parsePayload` replaces JSON parsing for legacy or custom sidecars. Its `unknown`
 result is passed to `shouldReclaim` and `shouldRemoveStaleLock`, allowing PID,
@@ -173,6 +176,9 @@ exclusive creation. It supplies no release, reclaim, or held-lock authority.
 Generic `Root.open()` and held-owner/reclaim reads still reject failed opens.
 Moved but linked records, unknown or inexact identities, retargeted ancestors,
 and unrelated filesystem or caller errors fail closed.
+Failure receipts belong only to the current Root observation, including during
+nested or concurrent acquisitions; historical error identity is not unlink or
+open-denial evidence.
 
 After creating a record, the async Root-backed acquirer checks the reopened
 bytes against its exact serialized payload and ownership token. A replacement

--- a/src/file-lock-sync.ts
+++ b/src/file-lock-sync.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
-import { isFileOpenFailure, recordFileOpenFailure } from "./opened-file-failure.js";
 import type { Root } from "./root-impl.js";
 import {
   readSidecarLockSnapshotSync,
+  readSidecarLockRawSnapshotSync,
+  parseSidecarLockSnapshot,
   relativeSidecarLockPath,
   removeSidecarLockIfUnchangedSync,
   serializeSidecarLockPayload,
@@ -253,7 +254,7 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
     attempt += 1;
   };
   const retryLockFileDenial = (error: unknown): boolean => {
-    if (!isFileOpenFailure(error, lockPath) || !isTransientLockFileDenial(error, lockPath) ||
+    if (!isTransientLockFileDenial(error, lockPath) ||
       ++transientDenials > maxTransientLockDenials) return false;
     try {
       waitForRetry();
@@ -271,9 +272,10 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
       continue;
     }
     let fd: number | undefined;
+    const payload = options.payload();
+    const { raw, ownershipToken } = serializeSidecarLockPayload(payload);
+    let lockFileCreateDenied = false;
     try {
-      const payload = options.payload();
-      const { raw, ownershipToken } = serializeSidecarLockPayload(payload);
       const noFollow =
         process.platform !== "win32" && typeof fs.constants.O_NOFOLLOW === "number"
           ? fs.constants.O_NOFOLLOW
@@ -285,7 +287,8 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
           0o600,
         );
       } catch (error) {
-        recordFileOpenFailure(error, lockPath);
+        lockFileCreateDenied = isTransientLockFileDenial(error, lockPath);
+        throw error;
       }
       fs.writeFileSync(fd, raw, "utf8");
       fs.fsyncSync(fd);
@@ -332,19 +335,24 @@ export function acquireFileLockSync<TPayload extends Record<string, unknown>>(
         fd = undefined;
         removeSidecarLockIfUnchangedSync(lockPath, failed);
       }
-      if (retryLockFileDenial(error)) continue;
+      if (lockFileCreateDenied && retryLockFileDenial(error)) continue;
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
       if (heldLocks.has(normalizedTargetPath)) {
         waitForRetry();
         continue;
       }
-      let snapshot: SidecarLockSnapshot | null;
+      let rawSnapshot: ReturnType<typeof readSidecarLockRawSnapshotSync>;
+      let lockFileOpenDenied = false;
       try {
-        snapshot = readSidecarLockSnapshotSync(lockPath, options.parsePayload, { rejectNonFile: true });
+        rawSnapshot = readSidecarLockRawSnapshotSync(lockPath, {
+          rejectNonFile: true,
+          onOpenFailure: (error) => { lockFileOpenDenied = isTransientLockFileDenial(error, lockPath); },
+        });
       } catch (readError) {
-        if (retryLockFileDenial(readError)) continue;
+        if (lockFileOpenDenied && retryLockFileDenial(readError)) continue;
         throw readError;
       }
+      const snapshot = parseSidecarLockSnapshot(rawSnapshot, options.parsePayload);
       if (!snapshot) {
         waitForRetry();
         continue;

--- a/src/file-observation.ts
+++ b/src/file-observation.ts
@@ -1,0 +1,25 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+type FailureKind = "identity" | "resolution" | `open:${string}` | `unlinked:${string}`;
+const active = new AsyncLocalStorage<Map<unknown, Set<FailureKind>>>();
+
+export function recordFileObservationFailure(error: unknown, kind: FailureKind): void {
+  const failures = active.getStore();
+  if (!failures) return;
+  let kinds = failures.get(error);
+  if (!kinds) failures.set(error, kinds = new Set());
+  kinds.add(kind);
+}
+
+export function isFileObservationFailure(error: unknown, kind: FailureKind): boolean {
+  return active.getStore()?.get(error)?.has(kind) === true;
+}
+
+// Each Root observation owns its receipts, including nested and concurrent reads.
+export function fileObservation() {
+  const failures = new Map<unknown, Set<FailureKind>>();
+  return {
+    run<T>(operation: () => T): T { return active.run(failures, operation); },
+    has(error: unknown, kind: FailureKind): boolean { return failures.get(error)?.has(kind) === true; },
+  };
+}

--- a/src/opened-file-failure.ts
+++ b/src/opened-file-failure.ts
@@ -1,25 +1,18 @@
 import type { BigIntStats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
-import { inspectFileIdentity, isFileIdentityMismatch } from "./strict-file-identity.js";
-
-const resolutionFailures = new WeakSet<Error>();
-const openFailures = new WeakMap<Error, string>();
-const unlinkedFailures = new WeakMap<Error, string>();
+import { inspectFileIdentity } from "./strict-file-identity.js";
+import { isFileObservationFailure, recordFileObservationFailure } from "./file-observation.js";
 
 export function recordFileOpenFailure(error: unknown, filePath: string): never {
-  if (error instanceof Error) openFailures.set(error, filePath);
+  recordFileObservationFailure(error, `open:${filePath}`);
   throw error;
-}
-
-export function isFileOpenFailure(error: unknown, filePath: string): boolean {
-  return error instanceof Error && openFailures.get(error) === filePath;
 }
 
 export function openedPathResolutionError(
   error: Error = new FsSafeError("path-mismatch", "unable to resolve opened file path"),
 ): Error {
-  resolutionFailures.add(error);
+  recordFileObservationFailure(error, "resolution");
   return error;
 }
 
@@ -29,16 +22,12 @@ export async function recordOpenedFileFailure(
   filePath: string,
   identity: BigIntStats,
 ): Promise<void> {
-  if (!(error instanceof Error) || (!resolutionFailures.has(error) && !isFileIdentityMismatch(error)) ||
+  if ((!isFileObservationFailure(error, "resolution") && !isFileObservationFailure(error, "identity")) ||
     !identity.isFile() || identity.nlink > 1n) return;
   try {
     const current = await inspectFileIdentity(() => handle.stat({ bigint: true }), identity);
-    if (current.isFile() && current.nlink === 0n) unlinkedFailures.set(error, filePath);
+    if (current.isFile() && current.nlink === 0n) recordFileObservationFailure(error, `unlinked:${filePath}`);
   } catch {
     // A closed, changed, or unknown descriptor provides no retry evidence.
   }
-}
-
-export function isUnlinkedFileFailure(error: unknown, filePath: string): boolean {
-  return error instanceof Error && unlinkedFailures.get(error) === filePath;
 }

--- a/src/sidecar-lock-acquire.ts
+++ b/src/sidecar-lock-acquire.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { isFileOpenFailure } from "./opened-file-failure.js";
 import { FsSafeError } from "./errors.js";
 import { readFileHandleBounded } from "./bounded-read.js";
 import { openSidecarRoot } from "./sidecar-lock-root.js";
@@ -15,7 +14,8 @@ import {
   validateSidecarLockTimeoutMs,
 } from "./sidecar-lock-policy.js";
 import {
-  readSidecarLockSnapshot,
+  readSidecarLockRawSnapshot,
+  parseSidecarLockSnapshot,
   relativeSidecarLockPath,
   releaseSidecarReclaimGuard,
   removeSidecarLockIfUnchanged,
@@ -155,9 +155,9 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
       let handle: SidecarFileHandle | null = null;
       let createdSnapshot: SidecarLockSnapshot | null = null;
       let lockFileCreateDenied = false;
+      const payload = await options.payload();
+      const { raw, ownershipToken } = serializeSidecarLockPayload(payload);
       try {
-        const payload = await options.payload();
-        const { raw, ownershipToken } = serializeSidecarLockPayload(payload);
         if (options.lockRoot) {
           const lockRoot = options.lockRoot;
           const relativeLockPath = relativeSidecarLockPath(lockRoot, lockPath);
@@ -290,20 +290,21 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
           continue;
         }
         const nowMs = Date.now();
-        let snapshot: SidecarLockSnapshot | null;
+        let rawSnapshot: Awaited<ReturnType<typeof readSidecarLockRawSnapshot>>;
+        let lockFileOpenDenied = false;
         try {
-          snapshot = await readSidecarLockSnapshot(lockPath, {
+          rawSnapshot = await readSidecarLockRawSnapshot(lockPath, {
             lockRoot: options.lockRoot,
-            parsePayload: options.parsePayload,
             rejectNonFile: true,
             discardUnlinked: true,
+            onOpenFailure: (error) => { lockFileOpenDenied = isTransientLockFileDenial(error, lockPath); },
           });
         } catch (readErr) {
-          if (!isFileOpenFailure(readErr, lockPath) ||
-            !isTransientLockFileDenial(readErr, lockPath) || !withinDenialBudget()) throw readErr;
+          if (!lockFileOpenDenied || !withinDenialBudget()) throw readErr;
           await retryOrRethrowDenial(readErr);
           continue;
         }
+        const snapshot = parseSidecarLockSnapshot(rawSnapshot, options.parsePayload);
         if (!snapshot) {
           await waitForRetry();
           continue;

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -7,7 +7,6 @@ import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import type { Root } from "./root-impl.js";
-import { recordFileOpenFailure } from "./opened-file-failure.js";
 import { openSidecarRoot } from "./sidecar-lock-root.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
 
@@ -33,6 +32,15 @@ export type SidecarLockSnapshot = {
   stat?: Stats;
   ownershipToken?: string;
 };
+
+type SidecarLockRawSnapshot = Omit<SidecarLockSnapshot, "payload"> & { raw: string };
+
+export function parseSidecarLockSnapshot(
+  snapshot: SidecarLockRawSnapshot | null,
+  parser?: (raw: string) => unknown,
+): SidecarLockSnapshot | null {
+  return snapshot && { ...snapshot, payload: parseSidecarLockPayload(snapshot.raw, parser) };
+}
 
 function createSidecarLockOwnershipToken(): string {
   let token = SIDECAR_LOCK_OWNERSHIP_TOKEN_PREFIX;
@@ -96,27 +104,33 @@ function missingSnapshotPath(error: unknown): null {
 
 export async function readSidecarLockSnapshot(
   lockPath: string,
+  options: Parameters<typeof readSidecarLockRawSnapshot>[1] & { parsePayload?: (raw: string) => unknown } = {},
+): Promise<SidecarLockSnapshot | null> {
+  return parseSidecarLockSnapshot(await readSidecarLockRawSnapshot(lockPath, options), options.parsePayload);
+}
+
+export async function readSidecarLockRawSnapshot(
+  lockPath: string,
   options: {
     lockRoot?: Root;
-    parsePayload?: (raw: string) => unknown;
     rejectNonFile?: boolean;
     allowDescriptorIdentityDrift?: boolean;
     // Acquisition alone may discard a proven-unlinked observation, never delete from it.
     discardUnlinked?: boolean;
+    onOpenFailure?: (error: unknown) => void;
   } = {},
-): Promise<SidecarLockSnapshot | null> {
+): Promise<SidecarLockRawSnapshot | null> {
   let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
     if (options.lockRoot) {
       const lockRoot = options.lockRoot;
       const relative = relativeSidecarLockPath(lockRoot, lockPath);
-      const opened = await openSidecarRoot(lockRoot, relative, options.discardUnlinked);
+      const opened = await openSidecarRoot(lockRoot, relative, options.discardUnlinked, options.onOpenFailure);
       if (!opened) return null;
       try {
         const raw = (await readFileHandleBounded(opened.handle, MAX_LOCK_PAYLOAD_BYTES)).toString("utf8");
         return {
           raw,
-          payload: parseSidecarLockPayload(raw, options.parsePayload),
           stat: opened.stat,
         };
       } finally {
@@ -150,7 +164,8 @@ export async function readSidecarLockSnapshot(
           cause: error,
         });
       }
-      recordFileOpenFailure(error, lockPath);
+      options.onOpenFailure?.(error);
+      throw error;
     }
     const opened = await handle.stat();
     if (!opened.isFile()) {
@@ -163,7 +178,7 @@ export async function readSidecarLockSnapshot(
     const raw = (await readFileHandleBounded(handle, MAX_LOCK_PAYLOAD_BYTES)).toString("utf8");
     const after = await fs.lstat(lockPath).catch(missingSnapshotPath);
     if (!after || !after.isFile() || !sameFileIdentity(before, after)) return null;
-    return { raw, payload: parseSidecarLockPayload(raw, options.parsePayload), stat: after };
+    return { raw, stat: after };
   } finally {
     await handle?.close().catch(() => undefined);
   }
@@ -180,8 +195,15 @@ function lstatSidecarLockSync(lockPath: string): Stats | null {
 export function readSidecarLockSnapshotSync(
   lockPath: string,
   parsePayload?: (raw: string) => unknown,
-  options: { rejectNonFile?: boolean } = {},
+  options: Parameters<typeof readSidecarLockRawSnapshotSync>[1] = {},
 ): SidecarLockSnapshot | null {
+  return parseSidecarLockSnapshot(readSidecarLockRawSnapshotSync(lockPath, options), parsePayload);
+}
+
+export function readSidecarLockRawSnapshotSync(
+  lockPath: string,
+  options: { rejectNonFile?: boolean; onOpenFailure?: (error: unknown) => void } = {},
+): SidecarLockRawSnapshot | null {
   let fd: number | undefined;
   try {
     const before = lstatSidecarLockSync(lockPath);
@@ -196,7 +218,8 @@ export function readSidecarLockSnapshotSync(
       fd = fsSync.openSync(lockPath, resolveReadOpenFlags());
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
-      recordFileOpenFailure(error, lockPath);
+      options.onOpenFailure?.(error);
+      throw error;
     }
     const opened = fsSync.fstatSync(fd);
     if (!opened.isFile()) {
@@ -210,7 +233,6 @@ export function readSidecarLockSnapshotSync(
     if (!after || !sameFileIdentity(before, opened) || !sameFileIdentity(opened, after)) return null;
     return {
       raw,
-      payload: parseSidecarLockPayload(raw, parsePayload),
       stat: after,
       ownershipToken: readSidecarLockOwnershipToken(raw),
     };

--- a/src/sidecar-lock-root.ts
+++ b/src/sidecar-lock-root.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { inspectDirectoryIdentity } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
-import { isFileOpenFailure, isUnlinkedFileFailure } from "./opened-file-failure.js";
+import { fileObservation } from "./file-observation.js";
 import { isNotFoundPathError } from "./path.js";
 import type { OpenResult, Root } from "./root-impl.js";
 import { resolveRootPath } from "./root-path.js";
@@ -10,6 +10,7 @@ export async function openSidecarRoot(
   lockRoot: Root,
   relative: string,
   discardUnlinked = false,
+  onOpenFailure?: (error: unknown) => void,
 ): Promise<OpenResult | null> {
   const resolved = await lockRoot.resolve(relative);
   const canonicalPath = async () => (await resolveRootPath({
@@ -34,17 +35,20 @@ export async function openSidecarRoot(
       if (dir === lockRoot.rootReal) break;
     }
   }
+  const observation = fileObservation();
   try {
-    const opened = await lockRoot.open(relative);
+    const opened = await observation.run(() => lockRoot.open(relative));
     if (opened.realPath !== expectedRealPath) {
       await opened.handle.close().catch(() => undefined);
       throw new FsSafeError("path-mismatch", "sidecar lock path changed during open");
     }
     return opened;
   } catch (error) {
-    const missing = isFileOpenFailure(error, resolved) && error instanceof FsSafeError && error.code === "not-found";
+    const openFailed = observation.has(error, `open:${resolved}`);
+    if (openFailed) onOpenFailure?.(error);
+    const missing = openFailed && error instanceof FsSafeError && error.code === "not-found";
     if (missing && !discardUnlinked) return null;
-    if (!discardUnlinked || (!missing && (!completeParents || !isUnlinkedFileFailure(error, resolved)))) throw error;
+    if (!discardUnlinked || (!missing && (!completeParents || !observation.has(error, `unlinked:${resolved}`)))) throw error;
     try {
       try {
         const current = await lockRoot.stat(relative);

--- a/src/strict-file-identity.ts
+++ b/src/strict-file-identity.ts
@@ -1,17 +1,12 @@
 import type { BigIntStats } from "node:fs";
 import { FsSafeError } from "./errors.js";
+import { recordFileObservationFailure } from "./file-observation.js";
 
 type ExactFileIdentity = Pick<BigIntStats, "dev" | "ino">;
 
-const identityMismatches = new WeakSet<Error>();
-
-export function isFileIdentityMismatch(error: unknown): error is Error {
-  return error instanceof Error && identityMismatches.has(error);
-}
-
 function identityMismatch(): FsSafeError {
   const error = new FsSafeError("path-mismatch", "file identity changed or could not be verified");
-  identityMismatches.add(error);
+  recordFileObservationFailure(error, "identity");
   return error;
 }
 

--- a/test/file-lock-error-replay.test.ts
+++ b/test/file-lock-error-replay.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeNative } from "../src/native-config.js";
+import { acquireFileLockSync, createFileLockManager } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+const foreign = '{"owner":"foreign"}\n';
+const retry = { retries: 2, minTimeout: 0, maxTimeout: 0 };
+const denial = (pathname: string, code = "EPERM") =>
+  Object.assign(new Error("synthetic open denial"), { code, syscall: "open", path: pathname });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+  configureFsSafeNative({ mode: "auto" });
+});
+
+for (const mode of ["sync", "async", "root"] as const) {
+  describe(`${mode} callback error replay (synthetic Windows/errno; real files)`, () => {
+    async function fixture() {
+      const directory = await tempRoot("fs-safe-error-replay-");
+      const lockRoot = mode === "root" ? await root(directory) : undefined;
+      const target = path.join(directory, "state"), lockPath = `${target}.lock`;
+      const manager = createFileLockManager(`replay:${target}`);
+      configureFsSafeNative({ mode: "off" });
+      Object.defineProperty(process, "platform", { value: "win32" });
+      const acquire = (file: string, options: {
+        payload: () => Record<string, unknown>;
+        parsePayload?: (raw: string) => unknown;
+        retry?: typeof retry;
+      }) => mode === "sync"
+        ? acquireFileLockSync(file, { retry, ...options, lockRoot })
+        : manager.acquire(file, { retry, ...options, lockRoot });
+      const failOpen = (file: string, error: Error) => {
+        if (mode === "sync") {
+          const open = fs.openSync.bind(fs);
+          return vi.spyOn(fs, "openSync").mockImplementation((candidate, flags, permissions) => {
+            if (candidate === file && typeof flags === "number" && !(flags & fs.constants.O_EXCL)) throw error;
+            return open(candidate, flags, permissions);
+          });
+        }
+        const open = fsp.open.bind(fsp);
+        return vi.spyOn(fsp, "open").mockImplementation(async (...args) => {
+          if (args[0] === file && typeof args[1] === "number" && !(args[1] & fs.constants.O_EXCL)) throw error;
+          return await open(...args);
+        });
+      };
+      return { directory, target, lockPath, manager, acquire, failOpen };
+    }
+
+    for (const callback of ["parsePayload", "payload", "toJSON"] as const) {
+      it.each(["same-path", "cross-path", "fresh"] as const)(
+        `propagates ${callback} %s errors exactly once`, async (history) => {
+          const { directory, target, lockPath, manager, acquire, failOpen } = await fixture();
+          const previousTarget = history === "cross-path" ? path.join(directory, "previous") : target;
+          const previousPath = `${previousTarget}.lock`;
+          const error = denial(history === "fresh" ? lockPath : previousPath);
+          if (history !== "fresh") {
+            fs.writeFileSync(previousPath, foreign);
+            const spy = failOpen(previousPath, error);
+            await expect((async () => acquire(previousTarget, {
+              payload: () => ({}), retry: { ...retry, retries: 0 },
+            }))()).rejects.toBe(error);
+            spy.mockRestore();
+          }
+          fs.writeFileSync(lockPath, foreign);
+          const fail = vi.fn((): never => { throw error; });
+          const payload = callback === "payload" ? fail : vi.fn(() => callback === "toJSON" ? { toJSON: fail } : {});
+          const parsePayload = callback === "parsePayload" ? fail : vi.fn(JSON.parse);
+          const shouldReclaim = vi.fn(() => true), shouldRemoveStaleLock = vi.fn(() => true);
+          await expect((async () => acquire(target, {
+            payload, parsePayload, ...{ shouldReclaim, shouldRemoveStaleLock, staleRecovery: "remove-if-unchanged" as const },
+          }))()).rejects.toBe(error);
+          expect(fail).toHaveBeenCalledTimes(1);
+          expect(payload).toHaveBeenCalledTimes(1);
+          expect(shouldReclaim).not.toHaveBeenCalled();
+          expect(shouldRemoveStaleLock).not.toHaveBeenCalled();
+          expect(manager.heldEntries()).toEqual([]);
+          expect(fs.readFileSync(lockPath, "utf8")).toBe(foreign);
+          if (history === "cross-path") expect(fs.readFileSync(previousPath, "utf8")).toBe(foreign);
+        },
+      );
+    }
+
+    it.each(["payload", "toJSON"])("does not interpret %s EEXIST as contention", async (callback) => {
+      const { target, lockPath, acquire } = await fixture();
+      fs.writeFileSync(lockPath, foreign);
+      const error = denial(lockPath, "EEXIST");
+      const fail = vi.fn((): never => { throw error; });
+      await expect((async () => acquire(target, {
+        payload: callback === "payload" ? fail : () => ({ toJSON: fail }),
+      }))()).rejects.toBe(error);
+      expect(fail).toHaveBeenCalledTimes(1);
+      expect(fs.readFileSync(lockPath, "utf8")).toBe(foreign);
+    });
+
+    it.each([
+      { retries: 2, attempts: 3 }, { retries: 20, attempts: 9 },
+    ])("classifies a reused Error from each current open ($retries retries)", async ({ retries, attempts }) => {
+      const { target, lockPath, acquire, failOpen } = await fixture();
+      fs.writeFileSync(lockPath, foreign);
+      const error = denial(lockPath);
+      const spy = failOpen(lockPath, error);
+      const payload = vi.fn(() => ({})), parsePayload = vi.fn(JSON.parse);
+      await expect((async () => acquire(target, { payload, parsePayload, retry: { ...retry, retries } }))())
+        .rejects.toBe(error);
+      expect(payload).toHaveBeenCalledTimes(attempts);
+      expect(parsePayload).not.toHaveBeenCalled();
+      spy.mockRestore();
+      expect(fs.readFileSync(lockPath, "utf8")).toBe(foreign);
+    });
+  });
+}

--- a/test/sidecar-lock-root-resolver.test.ts
+++ b/test/sidecar-lock-root-resolver.test.ts
@@ -198,3 +198,68 @@ it("ordinary snapshot reads do not discard failed descriptor observations", asyn
     .rejects.toMatchObject({ code: "path-mismatch" });
   expect(parsePayload).not.toHaveBeenCalled();
 });
+
+it("does not replay a never-consumed Root open failure in a later observation", async () => {
+  const capability = await root(await tempRoot("sidecar-root-replay-"));
+  const lockPath = path.join(capability.rootReal, "state.lock");
+  const historical = await capability.open("state.lock").catch((error: unknown) => error);
+  expect(historical).toBeInstanceOf(FsSafeError);
+  await capability.create("state.lock", "foreign");
+  const fail = vi.fn(() => { throw historical; });
+  __setFsSafeTestHooksForTest({ beforeOpen: fail });
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+    .rejects.toBe(historical);
+  expect(fail).toHaveBeenCalledTimes(1);
+  expect(await fs.readFile(lockPath, "utf8")).toBe("foreign");
+});
+
+it.each(["sequential", "nested", "interleaved"])(
+  "isolates %s Root resolver receipts even when the same Error is thrown again", async (order) => {
+    const capability = await root(await tempRoot("sidecar-root-receipts-"));
+    const firstPath = path.join(capability.rootReal, "first.lock");
+    const secondPath = firstPath;
+    await capability.create("first.lock", "first");
+    // Synthetic Windows resolver EPERM; unlink and descriptor checks are real.
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const failure = Object.assign(new Error("synthetic resolver failure"), { code: "EPERM" });
+    const realpath = fs.realpath.bind(fs);
+    let deny = false, observingFirst = false;
+    vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+      if (args[0] === firstPath && deny && observingFirst) throw failure;
+      return await realpath(...args);
+    });
+    let unblock!: () => void, entered!: () => void;
+    const paused = new Promise<void>((resolve) => { entered = resolve; });
+    const resume = new Promise<void>((resolve) => { unblock = resolve; });
+    const descriptors: FileHandle[] = [];
+    __setFsSafeTestHooksForTest({ async afterOpenedPathIdentityCheck(candidate, handle) {
+      descriptors.push(handle);
+      if (candidate === firstPath && observingFirst) {
+        await fs.unlink(firstPath);
+        deny = true;
+      } else if (candidate === secondPath) {
+        if (order === "nested") await expect(observeFirst()).resolves.toBeNull();
+        if (order === "interleaved") { entered(); await resume; }
+        throw failure;
+      }
+    } });
+    const observeFirst = async () => {
+      observingFirst = true;
+      try { return await readSidecarLockSnapshot(firstPath, { lockRoot: capability, discardUnlinked: true }); }
+      finally { observingFirst = false; }
+    };
+    if (order === "sequential") {
+      await expect(observeFirst()).resolves.toBeNull();
+      await capability.create("first.lock", "replacement");
+    }
+    const second = expect(readSidecarLockSnapshot(secondPath, { lockRoot: capability, discardUnlinked: true }))
+      .rejects.toBe(failure);
+    if (order === "interleaved") {
+      await paused;
+      try { await expect(observeFirst()).resolves.toBeNull(); } finally { unblock(); }
+    }
+    await second;
+    expect(descriptors).toHaveLength(2);
+    expect(descriptors.every((handle) => handle.fd === -1)).toBe(true);
+  },
+);


### PR DESCRIPTION
## Summary

Keep application callback failures out of lock-acquisition retry handling. A saved filesystem `Error` could retain its old failure brand: throwing that same object later from `parsePayload` on the same path caused repeated parser calls, and replaying a historical Root-open error could turn the original error into `file_lock_timeout` even while a foreign sidecar remained present.

This is the focused follow-up to the late replay finding from [PR #189](https://github.com/openclaw/fs-safe/pull/189). The reproduced baseline is main commit `59b9cc4ea1b12defd7e693aa3af8d56581d52e9f`; the proof uses unpublished main-snapshot packages, not a claim about every released version. No lock takeover or deletion of foreign bytes was demonstrated by these reproductions.

Production delta: **+100 / −56 / net +44 lines**. No new dependency, public API, version change, or archive change.

## What changed and why

Payload evaluation, JSON serialization (including `toJSON`), and parsing now run outside the acquisition I/O retry catches. Shared raw snapshot readers finish descriptor cleanup before invoking application parsing. Actual open failures set attempt-local denial flags rather than conferring reusable authority on an Error object.

Root identity, opened-path resolution, open, and unlink evidence now belongs to an observation-local receipt set carried by `AsyncLocalStorage`. Each Root observation gets a fresh set, including nested and concurrent observations. The permanent Error WeakMap/WeakSet brands are removed; an error saved from another observation cannot supply current open/unlink evidence.

The safety boundary is unchanged: a genuine current Windows lock-file open denial can still retry at most eight times within caller retry/deadline limits, returning the original denial on exhaustion. Every retry still requires fresh exclusive creation. Generic Root reads, parent/descriptor/ancestry checks, creator-byte/token admission, and identity-conditioned release/reclaim remain strict. Historical exception identity grants no ownership or removal authority.

## Executed before/after proof

The same frozen public-consumer scripts were run against baseline and candidate packages. Both were physically installed with npm, with no source/workspace symlinks. Candidate root tarball integrity:

```text
sha512-HJxy8iAGAjmrT7S/VuyHoaoOBnGacZ9H7Ag226Z+VN8wQOy3uINzGC4i97qJ0+7pNfcRfYK0NoxSG2Dg121XOQ==
```

**Native Windows, Node 24.20.0:** the parser control injects an `EPERM` at the Node open call to retain a genuine operation-classified Error, then rethrows that object from application parsing. This is explicitly controlled open-error injection, not a claim of a naturally timed Windows denial; Windows execution itself is real (`platformOverride:false`). With two retries, same-path parsing changed from three calls to one, for both sync and async acquisition. Fresh matching errors and different-path replays remained one call. The exact original Error and foreign bytes were preserved, and no handle was returned.

Before:

```jsonl
{"surface":"sync","control":"same-path-replayed-error","parserCalls":3,"caughtOriginalError":true,"acquired":false,"foreignBytesPreserved":true,"asyncHeldEntries":0}
{"surface":"async","control":"same-path-replayed-error","parserCalls":3,"caughtOriginalError":true,"acquired":false,"foreignBytesPreserved":true,"asyncHeldEntries":0}
{"proof":"read-only-error-replay","actualPlatform":"win32","node":"v24.20.0","platformOverride":false,"injectedOpenError":true,"cases":6,"passed":false}
```

After:

```jsonl
{"surface":"sync","control":"fresh-matching-error","parserCalls":1,"caughtOriginalError":true,"acquired":false,"foreignBytesPreserved":true,"asyncHeldEntries":0}
{"surface":"sync","control":"same-path-replayed-error","parserCalls":1,"caughtOriginalError":true,"acquired":false,"foreignBytesPreserved":true,"asyncHeldEntries":0}
{"surface":"sync","control":"other-path-replayed-error","parserCalls":1,"caughtOriginalError":true,"acquired":false,"foreignBytesPreserved":true,"asyncHeldEntries":0}
{"surface":"async","control":"fresh-matching-error","parserCalls":1,"caughtOriginalError":true,"acquired":false,"foreignBytesPreserved":true,"asyncHeldEntries":0}
{"surface":"async","control":"same-path-replayed-error","parserCalls":1,"caughtOriginalError":true,"acquired":false,"foreignBytesPreserved":true,"asyncHeldEntries":0}
{"surface":"async","control":"other-path-replayed-error","parserCalls":1,"caughtOriginalError":true,"acquired":false,"foreignBytesPreserved":true,"asyncHeldEntries":0}
{"proof":"read-only-error-replay","actualPlatform":"win32","node":"v24.20.0","platformOverride":false,"injectedOpenError":true,"cases":6,"passed":true}
```

**Root historical-evidence control:** a real earlier missing-file error from public `Root.open()` is replayed through a wrapper around that public method after creating a foreign sidecar. No filesystem error or platform is injected in this control. The old code discarded the observation and changed the error to a timeout; the candidate propagates the same original error, leaves the manager empty, and preserves foreign bytes through drain. Fresh/cross-path errors are controls. A separate real unlink immediately before the current open still recovers through a second, fresh exclusive creation, verifies ownership, and releases successfully.

Actual Windows output:

```jsonl
{"proof":"root-observation-replay","platform":"win32","node":"v24.20.0","case":"same-path","callbackCalls":1,"originalErrorPreserved":false,"code":"file_lock_timeout","heldRegistrations":0,"foreignBytesPreserved":true}
{"proof":"root-observation-replay","platform":"win32","node":"v24.20.0","case":"same-path","callbackCalls":1,"originalErrorPreserved":true,"code":"not-found","heldRegistrations":0,"foreignBytesPreserved":true}
{"proof":"root-observation-replay","platform":"win32","node":"v24.20.0","replayScheduling":"public-Root-open-wrapper","injectedFilesystemErrors":false,"cases":4,"currentLossRecoveredByFreshCreate":true,"passed":true}
{"proof":"windows-installed-replay-candidate","tree":"ea9a84e961f3d9caa88c4c30e046ea243d7c6d47","parserCases":6,"rootCases":4,"parserCalls":1,"originalErrorsPreserved":true,"foreignBytesPreserved":true,"currentMissingOpenRecoveryPassed":true,"platformOverride":false,"passed":true}
```

The identical six-parser/four-Root controls also passed candidate consumers on macOS with Node 22.23.2 and 24.20.0, after reproducing baseline failures. The Mac parser controls explicitly simulate Windows classification; the Root controls do not. The Linux installed-consumer parser gate also passed.

## Validation

- New regression RED proof on unchanged base: 11 callback cases failed / 28 passed; all four new Root history/isolation cases failed.
- Frozen candidate `pnpm check`: **6,317 passed / 81 skipped**, 179 test files passed / one skipped, including build, documentation and package checks.
- `pnpm native:test`: **63 passed**; `pnpm test:security`: **78 passed**.
- Native Windows focused callback/Root suite: **113 passed / 33 skipped**, with the existing platform-specific skips reported rather than counted as passes.
- `node scripts/sidecar-contention-proof.mjs off`, `auto`, and `require`: **1,200 contended acquisitions passed** on Linux, with release-retry controls.
- `pnpm package:smoke`: passed root-only npm/pnpm resolution, missing-binary and omitted-optionals cases. Foreign platform-filtering fixtures are synthetic, not foreign execution proof.
- Isolated Codex autoreview: scoped-clean at the configured P0 threshold, no accepted/actionable findings.
- `git diff --check`: passed.

An initial wrong test-helper import was corrected before the valid RED run. Five unchanged 5-second Root tests then timed out on the loaded Mac; they were not counted as passing. The same frozen candidate passed the isolated Linux full gate and Windows focused gate. No test deadline or invariant was relaxed.

Validated tree: `ea9a84e961f3d9caa88c4c30e046ea243d7c6d47`; head: `d9d1a2c4211c07d24a14945bd419b4c4131b59f1`. Hosted exact-head CI and review must pass before merge; this body does not claim pending hosted jobs have passed.

## Release boundary

Only the current 0.7.1 Unreleased notes change. Package versions remain 0.7.0; dependency lockfiles, dated 0.7.0 notes, tags, npm packages, and GitHub Release artifacts are untouched. This PR does not publish a release.
