### PR TITLE
fix(lock): discard stale pre-open observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### File locks
 
-- Recover Root-backed asynchronous handoffs only with exact descriptor identity and unlink evidence, including Windows resolver `EPERM`/`EBADF` failures. Recheck canonical ancestors and charge discarded observations to retry/deadline budgets without granting release or reclaim authority. ([#189](https://github.com/openclaw/fs-safe/pull/189))
+- Recover Root-backed asynchronous handoffs from unlinked opened records with exact descriptor identity and unlink evidence, including Windows resolver `EPERM`/`EBADF` failures. Recheck canonical ancestors and charge discarded observations to retry/deadline budgets without granting release or reclaim authority. ([#189](https://github.com/openclaw/fs-safe/pull/189))
+- Retry Root lock contention when a holder changes between pre-open inspection and opening the file. Discard only the verified stale observation, recheck canonical ancestors, and require fresh exclusive creation; generic reads, creator admission, and release/reclaim authority remain unchanged.
 - Verify reopened Root-created sidecars against the creator's exact serialized bytes and ownership token before admission. Reject replacements and unlinked descriptors, and retain the original creator receipt for failed-acquisition cleanup. ([#189](https://github.com/openclaw/fs-safe/pull/189))
 - Align Windows synchronous lock-parent canonicalization with Root, including short-name expansion, and bound lock-file create/open denials and missing or changed snapshot retries. Preserve the original `EPERM` when a retry budget is exhausted. ([#189](https://github.com/openclaw/fs-safe/pull/189))
 - Determine synchronous lock staleness from the captured payload timestamp or snapshot mtime, avoiding false stale decisions after unlink or replacement. ([#189](https://github.com/openclaw/fs-safe/pull/189))

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -162,23 +162,33 @@ path.
 
 An owner can finish releasing while another async acquirer inspects its record.
 Create-only Root writes do not open an existing record merely to inherit its
-mode. During acquisition, a failed snapshot can be discarded only when the
-original descriptor has exact identity, was not observed with multiple links,
-and proves it was unlinked (`nlink === 0`). This includes Windows resolver
+mode. Once a pathname sample and opened descriptor agree, a failed acquisition
+snapshot can be discarded only when the original descriptor has exact identity,
+was not observed with multiple links, and proves it was unlinked (`nlink === 0`).
+This includes Windows resolver
 `EPERM`/`EBADF` failures, with evidence captured at the failing operation before
 closing the descriptor. The canonical in-root ancestor chain and Root are
 rechecked; permitted in-root parent symlinks are resolved before those checks.
+
+A contending waiter may also encounter a new holder between its pre-open
+pathname inspection and opening the file. It may discard that stale observation
+only when the old sample and opened descriptor have different, strictly known
+regular-file identities, neither was observed with multiple links, and the
+opened descriptor and complete canonical ancestry pass reinspection. This does
+not prove the old pathname sample was unlinked rather than moved. The new
+holder's payload is not read or adopted. Post-create admission never opts into
+this pre-open-change policy.
 
 Discarding an acquisition observation is not proof that the pathname is absent:
 another owner may already have created the next record. Every discarded
 observation consumes the normal retry/deadline budget and requires fresh
 exclusive creation. It supplies no release, reclaim, or held-lock authority.
 Generic `Root.open()` and held-owner/reclaim reads still reject failed opens.
-Moved but linked records, unknown or inexact identities, retargeted ancestors,
-and unrelated filesystem or caller errors fail closed.
-Failure receipts belong only to the current Root observation, including during
-nested or concurrent acquisitions; historical error identity is not unlink or
-open-denial evidence.
+Moving an already-matched pinned descriptor without unlinking it, unknown or
+inexact identities, retargeted ancestors, and unrelated filesystem or caller
+errors fail closed. Failure receipts belong only to the current Root observation,
+including during nested or concurrent acquisitions; historical error identity
+is not changed-file, unlink, or open-denial evidence.
 
 After creating a record, the async Root-backed acquirer checks the reopened
 bytes against its exact serialized payload and ownership token. A replacement

--- a/src/file-observation.ts
+++ b/src/file-observation.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
-type FailureKind = "identity" | "resolution" | `open:${string}` | `unlinked:${string}`;
+type FailureKind = "identity" | "resolution" | `open:${string}` | `unlinked:${string}` | `changed:${string}`;
 const active = new AsyncLocalStorage<Map<unknown, Set<FailureKind>>>();
 
 export function recordFileObservationFailure(error: unknown, kind: FailureKind): void {

--- a/src/opened-file-failure.ts
+++ b/src/opened-file-failure.ts
@@ -16,6 +16,28 @@ export function openedPathResolutionError(
   return error;
 }
 
+export async function recordPreOpenFileChange(
+  error: unknown,
+  handle: FileHandle,
+  filePath: string,
+  before: BigIntStats | undefined,
+  opened: BigIntStats | undefined,
+): Promise<void> {
+  if (!isFileObservationFailure(error, "identity") || !before?.isFile() || !opened?.isFile() ||
+    ![0n, 1n].includes(before.nlink) || ![0n, 1n].includes(opened.nlink)) return;
+  try {
+    await inspectFileIdentity(async () => before);
+    const current = await inspectFileIdentity(() => handle.stat({ bigint: true }), opened);
+    if (current.isFile() && [0n, 1n].includes(current.nlink) &&
+      (before.dev !== current.dev || before.ino !== current.ino)) {
+      // A stale pathname sample is not proof that its former inode was unlinked.
+      recordFileObservationFailure(error, `changed:${filePath}`);
+    }
+  } catch {
+    // Unknown, changed, or closed descriptor evidence never permits a discard.
+  }
+}
+
 export async function recordOpenedFileFailure(
   error: unknown,
   handle: FileHandle,

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -22,7 +22,7 @@ import {
   type DenyMutationPolicy,
 } from "./deny-mutations.js";
 import { resolveOpenedFileRealPathForFd, resolveOpenedFileRealPathForHandle } from "./opened-realpath.js";
-import { openedPathResolutionError, recordFileOpenFailure, recordOpenedFileFailure } from "./opened-file-failure.js";
+import { openedPathResolutionError, recordFileOpenFailure, recordOpenedFileFailure, recordPreOpenFileChange } from "./opened-file-failure.js";
 import {
   type RenameIdentityPolicy,
   runPinnedWriteHelper,
@@ -264,10 +264,16 @@ async function openVerifiedLocalFile(
       throw new FsSafeError("not-file", "not a file");
     }
     // Keep numeric Stats for the public receipt, never for identity verification.
+    let openedIdentity: BigIntStats | undefined;
     const identity = await inspectFileIdentity(
-      () => handle.stat({ bigint: true }),
+      async () => (openedIdentity = await handle.stat({ bigint: true })),
       preOpenStat && !preOpenStat.isSymbolicLink() ? preOpenStat : undefined,
-    );
+    ).catch(async (error: unknown) => {
+      if ([0, 1].includes(stat.nlink)) {
+        await recordPreOpenFileChange(error, handle, filePath, preOpenStat, openedIdentity);
+      }
+      throw error;
+    });
     if (options?.hardlinks === "reject" && stat.nlink > 1) {
       throw hardlinkedPathNotAllowedError();
     }

--- a/src/sidecar-lock-acquire.ts
+++ b/src/sidecar-lock-acquire.ts
@@ -170,7 +170,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
             throw error;
           }
           createdSnapshot = { raw, payload, ownershipToken };
-          const opened = await openSidecarRoot(lockRoot, relativeLockPath, true);
+          const opened = await openSidecarRoot(lockRoot, relativeLockPath, "unlinked");
           if (!opened) {
             await waitForRetry();
             continue;
@@ -296,7 +296,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
           rawSnapshot = await readSidecarLockRawSnapshot(lockPath, {
             lockRoot: options.lockRoot,
             rejectNonFile: true,
-            discardUnlinked: true,
+            discardObservation: "changed",
             onOpenFailure: (error) => { lockFileOpenDenied = isTransientLockFileDenial(error, lockPath); },
           });
         } catch (readErr) {

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -115,8 +115,8 @@ export async function readSidecarLockRawSnapshot(
     lockRoot?: Root;
     rejectNonFile?: boolean;
     allowDescriptorIdentityDrift?: boolean;
-    // Acquisition alone may discard a proven-unlinked observation, never delete from it.
-    discardUnlinked?: boolean;
+    // Discarding acquisition evidence never grants ownership or removal authority.
+    discardObservation?: "unlinked" | "changed";
     onOpenFailure?: (error: unknown) => void;
   } = {},
 ): Promise<SidecarLockRawSnapshot | null> {
@@ -125,7 +125,7 @@ export async function readSidecarLockRawSnapshot(
     if (options.lockRoot) {
       const lockRoot = options.lockRoot;
       const relative = relativeSidecarLockPath(lockRoot, lockPath);
-      const opened = await openSidecarRoot(lockRoot, relative, options.discardUnlinked, options.onOpenFailure);
+      const opened = await openSidecarRoot(lockRoot, relative, options.discardObservation, options.onOpenFailure);
       if (!opened) return null;
       try {
         const raw = (await readFileHandleBounded(opened.handle, MAX_LOCK_PAYLOAD_BYTES)).toString("utf8");

--- a/src/sidecar-lock-root.ts
+++ b/src/sidecar-lock-root.ts
@@ -9,7 +9,7 @@ import { resolveRootPath } from "./root-path.js";
 export async function openSidecarRoot(
   lockRoot: Root,
   relative: string,
-  discardUnlinked = false,
+  discardObservation?: "unlinked" | "changed",
   onOpenFailure?: (error: unknown) => void,
 ): Promise<OpenResult | null> {
   const resolved = await lockRoot.resolve(relative);
@@ -23,7 +23,7 @@ export async function openSidecarRoot(
   if (expectedRealPath === lockRoot.rootReal) throw new FsSafeError("not-file", "sidecar lock is a directory");
   const parents = [];
   let completeParents = true;
-  if (discardUnlinked) {
+  if (discardObservation) {
     // Follow permitted in-root aliases first; receipts cover canonical ancestry.
     for (let dir = path.dirname(expectedRealPath); ; dir = path.dirname(dir)) {
       try {
@@ -47,8 +47,10 @@ export async function openSidecarRoot(
     const openFailed = observation.has(error, `open:${resolved}`);
     if (openFailed) onOpenFailure?.(error);
     const missing = openFailed && error instanceof FsSafeError && error.code === "not-found";
-    if (missing && !discardUnlinked) return null;
-    if (!discardUnlinked || (!missing && (!completeParents || !observation.has(error, `unlinked:${resolved}`)))) throw error;
+    if (missing && !discardObservation) return null;
+    const discardable = observation.has(error, `unlinked:${resolved}`) ||
+      (discardObservation === "changed" && observation.has(error, `changed:${resolved}`));
+    if (!discardObservation || (!missing && (!completeParents || !discardable))) throw error;
     try {
       try {
         const current = await lockRoot.stat(relative);

--- a/test/opened-file-change.test.ts
+++ b/test/opened-file-change.test.ts
@@ -1,0 +1,62 @@
+import type { BigIntStats } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import { afterEach, expect, it, vi } from "vitest";
+import { fileObservation, recordFileObservationFailure } from "../src/file-observation.js";
+import { recordPreOpenFileChange } from "../src/opened-file-failure.js";
+
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => Object.defineProperty(process, "platform", platform));
+const stat = (ino: bigint) => ({ dev: 1n, ino, nlink: 1n, isFile: () => true }) as BigIntStats;
+
+it.each([0n, 1n])("records a distinct pre-open generation with current nlink %s, not an unlink receipt", async (nlink) => {
+  const observation = fileObservation(), error = new Error("identity mismatch");
+  const before = stat(1n), opened = stat(2n), current = { ...opened, nlink };
+  const handle = { stat: vi.fn(async () => current) } as unknown as FileHandle;
+  await observation.run(async () => {
+    recordFileObservationFailure(error, "identity");
+    await recordPreOpenFileChange(error, handle, "state.lock", before, opened);
+  });
+  expect(observation.has(error, "changed:state.lock")).toBe(true);
+  expect(observation.has(error, "unlinked:state.lock")).toBe(false);
+});
+
+it.each([
+  "same", "before-missing", "opened-missing", "before-numeric", "opened-numeric", "current-numeric",
+  "before-unknown", "opened-unknown", "current-unknown", "before-multilink", "opened-multilink", "current-multilink",
+  "before-nonfile", "opened-nonfile", "current-nonfile", "current-drift", "closed", "EACCES", "unmarked",
+])("does not authorize discarding %s evidence", async (kind) => {
+  Object.defineProperty(process, "platform", { value: "win32" });
+  const observation = fileObservation(), error = new Error("identity mismatch");
+  const before = stat(1n), opened = stat(2n), current = stat(2n);
+  for (const [label, value] of [["before", before], ["opened", opened], ["current", current]] as const) {
+    if (kind === `${label}-numeric`) Object.assign(value, { ino: Number(value.ino) });
+    if (kind === `${label}-unknown`) value.ino = 0n;
+    if (kind === `${label}-multilink`) value.nlink = 2n;
+    if (kind === `${label}-nonfile`) value.isFile = () => false;
+  }
+  if (kind === "same") before.ino = opened.ino;
+  if (kind === "current-drift") current.ino = 3n;
+  const handle = { stat: vi.fn(async () => {
+    if (kind === "closed" || kind === "EACCES") throw Object.assign(new Error("stat failed"), { code: kind === "closed" ? "EBADF" : kind });
+    return current;
+  }) } as unknown as FileHandle;
+  await observation.run(async () => {
+    if (kind !== "unmarked") recordFileObservationFailure(error, "identity");
+    await recordPreOpenFileChange(error, handle, "state.lock",
+      kind === "before-missing" ? undefined : before, kind === "opened-missing" ? undefined : opened);
+  });
+  expect(observation.has(error, "changed:state.lock")).toBe(false);
+  expect(observation.has(error, "unlinked:state.lock")).toBe(false);
+});
+
+it("does not reuse a changed-file receipt in a later observation", async () => {
+  const first = fileObservation(), next = fileObservation(), error = new Error("identity mismatch");
+  const handle = { stat: vi.fn(async () => stat(2n)) } as unknown as FileHandle;
+  await first.run(async () => {
+    recordFileObservationFailure(error, "identity");
+    await recordPreOpenFileChange(error, handle, "state.lock", stat(1n), stat(2n));
+  });
+  await next.run(() => recordPreOpenFileChange(error, handle, "state.lock", stat(1n), stat(2n)));
+  expect(first.has(error, "changed:state.lock")).toBe(true);
+  expect(next.has(error, "changed:state.lock")).toBe(false);
+});

--- a/test/sidecar-lock-helpers-failure.test.ts
+++ b/test/sidecar-lock-helpers-failure.test.ts
@@ -89,7 +89,7 @@ describe("sidecar lock helper failure handling", () => {
       await capability.create(relative, '{"owner":"original"}');
       const probe = vi.spyOn(capability, "stat");
       const gate = pauseSidecarSnapshotOpen(lockPath, afterIdentityCheck);
-      const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true });
+      const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" });
       const result = expect(snapshot).resolves.toBeNull();
       const handle = await gate.opened;
       const close = vi.spyOn(handle, "close");
@@ -115,7 +115,7 @@ describe("sidecar lock helper failure handling", () => {
     await capability.create("owner.json", original);
     const probe = vi.spyOn(capability, "stat");
     const gate = pauseSidecarSnapshotOpen(lockPath, false);
-    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true });
+    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" });
     const result = expect(snapshot).rejects.toMatchObject({ code: "path-mismatch" });
     const handle = await gate.opened;
     try {
@@ -159,7 +159,7 @@ describe("sidecar lock helper failure handling", () => {
     await capability.create("owner.json", '{"owner":"original"}');
     const probe = vi.spyOn(capability, "stat");
     const gate = pauseSidecarSnapshotOpen(lockPath, true);
-    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true });
+    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" });
     const result = expect(snapshot).rejects.toMatchObject({ code: "path-mismatch" });
     const handle = await gate.opened;
     try {
@@ -305,7 +305,7 @@ describe("sidecar lock helper failure handling", () => {
     const capability = await root(rootDir);
     const lockPath = path.join(rootDir, "state.lock");
     await capability.create("state.lock", "old");
-    const snapshot = await readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true });
+    const snapshot = await readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" });
     await expect(removeStaleSidecarLockIfAllowed({
       lockPath,
       normalizedTargetPath: path.join(rootDir, "state"),

--- a/test/sidecar-lock-root-admission.test.ts
+++ b/test/sidecar-lock-root-admission.test.ts
@@ -150,7 +150,7 @@ posix.each([
         }
       }
     }, afterIdentity);
-    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true });
+    const snapshot = readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" });
     const error = await snapshot.catch((caught: unknown) => caught);
     expect(error).toMatchObject({ name: "FsSafeError" });
     expect(["path-mismatch", "outside-workspace", "path-alias", "not-found"]).toContain((error as { code: string }).code);
@@ -217,7 +217,7 @@ posix.each([false, true])("rejects a snapshot replacement (after identity: %s)",
     await fs.rename(lockPath, `${lockPath}.displaced`);
     await fs.writeFile(lockPath, '{"owner":"replacement"}', { flag: "wx" });
   }, afterIdentity);
-  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" }))
     .rejects.toMatchObject({ code: "path-mismatch" });
   expect(opened()?.fd).toBe(-1);
   await expect(fs.readFile(lockPath, "utf8")).resolves.toBe('{"owner":"replacement"}');
@@ -243,7 +243,7 @@ posix("rejects a Root replaced after its absence probe", async () => {
       throw error;
     }
   });
-  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" }))
     .rejects.toMatchObject({ code: "path-mismatch" });
   expect(opened()?.fd).toBe(-1);
 });

--- a/test/sidecar-lock-root-ancestry.test.ts
+++ b/test/sidecar-lock-root-ancestry.test.ts
@@ -28,7 +28,7 @@ it.skipIf(process.platform === "win32")("rechecks ancestors even when the immedi
     await fs.mkdir(ancestor);
     await fs.rename(`${ancestor}.old/parent`, `${ancestor}/parent`);
   } });
-  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" }))
     .rejects.toMatchObject({ code: "path-mismatch" });
 });
 
@@ -43,7 +43,7 @@ it.skipIf(process.platform === "win32")("permits an unchanged canonical parent r
     __setFsSafeTestHooksForTest();
     await fs.unlink(lockPath);
   } });
-  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true })).resolves.toBeNull();
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" })).resolves.toBeNull();
   const manager = createFileLockManager(`alias:${lockPath}`);
   const held = await manager.acquire(path.join(capability.rootReal, "state"), {
     lockRoot: capability, lockPath, payload: () => ({}),
@@ -71,7 +71,7 @@ it.each(["numeric", "unknown", "changed", "EACCES", "EIO"])("rejects %s canonica
       return value;
     });
   } });
-  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" }))
     .rejects.toMatchObject({ code: "path-mismatch" });
 });
 
@@ -85,7 +85,7 @@ it.each(["EACCES", "EIO"])("does not treat initial directory %s as missing-paren
     if (String(args[0]) === capability.rootReal && typeof args[1] === "object" && args[1]?.bigint) throw failure;
     return await lstat(...args);
   });
-  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true })).rejects.toBe(failure);
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" })).rejects.toBe(failure);
   expect(open).not.toHaveBeenCalled();
 });
 

