### PR TITLE
fix(lock): honor retries independently of infinite deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Honor explicit async file-lock retry counts independently of infinite deadlines, matching sync locks while preserving unlimited retries when the count is omitted.
 - Verify atomic secret writes through the writer's retained descriptor so restrictive POSIX modes such as `0o000` and `0o200` succeed without a readonly reopen or widened permissions.
 - Preserve pre-existing and substituted destination files when an archive merge fails, leaving guarded copy cleanup to the operation that owns publication.
 - Add the narrow `@openclaw/fs-safe/secure-temp-root` package subpath so consumers can import `resolveSecureTempRoot()` and its options type without loading the temp workspace implementation.

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -97,7 +97,12 @@ type FileLockRetryOptions = {
 Errors thrown by `payload`, its JSON serialization (including `toJSON`), or
 `parsePayload` propagate unchanged without retrying the callback. Rethrowing an
 error saved from an earlier filesystem operation does not grant retry authority.
-Retry counts must be non-negative safe integers. Retry factors and delays must be finite and non-negative, and when both delay bounds are provided `minTimeout` cannot exceed `maxTimeout`. `timeoutMs` accepts a finite non-negative deadline or positive infinity for an unbounded wait; invalid numeric values reject before filesystem acquisition starts.
+Retry counts must be non-negative safe integers. Retry factors and delays must be finite and non-negative, and when both delay bounds are provided `minTimeout` cannot exceed `maxTimeout`. `timeoutMs` accepts a finite non-negative deadline or positive infinity for no deadline; invalid numeric values reject before filesystem acquisition starts.
+Both async and sync locks enforce retry counts and deadlines independently: an
+explicit `retry.retries` still applies with `timeoutMs: Infinity`, and zero allows
+only the initial attempt. After process defaults are applied, an omitted retry
+count means unlimited retries, and an omitted or infinite timeout means no
+deadline. With neither budget bounded, contention can wait indefinitely.
 `parsePayload` replaces JSON parsing for legacy or custom sidecars. Its `unknown`
 result is passed to `shouldReclaim` and `shouldRemoveStaleLock`, allowing PID,
 process-start, argv, or role schemas to remain application-owned.

--- a/src/sidecar-lock-acquire.ts
+++ b/src/sidecar-lock-acquire.ts
@@ -105,7 +105,6 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
   }
 
   const startedAt = Date.now();
-  const maxRetries = options.timeoutMs === Number.POSITIVE_INFINITY ? undefined : retry.retries;
   const reclaimGuardPath = `${lockPath}.reclaim`;
   let ownsReclaimGuard = false;
   let attempt = 0;
@@ -118,7 +117,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
       (options.timeoutMs !== undefined &&
         options.timeoutMs !== Number.POSITIVE_INFINITY &&
         elapsed >= options.timeoutMs) ||
