### PR TITLE
fix(lock): reject oversized sidecars before acquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Reject serialized sidecar lock payloads above 1 MiB of UTF-8 bytes, including ownership overhead, with `too-large` before async or sync acquisition so admitted locks remain verifiable and releasable.
 - Honor explicit async file-lock retry counts independently of infinite deadlines, matching sync locks while preserving unlimited retries when the count is omitted.
 - Verify atomic secret writes through the writer's retained descriptor so restrictive POSIX modes such as `0o000` and `0o200` succeed without a readonly reopen or widened permissions.
 - Preserve pre-existing and substituted destination files when an archive merge fails, leaving guarded copy cleanup to the operation that owns publication.

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -94,6 +94,14 @@ type FileLockRetryOptions = {
 ```
 
 `payload` is a function so you can re-evaluate it on each retry (e.g. timestamp, PID).
+
+The complete serialized sidecar must fit within 1 MiB (1,048,576 UTF-8 bytes),
+including pretty-printed JSON, newlines, and the internal ownership token's
+trailing whitespace. The limit counts bytes, not string characters. Oversized
+payloads reject with `FsSafeError` code `too-large` before sidecar creation or
+acquisition, without retrying serialization or reclaiming an existing sidecar.
+This bound applies to raw and Root-backed locks, both async and sync.
+
 Errors thrown by `payload`, its JSON serialization (including `toJSON`), or
 `parsePayload` propagate unchanged without retrying the callback. Rethrowing an
 error saved from an earlier filesystem operation does not grant retry authority.

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -61,10 +61,15 @@ export function serializeSidecarLockPayload(payload: Record<string, unknown>): {
   ownershipToken: string;
 } {
   const ownershipToken = createSidecarLockOwnershipToken();
-  return {
-    raw: `${JSON.stringify(payload, null, 2)}\n${ownershipToken}\n`,
-    ownershipToken,
-  };
+  const raw = `${JSON.stringify(payload, null, 2)}\n${ownershipToken}\n`;
+  const bytes = Buffer.byteLength(raw, "utf8");
+  if (bytes > MAX_LOCK_PAYLOAD_BYTES) {
+    throw new FsSafeError(
+      "too-large",
+      `sidecar lock payload exceeds limit of ${MAX_LOCK_PAYLOAD_BYTES} bytes (got ${bytes})`,
+    );
+  }
+  return { raw, ownershipToken };
 }
 
 export function relativeSidecarLockPath(lockRoot: Root, lockPath: string): string {

--- a/test/sidecar-lock-payload-size.test.ts
+++ b/test/sidecar-lock-payload-size.test.ts
@@ -1,0 +1,203 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FsSafeError } from "../src/errors.js";
+import {
+  acquireFileLockSync,
+  createFileLockManager,
+  type FileLockSyncAcquireOptions,
+} from "../src/file-lock.js";
+import * as nativeOperations from "../src/native-operations.js";
+import { root } from "../src/root.js";
+import { readSidecarLockOwnershipToken, serializeSidecarLockPayload } from "../src/sidecar-lock-reclaim.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const cap = 1024 * 1024;
+const overhead = Buffer.byteLength(serializeSidecarLockPayload({ data: "" }).raw, "utf8");
+const encodings = ["ASCII", "multibyte"] as const;
+type Encoding = typeof encodings[number];
+type AcquireOptions = FileLockSyncAcquireOptions<Record<string, unknown>>;
+const budgets = [
+  { name: "finite deadline and retries", timeoutMs: 1000, retry: { retries: 2 } },
+  { name: "infinite deadline and finite retries", timeoutMs: Infinity, retry: { retries: 2 } },
+  { name: "infinite deadline and retries", timeoutMs: Infinity, retry: {} },
+  { name: "omitted deadline and retries", timeoutMs: undefined, retry: {} },
+];
+
+afterEach(() => vi.restoreAllMocks());
+
+function sizedPayload(bytes: number, encoding: Encoding) {
+  const dataBytes = bytes - overhead;
+  const data = encoding === "ASCII"
+    ? "x".repeat(dataBytes)
+    : "🦞".repeat(Math.floor(dataBytes / 4)) + "x".repeat(dataBytes % 4);
+  return { data };
+}
+
+describe("serialized sidecar payload byte admission", () => {
+  for (const encoding of encodings) {
+    it.each([cap - 1, cap, cap + 1])(`${encoding}: %s complete UTF-8 bytes`, (bytes) => {
+      const payload = sizedPayload(bytes, encoding);
+      if (encoding === "multibyte") expect(payload.data.length).toBeLessThan(cap / 2);
+      if (bytes > cap) {
+        expect(() => serializeSidecarLockPayload(payload))
+          .toThrow(expect.objectContaining({ name: "FsSafeError", code: "too-large" }));
+      } else {
+        const { raw, ownershipToken } = serializeSidecarLockPayload(payload);
+        expect(Buffer.byteLength(raw, "utf8")).toBe(bytes);
+        expect(raw).toBe(`${JSON.stringify(payload, null, 2)}\n${ownershipToken}\n`);
+        expect(readSidecarLockOwnershipToken(raw)).toBe(ownershipToken);
+        expect(JSON.parse(raw)).toEqual(payload);
+      }
+    });
+  }
+});
+
+for (const mode of ["raw async", "Root async", "raw sync", "Root sync"] as const) {
+  describe(`${mode} sidecar payload admission`, () => {
+    async function fixture() {
+      const directory = await tempRoot("fs-safe-lock-payload-");
+      const target = path.join(directory, "state");
+      const lockPath = `${target}.lock`;
+      const lockRoot = mode.startsWith("Root") ? await root(directory) : undefined;
+      const manager = createFileLockManager(`payload:${target}`);
+      const acquire = async (options: AcquireOptions) => mode.endsWith("async")
+        ? await manager.acquire(target, { ...options, lockRoot })
+        : acquireFileLockSync(target, { ...options, lockRoot });
+      const expectHeld = (count: number) => {
+        if (mode.endsWith("async")) {
+          expect(manager.heldEntries()).toHaveLength(count);
+        } else {
+          // Sync locks have no public diagnostics; inspect only this fixture's entry.
+          const held = Reflect.get(globalThis, Symbol.for("fsSafe.syncSidecarLocks")) as
+            Map<string, unknown> | undefined;
+          expect(held?.has(target) ?? false).toBe(count === 1);
+        }
+      };
+      const expectEmpty = async () => {
+        expectHeld(0);
+        expect(await fs.readdir(directory)).toEqual([]);
+      };
+      const expectUsable = async () => {
+        const payload = vi.fn(() => ({ owner: "later valid acquisition" }));
+        const lock = await acquire({ payload, retry: { retries: 0 } });
+        try {
+          expect(payload).toHaveBeenCalledTimes(1);
+          expectHeld(1);
+          expect(await lock.verifyStillHeld()).toBe(true);
+        } finally {
+          await lock.release();
+        }
+        await expectEmpty();
+      };
+      const observeCreation = () => {
+        const spies = [
+          vi.spyOn(fs, "open"),
+          vi.spyOn(fsSync, "openSync"),
+          vi.spyOn(nativeOperations, "createNativeExclusiveFile"),
+          ...(lockRoot ? [vi.spyOn(lockRoot, "create")] : []),
+        ];
+        return () => {
+          for (const spy of spies) expect(spy).not.toHaveBeenCalled();
+          for (const spy of spies) spy.mockRestore();
+        };
+      };
+      return { directory, lockPath, acquire, expectHeld, expectEmpty, expectUsable, observeCreation };
+    }
+
+    for (const encoding of encodings) {
+      it.each([cap - 1, cap])(`writes and releases ${encoding} at %s bytes`, async (bytes) => {
+        const { lockPath, acquire, expectHeld, expectEmpty } = await fixture();
+        const value = sizedPayload(bytes, encoding);
+        const toJSON = vi.fn(() => value);
+        const payload = vi.fn(() => ({ toJSON }));
+        const lock = await acquire({ payload, retry: { retries: 0 } });
+        try {
+          const raw = await fs.readFile(lockPath, "utf8");
+          expect((await fs.stat(lockPath)).size).toBe(bytes);
+          expect(Buffer.byteLength(raw, "utf8")).toBe(bytes);
+          expect(JSON.parse(raw)).toEqual(value);
+          const token = readSidecarLockOwnershipToken(raw);
+          expect(token).toBeDefined();
+          expect(raw).toBe(`${JSON.stringify(value, null, 2)}\n${token}\n`);
+          expectHeld(1);
+          expect(await lock.verifyStillHeld()).toBe(true);
+        } finally {
+          await lock.release();
+        }
+        expect(payload).toHaveBeenCalledTimes(1);
+        expect(toJSON).toHaveBeenCalledTimes(1);
+        await expectEmpty();
+      });
+
+      for (const budget of budgets) {
+        it.each([false, true])(
+          `refuses ${encoding} at cap+1 with ${budget.name} (foreign sidecar: %s)`,
+          async (foreign) => {
+            const { directory, lockPath, acquire, expectHeld, expectEmpty, expectUsable, observeCreation } =
+              await fixture();
+            const original = '{"owner":"foreign","createdAt":"2000-01-01T00:00:00.000Z"}\n';
+            if (foreign) await fs.writeFile(lockPath, original, { flag: "wx" });
+            const before = foreign ? await fs.stat(lockPath, { bigint: true }) : undefined;
+            const noCreation = observeCreation();
+            const toJSON = vi.fn(() => sizedPayload(cap + 1, encoding));
+            const payload = vi.fn(() => ({ toJSON }));
+            const parsePayload = vi.fn(JSON.parse);
+            const shouldReclaim = vi.fn(() => true);
+            const shouldRemoveStaleLock = vi.fn(() => true);
+            const error = await acquire({
+              ...budget,
+              payload,
+              parsePayload,
+              staleRecovery: "remove-if-unchanged",
+              shouldReclaim,
+              shouldRemoveStaleLock,
+            }).catch((caught: unknown) => caught);
+            expect(error).toBeInstanceOf(FsSafeError);
+            expect(error).toMatchObject({ code: "too-large" });
+            expect(payload).toHaveBeenCalledTimes(1);
+            expect(toJSON).toHaveBeenCalledTimes(1);
+            expect(parsePayload).not.toHaveBeenCalled();
+            expect(shouldReclaim).not.toHaveBeenCalled();
+            expect(shouldRemoveStaleLock).not.toHaveBeenCalled();
+            noCreation();
+            expectHeld(0);
+            if (foreign) {
+              const after = await fs.stat(lockPath, { bigint: true });
+              expect([after.dev, after.ino, after.size, after.mtimeNs, after.ctimeNs])
+                .toEqual([before!.dev, before!.ino, before!.size, before!.mtimeNs, before!.ctimeNs]);
+              expect(await fs.readFile(lockPath, "utf8")).toBe(original);
+              expect(await fs.readdir(directory)).toEqual(["state.lock"]);
+              await fs.unlink(lockPath);
+            }
+            await expectEmpty();
+            await expectUsable();
+          },
+        );
+      }
+    }
+
+    for (const budget of budgets) {
+      it.each(["payload", "toJSON"] as const)(
+        `preserves %s error identity without retry with ${budget.name}`,
+        async (callback) => {
+          const { acquire, expectEmpty, expectUsable, observeCreation } = await fixture();
+          const noCreation = observeCreation();
+          const failure = Object.assign(new Error("caller serialization failure"), { code: "EEXIST" });
+          // A distinct second-call error bounds a broken infinite-budget loop.
+          const fail = vi.fn((): never => { throw new Error("callback was retried"); })
+            .mockImplementationOnce(() => { throw failure; });
+          const payload = callback === "payload" ? fail : vi.fn(() => ({ toJSON: fail }));
+          await expect(acquire({ ...budget, payload })).rejects.toBe(failure);
+          expect(payload).toHaveBeenCalledTimes(1);
+          expect(fail).toHaveBeenCalledTimes(1);
+          noCreation();
+          await expectEmpty();
+          await expectUsable();
+        },
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary

A lock could successfully publish an owned sidecar larger than its own 1 MiB snapshot-read limit. Both `verifyStillHeld()` and `release()` then rejected with `too-large`, leaving the held entry and sidecar behind. This affected raw and Root-backed locks, async and sync.

Apply the existing snapshot limit in the shared serializer, before exclusive creation or held-state insertion. Serialize once and measure the complete UTF-8 byte string, including pretty-printed JSON, newlines and the ownership token. Reject oversize input with `FsSafeError("too-large")`; do not expand the read cap, trim fields, retry callbacks, or weaken identity/cleanup. Net production delta is +5 lines, with 118 focused regression cases and docs/Unreleased updates.

## Real consumer proof

Fresh physical registry 0.7.2 and packed-candidate consumers exercise exact serialized sizes 1,048,575 / 1,048,576 / 1,048,577 bytes. ASCII and multibyte inputs are tested across raw/Root async/sync. The multibyte oversize string has only 524,213 UTF-16 code units, demonstrating why character count is insufficient.

Representative actual Node24/off observations, reduced to relevant fields:

```json
{
  "before": [
    {"requestedSerializedBytes":1048576,"acquired":true,"writtenBytes":1048576,"sidecarRemains":false,"verdict":"pass"},
    {"requestedSerializedBytes":1048577,"unicode":false,"calls":1,"acquired":true,"writtenBytes":1048577,"verifyError":"too-large","releaseError":"too-large","sidecarRemains":true,"verdict":"fail"},
    {"requestedSerializedBytes":1048577,"unicode":true,"payloadCharacters":524213,"acquired":true,"verifyError":"too-large","releaseError":"too-large","sidecarRemains":true,"verdict":"fail"}
  ],
  "after": [
    {"requestedSerializedBytes":1048576,"acquired":true,"writtenBytes":1048576,"sidecarRemains":false,"verdict":"pass"},
    {"requestedSerializedBytes":1048577,"unicode":false,"calls":1,"acquired":false,"writtenBytes":null,"acquireError":"too-large","sidecarRemains":false,"verdict":"pass"},
    {"requestedSerializedBytes":1048577,"unicode":true,"payloadCharacters":524213,"calls":1,"acquired":false,"writtenBytes":null,"acquireError":"too-large","sidecarRemains":false,"verdict":"pass"}
  ]
}
```

All 16 fresh-consumer cases pass on each of Node 22.0.0, 22.23.2 and 24.20.0 under off/auto/require configuration: 144 observations. Successful boundary cases verify and release their files; rejected oversize cases create no sidecar.

Candidate tree: `373d7c7f28d73105901ab7108cefe7ce50176ec9`. macOS root tarball integrity: `sha512-X/TlypsN3QGc/o5/ASfhZe2BzuBNOmP0ITZ3Km9yrSIQHHR0YeTLaG8B2phzuuz2PsPFQy3DF/bPRFzJKdXc/w==`. Package version remains 0.7.2; tree/integrity distinguish the candidate from the published baseline. No release or publication is part of this PR.

## Validation

- Serializer cap+1 regressions: two failures before the production edit, all six boundary controls passing afterward.
- 118 new tests pass in default, off and require runs; 267 related ownership/acquisition/release/retry/provenance tests pass with two Windows-only skips. Creation spies only observe real calls. The tests verify exact bytes, single callback/serialization execution, no held entries or creation on refusal, preservation of foreign sidecar identity/timestamps/bytes, and later valid acquisition.
- macOS arm64 Node24: `CI=1 pnpm check` — 6,679 passed / 77 skipped; `pnpm test:security` — 84 passed; `pnpm package:smoke` passed.
- Frozen-tree Linux x64 Node24: native build, `FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm check` — 6,675 / 81 skipped; security — 84; package smoke passed.
- Package smoke includes physical npm/pnpm consumers, optional-dependency omission, missing-binary auto fallback and require refusal. Foreign filtering fixtures are not foreign runtime proof.
- `git diff --check` passed; independent Codex autoreview scoped-clean at P0, confidence 0.99.

Exact-head CI is required before merge. Normal-exit Root cleanup and queue durability findings remain separate work; no retry/deadline semantics are changed here.