--- a/test/sidecar-lock-root-preopen-boundary.test.ts
+++ b/test/sidecar-lock-root-preopen-boundary.test.ts
@@ -1,0 +1,139 @@
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createFileLockManager } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { readSidecarLockSnapshot } from "../src/sidecar-lock-reclaim.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const itPosix = it.skipIf(process.platform === "win32");
+afterEach(() => {
+  __setFsSafeTestHooksForTest();
+  vi.restoreAllMocks();
+});
+
+itPosix.each(["root", "strict", "unlinked", "changed"] as const)(
+  "keeps pre-open replacement separate from %s read authority", async (policy) => {
+    const capability = await root(await tempRoot("sidecar-preopen-policy-"));
+    const lockPath = path.join(capability.rootReal, "state.lock");
+    await capability.create("state.lock", '{"owner":"original"}');
+    let descriptor: FileHandle | undefined;
+    __setFsSafeTestHooksForTest({ async afterPreOpenLstat(candidate) {
+      if (candidate !== lockPath) return;
+      __setFsSafeTestHooksForTest();
+      await fs.rename(lockPath, `${lockPath}.old`);
+      await fs.writeFile(lockPath, '{"owner":"replacement"}', { flag: "wx" });
+    }, afterOpen(candidate, handle) {
+      if (candidate === lockPath) descriptor = handle;
+    } });
+    const parsePayload = vi.fn(JSON.parse);
+    const pending = policy === "root" ? capability.open("state.lock") : readSidecarLockSnapshot(lockPath, {
+      lockRoot: capability, parsePayload, discardObservation: policy === "strict" ? undefined : policy,
+    });
+    if (policy === "changed") await expect(pending).resolves.toBeNull();
+    else await expect(pending).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(descriptor?.fd).toBe(-1);
+    expect(parsePayload).not.toHaveBeenCalled();
+    expect(await fs.readFile(lockPath, "utf8")).toBe('{"owner":"replacement"}');
+    expect(await fs.readFile(`${lockPath}.old`, "utf8")).toBe('{"owner":"original"}');
+    expect((await fs.lstat(`${lockPath}.old`)).nlink).toBe(1);
+  },
+);
+
+itPosix.each(["root", "ancestor", "symlink-leaf", "directory-leaf", "before-multilink", "opened-multilink", "numeric-multilink"])(
+  "rejects a changed snapshot with %s evidence", async (mutation) => {
+    const base = await tempRoot("sidecar-preopen-boundary-");
+    const rootDir = path.join(base, "root"), relative = "ancestor/parent/state.lock";
+    await fs.mkdir(rootDir);
+    const capability = await root(rootDir);
+    const lockPath = path.join(capability.rootReal, relative), outside = path.join(base, "outside");
+    await fs.writeFile(outside, "sentinel");
+    await capability.create(relative, '{"owner":"original"}', { mkdir: true });
+    if (mutation === "before-multilink") await fs.link(lockPath, path.join(base, "original-alias"));
+    let descriptor: FileHandle | undefined;
+    __setFsSafeTestHooksForTest({ async afterPreOpenLstat(candidate) {
+      if (candidate !== lockPath) return;
+      __setFsSafeTestHooksForTest();
+      if (mutation === "root") {
+        await fs.rename(rootDir, path.join(base, "old-root"));
+        await fs.mkdir(path.dirname(lockPath), { recursive: true });
+      } else {
+        if (mutation === "ancestor") {
+          const ancestor = path.join(rootDir, "ancestor");
+          await fs.rename(ancestor, path.join(base, "old-ancestor"));
+          await fs.mkdir(ancestor);
+          await fs.rename(path.join(base, "old-ancestor/parent"), path.join(ancestor, "parent"));
+        }
+        await fs.rename(lockPath, `${lockPath}.old`);
+      }
+      await fs.writeFile(lockPath, '{"owner":"replacement"}', { flag: "wx" });
+      if (mutation === "opened-multilink") await fs.link(lockPath, path.join(base, "replacement-alias"));
+    }, async afterOpen(candidate, handle) {
+      if (candidate !== lockPath) return;
+      descriptor = handle;
+      if (mutation === "numeric-multilink") {
+        const stat = handle.stat.bind(handle);
+        vi.spyOn(handle, "stat").mockImplementation(async (options) => {
+          const value = await stat(options);
+          return options?.bigint ? value : Object.assign(value, { nlink: 2 });
+        });
+      }
+      if (mutation === "symlink-leaf" || mutation === "directory-leaf") {
+        await fs.unlink(lockPath);
+        if (mutation === "symlink-leaf") await fs.symlink(outside, lockPath);
+        else await fs.mkdir(lockPath);
+      }
+    } });
+    const parsePayload = vi.fn(JSON.parse);
+    await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "changed", parsePayload }))
+      .rejects.toMatchObject({ code: "path-mismatch" });
+    expect(descriptor?.fd).toBe(-1);
+    expect(parsePayload).not.toHaveBeenCalled();
+    expect(await fs.readFile(outside, "utf8")).toBe("sentinel");
+    if (!mutation.endsWith("-leaf")) expect(await fs.readFile(lockPath, "utf8")).toBe('{"owner":"replacement"}');
+  },
+);
+
+itPosix("does not discard a pre-open replacement during creator admission", async () => {
+  const capability = await root(await tempRoot("sidecar-preopen-admission-"));
+  const target = path.join(capability.rootReal, "state"), lockPath = `${target}.lock`;
+  const manager = createFileLockManager(`preopen-admission:${target}`), create = vi.spyOn(capability, "create");
+  __setFsSafeTestHooksForTest({ async afterPreOpenLstat(candidate) {
+    if (candidate !== lockPath) return;
+    __setFsSafeTestHooksForTest();
+    await fs.rename(lockPath, `${lockPath}.old`);
+    await fs.writeFile(lockPath, '{"owner":"replacement"}', { flag: "wx" });
+  } });
+  await expect(manager.acquire(target, { lockRoot: capability, payload: () => ({ owner: "creator" }), retry: { retries: 0 } }))
+    .rejects.toMatchObject({ code: "path-mismatch" });
+  expect(create).toHaveBeenCalledTimes(1);
+  expect(manager.heldEntries()).toEqual([]);
+  await manager.drain();
+  expect(JSON.parse(await fs.readFile(`${lockPath}.old`, "utf8"))).toEqual({ owner: "creator" });
+  expect(await fs.readFile(lockPath, "utf8")).toBe('{"owner":"replacement"}');
+});
+
+itPosix("charges a changed observation to the retry budget without parsing or reclaiming", async () => {
+  const capability = await root(await tempRoot("sidecar-preopen-budget-"));
+  const target = path.join(capability.rootReal, "state"), lockPath = `${target}.lock`;
+  await capability.create("state.lock", '{"owner":"original"}');
+  const manager = createFileLockManager(`preopen-budget:${target}`);
+  const create = vi.spyOn(capability, "create"), parsePayload = vi.fn(JSON.parse), shouldReclaim = vi.fn(() => true);
+  __setFsSafeTestHooksForTest({ async afterPreOpenLstat(candidate) {
+    if (candidate !== lockPath) return;
+    __setFsSafeTestHooksForTest();
+    await fs.rename(lockPath, `${lockPath}.old`);
+    await fs.writeFile(lockPath, '{"owner":"replacement"}', { flag: "wx" });
+  } });
+  await expect(manager.acquire(target, {
+    lockRoot: capability, payload: () => ({}), retry: { retries: 0 }, parsePayload, shouldReclaim,
+  })).rejects.toMatchObject({ code: "file_lock_timeout" });
+  expect(create).toHaveBeenCalledTimes(1);
+  expect(parsePayload).not.toHaveBeenCalled();
+  expect(shouldReclaim).not.toHaveBeenCalled();
+  expect(manager.heldEntries()).toEqual([]);
+  await manager.drain();
+  expect(await fs.readFile(lockPath, "utf8")).toBe('{"owner":"replacement"}');
+});

