### PR TITLE
fix(secret): verify writes through retained descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Verify atomic secret writes through the writer's retained descriptor so restrictive POSIX modes such as `0o000` and `0o200` succeed without a readonly reopen or widened permissions.
 - Preserve pre-existing and substituted destination files when an archive merge fails, leaving guarded copy cleanup to the operation that owns publication.
 - Add the narrow `@openclaw/fs-safe/secure-temp-root` package subpath so consumers can import `resolveSecureTempRoot()` and its options type without loading the temp workspace implementation.
 

--- a/docs/secret-file.md
+++ b/docs/secret-file.md
@@ -125,6 +125,13 @@ startWebhookVerifier(signingKey);
 
 Async. Creates the parent directory at `dirMode` (default `0o700`) if missing, writes content to a sibling temp file at `mode` (default `0o600`), atomically renames over the destination, and re-asserts the file mode after rename.
 
+Publication verification borrows the writer's still-open descriptor to check
+the exact file identity, regular-file and link policy, requested POSIX mode,
+and root/parent ancestry before the writer closes it. POSIX mode overrides such
+as `0o000` and `0o200` do not require read permission or a readonly reopen, and
+verification does not widen the final mode. Windows retains its existing
+pathname-identity verification policy without enforcing POSIX mode bits.
+
 ```ts
 import { writeSecretFileAtomic } from "@openclaw/fs-safe/secret";
 

--- a/src/root-write-verification.ts
+++ b/src/root-write-verification.ts
@@ -15,6 +15,7 @@ export async function verifyAtomicWriteResult(params: {
   targetPath: string;
   fd: number;
   expectedIdentity: PublishedWriteIdentity;
+  expectedMode?: number;
   parentGuard: AsyncDirectoryGuard;
 }): Promise<void> {
   let needsPathOpen = false;
@@ -43,6 +44,14 @@ export async function verifyAtomicWriteResult(params: {
       throw new FsSafeError("path-mismatch", "descriptor changed during write");
     }
     assertFile(stat);
+    if (process.platform !== "win32" && params.expectedMode !== undefined) {
+      const actualMode = Number(stat.mode & 0o777n);
+      if (actualMode !== params.expectedMode) {
+        throw new Error(
+          `Private secret file ${params.targetPath} has insecure permissions ${actualMode.toString(8)}.`,
+        );
+      }
+    }
     return stat;
   };
   try {

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -6,11 +6,11 @@ import { readFileDescriptorBoundedSync } from "./bounded-read.js";
 import { normalizeMaxBytes } from "./byte-budget.js";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard, type AsyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
-import { sameFileIdentity, type FileIdentityStat } from "./file-identity.js";
 import { resolveHomeRelativePath } from "./home-dir.js";
 import { openPinnedFileSync } from "./pinned-open.js";
-import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { runPinnedWriteHelper } from "./pinned-write.js";
+import { ensureTrailingSep } from "./root-context.js";
+import { verifyAtomicWriteResult } from "./root-write-verification.js";
 import {
   assertSecretFilePreview,
   DEFAULT_SECRET_FILE_MAX_BYTES,
@@ -155,40 +155,6 @@ async function enforcePrivatePathMode(
   }
 }
 
-async function enforcePrivateFileIdentityAndMode(
-  resolvedPath: string,
-  expectedIdentity: FileIdentityStat,
-  expectedMode: number,
-): Promise<void> {
-  const handle = await fsp.open(resolvedPath, resolveReadOpenFlags());
-  try {
-    const openedStat = await handle.stat();
-    if (!openedStat.isFile() || !sameFileIdentity(openedStat, expectedIdentity)) {
-      throw new FsSafeError("path-mismatch", "private secret file changed during write");
-    }
-    const pathStat = await fsp.lstat(resolvedPath);
-    if (pathStat.isSymbolicLink() || !sameFileIdentity(pathStat, openedStat)) {
-      throw new FsSafeError("path-mismatch", "private secret path changed during write");
-    }
-    if (process.platform !== "win32") {
-      await handle.chmod(expectedMode);
-      const chmodStat = await handle.stat();
-      const actualMode = chmodStat.mode & 0o777;
-      if (actualMode !== expectedMode) {
-        throw new Error(
-          `Private secret file ${resolvedPath} has insecure permissions ${actualMode.toString(8)}.`,
-        );
-      }
-      const refreshedPathStat = await fsp.lstat(resolvedPath);
-      if (refreshedPathStat.isSymbolicLink() || !sameFileIdentity(refreshedPathStat, chmodStat)) {
-        throw new FsSafeError("path-mismatch", "private secret path changed during mode check");
-      }
-    }
-  } finally {
-    await handle.close().catch(() => undefined);
-  }
-}
-
 async function ensurePrivateDirectory(
   rootDir: string,
   targetDir: string,
@@ -304,7 +270,7 @@ async function materializeSecretFileAtomic(
 
   await assertAsyncDirectoryGuard(rootGuard);
   await assertAsyncDirectoryGuard(parentGuard);
-  const identity = await runPinnedWriteHelper({
+  await runPinnedWriteHelper({
     rootPath: parentGuard.realPath,
     relativeParentPath: "",
     basename: fileName,
@@ -313,10 +279,24 @@ async function materializeSecretFileAtomic(
     overwrite: !createOnly,
     input: { kind: "buffer", data: typeof params.content === "string" ? params.content : Buffer.from(params.content) },
     rootIdentity: { dev: parentGuard.stat.dev, ino: parentGuard.stat.ino },
+    verifyPublished: async (fd, expectedIdentity, publishedParentGuard) => {
+      await assertAsyncDirectoryGuard(rootGuard);
+      await assertAsyncDirectoryGuard(parentGuard);
+      await verifyAtomicWriteResult({
+        root: {
+          rootDir: rootGuard.dir,
+          rootReal: rootGuard.realPath,
+          rootWithSep: ensureTrailingSep(rootGuard.realPath),
+          rootIdentity: { dev: rootGuard.stat.dev, ino: rootGuard.stat.ino },
+        },
+        targetPath: finalFilePath,
+        fd,
+        expectedIdentity,
+        expectedMode: mode,
+        parentGuard: publishedParentGuard,
+      });
+    },
   });
-  await assertAsyncDirectoryGuard(rootGuard);
-  await assertAsyncDirectoryGuard(parentGuard);
-  await enforcePrivateFileIdentityAndMode(finalFilePath, identity, mode);
 }
 
 export async function writeSecretFileAtomic(params: SecretFileWriteParams): Promise<void> {

--- a/test/deepsec-regression.test.ts
+++ b/test/deepsec-regression.test.ts
@@ -327,20 +327,24 @@ describe("deepsec regressions", () => {
     await fsp.chmod(outsideFile, 0o600);
     const secretPath = path.join(rootDir, "secret.txt");
     const finalSecretPath = path.join(await fsp.realpath(rootDir), "secret.txt");
-    const realOpen = fsp.open;
+    const realLstat = fsp.lstat;
     let swapped = false;
-    vi.spyOn(fsp, "open").mockImplementation(async (...args) => {
-      if (!swapped && args[0] === finalSecretPath) {
+    vi.spyOn(fsp, "lstat").mockImplementation(async (target, options) => {
+      // Exact pathname verification occurs after the writer publishes its file.
+      if (!swapped && target === finalSecretPath && (options as { bigint?: boolean })?.bigint) {
         swapped = true;
         await fsp.rm(finalSecretPath, { force: true });
         await fsp.symlink(outsideFile, finalSecretPath, "file");
       }
-      return await realOpen(...args);
+      return await realLstat(target, options as never);
     });
 
     await expect(
       writeSecretFileAtomic({ rootDir, filePath: secretPath, content: "secret" }),
     ).rejects.toBeTruthy();
+    expect(swapped).toBe(true);
+    expect((await fsp.lstat(finalSecretPath)).isSymbolicLink()).toBe(true);
+    expect(await fsp.readFile(outsideFile, "utf8")).toBe("outside");
     expect((await fsp.stat(outsideFile)).mode & 0o777).toBe(0o600);
   });
 

--- a/test/secret-file-failure.test.ts
+++ b/test/secret-file-failure.test.ts
@@ -10,6 +10,7 @@ import {
   writeSecretFileAtomic,
 } from "../src/secret-file.js";
 import { readSecretFile } from "../src/secret-read-async.js";
+import * as verification from "../src/root-write-verification.js";
 
 const { tempRoot } = useTempDirs();
 
@@ -159,18 +160,15 @@ describe("secret file refusal paths", () => {
   it("rejects a different descriptor identity during post-write verification", async () => {
     const root = await tempRoot("fs-safe-secret-write-identity-");
     const filePath = path.join(root, "token");
-    const realOpen = fs.open.bind(fs);
-    const changedIdentity = vi.fn<() => Promise<fsSync.Stats>>();
-    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
-      const handle = await realOpen(...args);
-      if (path.basename(String(args[0])) === "token" && typeof args[1] === "number") {
-        const stat = await handle.stat();
-        // Numeric Windows file IDs can round together; inject a distinct nonzero ID.
-        stat.ino = stat.ino === 12345 ? 54321 : 12345;
-        changedIdentity.mockResolvedValueOnce(stat);
-        vi.spyOn(handle, "stat").mockImplementationOnce(changedIdentity);
-      }
-      return handle;
+    const verify = verification.verifyAtomicWriteResult;
+    const changedIdentity = vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+      const fstat = fsSync.fstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "fstatSync").mockImplementationOnce(((fd: number) => {
+        expect(fd).toBe(params.fd);
+        const stat = fstat(fd, { bigint: true });
+        return Object.assign(Object.create(stat), { ino: stat.ino + 1n });
+      }) as typeof fsSync.fstatSync);
+      await verify(params);
     });
     await expect(
       writeSecretFileAtomic({ rootDir: root, filePath, content: "secret" }),
@@ -181,16 +179,10 @@ describe("secret file refusal paths", () => {
   itPosix("rejects an insecure mode reported after post-write chmod", async () => {
     const root = await tempRoot("fs-safe-secret-write-mode-");
     const filePath = path.join(root, "token");
-    const realOpen = fs.open.bind(fs);
-    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
-      const handle = await realOpen(...args);
-      if (path.basename(String(args[0])) === "token" && typeof args[1] === "number") {
-        const actual = await handle.stat();
-        vi.spyOn(handle, "stat")
-          .mockResolvedValueOnce(actual)
-          .mockResolvedValueOnce({ ...actual, mode: 0o100644 } as never);
-      }
-      return handle;
+    const verify = verification.verifyAtomicWriteResult;
+    vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+      fsSync.fchmodSync(params.fd, 0o644);
+      await verify(params);
     });
     await expect(
       writeSecretFileAtomic({ rootDir: root, filePath, content: "secret" }),

--- a/test/secret-write-publication.test.ts
+++ b/test/secret-write-publication.test.ts
@@ -1,0 +1,222 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeNative } from "../src/config.js";
+import { __loadBundledNativeForTest, __resetNativeLoaderForTest } from "../src/native.js";
+import { createSecretFileAtomic, writeSecretFileAtomic } from "../src/secret.js";
+import * as verification from "../src/root-write-verification.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+let nativeAvailable = false;
+try {
+  __loadBundledNativeForTest();
+  nativeAvailable = true;
+} catch (error) {
+  if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error;
+}
+const writers = [
+  { operation: "write", write: writeSecretFileAtomic },
+  { operation: "create", write: createSecretFileAtomic },
+] as const;
+const modes = [0o000, 0o200, 0o400, 0o600];
+const verify = verification.verifyAtomicWriteResult;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  configureFsSafeNative({ mode: "auto" });
+  __resetNativeLoaderForTest();
+});
+
+for (const backend of ["off", "require"] as const) {
+  describe.skipIf(process.platform === "win32" || (backend === "require" && !nativeAvailable))(
+    `secret publication: native ${backend}`,
+    () => {
+      it.skipIf(process.getuid?.() === 0).each(writers.flatMap((writer) =>
+        modes.map((mode) => ({ ...writer, mode })),
+      ))("$operation preserves mode $mode without a readonly reopen", async ({ write, mode }) => {
+        configureFsSafeNative({ mode: backend });
+        expect(process.getuid?.()).toBeGreaterThan(0);
+        const rootDir = await tempRoot("fs-safe-secret-mode-");
+        const filePath = path.join(rootDir, "token");
+        const content = Uint8Array.from([0, 10, 127, 128, 255]);
+        const open = vi.spyOn(fs, "open");
+        const openSync = vi.spyOn(fsSync, "openSync");
+
+        await expect(write({ rootDir, filePath, content, mode })).resolves.toBeUndefined();
+
+        const isReadonly = (flags: string | number) => typeof flags === "string"
+          ? flags === "r" || flags === "rs"
+          : (flags & (fsSync.constants.O_WRONLY | fsSync.constants.O_RDWR)) === 0;
+        for (const calls of [open.mock.calls, openSync.mock.calls]) {
+          expect(calls.filter(([candidate, flags]) =>
+            String(candidate) === filePath && isReadonly(flags),
+          )).toEqual([]);
+        }
+        vi.restoreAllMocks();
+        const stat = await fs.lstat(filePath);
+        expect(stat.isFile()).toBe(true);
+        expect(stat.nlink).toBe(1);
+        expect(stat.mode & 0o777).toBe(mode);
+        if ((mode & 0o400) === 0) {
+          await expect(fs.readFile(filePath)).rejects.toMatchObject({ code: "EACCES" });
+        }
+        // Inspect task-owned bytes only after proving the actual final permissions.
+        await fs.chmod(filePath, 0o600);
+        expect(await fs.readFile(filePath)).toEqual(Buffer.from(content));
+        expect(await fs.readdir(rootDir)).toEqual(["token"]);
+      });
+
+      it.each(writers)("$operation defaults to 0600", async ({ write }) => {
+        configureFsSafeNative({ mode: backend });
+        const rootDir = await tempRoot("fs-safe-secret-default-");
+        const filePath = path.join(rootDir, "token");
+        await write({ rootDir, filePath, content: "synthetic default\n" });
+        expect((await fs.stat(filePath)).mode & 0o777).toBe(0o600);
+        expect(await fs.readFile(filePath, "utf8")).toBe("synthetic default\n");
+      });
+
+      it.each(modes)("overwrites restrictive files and preserves create collisions at mode %i", async (mode) => {
+        configureFsSafeNative({ mode: backend });
+        const rootDir = await tempRoot("fs-safe-secret-overwrite-");
+        const filePath = path.join(rootDir, "token");
+        await createSecretFileAtomic({ rootDir, filePath, content: "original", mode });
+        const original = await fs.stat(filePath, { bigint: true });
+        await expect(createSecretFileAtomic({ rootDir, filePath, content: "collision", mode: 0o600 }))
+          .rejects.toMatchObject({ code: "secret-exists" });
+        const collided = await fs.stat(filePath, { bigint: true });
+        expect(collided.ino).toBe(original.ino);
+        expect(collided.mode & 0o777n).toBe(BigInt(mode));
+        await fs.chmod(filePath, 0o600);
+        expect(await fs.readFile(filePath, "utf8")).toBe("original");
+        await fs.chmod(filePath, mode);
+        await writeSecretFileAtomic({ rootDir, filePath, content: "overwritten", mode });
+        const overwritten = await fs.stat(filePath, { bigint: true });
+        expect(overwritten.ino).not.toBe(original.ino);
+        expect(overwritten.mode & 0o777n).toBe(BigInt(mode));
+        await fs.chmod(filePath, 0o600);
+        expect(await fs.readFile(filePath, "utf8")).toBe("overwritten");
+        expect(await fs.readdir(rootDir)).toEqual(["token"]);
+      });
+
+      const attacks = [
+        "none", "same bytes", "symlink", "hardlink replacement", "late hardlink",
+        "parent swap", "root swap", "parent rebind", "root rebind", "callback failure", "I/O failure", "late mode",
+      ] as const;
+      it.each(writers.flatMap((writer) => attacks.map((attack) => ({ ...writer, attack }))))(
+        "$operation retains ownership through $attack verification",
+        async ({ write, attack }) => {
+          configureFsSafeNative({ mode: backend });
+          const sandbox = await tempRoot("fs-safe-secret-publication-");
+          const rootDir = path.join(sandbox, "root");
+          const parent = path.join(rootDir, "parent");
+          const outside = path.join(sandbox, "outside");
+          const filePath = path.join(parent, "token");
+          await fs.mkdir(parent, { recursive: true });
+          await fs.mkdir(outside);
+          const outsideFile = path.join(outside, "untouched");
+          await fs.writeFile(outsideFile, "outside", { mode: 0o600 });
+          const payload = "synthetic published bytes";
+          const sentinel = Object.assign(new Error("verification failed"), { code: "EIO" });
+          let borrowedFd: number | undefined;
+          let publishedPath = filePath;
+          let injected = false;
+          const handles: Array<{ fd: number; close: ReturnType<typeof vi.spyOn> }> = [];
+          const open = fs.open.bind(fs);
+          vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+            const handle = await open(...args);
+            handles.push({ fd: handle.fd, close: vi.spyOn(handle, "close") });
+            return handle;
+          });
+          const closeSync = vi.spyOn(fsSync, "closeSync");
+          const checked = vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+            borrowedFd = params.fd;
+            const stat = fsSync.fstatSync(params.fd, { bigint: true });
+            expect(params.expectedIdentity).toMatchObject({ dev: stat.dev, ino: stat.ino });
+            expect(stat.mode & 0o777n).toBe(0n);
+            if (["same bytes", "symlink", "hardlink replacement"].includes(attack)) {
+              publishedPath = path.join(parent, "published");
+              await fs.rename(filePath, publishedPath);
+              if (attack === "symlink") await fs.symlink(outsideFile, filePath);
+              else if (attack === "hardlink replacement") await fs.link(outsideFile, filePath);
+              else await fs.writeFile(filePath, payload, { mode: 0o400 });
+              injected = true;
+            } else if (attack.startsWith("parent") || attack.startsWith("root")) {
+              const moved = path.join(outside, "moved");
+              const swapped = attack.startsWith("parent") ? parent : rootDir;
+              await fs.rename(swapped, moved);
+              publishedPath = path.join(moved, attack.startsWith("parent") ? "token" : "parent/token");
+              if (attack.endsWith("swap")) {
+                await fs.symlink(moved, swapped, "dir");
+              } else {
+                await fs.mkdir(swapped);
+                await fs.rename(attack.startsWith("parent") ? publishedPath : path.join(moved, "parent"),
+                  attack.startsWith("parent") ? filePath : parent);
+                publishedPath = filePath;
+              }
+              injected = true;
+            } else if (attack === "callback failure") {
+              injected = true;
+              throw sentinel;
+            } else if (attack === "I/O failure" || attack === "late hardlink" || attack === "late mode") {
+              const lstat = fs.lstat.bind(fs);
+              vi.spyOn(fs, "lstat").mockImplementation((async (...args: Parameters<typeof fs.lstat>) => {
+                if (attack === "I/O failure" && String(args[0]) === filePath) {
+                  injected = true;
+                  throw sentinel;
+                }
+                // Run after the first file check, during ancestry validation.
+                if (!injected && String(args[0]) === parent) {
+                  injected = true;
+                  if (attack === "late hardlink") await fs.link(filePath, path.join(parent, "alias"));
+                  else fsSync.fchmodSync(params.fd, 0o644);
+                }
+                return await lstat(...args);
+              }) as typeof fs.lstat);
+            }
+            try {
+              await verify(params);
+            } finally {
+              // The verifier borrows; success and failure both leave closing to the writer.
+              expect(fsSync.fstatSync(params.fd).isFile()).toBe(true);
+            }
+          });
+          const pending = write({ rootDir, filePath, content: payload, mode: 0o000 });
+          if (attack === "none") await expect(pending).resolves.toBeUndefined();
+          else if (attack.endsWith("failure")) await expect(pending).rejects.toBe(sentinel);
+          else if (attack === "late mode") await expect(pending).rejects.toThrow("has insecure permissions 644");
+          else {
+            const error = await pending.catch((error: unknown) => error);
+            expect(error).toMatchObject({ code: attack === "symlink" ? "symlink"
+              : attack === "late hardlink" ? "hardlink"
+                : attack.endsWith("swap") ? "outside-workspace" : "path-mismatch" });
+          }
+          expect(checked).toHaveBeenCalledTimes(1);
+          expect(injected).toBe(attack !== "none");
+          expect(borrowedFd).toBeTypeOf("number");
+          expect(() => fsSync.fstatSync(borrowedFd!)).toThrowError(expect.objectContaining({ code: "EBADF" }));
+          const closes = closeSync.mock.calls.filter(([fd]) => fd === borrowedFd).length
+            + handles.filter(({ fd }) => fd === borrowedFd).reduce((sum, { close }) => sum + close.mock.calls.length, 0);
+          expect(closes).toBe(1);
+          vi.restoreAllMocks();
+          expect((await fs.stat(publishedPath)).mode & 0o777).toBe(attack === "late mode" ? 0o644 : 0o000);
+          await fs.chmod(publishedPath, 0o600);
+          expect(await fs.readFile(publishedPath, "utf8")).toBe(payload);
+          expect(await fs.readFile(outsideFile, "utf8")).toBe("outside");
+          expect((await fs.stat(outsideFile)).mode & 0o777).toBe(0o600);
+          if (attack === "same bytes") {
+            expect((await fs.stat(filePath)).mode & 0o777).toBe(0o400);
+            expect(await fs.readFile(filePath, "utf8")).toBe(payload);
+          } else if (attack === "symlink") expect((await fs.lstat(filePath)).isSymbolicLink()).toBe(true);
+          else if (attack === "hardlink replacement") {
+            expect((await fs.stat(filePath)).ino).toBe((await fs.stat(outsideFile)).ino);
+            expect(await fs.readFile(filePath, "utf8")).toBe("outside");
+          }
+          expect((await fs.readdir(sandbox, { recursive: true })).filter((entry) => entry.endsWith(".tmp")))
+            .toEqual([]);
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Problem and ownership fix

Physical published 0.7.2 and packed-main consumers demonstrate that `writeSecretFileAtomic()` and `createSecretFileAtomic()` publish the requested bytes at POSIX modes `0000` or `0200`, then misleadingly throw EACCES. Their post-write verifier reopens the pathname readonly after the writer applied the requested mode and closed its descriptor. Mode `0400` is an unaffected control.

Remove that post-close reopen. Secret publication now uses the existing borrowed `verifyPublished` descriptor channel and shared exact publication verifier while the writer still owns the descriptor. It checks regular-file/link identity, the requested POSIX mode, root/parent ancestry and current pathname before the writer closes. The verifier never closes the borrowed descriptor or widens file permissions. The existing Windows opaque-path verification policy remains; POSIX mode bits are not newly enforced on Windows.

Production change: **net -11 lines**. No public API or dependency changes. The old numeric/path-reopen verification path is deleted rather than retained as a fallback. The separate shared-parent initialization and directory-policy documentation findings remain outside this repair.

## Verification

- Before: 16 initial regressions fail against unchanged production. Physical 0.7.2/main off/require consumers show EACCES after publication for `0000`/`0200`.
- After: 76 new regressions cover both writers, real non-root modes `0000`/`0200`/`0400`/`0600`, exact bytes, no readonly reopen, overwrite/collision behavior, substituted files/links, root/parent swaps, error propagation and exactly-once descriptor closure.
- Focused owner/Root/pinned-write run: 424 passed, 4 skipped.
- Complete local gate using the repository's existing CI four-worker configuration: 6,476 passed, 77 skipped, including lint/build/docs/package checks. The initial unbounded-worker run hit unrelated scheduling deadlines and a cleanup-after-timeout error; all outputs were retained. No deadlines were raised.
- Complete isolated Linux native-backed gate: 6,472 passed, 81 skipped; 84 security tests and host package smoke passed.
- Newly packed physical consumer tests pass all 12 mode cases in off/require configuration.

- Independent Codex autoreview: scoped-clean at the configured P0 threshold, with no accepted/actionable findings.

Frozen tested tree: `1c4e230c6b3ec99fcb224cc569787edfb20f36aa`.

## Inspectable real-run output

These selected fields come from the actual unprivileged macOS reports. Local paths are omitted; all file contents are synthetic. Final modes are recorded before the harness changes its own fixture mode solely to inspect the bytes. That inspection chmod is not part of the library operation.

```json
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "writeSecretFileAtomic", "requestedMode": "0", "errorCode": "EACCES", "published": true, "observedMode": "0", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "writeSecretFileAtomic", "requestedMode": "200", "errorCode": "EACCES", "published": true, "observedMode": "200", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "writeSecretFileAtomic", "requestedMode": "400", "errorCode": null, "published": true, "observedMode": "400", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "createSecretFileAtomic", "requestedMode": "0", "errorCode": "EACCES", "published": true, "observedMode": "0", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "createSecretFileAtomic", "requestedMode": "200", "errorCode": "EACCES", "published": true, "observedMode": "200", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "createSecretFileAtomic", "requestedMode": "400", "errorCode": null, "published": true, "observedMode": "400", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "writeSecretFileAtomic", "requestedMode": "0", "errorCode": "EACCES", "published": true, "observedMode": "0", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "writeSecretFileAtomic", "requestedMode": "200", "errorCode": "EACCES", "published": true, "observedMode": "200", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "writeSecretFileAtomic", "requestedMode": "400", "errorCode": null, "published": true, "observedMode": "400", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "createSecretFileAtomic", "requestedMode": "0", "errorCode": "EACCES", "published": true, "observedMode": "0", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "createSecretFileAtomic", "requestedMode": "200", "errorCode": "EACCES", "published": true, "observedMode": "200", "exactBytes": true}
{"target": "main-before", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "createSecretFileAtomic", "requestedMode": "400", "errorCode": null, "published": true, "observedMode": "400", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "writeSecretFileAtomic", "requestedMode": "0", "errorCode": null, "published": true, "observedMode": "0", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "writeSecretFileAtomic", "requestedMode": "200", "errorCode": null, "published": true, "observedMode": "200", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "writeSecretFileAtomic", "requestedMode": "400", "errorCode": null, "published": true, "observedMode": "400", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "createSecretFileAtomic", "requestedMode": "0", "errorCode": null, "published": true, "observedMode": "0", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "createSecretFileAtomic", "requestedMode": "200", "errorCode": null, "published": true, "observedMode": "200", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "off", "operation": "createSecretFileAtomic", "requestedMode": "400", "errorCode": null, "published": true, "observedMode": "400", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "writeSecretFileAtomic", "requestedMode": "0", "errorCode": null, "published": true, "observedMode": "0", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "writeSecretFileAtomic", "requestedMode": "200", "errorCode": null, "published": true, "observedMode": "200", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "writeSecretFileAtomic", "requestedMode": "400", "errorCode": null, "published": true, "observedMode": "400", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "createSecretFileAtomic", "requestedMode": "0", "errorCode": null, "published": true, "observedMode": "0", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "createSecretFileAtomic", "requestedMode": "200", "errorCode": null, "published": true, "observedMode": "200", "exactBytes": true}
{"target": "candidate-after", "runtime": "v24.20.0", "platform": "darwin", "nativeMode": "require", "operation": "createSecretFileAtomic", "requestedMode": "400", "errorCode": null, "published": true, "observedMode": "400", "exactBytes": true}
```

Candidate root tarball integrity: `sha512-HLZIbkg0bMusk/c6q1mmpvzAq0k3eSAuE8Z7oQgtV35qNNnqWzMQaKX2GZKvhwN1/W4KXqaXxkMujwBgYc/8UQ==`.

Docs and the existing Unreleased changelog describe the correction. No release, version bump or publication is included; the wider live-test matrix remains in progress.
