### PR TITLE
fix(archive): preserve unowned destinations on merge failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Preserve pre-existing and substituted destination files when an archive merge fails, leaving guarded copy cleanup to the operation that owns publication.
 - Add the narrow `@openclaw/fs-safe/secure-temp-root` package subpath so consumers can import `resolveSecureTempRoot()` and its options type without loading the temp workspace implementation.
 
 ## 0.7.2 - 2026-09-01

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -157,6 +157,17 @@ record and are then cleared; local PAX on unsupported types and GNU sparse
 
 If `kind` is omitted, the helper calls `resolveArchiveKind(archivePath)` and throws if the extension is not recognized. Pass `kind` explicitly when the archive name doesn't carry the type (e.g. content-addressed names). Archive inputs must remain regular files from preview through descriptor admission; POSIX opens are no-follow and nonblocking, so a FIFO swap cannot stall before deadline checks resume. A positive finite `timeoutMs` is a wall-clock budget; zero, negative, `NaN`, and infinity disable the deadline. Non-mutating work rejects promptly when the budget expires. If a live destination mutation is already in flight, rejection waits only for that mutation and any rollback to finish; no later destination mutation can begin.
 
+The destination merge is nontransactional: each file is published atomically,
+but completed files and directories can remain when a later copy, post-copy
+check, mode application, or deadline fails. This also applies to
+`mergeExtractedTreeIntoDestination()`. Guarded `Root.copyIn()` owns cleanup for
+its operation; the archive merge does not unlink the current destination name
+on error because it has no publication receipt proving ownership. A failure
+before publication preserves a pre-existing file, and rejection does not grant
+authority to delete a substituted file or alias. Failed extraction does not
+restore overwritten contents. Active destination mutations and their guarded
+cleanup still finish before rejection; no later destination mutation begins.
+
 ### Limits
 
 ```ts

--- a/src/archive-staging.ts
+++ b/src/archive-staging.ts
@@ -312,33 +312,6 @@ async function assertExtractedFileHasNoHardlinkAlias(params: {
   }
 }
 
-async function removeExtractedDestinationFile(params: {
-  destinationRealDir: string;
-  relPath: string;
-}): Promise<void> {
-  const destinationPath = path.join(params.destinationRealDir, params.relPath);
-  let stat: Awaited<ReturnType<typeof fs.lstat>>;
-  try {
-    stat = await fs.lstat(destinationPath);
-  } catch {
-    return;
-  }
-  if (!stat.isFile()) {
-    return;
-  }
-  let resolved: string;
-  try {
-    resolved = await fs.realpath(destinationPath);
-  } catch {
-    return;
-  }
-  if (!isPathInside(params.destinationRealDir, resolved)) {
-    return;
-  }
-  const targetRoot = await root(params.destinationRealDir);
-  await targetRoot.remove(params.relPath).catch(() => undefined);
-}
-
 function assertSafeArchiveStagingPrefix(prefix: string): string {
   if (
     !prefix ||
@@ -470,10 +443,8 @@ export async function mergeExtractedTreeIntoDestination(params: {
           });
           checkExtractionDeadline(params.deadline);
         } catch (err) {
-          await removeExtractedDestinationFile({
-            destinationRealDir: params.destinationRealDir,
-            relPath,
-          });
+          // copyIn owns its guarded cleanup. The merge has no publication
+          // receipt authorizing removal of the current destination entry.
           if (
             err instanceof FsSafeError &&
             (err.code === "hardlink" || err.code === "path-alias")

--- a/test/archive-merge-ownership.test.ts
+++ b/test/archive-merge-ownership.test.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { mergeExtractedTreeIntoDestination } from "../src/archive.js";
+import { withExtractionDeadline } from "../src/archive-deadline.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+
+afterEach(() => {
+  __setFsSafeTestHooksForTest(undefined);
+  __resetFsSafeNativeConfigForTest();
+});
+
+async function fixture() {
+  const base = await tempRoot("fs-safe-archive-ownership-");
+  const sourceDir = path.join(base, "source");
+  const destinationDir = path.join(base, "destination");
+  await fs.mkdir(sourceDir);
+  await fs.mkdir(destinationDir);
+  const source = path.join(sourceDir, "keep");
+  const target = path.join(destinationDir, "keep");
+  await fs.writeFile(source, "NEW");
+  await fs.writeFile(target, "OLD");
+  return {
+    base, source, target,
+    params: { sourceDir, destinationDir, destinationRealDir: destinationDir },
+  };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+describe("archive merge cleanup ownership", () => {
+  it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+    "preserves OLD when a real write-only source fails to open before publication",
+    async () => {
+      const { source, target, params } = await fixture();
+      const original = await fs.stat(target, { bigint: true });
+      await fs.chmod(source, 0o200);
+
+      try {
+        await expect(fs.readFile(source)).rejects.toMatchObject({ code: "EACCES" });
+        await expect(mergeExtractedTreeIntoDestination(params)).rejects.toMatchObject({
+          code: "EACCES",
+        });
+        await expect(fs.readFile(target, "utf8")).resolves.toBe("OLD");
+        await expect(fs.stat(target, { bigint: true })).resolves.toMatchObject({
+          dev: original.dev, ino: original.ino,
+        });
+        await expect(fs.readdir(params.destinationDir)).resolves.toEqual(["keep"]);
+      } finally {
+        await fs.chmod(source, 0o600);
+      }
+    },
+  );
+
+  it("successfully replaces OLD with NEW and merges nested entries", async () => {
+    const { source, target, params } = await fixture();
+    await fs.mkdir(path.join(params.sourceDir, "nested"));
+    await fs.writeFile(path.join(params.sourceDir, "nested", "entry"), "NESTED");
+    if (process.platform !== "win32") await fs.chmod(source, 0o640);
+
+    await mergeExtractedTreeIntoDestination(params);
+
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("NEW");
+    await expect(fs.readFile(path.join(params.destinationDir, "nested", "entry"), "utf8"))
+      .resolves.toBe("NESTED");
+    if (process.platform !== "win32") expect((await fs.stat(target)).mode & 0o777).toBe(0o640);
+  });
+
+  it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+    "retains a completed entry when the next source cannot be opened",
+    async () => {
+      const { params } = await fixture();
+      await fs.writeFile(path.join(params.sourceDir, "other"), "NEW");
+      await fs.writeFile(path.join(params.destinationDir, "other"), "OLD");
+      let completed = "";
+      let unreadable = "";
+      __setFsSafeTestHooksForTest({
+        async beforeArchiveOutputMutation(operation, targetPath) {
+          if (operation !== "chmod" || completed) return;
+          completed = path.basename(targetPath);
+          unreadable = completed === "keep" ? "other" : "keep";
+          await fs.chmod(path.join(params.sourceDir, unreadable), 0o200);
+        },
+      });
+
+      try {
+        await expect(mergeExtractedTreeIntoDestination(params)).rejects.toMatchObject({
+          code: "EACCES",
+        });
+        expect(completed).not.toBe("");
+        await expect(fs.readFile(path.join(params.destinationDir, completed), "utf8"))
+          .resolves.toBe("NEW");
+        await expect(fs.readFile(path.join(params.destinationDir, unreadable), "utf8"))
+          .resolves.toBe("OLD");
+      } finally {
+        if (unreadable) await fs.chmod(path.join(params.sourceDir, unreadable), 0o600);
+      }
+    },
+  );
+
+  itPosix.each(["file", "hardlink", "symlink"] as const)(
+    "preserves a substituted %s when copyIn rejects its post-rename identity check",
+    async (replacement) => {
+      configureFsSafeNative({ mode: "off" });
+      const { base, target, params } = await fixture();
+      const substitute = path.join(base, "substitute");
+      const published = path.join(base, "published");
+      await fs.writeFile(substitute, "SUBSTITUTE", { mode: 0o600 });
+      let replaced = false;
+      __setFsSafeTestHooksForTest({
+        async afterPinnedWriteFallbackRename(targetPath) {
+          if (targetPath !== target) return;
+          await fs.rename(target, published);
+          if (replacement === "file") await fs.rename(substitute, target);
+          else if (replacement === "hardlink") await fs.link(substitute, target);
+          else await fs.symlink(substitute, target);
+          replaced = true;
+        },
+      });
+
+      await expect(mergeExtractedTreeIntoDestination(params)).rejects.toMatchObject({
+        code: "path-mismatch",
+      });
+
+      expect(replaced).toBe(true);
+      await expect(fs.readFile(target, "utf8")).resolves.toBe("SUBSTITUTE");
+      await expect(fs.readFile(published, "utf8")).resolves.toBe("NEW");
+      if (replacement !== "file") {
+        await expect(fs.readFile(substitute, "utf8")).resolves.toBe("SUBSTITUTE");
+      }
+      expect((await fs.lstat(target)).isSymbolicLink()).toBe(replacement === "symlink");
+      if (replacement === "hardlink") expect((await fs.stat(target)).nlink).toBe(2);
+      expect((await fs.stat(target)).mode & 0o777).toBe(0o600);
+    },
+  );
+
+  itPosix("rejects a post-publication hardlink without unlinking either alias", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const { base, target, params } = await fixture();
+    const alias = path.join(base, "alias");
+    __setFsSafeTestHooksForTest({
+      async afterPinnedWriteFallbackRename(targetPath) {
+        if (targetPath === target) await fs.link(target, alias);
+      },
+    });
+
+    await expect(mergeExtractedTreeIntoDestination(params)).rejects.toMatchObject({
+      code: "destination-symlink-traversal",
+    });
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("NEW");
+    await expect(fs.readFile(alias, "utf8")).resolves.toBe("NEW");
+    expect((await fs.stat(target)).nlink).toBe(2);
+  });
+
+  itPosix("leaves receipt-based source-swap cleanup to copyIn", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const { base, source, target, params } = await fixture();
+    __setFsSafeTestHooksForTest({
+      async afterPinnedWriteFallbackRename(targetPath) {
+        if (targetPath !== target) return;
+        await fs.rename(source, path.join(base, "original-source"));
+        await fs.writeFile(source, "REPLACED SOURCE");
+      },
+    });
+
+    await expect(mergeExtractedTreeIntoDestination(params)).rejects.toMatchObject({
+      code: "path-mismatch",
+    });
+    await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(source, "utf8")).resolves.toBe("REPLACED SOURCE");
+  });
+
+  itPosix.each(["published", "file", "hardlink", "symlink"] as const)(
+    "joins post-copy timeout, preserves %s, and starts no later mutations",
+    async (replacement) => {
+      const { base, target, params } = await fixture();
+      const substitute = path.join(base, "substitute");
+      await fs.writeFile(substitute, "SUBSTITUTE", { mode: 0o600 });
+      await fs.writeFile(path.join(params.sourceDir, "later"), "LATER");
+      const entered = deferred();
+      const expired = deferred();
+      const release = deferred();
+      const mutations: string[] = [];
+      __setFsSafeTestHooksForTest({
+        async beforeArchiveOutputMutation(operation, targetPath) {
+          mutations.push(`${operation}:${targetPath}`);
+          if (operation !== "chmod" || targetPath !== target) return;
+          await expect(fs.readFile(target, "utf8")).resolves.toBe("NEW");
+          if (replacement !== "published") {
+            await fs.rename(target, path.join(base, "published"));
+            if (replacement === "file") await fs.rename(substitute, target);
+            else if (replacement === "hardlink") await fs.link(substitute, target);
+            else await fs.symlink(substitute, target);
+          }
+          entered.resolve();
+          await release.promise;
+        },
+      });
+      let settled = false;
+      const merge = withExtractionDeadline(1_000, "merge", async (deadline) => {
+        deadline.signal.addEventListener("abort", expired.resolve, { once: true });
+        await mergeExtractedTreeIntoDestination({ ...params, deadline });
+      });
+      void merge.then(() => { settled = true; }, () => { settled = true; });
+
+      try {
+        await entered.promise;
+        await expired.promise;
+        expect(settled).toBe(false);
+      } finally {
+        release.resolve();
+      }
+      await expect(merge).rejects.toThrow("merge timed out after 1000ms");
+      const expected = replacement === "published" ? "NEW" : "SUBSTITUTE";
+      await expect(fs.readFile(target, "utf8")).resolves.toBe(expected);
+      await expect(fs.readdir(params.destinationDir)).resolves.toEqual(["keep"]);
+      if (replacement === "hardlink" || replacement === "symlink") {
+        await expect(fs.readFile(substitute, "utf8")).resolves.toBe("SUBSTITUTE");
+      }
+      expect((await fs.lstat(target)).isSymbolicLink()).toBe(replacement === "symlink");
+      if (replacement === "hardlink") expect((await fs.stat(target)).nlink).toBe(2);
+      if (replacement !== "published") expect((await fs.stat(target)).mode & 0o777).toBe(0o600);
+
+      const mutationsAtRejection = [...mutations];
+      await fs.writeFile(target, "RECOVERY");
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(mutations).toEqual(mutationsAtRejection);
+      await expect(fs.readFile(target, "utf8")).resolves.toBe("RECOVERY");
+      await expect(fs.readdir(params.destinationDir)).resolves.toEqual(["keep"]);
+    },
+  );
+});

--- a/test/archive.test.ts
+++ b/test/archive.test.ts
@@ -374,7 +374,8 @@ describe("archive extraction", () => {
     }
 
     await expect(fs.readFile(outsideAlias, "utf8")).resolves.toBe("owned");
-    await expect(fs.stat(extractedPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(extractedPath, "utf8")).resolves.toBe("owned");
+    expect((await fs.stat(extractedPath)).nlink).toBe(2);
   });
 
   itPosix("pins the archive file before extraction", async () => {


### PR DESCRIPTION
## Problem

Whole-project live testing reproduced data loss in published 0.7.2 and current main. With a valid TAR or ZIP using a preserved write-only file mode, opening the staged replacement fails with `EACCES` before `Root.copyIn()` publishes anything. The archive merge's catch then unconditionally deletes the existing destination file. The public lower-level merge helper reproduces the same failure with a real mode-0200 source and an existing destination containing OLD.

The cleanup inspected the current pathname but had no publication receipt proving that the operation created or owned that inode. It could also delete a later replacement or hardlink alias.

## Fix and ownership boundary

Remove that archive-level path-only cleanup. `Root.copyIn()` still owns its guarded, receipt-based cleanup; archive path, link, identity, format, and byte checks remain. The archive merge is not a transaction: completed entries can remain after a later error, and already-overwritten bytes are not restored. Failure does not confer permission to delete a pre-existing or substituted entry. Active destination mutations and guarded cleanup are still joined before rejection, and no later mutation begins after rejection.

This removes **29 net production lines**, adds no executable production code, and introduces no dependency or public API change. Docs and the existing Unreleased changelog record the corrected failure semantics. Restrictive archive-mode staging itself is a separately tracked live-test finding, not claimed fixed here.

## Proof

- Real unprivileged macOS consumers: published 0.7.2 and freshly packed main fail before this patch, both with off and require configuration. Valid TAR and ZIP extraction removes OLD after source-open EACCES.
- Freshly packed candidate consumers: all four TAR/ZIP × off/require preservation cases retain OLD and the original EACCES; eight readable-mode successful controls still publish NEW correctly.
- Seven regressions fail against unchanged production code. The final ownership suite passes 12 cases covering old destinations, completed earlier entries, file/hardlink/symlink replacements, Root-owned source-swap cleanup, and post-copy timeout joining/no late mutation.
- Focused fallback run: 93 tests passed. Focused required-native run: 27 passed.
- Isolated Linux native-backed full `pnpm check`: **6,396 passed / 81 skipped**; security suite: **84 passed**; native build and host package smoke passed.
- Local full check had one unrelated ClawSweeper dispatch fixture timeout; that fixture passed its unchanged isolated rerun. No timeout or assertion was relaxed. The complete isolated Linux gate passed afterward.
- Independent Codex autoreview: scoped-clean at the configured P0 threshold, no accepted/actionable findings.

Reviewed, packed, and isolated-tested tree: `c7e42a75de2db74a6c7a88987553edf95691c7b4`.

No release, version bump, or publication is included. Broader live-test coverage and other confirmed defects remain active work.

## Inspectable real-run output

Selected fields from the actual unprivileged macOS consumer reports below; local paths are omitted. Every case starts with destination `keep` containing `OLD` and a valid TAR/ZIP member `keep` containing `NEW`, mode `0200`, then calls `extractArchive` with `entryModes: "preserve"`. The initiating source-open error intentionally remains; this patch fixes destination loss, not restrictive-mode support. These are physical npm/packed installations, not workspace import aliases.

```json
{"target": "published-0.7.2", "runtime": "v24.20.0", "platform": "darwin", "mode": "off", "format": "tar", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": false, "destinationBytes": null}
{"target": "published-0.7.2", "runtime": "v24.20.0", "platform": "darwin", "mode": "off", "format": "zip", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": false, "destinationBytes": null}
{"target": "published-0.7.2", "runtime": "v24.20.0", "platform": "darwin", "mode": "require", "format": "tar", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": false, "destinationBytes": null}
{"target": "published-0.7.2", "runtime": "v24.20.0", "platform": "darwin", "mode": "require", "format": "zip", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": false, "destinationBytes": null}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "mode": "off", "format": "tar", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": false, "destinationBytes": null}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "mode": "off", "format": "zip", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": false, "destinationBytes": null}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "mode": "require", "format": "tar", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": false, "destinationBytes": null}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "mode": "require", "format": "zip", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": false, "destinationBytes": null}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "mode": "off", "format": "tar", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": true, "destinationBytes": "OLD"}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "mode": "off", "format": "zip", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": true, "destinationBytes": "OLD"}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "mode": "require", "format": "tar", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": true, "destinationBytes": "OLD"}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "mode": "require", "format": "zip", "archivedMode": "0200", "errorCode": "EACCES", "destinationExists": true, "destinationBytes": "OLD"}
```

Candidate root tarball integrity: `sha512-M+9aeIez5F5YVYx13aaH9T7vn2oUj0JunqXVeepg/vifmK/vNapUE3eEoirSXTAPmv522xL1OS7BoSfwmYYZAw==`. Its tested source tree is `c7e42a75de2db74a6c7a88987553edf95691c7b4`, identical to PR head `479dcaa5e28ec22a4ca5006706e90fc67211f96a`. The valid mode-0600 controls all still return success and persist `NEW`. The regression suite additionally checks the unchanged original destination inode and preservation of substituted files/aliases.