--- a/test/sidecar-lock-root-preopen.test.ts
+++ b/test/sidecar-lock-root-preopen.test.ts
@@ -1,0 +1,79 @@
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createFileLockManager } from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+afterEach(() => {
+  __setFsSafeTestHooksForTest();
+  vi.restoreAllMocks();
+});
+
+it.skipIf(process.platform === "win32")("retries a completed handoff between pre-open lstat and open without adopting the successor", async () => {
+  const capability = await root(await tempRoot("sidecar-preopen-handoff-"));
+  const target = path.join(capability.rootReal, "state"), lockPath = `${target}.lock`;
+  const ownerManager = createFileLockManager(`preopen-owner:${target}`);
+  const successorManager = createFileLockManager(`preopen-successor:${target}`);
+  const waiterManager = createFileLockManager(`preopen-waiter:${target}`);
+  const options = { lockRoot: capability, retry: { retries: 1, minTimeout: 0, maxTimeout: 0 } };
+  const owner = await ownerManager.acquire(target, { ...options, payload: () => ({ owner: "original" }) });
+  const retained = await fs.open(lockPath, "r");
+  const original = await retained.stat({ bigint: true });
+  const parsePayload = vi.fn(JSON.parse), shouldReclaim = vi.fn(() => false);
+  let successor: Awaited<ReturnType<typeof successorManager.acquire>> | undefined;
+  let waiter: Awaited<ReturnType<typeof waiterManager.acquire>> | undefined;
+  let discarded: FileHandle | undefined;
+  let freshCreate = false;
+  let handoff = false;
+  __setFsSafeTestHooksForTest({
+    async afterPreOpenLstat(candidate) {
+      if (candidate !== lockPath || handoff) return;
+      handoff = true;
+      __setFsSafeTestHooksForTest();
+      await owner.release();
+      expect((await retained.stat({ bigint: true })).nlink).toBe(0n);
+      successor = await successorManager.acquire(target, { ...options, payload: () => ({ owner: "successor" }) });
+      const replacement = await fs.lstat(lockPath, { bigint: true });
+      expect([replacement.dev, replacement.ino]).not.toEqual([original.dev, original.ino]);
+      const bytes = await fs.readFile(lockPath);
+      const create = capability.create.bind(capability);
+      vi.spyOn(capability, "create").mockImplementationOnce(async (...args) => {
+        expect(discarded?.fd).toBe(-1);
+        expect(waiterManager.heldEntries()).toEqual([]);
+        expect(parsePayload).not.toHaveBeenCalled();
+        expect(shouldReclaim).not.toHaveBeenCalled();
+        expect(await fs.readFile(lockPath)).toEqual(bytes);
+        await successor!.release();
+        freshCreate = true;
+        return await create(...args);
+      });
+    },
+    afterOpen(candidate, handle) {
+      if (candidate === lockPath && !discarded) discarded = handle;
+    },
+  });
+  try {
+    waiter = await waiterManager.acquire(target, {
+      ...options, payload: () => ({ owner: "waiter" }), parsePayload, shouldReclaim,
+    });
+    expect(handoff).toBe(true);
+    expect(freshCreate).toBe(true);
+    expect(parsePayload).not.toHaveBeenCalled();
+    expect(shouldReclaim).not.toHaveBeenCalled();
+    expect(JSON.parse(await fs.readFile(lockPath, "utf8"))).toEqual({ owner: "waiter" });
+    await expect(waiter.verifyStillHeld()).resolves.toBe(true);
+  } finally {
+    __setFsSafeTestHooksForTest();
+    vi.restoreAllMocks();
+    await waiter?.release();
+    await successor?.release();
+    await owner.release();
+    await retained.close();
+    await ownerManager.drain();
+    await successorManager.drain();
+    await waiterManager.drain();
+  }
+});

