### PR TITLE
feat(exports): expose secure temp root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.7.3 - Unreleased
 
+- Add the narrow `@openclaw/fs-safe/secure-temp-root` package subpath so consumers can import `resolveSecureTempRoot()` and its options type without loading the temp workspace implementation.
+
 ## 0.7.2 - 2026-09-01
 
 - Add `movePathWithCopyFallback({ assertBeforeRename })` to synchronously recheck caller-owned authorization immediately before direct or staged rename, preserving refusal errors and rejecting asynchronous callbacks without publishing the move.

--- a/docs/temp.md
+++ b/docs/temp.md
@@ -358,6 +358,20 @@ const tempRoot = resolveSecureTempRoot({ fallbackPrefix: "my-app" });
 // e.g. /tmp/my-app-501
 ```
 
+Consumers that only need this resolver can use the narrow package subpath:
+
+```ts
+import {
+  resolveSecureTempRoot,
+  type ResolveSecureTempRootOptions,
+} from "@openclaw/fs-safe/secure-temp-root";
+```
+
+This entry excludes the temp workspace and store implementations from the
+module graph, keeping the import closure small for browser-aware builds that
+shim or exclude Node built-ins. The resolver remains a Node filesystem API; the
+narrow entry does not make it runnable in a browser.
+
 ### Options
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -93,6 +93,10 @@
       "types": "./dist/temp.d.ts",
       "default": "./dist/temp.js"
     },
+    "./secure-temp-root": {
+      "types": "./dist/secure-temp-dir.d.ts",
+      "default": "./dist/secure-temp-dir.js"
+    },
     "./atomic": {
       "types": "./dist/atomic.d.ts",
       "default": "./dist/atomic.js"

--- a/test/public-api.json
+++ b/test/public-api.json
@@ -488,6 +488,15 @@
       ],
       "errorCodes": {}
     },
+    "./secure-temp-root": {
+      "runtime": [
+        "resolveSecureTempRoot"
+      ],
+      "types": [
+        "ResolveSecureTempRootOptions"
+      ],
+      "errorCodes": {}
+    },
     "./atomic": {
       "runtime": [
         "movePathWithCopyFallback",


### PR DESCRIPTION
Related consumer failure: https://github.com/openclaw/openclaw/actions/runs/33592689200/job/100129782941

## What Problem This Solves

Fixes an export gap where consumers that only need `resolveSecureTempRoot()` cannot import its existing narrow implementation through a supported package subpath.

OpenClaw currently works around that gap with a synchronous `require()` of the broader ESM temp surface. During Full Release Validation under Node 24.19, that can race an active asynchronous import and fail with `ERR_REQUIRE_ESM_RACE_CONDITION`.

## Why This Change Was Made

This adds the additive `@openclaw/fs-safe/secure-temp-root` subpath, mapped directly to the existing `dist/secure-temp-dir.js` implementation and declaration file. It adds no wrapper and changes no runtime implementation.

The narrow entry keeps temp workspace and store modules out of the import graph. It remains a Node filesystem API and is not presented as browser-runnable.

## User Impact

Consumers can statically import:

```ts
import {
  resolveSecureTempRoot,
  type ResolveSecureTempRootOptions,
} from "@openclaw/fs-safe/secure-temp-root";
```

Existing imports and behavior remain unchanged.

## Evidence

- Base: `cce55330164eea3051d82114118d4b1de62e2f9c`
- Red proof before edit: importing `@openclaw/fs-safe/secure-temp-root` failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- Green proof after edit: the import succeeded and exposed `resolveSecureTempRoot`.
- `pnpm test test/secure-temp-dir.test.ts`: 13 passed.
- `pnpm public-api:update`: passed; generated exactly one runtime export and one type export for the new subpath.
- `pnpm pack:check`: passed, including packed install and import validation.
- `pnpm check`: 175 test files passed, 9 skipped; 4,082 tests passed, 2,333 skipped.
- `git diff --check`: passed.
- Mandatory Codex autoreview with `gpt-5.6-sol` at high reasoning: clean, no accepted or actionable findings.
- Exact-head PR CI at `ca8a1bffd322ec81d25ebe1b0f48badecc7d35c0`: 20 successful, 3 skipped, 0 failed.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included

## Scope And LOC

- Runtime implementation: `+0/-0`
- Package export metadata: `+4/-0`
- Generated public API inventory: `+9/-0`
- Documentation and changelog: `+16/-0`
- Total: `+29/-0`

## Release Gate

This PR must not trigger a local publish or version change. After merge, an authorized package owner must prepare `0.7.3`, create the protected annotated tag, let the trusted release workflow publish and verify all eight packages with provenance, and confirm the root package exposes `./secure-temp-root`. OpenClaw must not consume the subpath before that release is verified.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
source: local session
redaction: local paths, raw tool output, credentials, unrelated prior work

[user]
Execute Stage 1 only in fs-safe. Add the direct secure-temp-root export, generated
public API inventory, focused docs, and the existing 0.7.3 changelog entry. Prove
the pre-change export failure and post-change package behavior. Open a draft PR.
Do not merge, version, tag, publish, or edit OpenClaw.

[assistant]
Refreshed fs-safe origin/main and froze cce55330164e. The canonical checkout was
a partial clone, so created a separate full non-promisor source and a fresh GWT.
Hydrated dependencies only in that source; the task worktree uses a node_modules
symlink.

[assistant]
Captured the required red proof: after build, the new subpath failed with
ERR_PACKAGE_PATH_NOT_EXPORTED.

[assistant]
Changed only package.json, test/public-api.json, docs/temp.md, and CHANGELOG.md.
The API inventory came from the canonical generator. Runtime implementation
remained unchanged.

[assistant]
Green import, focused resolver tests, public API generation, pack validation,
the full repository gate, diff checks, privacy scrub, and mandatory autoreview
all passed. Committed and pushed ca8a1bf without any release mutation.
```

</details>
<!-- agent-transcript:end -->