-      (maxRetries !== undefined && attempt >= maxRetries)
+      (retry.retries !== undefined && attempt >= retry.retries)
     ) {
       throw Object.assign(new Error(`file lock timeout for ${normalizedTargetPath}`), {
         code: "file_lock_timeout",

--- a/test/file-lock-error-replay.test.ts
+++ b/test/file-lock-error-replay.test.ts
@@ -20,8 +20,9 @@ afterEach(() => {
   configureFsSafeNative({ mode: "auto" });
 });
 
-for (const mode of ["sync", "async", "root"] as const) {
-  describe(`${mode} callback error replay (synthetic Windows/errno; real files)`, () => {
+for (const { mode, timeoutMs } of (["sync", "async", "root"] as const).flatMap((mode) =>
+  [undefined, Infinity].map((timeoutMs) => ({ mode, timeoutMs })))) {
+  describe(`${mode} callback error replay, timeout ${timeoutMs} (synthetic Windows/errno; real files)`, () => {
     async function fixture() {
       const directory = await tempRoot("fs-safe-error-replay-");
       const lockRoot = mode === "root" ? await root(directory) : undefined;
@@ -34,8 +35,8 @@ for (const mode of ["sync", "async", "root"] as const) {
         parsePayload?: (raw: string) => unknown;
         retry?: typeof retry;
       }) => mode === "sync"
-        ? acquireFileLockSync(file, { retry, ...options, lockRoot })
-        : manager.acquire(file, { retry, ...options, lockRoot });
+        ? acquireFileLockSync(file, { retry, timeoutMs, ...options, lockRoot })
+        : manager.acquire(file, { retry, timeoutMs, ...options, lockRoot });
       const failOpen = (file: string, error: Error) => {
         if (mode === "sync") {
           const open = fs.openSync.bind(fs);
@@ -100,7 +101,7 @@ for (const mode of ["sync", "async", "root"] as const) {
     });
 
     it.each([
-      { retries: 2, attempts: 3 }, { retries: 20, attempts: 9 },
+      { retries: 0, attempts: 1 }, { retries: 2, attempts: 3 }, { retries: 20, attempts: 9 },
     ])("classifies a reused Error from each current open ($retries retries)", async ({ retries, attempts }) => {
       const { target, lockPath, acquire, failOpen } = await fixture();
       fs.writeFileSync(lockPath, foreign);

--- a/test/file-lock-retry-budget.test.ts
+++ b/test/file-lock-retry-budget.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeLocks, getFsSafeLockConfig } from "../src/config.js";
+import {
+  acquireFileLockSync, createFileLockManager,
+  type FileLockHandle, type FileLockRetryOptions, type FileLockSyncHandle,
+} from "../src/file-lock.js";
+import { root } from "../src/root.js";
+import * as timing from "../src/timing.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const savedConfig = getFsSafeLockConfig();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  configureFsSafeLocks({ retry: undefined, timeoutMs: undefined, ...savedConfig });
+});
+
+for (const mode of ["async", "Root async", "sync", "Root sync"] as const) {
+  describe(`${mode} independent lock budgets`, () => {
+    async function fixture(releaseAfterWaits: number) {
+      const directory = await tempRoot("fs-safe-lock-budget-");
+      const lockRoot = mode.startsWith("Root") ? await root(directory) : undefined;
+      const target = path.join(directory, "state");
+      const lockPath = `${target}.lock`;
+      const holder = acquireFileLockSync(target, { lockRoot, payload: () => ({ owner: "holder" }) });
+      const original = fs.readFileSync(lockPath, "utf8");
+      const manager = createFileLockManager(`budget:${target}`);
+      const acquired: Array<FileLockHandle | FileLockSyncHandle> = [];
+      const payload = vi.fn(() => ({ owner: "waiter" }));
+      const waits: number[] = [];
+      const startedAt = Date.now();
+      let elapsed = 0;
+      vi.spyOn(Date, "now").mockImplementation(() => startedAt + elapsed);
+      // Control only sleeps; use real exclusive creation and owner-authorized release.
+      // Releasing at the first excess wait also bounds a broken retry loop without a sentinel.
+      const sleep = (ms: number) => {
+        waits.push(ms);
+        elapsed += ms;
+        if (waits.length >= releaseAfterWaits) holder.release();
+      };
+      vi.spyOn(timing, "sleepSync").mockImplementation(sleep);
+      vi.spyOn(globalThis, "setTimeout").mockImplementation((callback, ms = 0, ...args) => {
+        sleep(ms);
+        queueMicrotask(() => callback(...args));
+        return {} as ReturnType<typeof setTimeout>;
+      });
+      const acquire = async (retry?: FileLockRetryOptions, timeoutMs?: number) => {
+        const options = { lockRoot, payload, retry, timeoutMs, shouldReclaim: () => false };
+        const lock = mode.endsWith("async")
+          ? await manager.acquire(target, options)
+          : acquireFileLockSync(target, options);
+        acquired.push(lock);
+        return lock;
+      };
+      const cleanup = async () => {
+        holder.release();
+        for (const lock of acquired) await lock.release();
+        await manager.drain();
+      };
+      return { holder, original, lockPath, manager, payload, waits, acquire, cleanup };
+    }
+
+    it.each([0, 2])("honors %s retries with an infinite deadline", async (retries) => {
+      const { holder, original, lockPath, manager, payload, waits, acquire, cleanup } = await fixture(retries + 1);
+      try {
+        await expect(acquire({ retries, minTimeout: 0, maxTimeout: 0 }, Infinity))
+          .rejects.toMatchObject({ code: "file_lock_timeout", lockPath });
+        expect(payload).toHaveBeenCalledTimes(retries + 1);
+        expect(waits).toEqual(Array(retries).fill(0));
+        expect(holder.verifyStillHeld()).toBe(true);
+        expect(fs.readFileSync(lockPath, "utf8")).toBe(original);
+        expect(manager.heldEntries()).toEqual([]);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it.each([1, 3])("acquires on the final allowed retry (%s)", async (retries) => {
+      const { lockPath, payload, waits, acquire, cleanup } = await fixture(retries);
+      try {
+        const lock = await acquire({ retries, minTimeout: 10, maxTimeout: 10 }, Infinity);
+        try {
+          expect(payload).toHaveBeenCalledTimes(retries + 1);
+          expect(waits).toEqual(Array(retries).fill(10));
+          expect(await lock.verifyStillHeld()).toBe(true);
+          expect(JSON.parse(fs.readFileSync(lockPath, "utf8"))).toEqual({ owner: "waiter" });
+        } finally {
+          await lock.release();
+        }
+        expect(fs.existsSync(lockPath)).toBe(false);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it.each([
+      { retry: undefined, timeoutMs: undefined }, { retry: {}, timeoutMs: undefined },
+      { retry: undefined, timeoutMs: Infinity }, { retry: {}, timeoutMs: Infinity },
+    ])("keeps omitted counts unbounded (retry $retry, timeout $timeoutMs)", async ({ retry, timeoutMs }) => {
+      const { payload, waits, acquire, cleanup } = await fixture(12);
+      try {
+        const lock = await acquire(retry, timeoutMs);
+        try {
+          expect(payload).toHaveBeenCalledTimes(13);
+          expect(waits).toEqual(Array(12).fill(50));
+          expect(await lock.verifyStillHeld()).toBe(true);
+        } finally {
+          await lock.release();
+        }
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("stops at the finite deadline before exhausting retries", async () => {
+      const { holder, payload, waits, acquire, cleanup } = await fixture(4);
+      try {
+        await expect(acquire({ retries: 3, minTimeout: 10, maxTimeout: 10 }, 15))
+          .rejects.toMatchObject({ code: "file_lock_timeout" });
+        expect(payload).toHaveBeenCalledTimes(3);
+        expect(waits).toEqual([10, 5]);
+        expect(holder.verifyStillHeld()).toBe(true);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("honors configured counts and replaces them with a per-call retry object", async () => {
+      const { payload, waits, acquire, cleanup } = await fixture(3);
+      configureFsSafeLocks({ timeoutMs: Infinity, retry: { retries: 0 } });
+      try {
+        await expect(acquire()).rejects.toMatchObject({ code: "file_lock_timeout" });
+        expect(payload).toHaveBeenCalledTimes(1);
+        expect(waits).toEqual([]);
+        const lock = await acquire({ minTimeout: 5, maxTimeout: 5 });
+        try {
+          expect(payload).toHaveBeenCalledTimes(5);
+          expect(waits).toEqual([5, 5, 5]);
+          expect(await lock.verifyStillHeld()).toBe(true);
+        } finally {
+          await lock.release();
+        }
+      } finally {
+        await cleanup();
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Async lock acquisition discarded an explicitly finite retry count whenever `timeoutMs` was `Infinity`. Thus a caller asking for zero retries could keep attempting acquisition indefinitely, unlike the synchronous API. The fix removes the derived override and checks the existing retry count directly. An omitted count still means unlimited retries; a finite deadline and an explicit retry count remain independent budgets. No acquisition, callback-provenance, identity, reclaim, or release authority changes.

Net production change: −1 line. Add 40 independent-budget cases across raw/Root async and sync APIs, extend callback/error-replay coverage to infinite deadlines and zero retries, and clarify the existing option semantics in the docs and Unreleased changelog.

## Observable before/after

A physical registry 0.7.2 consumer holds a real sidecar with one manager while another contends with `timeoutMs: Infinity`, zero-delay retries, and reclaim disabled. The payload callback throws a unique sentinel only if called beyond the explicit count, bounding the broken baseline without an arbitrary time cutoff. The existing owner's inode and bytes are checked afterward.

These are representative actual rows from the macOS Node 24 run (paths omitted):

```json
{
  "before": [
    {"rooted":false,"retries":0,"sync":false,"calls":2,"boundedSentinel":true,"ownerPreserved":true,"verdict":"fail"},
    {"rooted":false,"retries":0,"sync":true,"calls":1,"errorCode":"file_lock_timeout","boundedSentinel":false,"ownerPreserved":true,"verdict":"pass"},
    {"rooted":true,"retries":2,"sync":false,"calls":4,"boundedSentinel":true,"ownerPreserved":true,"verdict":"fail"}
  ],
  "after": [
    {"rooted":false,"retries":0,"sync":false,"calls":1,"errorCode":"file_lock_timeout","boundedSentinel":false,"ownerPreserved":true,"verdict":"pass"},
    {"rooted":false,"retries":0,"sync":true,"calls":1,"errorCode":"file_lock_timeout","boundedSentinel":false,"ownerPreserved":true,"verdict":"pass"},
    {"rooted":true,"retries":2,"sync":false,"calls":3,"errorCode":"file_lock_timeout","boundedSentinel":false,"ownerPreserved":true,"verdict":"pass"}
  ]
}
```

Fresh candidate consumer: source tree `969ef38d8706dd8639bb5feabe5f959407d1f032`, root tarball integrity `sha512-2iJiJEGoqd8D+tFwKn4Q3BeFVh86Bq+K1p14L9TF/4NC0LYH1aCjuISzFzFCQ4ssqxWM3Hs4Gk8koSajWC1rkA==`. It retains package version 0.7.2 but is distinguished from the published baseline by tree and integrity; this PR does not publish a release.

All eight consumer cases pass on Node 22.0.0, 22.23.2 and 24.20.0 under each of off/auto/require: 72 observations. Actual loaded `fs-safe-darwin-arm64` native modules were recorded in auto/require runs; off loaded none. This is a real native binary/consumer check, not a platform override.

## Validation

- Before the production edit: all four targeted async regressions failed; all four sync controls passed. The unit fixture controls only time/waits and uses real exclusive creation plus owner-authorized release; releasing at the first excess wait bounds old-code execution.
- Focused budget/replay suite: 124 passed. All lock suites: 400 passed, 9 skipped. Includes final-allowed-retry success, unlimited omitted counts, configured defaults, finite deadline exhaustion, holder preservation, original callback/serialization/parser errors, and bounded current-open denial handling.
- macOS arm64, Node 24.20.0: `CI=1 pnpm check` passed, 6,561 tests / 77 skips. `pnpm test:security`: 84 passed. The worker independently ran the same full count on Node 26.8.1.
- Frozen-tree isolated Linux x64, Node 24.20.0: `pnpm native:build`, `FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm check` (6,557 / 81 skips), `pnpm test:security` (84), and `pnpm package:smoke` all passed.
- macOS `pnpm package:smoke` passed npm/pnpm physical installs, loaded/omitted optional dependencies, and missing-binary fallback/refusal controls. Two attempted out-of-lifecycle helper invocations refused before package collection; using the repository's prescribed script succeeded. No product change was made for that invocation mistake.
- `git diff --check` passed; independent Codex autoreview is scoped-clean at its P0 threshold, confidence 0.99.

Foreign package filter fixtures are not foreign runtime proof. A separate fresh Windows lease was blocked at SSH bootstrap; platform-gated skips remain skips. Exact-head CI is required before merge. Oversized payload admission and Root normal-exit cleanup are distinct findings and are intentionally not changed here.