--- a/test/sidecar-lock-root-resolver.test.ts
+++ b/test/sidecar-lock-root-resolver.test.ts
@@ -103,7 +103,7 @@ it.each(["numeric", "unknown", "closed", "changed", "linked", "multiple-links"])
         });
       },
     });
-    await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true })).rejects.toBe(failure);
+    await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" })).rejects.toBe(failure);
     expect(descriptor?.fd).toBe(-1);
   },
 );
@@ -124,7 +124,7 @@ it.each(["beforeOpen", "afterOpen", "afterOpenedPathIdentityCheck"] as const)(
         await fs.unlink(lockPath);
         throw failure;
       } });
-      await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+      await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" }))
         .rejects.toBe(failure);
       if (descriptor) expect(descriptor.fd).toBe(-1);
     }
@@ -158,7 +158,7 @@ it.each([false, true])("parser ENOENT remains a caller error (Root: %s)", async 
   const failure = Object.assign(new Error("parser failure"), { code: "ENOENT" });
   await expect(readSidecarLockSnapshot(lockPath, {
     ...(bounded ? { lockRoot: capability } : {}),
-    discardUnlinked: true, parsePayload: () => { throw failure; },
+    discardObservation: "unlinked", parsePayload: () => { throw failure; },
   })).rejects.toBe(failure);
 });
 
