### PR TITLE
fix(atomic): recheck move authorization before rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.2 - 2026-09-01
+
+- Add `movePathWithCopyFallback({ assertBeforeRename })` to synchronously recheck caller-owned authorization immediately before direct or staged rename, preserving refusal errors and rejecting asynchronous callbacks without publishing the move.
+
 ## 0.7.1 - 2026-09-01
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "fs-safe-native"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bzip2",
  "flate2",

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -209,6 +209,40 @@ throws `ESTALE` before commit when possible. If the destination has already
 been committed, cleanup still preserves the changed source entries and throws
 `ESTALE`.
 
+### Final rename authorization
+
+Pass `assertBeforeRename` when a move depends on a revocable lease or another
+caller-owned authorization. The helper captures this callback when called and
+runs it synchronously after asynchronous preparation and directory checks,
+immediately before each rename is dispatched:
+
+```ts
+type MovePathWithCopyFallbackOptions = {
+  from: string;
+  sourceHardlinks?: "allow" | "reject";
+  to: string;
+  assertBeforeRename?: () => void;
+};
+```
+
+Throw to refuse publication. The original error is propagated, including errors
+with `EXDEV` or `EPERM` codes; an authorization failure never starts a copy
+fallback. A genuine rename failure may still require a second authorization
+check before publishing the staged copy.
+
+The callback must return `undefined` synchronously. Returning a Promise, thenable,
+or any other value refuses the rename with a `TypeError`; rejected asynchronous
+results are consumed without authorizing the operation. Perform asynchronous
+policy checks before calling the helper and use this callback to recheck the
+current owner at the mutation boundary.
+
+A refused rename leaves the source and destination unchanged; any private
+staged copy follows the helper's normal cleanup. The check does not cancel an
+already-dispatched rename or make an external lease store atomic with the
+filesystem. Cleanup after a successful move retains the existing source-identity
+checks. Omitting the
+callback preserves the usual move behavior.
+
 ## Difference from `root()`
 
 | `Root` methods | `atomic` helpers |

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fs-safe-native"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/openclaw/fs-safe"

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-native-build",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Private build workspace for the native bindings bundled by @openclaw/fs-safe.",
   "private": true,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Capability-style filesystem roots for Node.js apps that handle untrusted relative paths.",
   "keywords": [
     "filesystem",
@@ -149,13 +149,13 @@
     "crabbox:warmup": "crabbox warmup"
   },
   "optionalDependencies": {
-    "@openclaw/fs-safe-darwin-arm64": "0.7.1",
-    "@openclaw/fs-safe-darwin-x64": "0.7.1",
-    "@openclaw/fs-safe-linux-arm64-gnu": "0.7.1",
-    "@openclaw/fs-safe-linux-arm64-musl": "0.7.1",
-    "@openclaw/fs-safe-linux-x64-gnu": "0.7.1",
-    "@openclaw/fs-safe-linux-x64-musl": "0.7.1",
-    "@openclaw/fs-safe-win32-x64-msvc": "0.7.1",
+    "@openclaw/fs-safe-darwin-arm64": "0.7.2",
+    "@openclaw/fs-safe-darwin-x64": "0.7.2",
+    "@openclaw/fs-safe-linux-arm64-gnu": "0.7.2",
+    "@openclaw/fs-safe-linux-arm64-musl": "0.7.2",
+    "@openclaw/fs-safe-linux-x64-gnu": "0.7.2",
+    "@openclaw/fs-safe-linux-x64-musl": "0.7.2",
+    "@openclaw/fs-safe-win32-x64-msvc": "0.7.2",
     "jszip": "^3.10.1",
     "tar": "7.5.22"
   },

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-darwin-arm64",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "macOS arm64 native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-darwin-x64",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "macOS x64 native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-arm64-gnu",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Linux arm64 glibc native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-musl/package.json
+++ b/packages/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-arm64-musl",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Linux arm64 musl native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-x64-gnu",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Linux x64 glibc native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-x64-musl/package.json
+++ b/packages/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-x64-musl",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Linux x64 musl native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/win32-x64-msvc/package.json
+++ b/packages/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-win32-x64-msvc",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Windows x64 MSVC native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,25 +46,25 @@ importers:
         version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1))
     optionalDependencies:
       '@openclaw/fs-safe-darwin-arm64':
-        specifier: 0.7.1
+        specifier: 0.7.2
         version: link:packages/darwin-arm64
       '@openclaw/fs-safe-darwin-x64':
-        specifier: 0.7.1
+        specifier: 0.7.2
         version: link:packages/darwin-x64
       '@openclaw/fs-safe-linux-arm64-gnu':
