### PR TITLE
fix(atomic): preserve long destination filenames

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -144,6 +144,9 @@ rename, so that fallback is temporarily non-atomic while retaining the staged
 file's `0600` mode; use the async `writeJson()`/`replaceFileAtomic()` surfaces
 when fallback policy must be explicit.
 
+Its private sibling temporary name is independent of the destination basename,
+so staging does not lengthen a valid destination filename.
+
 ```ts
 writeJsonSync("./prefs.json", { theme: "dark" });
 ```

--- a/docs/output.md
+++ b/docs/output.md
@@ -58,9 +58,12 @@ through the package's filename sanitizer; `fallbackFileName` supplies the name
 when nothing remains. This removes traversal, device-name, and invalid-character
 hazards but does not trim Windows-normalized trailing dots or spaces; reject or
 rewrite those when cross-platform filename uniqueness matters.
-The same sanitized basename is used for producer staging, guarded internal
-temps, the final rename target, and the returned `path`; raw and staged names
-never diverge.
+`staging: "workspace"` passes the sanitized basename to the producer.
+`staging: "sibling"` embeds that basename in its randomized temporary name.
+The final target and returned `path` use the destination basename, sanitized
+when needed as described above. Guarded temporary files used only inside
+fs-safe have independent names so their length does not grow with the
+destination basename.
 
 ## Choosing a staging mode
 

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -27,6 +27,9 @@ await fs.mkdir("snapshots/2026/05");
 5. Atomically rename the temp file over the destination.
 6. Stat the resulting fd and verify identity.
 