@@ -207,7 +207,7 @@ it("does not replay a never-consumed Root open failure in a later observation", 
   await capability.create("state.lock", "foreign");
   const fail = vi.fn(() => { throw historical; });
   __setFsSafeTestHooksForTest({ beforeOpen: fail });
-  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardUnlinked: true }))
+  await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" }))
     .rejects.toBe(historical);
   expect(fail).toHaveBeenCalledTimes(1);
   expect(await fs.readFile(lockPath, "utf8")).toBe("foreign");
@@ -245,14 +245,14 @@ it.each(["sequential", "nested", "interleaved"])(
     } });
     const observeFirst = async () => {
       observingFirst = true;
-      try { return await readSidecarLockSnapshot(firstPath, { lockRoot: capability, discardUnlinked: true }); }
+      try { return await readSidecarLockSnapshot(firstPath, { lockRoot: capability, discardObservation: "unlinked" }); }
       finally { observingFirst = false; }
     };
     if (order === "sequential") {
       await expect(observeFirst()).resolves.toBeNull();
       await capability.create("first.lock", "replacement");
     }
-    const second = expect(readSidecarLockSnapshot(secondPath, { lockRoot: capability, discardUnlinked: true }))
+    const second = expect(readSidecarLockSnapshot(secondPath, { lockRoot: capability, discardObservation: "unlinked" }))
       .rejects.toBe(failure);
     if (order === "interleaved") {
       await paused;


### PR DESCRIPTION
## Problem and fix

The 0.7.1 preparation passed PR CI, but [the merged-main gate](https://github.com/openclaw/fs-safe/actions/runs/33535430505) caught a macOS Node 24 Root-async contention failure (`path-mismatch`, 79/100 completed acquisitions). Publication is still paused: no release tag has been pushed.

A deterministic regression on macOS and isolated Linux confirms a missing handoff case: a waiter samples holder A with pre-open lstat, A releases, and holder B creates the next record before the waiter opens it. Root correctly rejects the A/B identity mismatch. The lock contender previously had no way to discard this stale observation, even though it was not acquiring or removing anything from it.

Record a distinct, current-observation pre-open-change receipt only with strictly known, different, regular-file identities, no observed multiple links, and a stable descriptor reinspection. Only an EEXIST contention snapshot may consume that receipt, after the existing complete canonical-ancestry and current-leaf checks. It discards the observation and charges the normal retry budget; success still requires fresh exclusive creation. It does not read or adopt B's payload, infer that A was unlinked, or grant absence/removal/reclaim authority.

Generic Root reads remain strict. Post-create admission explicitly retains its narrower unlinked-only policy, and held/reclaim/cleanup reads do not opt into changed-observation discard. The creator's exact-byte/token check and original cleanup receipt remain unchanged. Production change: **net +30 lines**, with no public API, dependency, or native-code change.

## Verification

- Before: the real-filesystem regression fails at the strict pre-open/descriptor identity comparison on macOS and Linux.
- After: 158 focused lock/identity/provenance/admission/ancestry tests pass, including 36 new regression/control cases.
- Full native-backed `pnpm check`: **6,364 passed / 81 skipped**.
- `pnpm test:security`: **84 passed**; locked Rust tests: **63 passed**; Clippy with warnings denied passed.
- Public contention: five repetitions of all four pathname/Root async/sync cases in each native mode, **6,000 completed acquisitions**, with release-retry permission controls passing.
- Docs build, documentation examples, npm/pnpm host-native package smoke, and whitespace/source consistency checks passed.
- New controls cover stale pre-open samples whose old inode remains linked, generic/strict/unlinked-only readers, creator admission, retry exhaustion, ancestor/Root replacement, unsafe current leaves, observed multiple links, unknown/inexact/drifting/closed descriptors, and historical receipts.
- The first expanded-test run exposed fixture setup errors (hooks are captured at open entry, and the Root directory must already exist). Those fixtures were corrected without weakening assertions or increasing deadlines. Full proof above is on the corrected frozen candidate.

Frozen tested tree: `f572891984b3d03d79220c4c20a4a323f580bc6a`.

The dated 0.7.1 changelog and lock documentation are updated as part of the explicitly requested in-progress release. All 0.7.0-and-older notes remain unchanged. The release tag will target latest main only after this fix lands and its prerequisites pass.