-        specifier: 0.7.1
+        specifier: 0.7.2
         version: link:packages/linux-arm64-gnu
       '@openclaw/fs-safe-linux-arm64-musl':
-        specifier: 0.7.1
+        specifier: 0.7.2
         version: link:packages/linux-arm64-musl
       '@openclaw/fs-safe-linux-x64-gnu':
-        specifier: 0.7.1
+        specifier: 0.7.2
         version: link:packages/linux-x64-gnu
       '@openclaw/fs-safe-linux-x64-musl':
-        specifier: 0.7.1
+        specifier: 0.7.2
         version: link:packages/linux-x64-musl
       '@openclaw/fs-safe-win32-x64-msvc':
-        specifier: 0.7.1
+        specifier: 0.7.2
         version: link:packages/win32-x64-msvc
       jszip:
         specifier: ^3.10.1

--- a/src/guarded-mutation.ts
+++ b/src/guarded-mutation.ts
@@ -64,6 +64,7 @@ export function withSyncDirectoryGuards<T>(
 }
 
 export async function guardedRename(params: {
+  assertBeforeRename?: () => void;
   from: string;
   to: string;
   targetRoot?: string;
@@ -76,6 +77,8 @@ export async function guardedRename(params: {
   await withAsyncDirectoryGuards(
     [sourceGuard, targetGuard],
     async () => {
+      // Authority must survive all awaited guards; do not yield before rename dispatch.
+      params.assertBeforeRename?.();
       await fs.rename(params.from, params.to);
     },
     { verifyAfter: params.verifyAfter },

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -9,6 +9,8 @@ import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { registerTempPathForExit } from "./temp-cleanup.js";
 
 export type MovePathWithCopyFallbackOptions = {
+  /** Rechecks caller authority synchronously immediately before each rename dispatch. */
+  assertBeforeRename?: () => void;
   from: string;
   sourceHardlinks?: "allow" | "reject";
   to: string;
@@ -368,6 +370,22 @@ async function cleanupCopiedEntry(
 export async function movePathWithCopyFallback(
   options: MovePathWithCopyFallbackOptions,
 ): Promise<void> {
+  // Keep the initiating owner's callback across preparation and copy fallback.
+  const callerAssert = options.assertBeforeRename;
+  let assertionRejected = false;
+  const assertBeforeRename = () => {
+    try {
+      const returned = callerAssert?.();
+      if (returned !== undefined) {
+        // TypeScript permits async functions for () => void; they cannot authorize a rename.
+        void Promise.resolve(returned).catch(() => {});
+        throw new TypeError("assertBeforeRename must return undefined synchronously");
+      }
+    } catch (error) {
+      assertionRejected = true;
+      throw error;
+    }
+  };
   const sourcePath = path.resolve(options.from);
   const targetPath = path.resolve(options.to);
   const rejectHardlinks = options.sourceHardlinks === "reject";
@@ -377,10 +395,11 @@ export async function movePathWithCopyFallback(
 
   if (!rejectHardlinks) {
     try {
-      await guardedRename({ from: sourcePath, to: targetPath });
+      await guardedRename({ from: sourcePath, to: targetPath, assertBeforeRename });
       return;
     } catch (error) {
-      if (!moveCopyFallbackReasonForRenameError(error)) {
+      // An owner's EXDEV/EPERM refusal is not permission to copy instead.
+      if (assertionRejected || !moveCopyFallbackReasonForRenameError(error)) {
         throw error;
       }
     }
@@ -401,7 +420,7 @@ export async function movePathWithCopyFallback(
     });
     unregisterStaged.setIdentity(await fs.lstat(staged, { bigint: true }));
     await assertCopyDestinationOutsideSource(sourcePath, targetPath);
-    await guardedRename({ from: staged, to: targetPath });
+    await guardedRename({ from: staged, to: targetPath, assertBeforeRename });
     stagedCommitted = true;
     unregisterStaged();
     const cleanupResult = await cleanupCopiedEntry(sourcePath, manifest);

--- a/test/move-path-authority.test.ts
+++ b/test/move-path-authority.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  movePathWithCopyFallback,
+  type MovePathWithCopyFallbackOptions,
+} from "../src/atomic.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+const routes = [
+  { name: "direct rename", sourceHardlinks: "allow", fallback: false },
+  { name: "staged copy", sourceHardlinks: "reject", fallback: false },
+  { name: "EXDEV fallback", sourceHardlinks: "allow", fallback: true },
+] as const;
+
+async function moveFixture() {
+  const root = await tempRoot("fs-safe-move-authority-");
+  const sourceParent = path.join(root, "incoming");
+  const targetParent = path.join(root, "installed");
+  await fs.mkdir(sourceParent);
+  await fs.mkdir(targetParent);
+  const source = path.join(sourceParent, "payload.txt");
+  const target = path.join(targetParent, "payload.txt");
+  await fs.writeFile(source, "replacement");
+  await fs.writeFile(target, "original");
+  return { source, target, targetParent };
+}
+
+type MoveFixture = Awaited<ReturnType<typeof moveFixture>>;
+
+function observeRename(fixture: MoveFixture, fallback: boolean, onDispatch?: () => void) {
+  const rename = fs.rename;
+  return vi.spyOn(fs, "rename").mockImplementation((from, to) => {
+    onDispatch?.();
+    if (fallback && from === fixture.source && to === fixture.target) {
+      return Promise.reject(Object.assign(new Error("cross-device"), { code: "EXDEV" }));
+    }
+    return rename(from, to);
+  });
+}
+
+async function expectUnpublished(fixture: MoveFixture) {
+  await expect(fs.readFile(fixture.source, "utf8")).resolves.toBe("replacement");
+  await expect(fs.readFile(fixture.target, "utf8")).resolves.toBe("original");
+  await expect(fs.readdir(fixture.targetParent)).resolves.toEqual(["payload.txt"]);
+}
+
+describe("movePathWithCopyFallback publication authority", () => {
+  it.each(routes)("refuses $name when authority expires during directory preparation", async (route) => {
+    const fixture = await moveFixture();
+    const expired = new Error("move owner expired");
+    let active = true;
+    const rename = observeRename(fixture, route.fallback);
+    const paused = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const lstat = fs.lstat;
+    let pausedOnce = false;
+    vi.spyOn(fs, "lstat").mockImplementation(async (candidate, options) => {
+      const stat = await lstat(candidate, options as never);
+      if (
+        !pausedOnce && candidate === fixture.targetParent &&
+        (!route.fallback || rename.mock.calls.length > 0)
+      ) {
+        pausedOnce = true;
+        paused.resolve();
+        // Deliver unchanged filesystem evidence after the caller loses authority.
+        await release.promise;
+      }
+      return stat;
+    });
+    const move = movePathWithCopyFallback({
+      from: fixture.source,
+      to: fixture.target,
+      sourceHardlinks: route.sourceHardlinks,
+      assertBeforeRename: () => {
+        if (!active) throw expired;
+      },
+    }).catch((error: unknown) => error);
+
+    try {
+      await Promise.race([
+        paused.promise,
+        move.then(() => { throw new Error("move settled before the preparation barrier"); }),
+      ]);
+      active = false;
+      release.resolve();
+      expect(await move).toBe(expired);
+      expect(rename).toHaveBeenCalledTimes(route.fallback ? 1 : 0);
+      await expectUnpublished(fixture);
+    } finally {
+      release.resolve();
+      await move;
+    }
+  });
+
+  it.each(routes)("does not yield between approval and $name dispatch", async (route) => {
+    const fixture = await moveFixture();
+    const events: string[] = [];
+    observeRename(fixture, route.fallback, () => events.push("rename"));
+
+    await movePathWithCopyFallback({
+      from: fixture.source,
+      to: fixture.target,
+      sourceHardlinks: route.sourceHardlinks,
+      assertBeforeRename: () => {
+        events.push("assert");
+        queueMicrotask(() => events.push("yield"));
+      },
+    });
+
+    const attempt = ["assert", "rename", "yield"];
+    expect(events).toEqual(route.fallback ? [...attempt, ...attempt] : attempt);
+    await expect(fs.readFile(fixture.target, "utf8")).resolves.toBe("replacement");
+    await expect(fs.lstat(fixture.source)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readdir(fixture.targetParent)).resolves.toEqual(["payload.txt"]);
+  });
+
+  it.each(["allow", "reject"] as const)(
+    "captures the initiating callback before awaiting with hardlinks %s",
+    async (sourceHardlinks) => {
+      const fixture = await moveFixture();
+      const expired = new Error("original owner expired");
+      const successor = vi.fn(() => {});
+      const options: MovePathWithCopyFallbackOptions = {
+        from: fixture.source,
+        to: fixture.target,
+        sourceHardlinks,
+        assertBeforeRename: () => { throw expired; },
+      };
+
+      const move = movePathWithCopyFallback(options);
+      options.assertBeforeRename = successor;
+
+      await expect(move).rejects.toBe(expired);
+      expect(successor).not.toHaveBeenCalled();
+      await expectUnpublished(fixture);
+    },
+  );
+
+  it.each(["EXDEV", "EPERM"])("does not copy when the assertion throws %s", async (code) => {
+    const fixture = await moveFixture();
+    const denied = Object.assign(new Error("caller denied publication"), { code });
+    const rename = vi.spyOn(fs, "rename");
+    const open = vi.spyOn(fs, "open");
+
+    await expect(movePathWithCopyFallback({
+      from: fixture.source,
+      to: fixture.target,
+      assertBeforeRename: () => { throw denied; },
+    })).rejects.toBe(denied);
+
+    expect(rename).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+    await expectUnpublished(fixture);
+  });
+
+  describe.each(["allow", "reject"] as const)("synchronous contract with hardlinks %s", (sourceHardlinks) => {
+    it.each([
+      { name: "false", create: () => false },
+      { name: "null", create: () => null },
+      { name: "fulfilled Promise", create: () => Promise.resolve() },
+      { name: "rejected Promise", create: () => Promise.reject(new Error("async denial")) },
+      {
+        name: "rejecting thenable",
+        create: () => ({
+          then(_resolve: unknown, reject: (reason: Error) => void) {
+            reject(new Error("thenable denial"));
+          },
+        }),
+      },
+    ])("refuses $name without publication or an unhandled rejection", async ({ create }) => {
+      const fixture = await moveFixture();
+      const rename = vi.spyOn(fs, "rename");
+      const unhandled: unknown[] = [];
+      const observeUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on("unhandledRejection", observeUnhandled);
+      try {
+        await expect(movePathWithCopyFallback({
+          from: fixture.source,
+          to: fixture.target,
+          sourceHardlinks,
+          assertBeforeRename: create,
+        })).rejects.toBeInstanceOf(TypeError);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(rename).not.toHaveBeenCalled();
+        expect(unhandled).toEqual([]);
+        await expectUnpublished(fixture);
+      } finally {
+        process.off("unhandledRejection", observeUnhandled);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers moving files or directories under a revocable authorization could publish after that authorization expired during asynchronous preparation. Checking immediately before calling `movePathWithCopyFallback` did not protect the eventual rename, including the staged-copy path.

## Why This Change Was Made

Add the optional `assertBeforeRename` callback, captured when the move starts and called synchronously after the directory guards, immediately before each rename dispatch. A refusal preserves the original error and cannot trigger copy fallback, even for `EXDEV` or `EPERM`. Promise, thenable, and other non-undefined returns refuse publication; asynchronous rejections are consumed.

Both direct moves and staged-copy publication use the same guarded rename boundary. Existing source-identity checks and cleanup remain in place. This does not cancel an already-dispatched syscall or make an external authorization store atomic with the filesystem. Production source delta is +22 lines; the new public contract and refusal handling require those additions.

## User Impact

Consumers can now revalidate the original operation owner at the last synchronous point before publication. Omitting the callback preserves existing behavior. The options type and atomic-operation documentation describe the contract. This PR also prepares the root package, seven native packages, private build workspace, crate, and generated locks for release 0.7.2.

## Evidence

- All 20 new regression cases fail against the unchanged 0.7.1 source and pass with this fix. They cover direct and staged moves, genuine cross-device fallback, callback capture, refusal identity, same-turn dispatch, and asynchronous return rejection. The focused move/atomic cohort passes 79 tests, with one existing platform skip.
- Live real-directory reproduction through the public package export: registry 0.7.1 publishes replacement bytes after cancellation and permits stale rollback to replace a successor directory. Built 0.7.2 refuses both before rename, preserves source/backup bytes and the successor inode, and still permits restoration by the active original owner. Package hashes remain unchanged during the run.
- `pnpm check`: 4,082 tests pass; 2,333 platform/native-specific cases skip in the JavaScript-fallback run. Includes build, boundary lint, documentation examples, package imports, and public API checks.
- `pnpm test:security`: 84 tests pass. `cargo test --workspace --locked`: 65 pass. `cargo clippy --workspace --locked -- -D warnings`, `pnpm docs:site`, and `git diff --check` pass.
- `pnpm native:build` and `pnpm package:smoke` pass on macOS arm64: real root-only npm 12.0.2 and pnpm 11.24.0 installs exercise require/auto/off modes, omitted optionals, and missing-binary refusal. Foreign filtering fixtures prove selection only; platform execution is covered separately by CI.
- Independent Codex review reports no actionable P0–P2 findings. The new test file adds 197 lines.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