+Private sibling temporary names are independent of the destination basename,
+so staging does not add a suffix to an otherwise valid long filename.
+
 A failure before the final rename leaves the destination at its previous
 contents. A successful rename publishes the complete replacement. This
 old-or-new guarantee does not apply to `append()` or `openWritable()`, which

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -177,7 +177,6 @@ async function writeZipFileEntry(params: {
   try {
     await writeSiblingTempFile({
       dir: path.dirname(destinationPath),
-      tempPrefix: `.${path.basename(destinationPath)}.fs-safe-archive`,
       chmodDir: false,
       mode: params.mode,
       writeTemp: async (tempPath) => {

--- a/src/json.ts
+++ b/src/json.ts
@@ -186,17 +186,17 @@ export function tryReadJsonSync<T = unknown>(
 }
 
 export function writeJsonSync(pathname: string, data: unknown) {
-  const targetPath = pathname;
-  const tmpPath = `${targetPath}.${randomUUID()}.tmp`;
+  // Keep literal parent segments so staging follows the same symlinks as the target.
+  const tmpPath = path.format({ ...path.parse(pathname), base: `.fs-safe-${randomUUID()}.tmp` });
   const payload = `${stringifyJsonDocument(data, null, 2)}\n`;
 
-  fsSync.mkdirSync(path.dirname(targetPath), { recursive: true, mode: JSON_DIR_MODE });
+  fsSync.mkdirSync(path.dirname(pathname), { recursive: true, mode: JSON_DIR_MODE });
   try {
     const tempIdentity = writeTempJsonFile(tmpPath, payload);
     trySetSecureMode(tmpPath, tempIdentity);
-    renameJsonFileWithFallback(tmpPath, targetPath);
-    trySetSecureMode(targetPath, tempIdentity);
-    trySyncDirectory(targetPath);
+    renameJsonFileWithFallback(tmpPath, pathname);
+    trySetSecureMode(pathname, tempIdentity);
+    trySyncDirectory(pathname);
   } finally {
     try {
       fsSync.rmSync(tmpPath, { force: true });

--- a/src/native-pinned-write-windows.ts
+++ b/src/native-pinned-write-windows.ts
@@ -44,7 +44,7 @@ export async function runPinnedWriteWindows(
   let renamed = false;
   let completed = false;
   try {
-    tempName = `.${params.basename}.${randomUUID()}.native.tmp`;
+    tempName = `.fs-safe-${randomUUID()}.tmp`;
     tempFd = binding.openBeneath(
       parentFd,
       tempName,

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -231,7 +231,8 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
     }
   }
 
-  const tempPath = path.join(parentPath, `.${params.basename}.${randomUUID()}.fallback.tmp`);
+  // Private staging must not consume the destination basename's filename budget.
+  const tempPath = path.join(parentPath, `.fs-safe-${randomUUID()}.tmp`);
   const tempFlags =
     fsSync.constants.O_WRONLY |
     fsSync.constants.O_CREAT |

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -783,9 +783,7 @@ function emitWriteBoundaryWarning(reason: string) {
 }
 
 function buildAtomicWriteTempPath(targetPath: string): string {
-  const dir = path.dirname(targetPath);
-  const base = path.basename(targetPath);
-  return path.join(dir, `.${base}.${process.pid}.${randomUUID()}.tmp`);
+  return path.join(path.dirname(targetPath), `.fs-safe-${randomUUID()}.tmp`);
 }
 
 function rootWriteQueueKey(root: RootContext, relativePath: string): string {

--- a/test/archive.test.ts
+++ b/test/archive.test.ts
@@ -92,6 +92,24 @@ describe("archive extraction", () => {
     await expect(fs.readFile(path.join(packageDir, "my file.txt"), "utf8")).resolves.toBe("space");
   });
 
+  it.each([12, 200, 240])("extracts filesystem-admitted %i-byte ZIP basenames", async (length) => {
+    const directory = await tempRoot("fs-safe-zip-name-");
+    const destDir = path.join(directory, "dest");
+    await fs.mkdir(destDir);
+    const basename = `${"a".repeat(length - 4)}.txt`;
+    const target = path.join(destDir, basename);
+    await fs.writeFile(target, "original");
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("original");
+    const zip = new JSZip().file(basename, "replacement");
+    const archivePath = path.join(directory, "fixture.zip");
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+
+    await extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 15_000 });
+
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("replacement");
+    await expect(fs.readdir(destDir)).resolves.toEqual([basename]);
+  });
+
   it("supports buffer-only ZIP entries while stripping the archive root", async () => {
     const root = await tempRoot("fs-safe-archive-buffer-only-");
     const archivePath = path.join(root, "pkg.zip");

--- a/test/fs-safe.test.ts
+++ b/test/fs-safe.test.ts
@@ -96,6 +96,29 @@ describe("@openclaw/fs-safe", () => {
     await expect(root.exists("nested/copied.txt")).resolves.toBe(false);
   });
 
+  it.each([12, 200, 240].flatMap((length) =>
+    (["write", "copyIn"] as const).map((operation) => ({ length, operation })),
+  ))("$operation preserves filesystem-admitted $length-byte basenames", async ({ length, operation }) => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-name-");
+    const basename = `${"a".repeat(length - 4)}.txt`;
+    const target = path.join(directory, basename);
+    await writeFile(target, "original");
+    await expect(readFile(target, "utf8")).resolves.toBe("original");
+    const scoped = await openRoot(directory);
+
+    if (operation === "write") {
+      await scoped.write(basename, "replacement");
+    } else {
+      const source = path.join(await tempRoot("fs-safe-name-source-"), "source.txt");
+      await writeFile(source, "replacement");
+      await scoped.copyIn(basename, source);
+    }
+
+    await expect(readFile(target, "utf8")).resolves.toBe("replacement");
+    await expect(readdir(directory)).resolves.toEqual([basename]);
+  });
+
   it.skipIf(skipOnWindows)("preserves concurrent append writes", async () => {
     const rootPath = await tempRoot("fs-safe-append-concurrent-");
     const root = await openRoot(rootPath);

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -225,6 +225,19 @@ describe("json file helpers", () => {
     expect(JSON.parse(await fs.readFile(filePath, "utf8"))).toEqual({ ok: true });
   });
 
+  it.each([12, 240])("writes filesystem-admitted %i-byte JSON basenames synchronously", async (length) => {
+    const directory = await tempRoot("fs-safe-json-name-");
+    const basename = `${"a".repeat(length - 5)}.json`;
+    const filePath = path.join(directory, basename);
+    await fs.writeFile(filePath, "original");
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe("original");
+
+    writeJsonSync(filePath, { replacement: true });
+
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe('{\n  "replacement": true\n}\n');
+    await expect(fs.readdir(directory)).resolves.toEqual([basename]);
+  });
+
   it("serializes work through createAsyncLock", async () => {
     const lock = createAsyncLock();
     const events: string[] = [];

--- a/test/pinned-write-fallback-coverage.test.ts
+++ b/test/pinned-write-fallback-coverage.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -67,9 +68,10 @@ describe("pinned write fallback coverage", () => {
     ).rejects.toMatchObject({ code: "EEXIST" });
 
     const realOpen = fs.open;
+    let shortenedWrites = 0;
     vi.spyOn(fs, "open").mockImplementation(async (...args) => {
       const handle = await realOpen(...args);
-      if (String(args[0]).includes("streamed.txt")) {
+      if ((Number(args[1]) & fsConstants.O_WRONLY) !== 0) {
         const realWrite = handle.write.bind(handle);
         vi.spyOn(handle, "write").mockImplementation((async (
           buffer: Buffer,
@@ -78,6 +80,7 @@ describe("pinned write fallback coverage", () => {
           position?: number | null,
         ) => {
           const partialLength = Math.max(1, Math.ceil(length / 2));
+          if (partialLength < length) shortenedWrites += 1;
           const result = await realWrite(buffer, offset, partialLength, position);
           return { bytesWritten: result.bytesWritten, buffer };
         }) as typeof handle.write);
@@ -96,6 +99,7 @@ describe("pinned write fallback coverage", () => {
       input: { kind: "stream", stream: Readable.from(["stream", "ed"]) },
     });
     expect(streamed.dev).toBeGreaterThan(0);
+    expect(shortenedWrites).toBeGreaterThan(0);
     await expect(fs.readFile(path.join(root, "nested", "streamed.txt"), "utf8")).resolves.toBe(
       "streamed",
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers writing or extracting valid long filenames would receive `ENAMETOOLONG`, or a wrapped filesystem error, because an internal temporary filename copied the entire destination basename before adding a random suffix.

On current main `790472f73bb499ec8eb0ee7a823de1e98b0a94c0`, this reproduces for 200/240-byte ZIP basenames, 240-byte `Root.write` and `Root.copyIn` basenames, and 240-byte synchronous JSON basenames. Each regression first creates and reads the destination directly to establish that the filesystem accepts it.

## Why This Change Was Made

Private staging names now use a fixed prefix and UUID independent of the destination. Archive extraction reuses its existing bounded default. JSON staging preserves literal parent segments and drive-relative semantics rather than normalizing the path through a different parent.

The repair leaves public producer/callback filenames, custom `tempPrefix`, final destinations, exports, configuration, permissions, and identity checks unchanged. The existing retained-descriptor, publication, and cleanup logic remains responsible for safety. A partial-write test now identifies write handles by their flags and asserts that a short write actually occurred, so it no longer depends on an internal filename containing the destination.

Production: **+10/−12, net −2**. Tests: **+59/−1, net +58**. Docs: **+12/−3, net +9**.

## User Impact

Consumers can use long filenames accepted by the filesystem without private staging consuming extra filename space. Short-name controls and the public naming contracts retain their behavior. No new fallback, setting, dependency, or migration is introduced. Release-note context is recorded here; changelog changes remain release-owned.

## Evidence

- On the same current-main checkout, the 11 selected regressions changed from **5 failed / 6 passed** to **11 passed**. The failures occur at private staging creation; the tests also verify replacement contents and absence of leaked temporary siblings.
- The 24 owner/security files passed **461 tests**, with **113 platform/native-dependent skips**.
- Canonical `pnpm check:changed` (the repository's `pnpm check` alias) passed lint, build, documentation checks, the full suite (**4,026 passed / 2,333 skipped**), and real root-tarball consumer installation/import/public-API checks. No dependency or lockfile changes and no test retries.
- Fresh independent managed P0–P2 review of the complete current twelve-file diff found no actionable findings.
- Native Windows execution was not performed locally. The separate native-platform `pnpm package:smoke` requires a prebuilt host `.node` payload that is absent locally; its normal CI jobs remain required before landing. The packed-consumer check above is not claimed as native-platform proof.

Focused command before and after:

```sh
pnpm test test/archive.test.ts test/fs-safe.test.ts test/json.test.ts \
  -t filesystem-admitted --reporter=json --outputFile=results.json
pnpm check:changed
```

Environment: macOS arm64, Node 24.20.0, pnpm 11.24.0. Introduction provenance is unknown.
