### PR TITLE
fix(archive): close TAR preflight streams on setup failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Avoid opening the TAR metadata stream until preflight setup succeeds, and always destroy it after pipeline completion, preventing descriptor leaks on setup failures. Thanks @SebTardif.
 - Separate archive staging permissions from final publication modes so zero/write-only files and restrictive directories extract correctly; finalize explicit and implicit directory modes through retained, verified authority and reject unsafe mode application instead of silently skipping it.
 - Decode absent TAR modes and supported signed GNU binary permission bits in native manifests, matching JavaScript defaults without changing the native ABI.
 - Reject serialized sidecar lock payloads above 1 MiB of UTF-8 bytes, including ownership overhead, with `too-large` before async or sync acquisition so admitted locks remain verifiable and releasable.

--- a/src/archive-tar-meta.ts
+++ b/src/archive-tar-meta.ts
@@ -259,12 +259,16 @@ export async function preflightTarMetadata(params: {
   signal?: AbortSignal;
   onMember?: (entry: TarEntryInfo) => void;
 }): Promise<void> {
-  const input = fs.createReadStream(params.archivePath);
   const meter = new TarMetadataMeter(params.limits, params.onMember);
   const sink = new Writable({ write(_chunk, _encoding, callback) { callback(); } });
-  if (await isGzip(params.archivePath)) {
-    await pipeline(input, createGunzip(), meter, sink, { signal: params.signal });
-  } else {
-    await pipeline(input, meter, sink, { signal: params.signal });
+  const gzip = await isGzip(params.archivePath);
+  const decoder = gzip ? createGunzip() : undefined;
+  const input = fs.createReadStream(params.archivePath);
+  try {
+    await (decoder
+      ? pipeline(input, decoder, meter, sink, { signal: params.signal })
+      : pipeline(input, meter, sink, { signal: params.signal }));
+  } finally {
+    input.destroy();
   }
 }

--- a/test/archive-read-boundaries.test.ts
+++ b/test/archive-read-boundaries.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
@@ -168,6 +169,43 @@ describe("TAR metadata preflight boundaries", () => {
       limits: resolveTarMeterLimits({ maxMetaEntryBytes: 1024 }),
       signal: controller.signal,
     })).rejects.toMatchObject({ code: "ABORT_ERR" });
+  });
+
+  it("finishes preflight setup before creating the archive stream", async () => {
+    const root = await tempRoot("fs-safe-tar-preflight-setup-");
+    const archivePath = path.join(root, "fixture.tar");
+    await fs.writeFile(archivePath, tarFixture([{ path: "value", body: "ok" }]));
+    const createReadStream = vi.spyOn(fsSync, "createReadStream");
+
+    await expect(preflightTarMetadata({
+      archivePath,
+      limits: { ...resolveTarMeterLimits({ maxMetaEntryBytes: 1024 }), maxDecodedBytes: Number.NaN },
+    })).rejects.toThrow("maxDecodedBytes must be a non-negative safe integer");
+    await expect(preflightTarMetadata({
+      archivePath: path.join(root, "missing.tar"),
+      limits: resolveTarMeterLimits({ maxMetaEntryBytes: 1024 }),
+    })).rejects.toMatchObject({ code: "ENOENT" });
+    expect(createReadStream).not.toHaveBeenCalled();
+  });
+
+  it("destroys the archive stream after a pipeline failure", async () => {
+    const root = await tempRoot("fs-safe-tar-preflight-pipeline-");
+    const archivePath = path.join(root, "truncated.tar");
+    await fs.writeFile(archivePath, Buffer.alloc(511));
+    const realCreateReadStream = fsSync.createReadStream;
+    const streams: fsSync.ReadStream[] = [];
+    vi.spyOn(fsSync, "createReadStream").mockImplementation(((...args: unknown[]) => {
+      const stream = Reflect.apply(realCreateReadStream, fsSync, args) as fsSync.ReadStream;
+      streams.push(stream);
+      return stream;
+    }) as typeof fsSync.createReadStream);
+
+    await expect(preflightTarMetadata({
+      archivePath,
+      limits: resolveTarMeterLimits({ maxMetaEntryBytes: 1024 }),
+    })).rejects.toThrow("truncated TAR header");
+    expect(streams).toHaveLength(1);
+    expect(streams[0]?.destroyed).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

`preflightTarMetadata()` opened its archive `ReadStream` before preflight setup had finished. If meter construction or the gzip probe failed before `pipeline()` owned the streams, the archive descriptor remained open until nondeterministic garbage collection.

This revision keeps the contributor's owner-boundary fix and tightens partial initialization:

- construct the metadata meter, sink, gzip classification and optional decoder before creating the archive stream;
- preserve the existing invalid-limit error precedence;
- once the stream exists, wrap pipeline execution in `finally` and always destroy it;
- verify both setup-before-open and pipeline-failure cleanup.

Thanks @SebTardif for identifying and fixing the leak. The rewritten commit retains `Co-authored-by: Sebastien Tardif <sebtardif@ncf.ca>`.

## Real descriptor proof

A real macOS Node 24 probe invokes the actual preflight entrypoint five times with an invalid internal decoded-byte limit. It identifies descriptors by exact bigint `dev`/`ino`; no descriptor values are fabricated.

```json
{
  "before": [
    {"attempt":1,"error":"RangeError","archiveDescriptors":[11]},
    {"attempt":2,"error":"RangeError","archiveDescriptors":[11,12]},
    {"attempt":3,"error":"RangeError","archiveDescriptors":[11,12,13]},
    {"attempt":4,"error":"RangeError","archiveDescriptors":[11,12,13,14]},
    {"attempt":5,"error":"RangeError","archiveDescriptors":[11,12,13,14,15]}
  ],
  "afterPackedInstall": [
    {"attempt":1,"error":"RangeError","archiveDescriptors":[]},
    {"attempt":2,"error":"RangeError","archiveDescriptors":[]},
    {"attempt":3,"error":"RangeError","archiveDescriptors":[]},
    {"attempt":4,"error":"RangeError","archiveDescriptors":[]},
    {"attempt":5,"error":"RangeError","archiveDescriptors":[]}
  ]
}
```

The after case runs through a fresh physical install of packed tree `09b6dfc28083f8eaff8ff1252b2dbd44f3da1718`. The packed artifact repeated 30 failed preflights across Node 22.0.0, 22.23.2 and 24.20.0 on arm64 plus real x64 Node under Rosetta; every descriptor census remained empty. Rosetta is translated execution, not physical Intel-hardware proof. Root artifact integrity: `sha512-crzfS0tebctS5PDYMNEBpPMUj7QO01jwNpPZk6e6zuCH/XkmnlaODhKZ4Re542jBVbIrIAhV+Gyc+yWqmVQ6qw==`. Package version remains 0.7.2; this PR does not publish a release.

## Validation

- Focused archive-read boundaries: 15 passed.
- `CI=1 pnpm check`: 6,808 passed / 77 skipped.
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: physical npm/pnpm consumers, optional-dependency omission and missing-binary behavior passed.
- Build, docs, file-size, filesystem-boundary and `git diff --check` passed.
- Independent Codex autoreview: scoped-clean at the P0 threshold, confidence 0.99.

Exact-head cross-platform CI is required before merge. The separate public `readArchiveEntry()` temp-allocation descriptor leak remains tracked independently and is not hidden by this repair.
