### PR TITLE
fix(archive): apply modes at publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.7.3 - Unreleased
 
+- Separate archive staging permissions from final publication modes so zero/write-only files and restrictive directories extract correctly; finalize explicit and implicit directory modes through retained, verified authority and reject unsafe mode application instead of silently skipping it.
+- Decode absent TAR modes and supported signed GNU binary permission bits in native manifests, matching JavaScript defaults without changing the native ABI.
 - Reject serialized sidecar lock payloads above 1 MiB of UTF-8 bytes, including ownership overhead, with `too-large` before async or sync acquisition so admitted locks remain verifiable and releasable.
 - Honor explicit async file-lock retry counts independently of infinite deadlines, matching sync locks while preserving unlimited retries when the count is omitted.
 - Verify atomic secret writes through the writer's retained descriptor so restrictive POSIX modes such as `0o000` and `0o200` succeed without a readonly reopen or widened permissions.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -61,9 +61,42 @@ type ExtractArchiveOptions = {
 `entryModes` defaults to `"clamp"`: directories become `0o755`; files become
 `0o644`, or `0o755` when the archived owner-execute bit is set. `"preserve"`
 keeps archived read/write/execute bits. Both policies strip setuid, setgid, and
-sticky bits, and neither applies archived ownership. TAR extraction disables
-`tar`'s ownership and mode restoration and applies the selected modes in the
-private staging tree; ZIP applies the same policy to `unixPermissions`.
+sticky bits, and neither applies archived ownership. An explicit zero mode,
+including a mode containing only stripped special bits, stays zero under
+`"preserve"`. Absent metadata defaults to `0o644` for files and `0o755` for
+directories; ZIP UNIX creator records with zero attributes are explicit zero,
+while non-UNIX ZIP records use the absent-metadata defaults.
+
+TAR mode fields containing only NUL/ASCII-space padding use absent defaults.
+Native extraction also recognizes GNU binary modes, including signed values,
+within node-tar's JavaScript safe-integer range before masking permission bits.
+Malformed or unsupported mode representations retain existing decoder behavior:
+native falls back to zero, while JavaScript may default, parse an octal prefix,
+or reject. These representations are not newly admitted or standardized by the
+mode repair; raw framing and other numeric-field checks remain unchanged.
+
+Final modes remain separate from private working staging permissions: files
+stay `0o600` and directories `0o700` until publication. Files receive their final
+mode through the guarded copy's owned writer descriptor. Directories are pinned
+before descending and finalized after their children, including empty and
+restrictive directories. Explicit accepted directory modes win regardless of
+archive order; implicit parents receive `0o755`. Existing destination directories
+also receive the requested final mode. They are never temporarily widened to
+allow child writes; insufficient write/search access still rejects.
+
+Directory mode changes use a retained no-follow read descriptor when possible.
+On macOS x64/arm64, read-denied directories can use a retained search descriptor.
+On Linux x64/arm64, the Node-only search route retains an `O_PATH` descriptor and
+changes modes through its exact `/proc/self/fd/N` reference after verifying the
+procfs namespace and followed identity. The descriptor stays open through the
+operation and verification; original root, ancestor and named-directory checks
+still apply. This route trusts host mount-namespace integrity and does not claim
+atomic ancestry checks or protection against privileged mount replacement.
+Readable directories do not depend on procfs. A Linux search-only directory
+needing a mode change requires accessible, genuine procfs; unavailable or
+untrusted authority rejects explicitly instead of silently accepting a wrong
+mode. Other unsupported search-only routes also fail closed. Windows retains
+its existing bounded lack of POSIX mode enforcement.
 
 Native extraction is deliberately split into two phases. Rust first reports an
 entry manifest without creating paths. TypeScript validates paths, applies
@@ -167,6 +200,11 @@ before publication preserves a pre-existing file, and rejection does not grant
 authority to delete a substituted file or alias. Failed extraction does not
 restore overwritten contents. Active destination mutations and their guarded
 cleanup still finish before rejection; no later destination mutation begins.
+New directories whose postorder finalization was never reached can retain their
+private working mode after failure. Failure cleanup closes retained descriptors;
+it does not run a final chmod sweep or roll back the archive. The public merge
+helper still derives modes from its external source tree and must be able to
+read that source; it never chmods an unreadable external source to admit it.
 
 ### Limits
 

--- a/native/src/archive.rs
+++ b/native/src/archive.rs
@@ -238,7 +238,7 @@ fn inspect_tar(
             path,
             kind: tar_kind(header.entry_type()).to_owned(),
             size,
-            mode: header.mode().unwrap_or(0),
+            mode: crate::tar_mode::manifest_mode(header, tar_kind(header.entry_type()) == "directory"),
         });
     }
     Ok(result)
@@ -975,6 +975,48 @@ mod tests {
             max_meta_entry_bytes: value,
             max_decoded_bytes: value,
             max_manifest_bytes: value,
+        }
+    }
+
+    #[test]
+    fn tar_manifest_modes_distinguish_absence_and_signed_binary_for_all_codecs() {
+        let binary = |value: i64| {
+            let mut field = value.to_be_bytes();
+            if value >= 0 { field[0] = 0x80; }
+            field
+        };
+        let fields = [
+            ([0; 8], None), ([b' '; 8], None), (*b"0000000\0", Some(0)),
+            (binary(0), Some(0)), (binary(0o755), Some(0o755)),
+            (binary((1_i64 << 32) + 0o755), Some(0o755)),
+            (binary(MAX_SAFE_INTEGER as i64), Some(0o7777)),
+            (binary(-1), Some(0o7777)), (binary(-256), Some(0o7400)),
+            (binary(-512), Some(0o7000)), (binary(-(MAX_SAFE_INTEGER as i64)), Some(1)),
+        ];
+        for (mode, expected) in fields {
+            for entry_type in [b'0', b'7', b'5', b'D'] {
+                let mut header = tar::Header::new_ustar();
+                header.set_path("entry").unwrap();
+                header.set_entry_type(tar::EntryType::new(entry_type));
+                header.set_size(0);
+                header.as_old_mut().mode = mode;
+                header.set_cksum();
+                let bytes = [header.as_bytes().as_slice(), &[0; 1024]].concat();
+                for (format, encoded) in [
+                    (ArchiveFormat::Tar, bytes.clone()), (ArchiveFormat::Tar, gzip(&bytes)),
+                    (ArchiveFormat::TarZstd, zstd::stream::encode_all(bytes.as_slice(), 1).unwrap()),
+                    (ArchiveFormat::TarBzip2, bzip(&bytes)),
+                ] {
+                    let path = temp_path("tar-modes");
+                    std::fs::write(&path, encoded).unwrap();
+                    let result = inspect_tar(path.to_str().unwrap(), format, limits(10), Arc::new(AtomicBool::new(false)));
+                    std::fs::remove_file(path).unwrap();
+                    let manifest = result.unwrap();
+                    let kind = tar_kind(tar::EntryType::new(entry_type));
+                    assert_eq!(manifest[0].kind, kind);
+                    assert_eq!(manifest[0].mode, expected.unwrap_or(if kind == "directory" { 0o755 } else { 0o644 }), "mode={mode:?}, type={entry_type}");
+                }
+            }
         }
     }
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -9,6 +9,7 @@ mod owned_tree;
 #[cfg(unix)]
 mod staged_file;
 mod tar_meter;
+mod tar_mode;
 mod tar_path;
 mod tar_pax;
 #[cfg(unix)]

--- a/native/src/tar_mode.rs
+++ b/native/src/tar_mode.rs
@@ -1,0 +1,75 @@
+use crate::tar_meter::MAX_SAFE_INTEGER;
+
+/// Normalize absent and supported GNU modes without changing the native manifest ABI.
+pub(crate) fn manifest_mode(header: &tar::Header, directory: bool) -> u32 {
+    let field = &header.as_old().mode;
+    if field.iter().all(|byte| matches!(*byte, 0 | b' ')) {
+        return if directory { 0o755 } else { 0o644 };
+    }
+    let value = match field[0] {
+        0x80 => {
+            let mut bytes = *field;
+            bytes[0] = 0;
+            Some(i64::from_be_bytes(bytes))
+        }
+        0xff => Some(i64::from_be_bytes(*field)),
+        _ => None,
+    };
+    if let Some(value) = value
+        && (-(MAX_SAFE_INTEGER as i64)..=MAX_SAFE_INTEGER as i64).contains(&value)
+    {
+        // node-tar's ReadEntry masks safe signed numbers to rwx + special bits.
+        // Do not narrow to u32 before checking its JavaScript numeric domain.
+        return (value & 0o7777) as u32;
+    }
+    // Keep the existing octal decoder and its malformed/unsupported-mode fallback.
+    // In particular, an out-of-domain binary value must not wrap into rwx bits.
+    header.mode().unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mode(field: [u8; 8], directory: bool) -> u32 {
+        let mut header = tar::Header::new_ustar();
+        header.as_old_mut().mode = field;
+        manifest_mode(&header, directory)
+    }
+
+    #[test]
+    fn blank_padding_is_absent_but_octal_zero_is_explicit() {
+        for directory in [false, true] {
+            for field in [[0; 8], [b' '; 8], [b' ', 0, b' ', 0, 0, 0, 0, 0]] {
+                assert_eq!(mode(field, directory), if directory { 0o755 } else { 0o644 });
+            }
+            assert_eq!(mode(*b"0000000\0", directory), 0);
+        }
+    }
+
+    #[test]
+    fn supported_binary_domain_retains_permission_bits() {
+        for (value, expected) in [
+            (0, 0), (0o755, 0o755), ((1_i64 << 32) + 0o755, 0o755),
+            (MAX_SAFE_INTEGER as i64, 0o7777), (-1, 0o7777),
+            (-256, 0o7400), (-512, 0o7000), (-(MAX_SAFE_INTEGER as i64), 1),
+        ] {
+            let mut field = value.to_be_bytes();
+            if value >= 0 { field[0] = 0x80; }
+            assert_eq!(mode(field, false), expected, "value={value}");
+        }
+    }
+
+    #[test]
+    fn malformed_and_unsupported_modes_keep_the_existing_zero_fallback() {
+        for field in [
+            *b"invalid!", *b"0000755x", *b"-0000400", *b"\0invalid",
+            [0x81, 0, 0, 0, 0, 0, 1, 0xff],
+            [0x80, 0x20, 0, 0, 0, 0, 0, 1], // Above Number.MAX_SAFE_INTEGER.
+            [0xff, 0xdf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+        ] {
+            assert_eq!(mode(field, false), 0, "field={field:?}");
+            assert_eq!(mode(field, true), 0, "field={field:?}");
+        }
+    }
+}

--- a/src/archive-merge.ts
+++ b/src/archive-merge.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ownExtractionDestinationMutation, type ExtractionDeadline } from "./archive-deadline.js";
+import {
+  assertDirectoryIdentityGuard, assertResolvedInsideDestination,
+  createDirectoryIdentityGuard, createArchiveSymlinkTraversalError,
+  preparePrivateArchiveOutputPath,
+} from "./archive-staging.js";
+import { type AsyncDirectoryGuard } from "./directory-guard.js";
+import { type DirectoryModeOwner } from "./directory-mode-owner.js";
+import { pinNodeDirectoryForMode } from "./directory-mode-node.js";
+import { FsSafeError } from "./errors.js";
+import { formatErrorDetail } from "./error-detail.js";
+import { isPathInside } from "./path.js";
+import { root } from "./root.js";
+import { getFsSafeTestHooks } from "./test-hooks.js";
+
+export type ArchivePublicationEntry = { path: string; kind: "file" | "directory"; mode: number };
+type MergeParams = {
+  sourceDir: string;
+  destinationDir: string;
+  destinationRealDir: string;
+  deadline?: ExtractionDeadline;
+};
+
+export async function mergePlannedArchiveIntoDestination(
+  params: MergeParams & { entries: readonly ArchivePublicationEntry[] },
+): Promise<void> {
+  await mergeTree(params, params.entries);
+}
+
+export async function mergeExtractedTreeIntoDestination(params: MergeParams): Promise<void> {
+  await mergeTree(params);
+}
+
+async function mergeTree(params: MergeParams, publication?: readonly ArchivePublicationEntry[]): Promise<void> {
+  const check = () => params.deadline?.check();
+  check();
+  const destinationGuard = await createDirectoryIdentityGuard(params.destinationRealDir);
+  check();
+  const targetRoot = await root(params.destinationRealDir);
+  check();
+  const sourceGuard = await createDirectoryIdentityGuard(params.sourceDir);
+  check();
+  const plan = publication ? new Map<string, ArchivePublicationEntry>() : undefined;
+  for (const entry of publication ?? []) {
+    // Resolve admitted spelling in private staging, preserving the volume's case
+    // and Unicode behavior without assigning explicit modes to distinct parents.
+    const stagedPath = await fs.realpath(path.join(params.sourceDir, entry.path));
+    check();
+    if (!isPathInside(sourceGuard.realPath, stagedPath) || plan!.has(stagedPath)) {
+      throw new FsSafeError("path-mismatch", "archive publication paths changed in staging");
+    }
+    plan!.set(stagedPath, entry);
+  }
+  const ancestors: Array<{ guard: AsyncDirectoryGuard; owner: DirectoryModeOwner }> = [];
+  const assertGuards = async () => {
+    await assertDirectoryIdentityGuard(destinationGuard);
+    check();
+    for (const ancestor of ancestors) {
+      await assertDirectoryIdentityGuard(ancestor.guard);
+      check();
+      await ancestor.owner.verify(check);
+      check();
+    }
+    await assertDirectoryIdentityGuard(sourceGuard);
+    check();
+  };
+  const walk = async (sourceDir: string): Promise<void> => {
+    await assertGuards();
+    const entries = await fs.readdir(sourceDir, { withFileTypes: true });
+    check();
+    for (const entry of entries) {
+      await assertGuards();
+      const sourcePath = path.join(sourceDir, entry.name);
+      const relPath = path.relative(params.sourceDir, sourcePath);
+      const originalPath = relPath.split(path.sep).join("/");
+      const destinationPath = path.join(params.destinationDir, relPath);
+      const sourceStat = await fs.lstat(sourcePath);
+      check();
+      if (sourceStat.isSymbolicLink()) throw createArchiveSymlinkTraversalError(originalPath);
+      const sourceReal = await fs.realpath(sourcePath);
+      check();
+      if (!isPathInside(sourceGuard.realPath, sourceReal)) throw createArchiveSymlinkTraversalError(originalPath);
+      if (!sourceStat.isFile() && !sourceStat.isDirectory()) {
+        throw new Error(`archive staging contains unsupported entry: ${formatErrorDetail(originalPath)}`);
+      }
+      const kind = sourceStat.isDirectory() ? "directory" : "file";
+      const planned = plan?.get(sourceReal);
+      if (plan && ((planned && planned.kind !== kind) || (!planned && kind === "file"))) {
+        throw new FsSafeError("path-mismatch", "archive staging disagrees with the admitted publication plan");
+      }
+      const mode = plan ? planned?.mode ?? 0o755 : sourceStat.mode & 0o777;
+      await preparePrivateArchiveOutputPath({
+        ...params, relPath, outPath: destinationPath, originalPath, isDirectory: kind === "directory",
+      }, assertGuards);
+      check();
+      if (kind === "directory") {
+        // Ownership spans open, descendants, finalization and close, including timeout.
+        await ownExtractionDestinationMutation(params.deadline, async () => {
+          await assertGuards();
+          const owner = await pinNodeDirectoryForMode(destinationPath).catch((error: unknown) => {
+            if (error instanceof FsSafeError && (error.code === "not-file" || error.code === "path-mismatch")) {
+              throw createArchiveSymlinkTraversalError(originalPath);
+            }
+            throw error;
+          });
+          try {
+            check();
+            const guard = await createDirectoryIdentityGuard(destinationPath);
+            check();
+            await owner.verify(check);
+            ancestors.push({ guard, owner });
+            try {
+              await walk(sourcePath);
+              await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("chmod", destinationPath);
+              check();
+              await assertGuards();
+              // Do not recursively verify this owner from inside its serialized apply.
+              ancestors.pop();
+              await owner.apply(mode, { check, beforeChmod: async () => {
+                await assertGuards();
+                await assertDirectoryIdentityGuard(guard);
+                check();
+                await assertResolvedInsideDestination({
+                  destinationRealDir: params.destinationRealDir, targetPath: destinationPath, originalPath,
+                });
+                check();
+              } });
+              check();
+              await assertGuards();
+            } finally {
+              if (ancestors.at(-1)?.owner === owner) ancestors.pop();
+            }
+          } finally {
+            await owner.close();
+          }
+        });
+      } else {
+        await ownExtractionDestinationMutation(params.deadline, async () => {
+          await assertGuards();
+          try {
+            await targetRoot.copyIn(relPath, sourcePath, { mkdir: true, mode });
+            check();
+            await assertGuards();
+            await assertResolvedInsideDestination({
+              destinationRealDir: params.destinationRealDir, targetPath: destinationPath, originalPath,
+            });
+            check();
+            const stat = await fs.lstat(destinationPath);
+            check();
+            if (stat.isSymbolicLink() || (stat.isFile() && stat.nlink > 1)) {
+              throw createArchiveSymlinkTraversalError(originalPath);
+            }
+          } catch (error) {
+            // copyIn alone owns cleanup; no receipt permits archive-layer unlink.
+            if (error instanceof FsSafeError && (error.code === "hardlink" || error.code === "path-alias")) {
+              throw createArchiveSymlinkTraversalError(originalPath);
+            }
+            throw error;
+          }
+        });
+      }
+    }
+  };
+  await walk(params.sourceDir);
+}

--- a/src/archive-native.ts
+++ b/src/archive-native.ts
@@ -28,10 +28,11 @@ import {
 import type { ExtractArchiveOptions } from "./archive-options.js";
 import { resolveArchiveEntryMode, shouldExtractArchiveEntry } from "./archive-policy.js";
 import {
-  mergeExtractedTreeIntoDestination,
   prepareArchiveDestinationDir,
   withStagedArchiveDestination,
 } from "./archive-staging.js";
+import { mergePlannedArchiveIntoDestination } from "./archive-merge.js";
+import type { ZipDirectoryEntry } from "./archive-zip-directory.js";
 import type { NativeBinding } from "./native.js";
 import { admitZipFile } from "./archive-zip-admission.js";
 
@@ -79,8 +80,9 @@ export async function extractNativeArchive(params: {
     deadline: params.deadline,
   });
   try {
+    const zipEntries: ZipDirectoryEntry[] = [];
     const physicalCount = params.kind === "zip"
-      ? await admitZipFile(stagedArchive.path, limits, params.deadline)
+      ? await admitZipFile(stagedArchive.path, limits, params.deadline, (entry) => { zipEntries.push(entry); })
       : undefined;
     const destinationRealDir = await prepareArchiveDestinationDir(params.destDir);
     await withStagedArchiveDestination({
@@ -100,6 +102,19 @@ export async function extractNativeArchive(params: {
         if (physicalCount !== undefined && manifest.length !== physicalCount) {
           throw new ArchiveSecurityError("entry-path", "zip decoder collapsed entry names");
         }
+        if (params.kind === "zip") {
+          for (const [ordinal, entry] of manifest.entries()) {
+            const physical = zipEntries[ordinal];
+            // Native ZIP indices are physical central-directory ordinals. Legacy
+            // filename decoding remains native-selected; compare names when known.
+            if (!physical || physical.index !== ordinal || entry.index !== ordinal ||
+                entry.size !== physical.size ||
+                (physical.path !== undefined && stripArchivePath(entry.path, 0) !== stripArchivePath(physical.path, 0)) ||
+                (physical.creatorSystem === 3 && entry.mode !== physical.externalAttributes >>> 16)) {
+              throw new ArchiveFormatError("ZIP decoder disagrees with admitted directory metadata");
+            }
+          }
+        }
         // Recheck the native manifest at the shared policy boundary before
         // any caller callback observes an entry.
         if (params.kind !== "zip") {
@@ -111,7 +126,7 @@ export async function extractNativeArchive(params: {
         const plan: Array<{
           index: number;
           path: string;
-          kind: string;
+          kind: "file" | "directory";
           size: number;
           mode: number;
         }> = [];
@@ -167,7 +182,11 @@ export async function extractNativeArchive(params: {
               size: entry.size,
               mode: resolveArchiveEntryMode({
                 kind,
-                archivedMode: entry.mode,
+                archivedMode: params.kind === "zip"
+                  ? zipEntries[entry.index]!.creatorSystem === 3
+                    ? zipEntries[entry.index]!.externalAttributes >>> 16
+                    : undefined
+                  : entry.mode,
                 policy: params.entryModes,
               }),
             });
@@ -185,7 +204,7 @@ export async function extractNativeArchive(params: {
             stagedArchive.path,
             params.kind,
             directory.fd,
-            plan,
+            plan.map((entry) => ({ ...entry, mode: entry.kind === "directory" ? 0o700 : 0o600 })),
             tarLimits,
             params.deadline.signal,
           ).catch(throwMappedNativeError);
@@ -193,7 +212,8 @@ export async function extractNativeArchive(params: {
           await directory.close().catch(() => undefined);
         }
         params.deadline.check();
-        await mergeExtractedTreeIntoDestination({
+        await mergePlannedArchiveIntoDestination({
+          entries: plan,
           sourceDir: stagingDir,
           destinationDir: params.destDir,
           destinationRealDir,

--- a/src/archive-policy.ts
+++ b/src/archive-policy.ts
@@ -20,12 +20,12 @@ export function archiveEntryKindFromTarType(type: string): ArchiveEntryKind {
 
 export function resolveArchiveEntryMode(params: {
   kind: "file" | "directory";
-  archivedMode?: number;
+  archivedMode?: number | null;
   policy?: ArchiveEntryModePolicy;
 }): number {
   const archivedMode = (params.archivedMode ?? 0) & 0o777;
   if (params.policy === "preserve") {
-    return archivedMode || (params.kind === "directory" ? 0o755 : 0o644);
+    return params.archivedMode == null ? (params.kind === "directory" ? 0o755 : 0o644) : archivedMode;
   }
   if (params.kind === "directory") {
     return 0o755;

--- a/src/archive-staging.ts
+++ b/src/archive-staging.ts
@@ -15,11 +15,13 @@ import {
 } from "./archive-errors.js";
 import { FsSafeError } from "./errors.js";
 import { formatErrorDetail } from "./error-detail.js";
-import { resolveOpenedFileRealPathForHandle, root } from "./root.js";
+import { root } from "./root.js";
 import { isNotFoundPathError, isPathInside } from "./path.js";
-import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { resolveSecureTempRoot } from "./secure-temp-dir.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
+import { mkdirPathComponentsWithGuards } from "./guarded-mkdir.js";
+import { expandRelativePathWithHome } from "./root-context.js";
+import { resolveRootPath } from "./root-path.js";
 
 const ERROR_ARCHIVE_ENTRY_TRAVERSES_SYMLINK = "archive entry traverses symlink in destination";
 const ARCHIVE_STAGING_MODE = 0o700;
@@ -37,7 +39,7 @@ function symlinkTraversalError(originalPath: string): ArchiveSecurityError {
   );
 }
 
-async function createDirectoryIdentityGuard(dir: string): Promise<AsyncDirectoryGuard> {
+export async function createDirectoryIdentityGuard(dir: string): Promise<AsyncDirectoryGuard> {
   try {
     return await createAsyncDirectoryGuard(dir);
   } catch (err) {
@@ -48,7 +50,7 @@ async function createDirectoryIdentityGuard(dir: string): Promise<AsyncDirectory
   }
 }
 
-async function assertDirectoryIdentityGuard(guard: AsyncDirectoryGuard): Promise<void> {
+export async function assertDirectoryIdentityGuard(guard: AsyncDirectoryGuard): Promise<void> {
   try {
     await assertAsyncDirectoryGuard(guard);
   } catch (err) {
@@ -116,7 +118,7 @@ async function assertNoSymlinkTraversal(params: {
   }
 }
 
-async function assertResolvedInsideDestination(params: {
+export async function assertResolvedInsideDestination(params: {
   destinationRealDir: string;
   targetPath: string;
   originalPath: string;
@@ -150,7 +152,7 @@ async function mkdirArchiveOutput(params: {
   }
 }
 
-export async function prepareArchiveOutputPath(params: {
+type ArchiveOutputPathParams = {
   destinationDir: string;
   destinationRealDir: string;
   relPath: string;
@@ -158,9 +160,48 @@ export async function prepareArchiveOutputPath(params: {
   originalPath: string;
   isDirectory: boolean;
   deadline?: ExtractionDeadline;
-}): Promise<void> {
+};
+
+export async function prepareArchiveOutputPath(params: ArchiveOutputPathParams): Promise<void> {
+  await prepareOutputPath(params);
+}
+
+export async function preparePrivateArchiveOutputPath(
+  params: ArchiveOutputPathParams, assertGuards?: () => Promise<void>,
+): Promise<void> {
+  await prepareOutputPath(params, assertGuards, true);
+}
+
+async function prepareOutputPath(
+  params: ArchiveOutputPathParams, assertGuards?: () => Promise<void>, privateWorkingMode = false,
+): Promise<void> {
   checkExtractionDeadline(params.deadline);
-  const targetRoot = await root(params.destinationRealDir);
+  const targetRoot = privateWorkingMode ? {
+    async mkdir(relativePath: string) {
+      // Retain Root.mkdir's strict alias admission before the shared traversal,
+      // while selecting private creation modes without adding a public option.
+      const resolved = await resolveRootPath({
+        absolutePath: path.resolve(params.destinationRealDir, await expandRelativePathWithHome(relativePath)),
+        rootPath: params.destinationRealDir,
+        rootCanonicalPath: params.destinationRealDir,
+        boundaryLabel: "archive destination",
+        rejectSymlinks: true,
+      });
+      checkExtractionDeadline(params.deadline);
+      await mkdirPathComponentsWithGuards({
+        rootReal: params.destinationRealDir,
+        targetPath: resolved.canonicalPath,
+        mode: 0o700,
+        rejectSymlinks: true,
+        beforeComponent: async () => {
+          await assertDirectoryIdentityGuard(destinationGuard);
+          checkExtractionDeadline(params.deadline);
+          await assertGuards?.();
+          checkExtractionDeadline(params.deadline);
+        },
+      });
+    },
+  } : await root(params.destinationRealDir);
   checkExtractionDeadline(params.deadline);
   const destinationGuard = await createDirectoryIdentityGuard(params.destinationRealDir);
   checkExtractionDeadline(params.deadline);
@@ -177,6 +218,8 @@ export async function prepareArchiveOutputPath(params: {
     checkExtractionDeadline(params.deadline);
     await ownExtractionDestinationMutation(params.deadline, async () => {
       await assertDirectoryIdentityGuard(destinationGuard);
+      checkExtractionDeadline(params.deadline);
+      await assertGuards?.();
       checkExtractionDeadline(params.deadline);
       await mkdirArchiveOutput({
         targetRoot,
@@ -203,6 +246,8 @@ export async function prepareArchiveOutputPath(params: {
     await ownExtractionDestinationMutation(params.deadline, async () => {
       await assertDirectoryIdentityGuard(destinationGuard);
       checkExtractionDeadline(params.deadline);
+      await assertGuards?.();
+      checkExtractionDeadline(params.deadline);
       await mkdirArchiveOutput({
         targetRoot,
         relativePath: parentRel,
@@ -219,97 +264,6 @@ export async function prepareArchiveOutputPath(params: {
     originalPath: params.originalPath,
   });
   checkExtractionDeadline(params.deadline);
-}
-
-async function chmodInsideDestinationBestEffort(params: {
-  destinationRealDir: string;
-  destinationPath: string;
-  mode: number;
-  originalPath: string;
-  deadline?: ExtractionDeadline;
-}): Promise<void> {
-  await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("chmod", params.destinationPath);
-  checkExtractionDeadline(params.deadline);
-  const destinationGuard = await createDirectoryIdentityGuard(params.destinationRealDir);
-  checkExtractionDeadline(params.deadline);
-  await assertDirectoryIdentityGuard(destinationGuard);
-  checkExtractionDeadline(params.deadline);
-  const handle = await fs
-    .open(params.destinationPath, resolveReadOpenFlags())
-    .catch(() => null);
-  checkExtractionDeadline(params.deadline);
-  if (!handle) {
-    const stat = await fs.lstat(params.destinationPath).catch(() => null);
-    checkExtractionDeadline(params.deadline);
-    if (stat?.isSymbolicLink()) {
-      throw symlinkTraversalError(params.originalPath);
-    }
-    return;
-  }
-  try {
-    const stat = await handle.stat();
-    checkExtractionDeadline(params.deadline);
-    if (!stat.isDirectory() && !stat.isFile()) {
-      return;
-    }
-    const realPath = await resolveOpenedFileRealPathForHandle(handle, params.destinationPath);
-    checkExtractionDeadline(params.deadline);
-    if (!isPathInside(params.destinationRealDir, realPath)) {
-      throw symlinkTraversalError(params.originalPath);
-    }
-    await ownExtractionDestinationMutation(params.deadline, async () => {
-      await handle.chmod(params.mode).catch(() => undefined);
-      checkExtractionDeadline(params.deadline);
-      await assertDirectoryIdentityGuard(destinationGuard);
-      checkExtractionDeadline(params.deadline);
-    });
-  } finally {
-    await handle.close().catch(() => undefined);
-  }
-}
-
-async function applyStagedEntryMode(params: {
-  destinationRealDir: string;
-  relPath: string;
-  mode: number;
-  originalPath: string;
-  deadline?: ExtractionDeadline;
-}): Promise<void> {
-  checkExtractionDeadline(params.deadline);
-  const destinationPath = path.join(params.destinationRealDir, params.relPath);
-  await assertResolvedInsideDestination({
-    destinationRealDir: params.destinationRealDir,
-    targetPath: destinationPath,
-    originalPath: params.originalPath,
-  });
-  checkExtractionDeadline(params.deadline);
-  if (params.mode !== 0) {
-    await chmodInsideDestinationBestEffort({
-      destinationRealDir: params.destinationRealDir,
-      destinationPath,
-      mode: params.mode,
-      originalPath: params.originalPath,
-      deadline: params.deadline,
-    });
-  }
-  checkExtractionDeadline(params.deadline);
-}
-
-async function assertExtractedFileHasNoHardlinkAlias(params: {
-  destinationRealDir: string;
-  relPath: string;
-  originalPath: string;
-}): Promise<void> {
-  const destinationPath = path.join(params.destinationRealDir, params.relPath);
-  await assertResolvedInsideDestination({
-    destinationRealDir: params.destinationRealDir,
-    targetPath: destinationPath,
-    originalPath: params.originalPath,
-  });
-  const stat = await fs.lstat(destinationPath);
-  if (stat.isFile() && stat.nlink > 1) {
-    throw symlinkTraversalError(params.originalPath);
-  }
 }
 
 function assertSafeArchiveStagingPrefix(prefix: string): string {
@@ -361,104 +315,7 @@ export async function withStagedArchiveDestination<T>(params: {
   }
 }
 
-export async function mergeExtractedTreeIntoDestination(params: {
-  sourceDir: string;
-  destinationDir: string;
-  destinationRealDir: string;
-  deadline?: ExtractionDeadline;
-}): Promise<void> {
-  const targetRoot = await root(params.destinationRealDir);
-  const sourceRootGuard = await createDirectoryIdentityGuard(params.sourceDir);
-  const sourceRootReal = sourceRootGuard.realPath;
-  const walk = async (currentSourceDir: string): Promise<void> => {
-    await assertDirectoryIdentityGuard(sourceRootGuard);
-    const entries = await fs.readdir(currentSourceDir, { withFileTypes: true });
-    for (const entry of entries) {
-      await assertDirectoryIdentityGuard(sourceRootGuard);
-      const sourcePath = path.join(currentSourceDir, entry.name);
-      const relPath = path.relative(params.sourceDir, sourcePath);
-      const originalPath = relPath.split(path.sep).join("/");
-      const destinationPath = path.join(params.destinationDir, relPath);
-      const sourceStat = await fs.lstat(sourcePath);
-      if (sourceStat.isSymbolicLink()) {
-        throw symlinkTraversalError(originalPath);
-      }
-      const sourceReal = await fs.realpath(sourcePath);
-      if (!isPathInside(sourceRootReal, sourceReal)) {
-        throw symlinkTraversalError(originalPath);
-      }
-
-      if (sourceStat.isDirectory()) {
-        await prepareArchiveOutputPath({
-          destinationDir: params.destinationDir,
-          destinationRealDir: params.destinationRealDir,
-          relPath,
-          outPath: destinationPath,
-          originalPath,
-          isDirectory: true,
-          deadline: params.deadline,
-        });
-        await walk(sourcePath);
-        await applyStagedEntryMode({
-          destinationRealDir: params.destinationRealDir,
-          relPath,
-          mode: sourceStat.mode & 0o777,
-          originalPath,
-          deadline: params.deadline,
-        });
-        continue;
-      }
-
-      if (!sourceStat.isFile()) {
-        throw new Error(
-          `archive staging contains unsupported entry: ${formatErrorDetail(originalPath)}`,
-        );
-      }
-
-      await prepareArchiveOutputPath({
-        destinationDir: params.destinationDir,
-        destinationRealDir: params.destinationRealDir,
-        relPath,
-        outPath: destinationPath,
-        originalPath,
-        isDirectory: false,
-        deadline: params.deadline,
-      });
-      await ownExtractionDestinationMutation(params.deadline, async () => {
-        try {
-          await targetRoot.copyIn(relPath, sourcePath, { mkdir: true });
-          checkExtractionDeadline(params.deadline);
-          await assertExtractedFileHasNoHardlinkAlias({
-            destinationRealDir: params.destinationRealDir,
-            relPath,
-            originalPath,
-          });
-          checkExtractionDeadline(params.deadline);
-          await applyStagedEntryMode({
-            destinationRealDir: params.destinationRealDir,
-            relPath,
-            mode: sourceStat.mode & 0o777,
-            originalPath,
-            deadline: params.deadline,
-          });
-          checkExtractionDeadline(params.deadline);
-        } catch (err) {
-          // copyIn owns its guarded cleanup. The merge has no publication
-          // receipt authorizing removal of the current destination entry.
-          if (
-            err instanceof FsSafeError &&
-            (err.code === "hardlink" || err.code === "path-alias")
-          ) {
-            throw symlinkTraversalError(originalPath);
-          }
-          throw err;
-        }
-      });
-    }
-  };
-
-  await walk(params.sourceDir);
-}
+export { mergeExtractedTreeIntoDestination } from "./archive-merge.js";
 
 export function createArchiveSymlinkTraversalError(originalPath: string): ArchiveSecurityError {
   return symlinkTraversalError(originalPath);

--- a/src/archive-tar-runtime.ts
+++ b/src/archive-tar-runtime.ts
@@ -31,6 +31,7 @@ export type TarModule = {
     noChmod: true;
     preserveOwner: false;
     noMtime: true;
+    dmode: number;
     strict: true;
     maxMetaEntrySize: number;
     maxDecompressionRatio: number;

--- a/src/archive-zip-admission.ts
+++ b/src/archive-zip-admission.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { ExtractionDeadline } from "./archive-deadline.js";
 import { ARCHIVE_LIMIT_ERROR_CODE, ArchiveLimitError, type ResolvedArchiveExtractLimits } from "./archive-limits.js";
 import { openRootFile } from "./root-file.js";
-import { scanZipDirectory } from "./archive-zip-directory.js";
+import { scanZipDirectory, type ZipDirectoryEntry } from "./archive-zip-directory.js";
 import { zipFormat } from "./archive-zip-names.js";
 
 function checkSize(size: number, limits: ResolvedArchiveExtractLimits): void {
@@ -27,7 +27,10 @@ export function admitZipBuffer(input: Uint8Array, limits: ResolvedArchiveExtract
 }
 
 /** The extraction input is already private and staged; read only bounded metadata. */
-export async function admitZipFile(archivePath: string, limits: ResolvedArchiveExtractLimits, deadline: ExtractionDeadline): Promise<number> {
+export async function admitZipFile(
+  archivePath: string, limits: ResolvedArchiveExtractLimits, deadline: ExtractionDeadline,
+  onEntry?: (entry: ZipDirectoryEntry) => void,
+): Promise<number> {
   deadline.check();
   const opened = await openRootFile({
     absolutePath: archivePath, rootPath: path.dirname(archivePath),
@@ -36,7 +39,7 @@ export async function admitZipFile(archivePath: string, limits: ResolvedArchiveE
   if (!opened.ok) throw opened.error ?? new Error("cannot open staged ZIP archive");
   try {
     checkSize(opened.stat.size, limits);
-    const scan = scanZipDirectory(opened.stat.size, limits);
+    const scan = scanZipDirectory(opened.stat.size, limits, onEntry);
     let step = scan.next();
     while (!step.done) {
       const { offset, length } = step.value;

--- a/src/archive-zip-directory.ts
+++ b/src/archive-zip-directory.ts
@@ -6,6 +6,13 @@ import { admitZipNames, zipExtraFields, zipFormat, zipUInt64 } from "./archive-z
 
 export type ZipRead = { offset: number; length: number };
 export type ZipScan = Generator<ZipRead, number, Buffer>;
+export type ZipDirectoryEntry = {
+  index: number;
+  creatorSystem: number;
+  externalAttributes: number;
+  size: number;
+  path?: string;
+};
 
 function* read(offset: number, length: number, bound: number): Generator<ZipRead, Buffer, Buffer> {
   if (!Number.isSafeInteger(offset) || !Number.isSafeInteger(length) || offset < 0 || length < 0 || length > bound - offset) {
@@ -136,7 +143,9 @@ function* descriptorEnd(at: number, bound: number, crc: number, compressed: numb
   return matches[0]!;
 }
 
-export function* scanZipDirectory(size: number, limits: ResolvedArchiveExtractLimits): ZipScan {
+export function* scanZipDirectory(
+  size: number, limits: ResolvedArchiveExtractLimits, onEntry?: (entry: ZipDirectoryEntry) => void,
+): ZipScan {
   const directory = yield* layout(size);
   assertArchiveEntryCountWithinLimit(directory.count, limits);
   const seen = new Set<string>();
@@ -174,7 +183,7 @@ export function* scanZipDirectory(size: number, limits: ResolvedArchiveExtractLi
     const localExtraLength = local.readUInt16LE(28);
     const localNames = yield* read(localAt + 30, localNameLength + localExtraLength, directory.start);
     const localExtra = zipExtraFields(localNames.subarray(localNameLength));
-    admitZipNames({ central: centralName, local: localNames.subarray(0, localNameLength), flags, centralExtra, localExtra, seen });
+    const entryPath = admitZipNames({ central: centralName, local: localNames.subarray(0, localNameLength), flags, centralExtra, localExtra, seen });
     const localValues = wideValues(local, localExtra, false);
     const crc = central.readUInt32LE(16);
     if (!(flags & 8) && (local.readUInt32LE(14) !== crc || localValues.compressed !== values.compressed || localValues.uncompressed !== values.uncompressed)) {
@@ -190,6 +199,10 @@ export function* scanZipDirectory(size: number, limits: ResolvedArchiveExtractLi
     let dataEnd = dataStart + values.compressed;
     if (flags & 8) dataEnd = yield* descriptorEnd(dataEnd, directory.start, crc, values.compressed, values.uncompressed, values.wide || localValues.wide);
     spans.push({ start: localAt, end: dataEnd });
+    onEntry?.({
+      index: count - 1, creatorSystem: central[5]!, externalAttributes: central.readUInt32LE(38),
+      size: values.uncompressed, path: entryPath,
+    });
     at = next;
   }
   if (count !== directory.count) zipFormat("physical and declared entry counts disagree");

--- a/src/archive-zip-entry.ts
+++ b/src/archive-zip-entry.ts
@@ -6,7 +6,7 @@ import {
 export type ZipEntry = {
   name: string;
   dir: boolean;
-  unixPermissions?: number;
+  unixPermissions?: number | null;
   _data?: { crc32?: number; uncompressedSize?: number } | PromiseLike<unknown>;
   nodeStream?: () => NodeJS.ReadableStream;
   async: (type: "nodebuffer") => Promise<Buffer>;

--- a/src/archive-zip-names.ts
+++ b/src/archive-zip-names.ts
@@ -60,7 +60,7 @@ export function admitZipNames(params: {
   central: Buffer; local: Buffer; flags: number;
   centralExtra: Map<number, Buffer>; localExtra: Map<number, Buffer>;
   seen: Set<string>;
-}): void {
+}): string | undefined {
   const { central, local, flags, centralExtra, localExtra, seen } = params;
   if (!central.length || !local.length) zipFormat("empty entry name");
   const centralUtf8 = originalName(central, flags); const localUtf8 = originalName(local, flags);
@@ -89,4 +89,5 @@ export function admitZipNames(params: {
     throw new ArchiveSecurityError("entry-path", "zip archive contains duplicate or colliding entry names");
   }
   for (const identity of identities) seen.add(identity);
+  return centralUnicode ?? centralUtf8 ?? (central.every((byte) => byte < 128) ? central.toString("ascii") : undefined);
 }

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -27,11 +27,11 @@ import {
 } from "./archive-limits.js";
 import { resolveArchiveKind } from "./archive-kind.js";
 import {
-  mergeExtractedTreeIntoDestination,
   prepareArchiveDestinationDir,
-  prepareArchiveOutputPath,
+  preparePrivateArchiveOutputPath,
   withStagedArchiveDestination,
 } from "./archive-staging.js";
+import { mergePlannedArchiveIntoDestination, type ArchivePublicationEntry } from "./archive-merge.js";
 import {
   createTarEntryPreflightChecker,
   readTarEntryInfo,
@@ -147,24 +147,11 @@ function resolveZipOutputPath(params: {
   };
 }
 
-async function prepareZipOutputPath(params: {
-  destinationDir: string;
-  destinationRealDir: string;
-  relPath: string;
-  outPath: string;
-  originalPath: string;
-  isDirectory: boolean;
-  deadline: ExtractionDeadline;
-}): Promise<void> {
-  await prepareArchiveOutputPath(params);
-}
-
 async function writeZipFileEntry(params: {
   entry: ZipEntry;
   outPath: string;
   budget: ZipExtractBudget;
   deadline: ExtractionDeadline;
-  mode: number;
 }): Promise<void> {
   params.deadline.check();
   params.budget.startEntry();
@@ -178,9 +165,9 @@ async function writeZipFileEntry(params: {
     await writeSiblingTempFile({
       dir: path.dirname(destinationPath),
       chmodDir: false,
-      mode: params.mode,
+      mode: 0o600,
       writeTemp: async (tempPath) => {
-        tempHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, 0o666);
+        tempHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, 0o600);
         const writable = tempHandle.createWriteStream();
         writable.once("close", () => {
           handleClosedByStream = true;
@@ -254,6 +241,7 @@ async function extractZip(params: {
       destinationRealDir,
       run: async (stagingDir) => {
         const stagingRealDir = await fs.realpath(stagingDir);
+        const acceptedEntries: ArchivePublicationEntry[] = [];
         for (const entry of entries) {
           params.deadline.check();
           const output = resolveZipOutputPath({
@@ -283,8 +271,9 @@ async function extractZip(params: {
             throw new ArchiveSecurityError("entry-link", `zip entry is a link: ${entry.name}`);
           }
           const mode = zipEntryMode(entry, params.entryModes);
+          acceptedEntries.push({ path: output.relPath, kind: entry.dir ? "directory" : "file", mode });
 
-          await prepareZipOutputPath({
+          await preparePrivateArchiveOutputPath({
             destinationDir: stagingRealDir,
             destinationRealDir: stagingRealDir,
             relPath: output.relPath,
@@ -294,7 +283,6 @@ async function extractZip(params: {
             deadline: params.deadline,
           });
           if (entry.dir) {
-            await fs.chmod(output.outPath, mode);
             continue;
           }
 
@@ -303,12 +291,12 @@ async function extractZip(params: {
             outPath: output.outPath,
             budget,
             deadline: params.deadline,
-            mode,
           });
         }
 
         params.deadline.check();
-        await mergeExtractedTreeIntoDestination({
+        await mergePlannedArchiveIntoDestination({
+          entries: acceptedEntries,
           sourceDir: stagingRealDir,
           destinationDir: params.destDir,
           destinationRealDir,
@@ -392,7 +380,7 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
               deadline.check();
               return checkTarEntrySafety(entry);
             }, strip);
-            const acceptedEntries: Array<{ path: string; mode: number }> = [];
+            const acceptedEntries: ArchivePublicationEntry[] = [];
             // Extract privately, then merge through the safe-open boundary.
             const extractor = tar.x({
               cwd: stagingDir,
@@ -405,6 +393,7 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
               noChmod: true,
               preserveOwner: false,
               noMtime: true,
+              dmode: 0o700,
               strict: true,
               maxMetaEntrySize: tarLimits.maxMetaEntryBytes,
               maxDecompressionRatio: NODE_TAR_RATIO_DISABLED,
@@ -415,19 +404,19 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
                   if (!relPath) {
                     return false;
                   }
-                  // Writes and the mode pass use the admitted output identity.
+                  const kind = info.type === "Directory" || info.type === "GNUDumpDir" ? "directory" : "file";
+                  // Keep archived modes before changing node-tar's creation mode.
                   (entry as { path: string }).path = relPath;
                   acceptedEntries.push({
                     path: relPath,
+                    kind,
                     mode: resolveArchiveEntryMode({
-                      kind:
-                        info.type === "Directory" || info.type === "GNUDumpDir"
-                          ? "directory"
-                          : "file",
+                      kind,
                       archivedMode: info.mode,
                       policy: params.entryModes,
                     }),
                   });
+                  (entry as { mode: number }).mode = kind === "directory" ? 0o700 : 0o600;
                   return true;
                 } catch (error) {
                   // Abort through the parser so pipeline tears down both the
@@ -456,18 +445,9 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
               throw normalizeTarParserError(createPipelineTimeoutError(error, deadline));
             }
             admission.finish();
-            for (const accepted of acceptedEntries) {
-              deadline.check();
-              const outputPath = resolveArchiveOutputPath({
-                rootDir: stagingDir,
-                relPath: accepted.path,
-                originalPath: accepted.path,
-              });
-              await fs.chmod(outputPath, accepted.mode);
-              deadline.check();
-            }
             deadline.check();
-            await mergeExtractedTreeIntoDestination({
+            await mergePlannedArchiveIntoDestination({
+              entries: acceptedEntries,
               sourceDir: stagingDir,
               destinationDir: params.destDir,
               destinationRealDir,

--- a/src/directory-mode-node.ts
+++ b/src/directory-mode-node.ts
@@ -1,0 +1,78 @@
+import { constants } from "node:fs";
+import fs from "node:fs/promises";
+import { FsSafeError } from "./errors.js";
+import { inspectDirectoryIdentity } from "./directory-guard.js";
+import { inspectFileIdentity } from "./strict-file-identity.js";
+import { assertOwnedDirectory, ownDirectoryMode, type DirectoryModeOwner } from "./directory-mode-owner.js";
+
+function searchOnlyFlags(): { flags: number; proc: boolean } | undefined {
+  if (process.arch !== "x64" && process.arch !== "arm64") return undefined;
+  // Darwin SDK O_SEARCH = O_EXEC (0x40000000) | O_DIRECTORY, on x64/arm64.
+  if (process.platform === "darwin") return { flags: 0x40000000, proc: false };
+  // Linux x86-64/aarch64 UAPI O_PATH = 010000000. Not a usable fchmod fd.
+  if (process.platform === "linux") return { flags: 0x200000, proc: true };
+  return undefined;
+}
+
+/** Real Node only: injected filesystem adapters must retain descriptor-chmod semantics. */
+export async function pinNodeDirectoryForMode(dirPath: string): Promise<DirectoryModeOwner> {
+  const expected = await inspectDirectoryIdentity(dirPath);
+  if (process.platform === "win32") {
+    // POSIX mode enforcement is unsupported; retain strict path identity checks.
+    return ownDirectoryMode({
+      inspect: async () => { await inspectDirectoryIdentity(dirPath, expected); return 0; },
+      chmod: async () => undefined, close: async () => undefined, ignoreChmodError: true,
+    });
+  }
+  if ([constants.O_DIRECTORY, constants.O_NOFOLLOW, constants.O_NONBLOCK, constants.O_RDONLY]
+    .some((flag) => typeof flag !== "number")) {
+    throw new FsSafeError("helper-unavailable", "no-follow directory mode descriptors are unavailable");
+  }
+  const flags = constants.O_DIRECTORY | constants.O_NOFOLLOW | constants.O_NONBLOCK;
+  let proc = false;
+  const handle = await fs.open(dirPath, constants.O_RDONLY | flags).catch(async (error: NodeJS.ErrnoException) => {
+    if (error.code !== "EACCES") throw error;
+    const route = searchOnlyFlags();
+    if (!route) throw error;
+    proc = route.proc;
+    return await fs.open(dirPath, route.flags | flags);
+  });
+  try {
+    const inspect = async () => {
+      const opened = await inspectFileIdentity(() => handle.stat({ bigint: true }), expected);
+      assertOwnedDirectory(expected, opened);
+      await inspectDirectoryIdentity(dirPath, expected);
+      return Number(opened.mode & 0o7777n);
+    };
+    const procPath = `/proc/self/fd/${handle.fd}`;
+    const assertProcAuthority = async () => {
+      // Authenticate the fd namespace, not the followed target's filesystem.
+      // This trusts host mount-namespace integrity, not privileged mount replacement.
+      const namespace = await fs.statfs("/proc/self/fd", { bigint: true });
+      if (namespace.type !== 0x9fa0n) {
+        throw new FsSafeError("path-mismatch", "directory mode requires a trusted procfs fd namespace");
+      }
+      const opened = await inspectFileIdentity(() => handle.stat({ bigint: true }), expected);
+      const followed = await inspectFileIdentity(() => fs.stat(procPath, { bigint: true }), expected);
+      assertOwnedDirectory(opened, followed);
+    };
+    const owner = ownDirectoryMode({
+      inspect,
+      prepareChmod: proc ? assertProcAuthority : undefined,
+      verifyChmod: proc ? assertProcAuthority : undefined,
+      async chmod(mode) {
+        if (proc) {
+          await fs.chmod(procPath, mode);
+        } else {
+          await handle.chmod(mode);
+        }
+      },
+      close: () => handle.close(),
+    });
+    await owner.verify();
+    return owner;
+  } catch (error) {
+    await handle.close();
+    throw error;
+  }
+}

--- a/src/directory-mode-owner.ts
+++ b/src/directory-mode-owner.ts
@@ -1,0 +1,84 @@
+import type { BigIntStats, Stats } from "node:fs";
+import { FsSafeError } from "./errors.js";
+import { sameFileIdentityForCleanup } from "./file-identity.js";
+
+export type DirectoryModeChecks = {
+  check?: () => void;
+  beforeChmod?: () => Promise<void>;
+};
+export type DirectoryModeOwner = {
+  verify(check?: () => void): Promise<void>;
+  apply(mode: number, checks?: DirectoryModeChecks): Promise<void>;
+  close(): Promise<void>;
+};
+
+export function assertOwnedDirectory(expected: Stats | BigIntStats, actual: Stats | BigIntStats): void {
+  if (actual.isSymbolicLink() || !actual.isDirectory()) {
+    throw new FsSafeError("not-file", "directory mode target must be a real directory");
+  }
+  if (!sameFileIdentityForCleanup(expected, actual)) {
+    throw new FsSafeError("path-mismatch", "directory changed before its mode could be applied");
+  }
+}
+
+/** Serializes use and close: even a queued path-based fd operation retains its descriptor. */
+export function ownDirectoryMode(params: {
+  inspect: () => Promise<number>;
+  chmod: (mode: number) => Promise<void>;
+  prepareChmod?: () => Promise<void>;
+  verifyChmod?: () => Promise<void>;
+  close: () => Promise<void>;
+  ignoreChmodError?: boolean;
+}): DirectoryModeOwner {
+  let pending = Promise.resolve();
+  let closing: Promise<void> | undefined;
+  const enqueue = (run: () => Promise<void>): Promise<void> => {
+    if (closing) return Promise.reject(new FsSafeError("path-mismatch", "directory mode owner is closed"));
+    const operation = pending.then(run);
+    pending = operation.catch(() => undefined);
+    return operation;
+  };
+  return {
+    verify: (check) => enqueue(async () => {
+      check?.();
+      await params.inspect();
+      check?.();
+    }),
+    apply: (mode, checks = {}) => enqueue(async () => {
+      checks.check?.();
+      const currentMode = await params.inspect();
+      checks.check?.();
+      if (currentMode !== mode) {
+        await params.prepareChmod?.();
+        checks.check?.();
+      }
+      await checks.beforeChmod?.();
+      checks.check?.();
+      // Hooks/ancestor checks can yield; recheck the original named association.
+      await params.inspect();
+      checks.check?.();
+      let dispatchDeadlineError: unknown;
+      if (currentMode !== mode) {
+        try {
+          checks.check?.();
+          await params.chmod(mode);
+        } catch (error) {
+          if (!params.ignoreChmodError) throw error;
+        }
+        // Expiry cannot release the fd while post-dispatch verification is pending.
+        try { checks.check?.(); } catch (error) { dispatchDeadlineError = error; }
+        await params.verifyChmod?.();
+      }
+      const finalMode = await params.inspect();
+      if (dispatchDeadlineError) throw dispatchDeadlineError;
+      checks.check?.();
+      if (!params.ignoreChmodError && finalMode !== mode) {
+        throw new FsSafeError("path-mismatch", "directory final mode could not be verified");
+      }
+    }),
+    close() {
+      closing ??= pending.then(params.close);
+      return closing;
+    },
+  };
+}

--- a/src/guarded-mkdir.ts
+++ b/src/guarded-mkdir.ts
@@ -33,6 +33,8 @@ export async function mkdirPathComponentsWithGuards(params: {
   rootReal: string;
   targetPath: string;
   beforeComponent?: (componentPath: string) => Promise<void> | void;
+  mode?: number;
+  rejectSymlinks?: boolean;
 }): Promise<string> {
   const root = path.resolve(params.rootReal);
   const rootCanonical = path.resolve(await fs.realpath(root));
@@ -48,14 +50,14 @@ export async function mkdirPathComponentsWithGuards(params: {
     await assertAsyncDirectoryGuard(parentGuard);
     await params.beforeComponent?.(next);
     try {
-      await fs.mkdir(next);
+      await fs.mkdir(next, { mode: params.mode });
     } catch (error) {
       if (!error || typeof error !== "object" || !("code" in error) || error.code !== "EEXIST") {
         throw error;
       }
     }
     const stat = await fs.lstat(next);
-    if (!stat.isSymbolicLink() && !stat.isDirectory()) {
+    if ((params.rejectSymlinks && stat.isSymbolicLink()) || (!stat.isSymbolicLink() && !stat.isDirectory())) {
       throw directoryComponentNotDirectoryError();
     }
     // Node's recursive mkdir follows symlinks in missing components. Build one

--- a/src/replace-file-descriptor.ts
+++ b/src/replace-file-descriptor.ts
@@ -3,6 +3,7 @@ import fs, { type FileHandle } from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { inspectFileIdentity, inspectFileIdentitySync } from "./strict-file-identity.js";
+import { assertOwnedDirectory, ownDirectoryMode, type DirectoryModeOwner } from "./directory-mode-owner.js";
 
 type AsyncTempFileSystem = Pick<typeof fs, "lstat" | "open" | "writeFile">;
 type SyncTempFileSystem = Pick<
@@ -37,13 +38,12 @@ function assertSameDirectory(expected: Stats, opened: Stats, dirPath: string): v
   }
 }
 
-export async function applyDirectoryMode(params: {
+export async function pinDirectoryForMode(params: {
   fsModule: AsyncTempFileSystem;
   dirPath: string;
-  mode: number;
   /** Compatibility for best-effort directory modes; admission and close still fail closed. */
   ignoreChmodError?: boolean;
-}): Promise<void> {
+}): Promise<DirectoryModeOwner | undefined> {
   // Node does not enforce POSIX directory modes on Windows, and its directory
   // descriptors are not consistently openable. mkdir(mode) remains the only
   // bounded behavior there; never fall back to a pathname chmod.
@@ -55,14 +55,35 @@ export async function applyDirectoryMode(params: {
   assertDirectory(expected, params.dirPath);
   const handle = await params.fsModule.open(params.dirPath, directoryOpenFlags());
   try {
-    assertSameDirectory(expected, await handle.stat(), params.dirPath);
-    try {
-      await handle.chmod(params.mode);
-    } catch (error) {
-      if (params.ignoreChmodError !== true) throw error;
-    }
-  } finally {
+    const owner = ownDirectoryMode({
+      async inspect() {
+        const opened = await handle.stat();
+        assertOwnedDirectory(expected, opened);
+        return opened.mode & 0o7777;
+      },
+      chmod: (mode) => handle.chmod(mode),
+      close: () => handle.close(),
+      ignoreChmodError: params.ignoreChmodError,
+    });
+    await owner.verify();
+    return owner;
+  } catch (error) {
     await handle.close();
+    throw error;
+  }
+}
+
+export async function applyDirectoryMode(params: {
+  fsModule: AsyncTempFileSystem;
+  dirPath: string;
+  mode: number;
+  ignoreChmodError?: boolean;
+}): Promise<void> {
+  const owner = await pinDirectoryForMode(params);
+  try {
+    await owner?.apply(params.mode);
+  } finally {
+    await owner?.close();
   }
 }
 

--- a/test/archive-directory-publication.test.ts
+++ b/test/archive-directory-publication.test.ts
@@ -1,0 +1,197 @@
+import type { BigIntStats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mergeExtractedTreeIntoDestination } from "../src/archive.js";
+import { withExtractionDeadline } from "../src/archive-deadline.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const restoreModes: string[] = [];
+afterEach(async () => {
+  __setFsSafeTestHooksForTest(undefined);
+  __resetFsSafeNativeConfigForTest();
+  vi.restoreAllMocks();
+  for (const directory of restoreModes.splice(0)) await fs.chmod(directory, 0o700).catch(() => undefined);
+});
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+async function fixture(children = true) {
+  configureFsSafeNative({ mode: "off" });
+  const base = await tempRoot("fs-safe-dir-publication-");
+  const sourceDir = path.join(base, "source");
+  const destinationDir = path.join(base, "destination");
+  const sourceNested = path.join(sourceDir, "nested");
+  const target = path.join(destinationDir, "nested");
+  await fs.mkdir(sourceNested, { recursive: true });
+  await fs.chmod(sourceNested, 0o555);
+  if (children) {
+    await fs.chmod(sourceNested, 0o700);
+    await fs.writeFile(path.join(sourceNested, "value"), "NEW");
+    await fs.chmod(sourceNested, 0o555);
+  }
+  await fs.mkdir(destinationDir);
+  restoreModes.push(sourceNested, target);
+  return { base, sourceNested, target, params: { sourceDir, destinationDir, destinationRealDir: destinationDir } };
+}
+
+describe.skipIf(process.platform === "win32" || process.getuid?.() === 0)("real non-root directory publication", () => {
+  it("retains only depth-proportional directory descriptors across many siblings", async () => {
+    const { params } = await fixture(false);
+    await fs.rmdir(path.join(params.sourceDir, "nested"));
+    for (let sibling = 0; sibling < 20; sibling++) {
+      await fs.mkdir(path.join(params.sourceDir, `sibling-${sibling}`, "middle", "leaf"), { recursive: true });
+    }
+    const realOpen = fs.open.bind(fs);
+    let active = 0;
+    let peak = 0;
+    let closes = 0;
+    vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+      const handle = await realOpen(...args);
+      if (String(args[0]).startsWith(params.destinationDir + path.sep)) {
+        active++;
+        peak = Math.max(peak, active);
+        const close = handle.close.bind(handle);
+        handle.close = async () => { active--; closes++; await close(); };
+      }
+      return handle;
+    });
+    await mergeExtractedTreeIntoDestination(params);
+    expect({ active, peak, closes }).toEqual({ active: 0, peak: 3, closes: 60 });
+  });
+
+  it.each([0o300, 0o700])("updates an existing %s directory after publishing children", async (mode) => {
+    const { target, params } = await fixture();
+    await fs.mkdir(target, { mode: 0o700 });
+    await fs.writeFile(path.join(target, "value"), "OLD");
+    await fs.chmod(target, mode);
+    await mergeExtractedTreeIntoDestination(params);
+    expect((await fs.stat(target)).mode & 0o777).toBe(0o555);
+    expect(await fs.readFile(path.join(target, "value"), "utf8")).toBe("NEW");
+  });
+
+  it("finalizes an existing empty search-only directory", async () => {
+    const { target, params } = await fixture(false);
+    await fs.mkdir(target, { mode: 0o100 });
+    await mergeExtractedTreeIntoDestination(params);
+    expect((await fs.stat(target)).mode & 0o777).toBe(0o555);
+  });
+
+  it.each([0o500, 0])("does not widen an existing inaccessible %s directory to write children", async (mode) => {
+    const { target, params } = await fixture();
+    await fs.mkdir(target, { mode: 0o700 });
+    await fs.writeFile(path.join(target, "value"), "OLD");
+    await fs.chmod(target, mode);
+    await expect(mergeExtractedTreeIntoDestination(params)).rejects.toBeDefined();
+    expect((await fs.stat(target)).mode & 0o777).toBe(mode);
+    await fs.chmod(target, 0o700);
+    expect(await fs.readFile(path.join(target, "value"), "utf8")).toBe("OLD");
+  });
+
+  it.each(["directory", "root", "ancestor"] as const)("rejects a %s substitution before finalization without chmodding it", async (swap) => {
+    const { base, sourceNested, target, params } = await fixture();
+    if (swap === "ancestor") {
+      await fs.chmod(sourceNested, 0o700);
+      await fs.mkdir(path.join(sourceNested, "child"), { mode: 0o555 });
+      await fs.chmod(sourceNested, 0o555);
+    }
+    const moved = path.join(base, "moved");
+    const replaced = swap === "root" ? params.destinationDir : target;
+    const finalizing = swap === "ancestor" ? path.join(target, "child") : target;
+    let original: BigIntStats | undefined;
+    __setFsSafeTestHooksForTest({ async beforeArchiveOutputMutation(operation, candidate) {
+      if (operation !== "chmod" || candidate !== finalizing) return;
+      original = await fs.stat(replaced, { bigint: true });
+      await fs.rename(replaced, moved);
+      await fs.mkdir(replaced, { mode: 0o750 });
+      await fs.chmod(replaced, 0o750);
+    } });
+    await expect(mergeExtractedTreeIntoDestination(params)).rejects.toMatchObject({ code: "destination-symlink-traversal" });
+    expect(original).toBeDefined();
+    expect((await fs.stat(replaced)).mode & 0o777).toBe(0o750);
+    const retained = await fs.stat(moved, { bigint: true });
+    expect({ dev: retained.dev, ino: retained.ino, mode: retained.mode }).toEqual({
+      dev: original!.dev, ino: original!.ino, mode: original!.mode,
+    });
+  });
+
+  it("propagates directory chmod failures and performs no final mode sweep", async () => {
+    const { target, params } = await fixture();
+    const realOpen = fs.open.bind(fs);
+    let closes = 0;
+    let pinned = false;
+    vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+      const handle = await realOpen(...args);
+      if (args[0] === target && !pinned) {
+        pinned = true;
+        const close = handle.close.bind(handle);
+        handle.close = async () => { closes++; await close(); };
+        handle.chmod = async () => { throw Object.assign(new Error("injected directory chmod failure"), { code: "EIO" }); };
+      }
+      return handle;
+    });
+    await expect(mergeExtractedTreeIntoDestination(params)).rejects.toMatchObject({ code: "EIO" });
+    expect(closes).toBe(1);
+    expect((await fs.stat(target)).mode & 0o777).toBe(0o700);
+    expect(await fs.readFile(path.join(target, "value"), "utf8")).toBe("NEW");
+  });
+
+  it.each(["before-dispatch", "active-chmod", "opening"] as const)("joins %s timeout and closes the pinned directory exactly once", async (stage) => {
+    const { target, params } = await fixture();
+    await fs.mkdir(path.join(params.sourceDir, "zz-later"), { mode: 0o555 });
+    const entered = deferred();
+    const expired = deferred();
+    const release = deferred();
+    let closes = 0;
+    let chmods = 0;
+    let pinned = false;
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+      const handle = await realOpen(...args);
+      if (args[0] !== target || pinned) return handle;
+      pinned = true;
+      const chmod = handle.chmod.bind(handle);
+      const close = handle.close.bind(handle);
+      handle.chmod = async (mode) => {
+        chmods++;
+        if (stage === "active-chmod") { entered.resolve(); await release.promise; }
+        await chmod(mode);
+      };
+      handle.close = async () => { closes++; await close(); };
+      if (stage === "opening") { entered.resolve(); await release.promise; }
+      return handle;
+    });
+    __setFsSafeTestHooksForTest({ async beforeArchiveOutputMutation(operation, candidate) {
+      if (operation === "chmod" && candidate === target && stage === "before-dispatch") {
+        entered.resolve(); await release.promise;
+      }
+    } });
+    let settled = false;
+    const merge = withExtractionDeadline(500, "directory merge", async (deadline) => {
+      deadline.signal.addEventListener("abort", expired.resolve, { once: true });
+      await mergeExtractedTreeIntoDestination({ ...params, deadline });
+    });
+    void merge.then(() => { settled = true; }, () => { settled = true; });
+    try {
+      await entered.promise;
+      await expired.promise;
+      expect(settled).toBe(false);
+      expect(closes).toBe(0);
+    } finally { release.resolve(); }
+    await expect(merge).rejects.toThrow("directory merge timed out");
+    expect(closes).toBe(1);
+    expect(chmods).toBe(stage === "active-chmod" ? 1 : 0);
+    expect((await fs.stat(target)).mode & 0o777).toBe(stage === "active-chmod" ? 0o555 : 0o700);
+    await expect(fs.stat(path.join(params.destinationDir, "zz-later"))).rejects.toMatchObject({ code: "ENOENT" });
+    const after = chmods;
+    await new Promise<void>((done) => setImmediate(done));
+    expect(chmods).toBe(after);
+  });
+});

--- a/test/archive-merge-ownership.test.ts
+++ b/test/archive-merge-ownership.test.ts
@@ -77,14 +77,15 @@ describe("archive merge cleanup ownership", () => {
   it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
     "retains a completed entry when the next source cannot be opened",
     async () => {
+      configureFsSafeNative({ mode: "off" });
       const { params } = await fixture();
       await fs.writeFile(path.join(params.sourceDir, "other"), "NEW");
       await fs.writeFile(path.join(params.destinationDir, "other"), "OLD");
       let completed = "";
       let unreadable = "";
       __setFsSafeTestHooksForTest({
-        async beforeArchiveOutputMutation(operation, targetPath) {
-          if (operation !== "chmod" || completed) return;
+        async afterPinnedWriteFallbackRename(targetPath) {
+          if (completed) return;
           completed = path.basename(targetPath);
           unreadable = completed === "keep" ? "other" : "keep";
           await fs.chmod(path.join(params.sourceDir, unreadable), 0o200);
@@ -181,6 +182,7 @@ describe("archive merge cleanup ownership", () => {
   itPosix.each(["published", "file", "hardlink", "symlink"] as const)(
     "joins post-copy timeout, preserves %s, and starts no later mutations",
     async (replacement) => {
+      configureFsSafeNative({ mode: "off" });
       const { base, target, params } = await fixture();
       const substitute = path.join(base, "substitute");
       await fs.writeFile(substitute, "SUBSTITUTE", { mode: 0o600 });
@@ -190,9 +192,9 @@ describe("archive merge cleanup ownership", () => {
       const release = deferred();
       const mutations: string[] = [];
       __setFsSafeTestHooksForTest({
-        async beforeArchiveOutputMutation(operation, targetPath) {
-          mutations.push(`${operation}:${targetPath}`);
-          if (operation !== "chmod" || targetPath !== target) return;
+        async afterPinnedWriteFallbackRename(targetPath) {
+          mutations.push(`publish:${targetPath}`);
+          if (targetPath !== target) return;
           await expect(fs.readFile(target, "utf8")).resolves.toBe("NEW");
           if (replacement !== "published") {
             await fs.rename(target, path.join(base, "published"));

--- a/test/archive-native-mode-admission.test.ts
+++ b/test/archive-native-mode-admission.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { extractArchive } from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __loadBundledNativeForTest, __resetNativeLoaderForTest, __setNativeLoaderForTest, type NativeBinding } from "../src/native.js";
+import { modeArchive } from "./helpers/archive-modes.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+let native: NativeBinding | undefined;
+try { native = __loadBundledNativeForTest(); }
+catch (error) { if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error; }
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+describe.skipIf(!native)("native ZIP permission metadata association", () => {
+  it.each(["index", "path", "size", "mode"] as const)("rejects mocked %s disagreement before filters or extraction", async (field) => {
+    const base = await tempRoot("fs-safe-native-mode-admission-");
+    const archivePath = path.join(base, "fixture.zip");
+    const destDir = path.join(base, "output");
+    await fs.mkdir(destDir);
+    await fs.writeFile(archivePath, await modeArchive("zip", [{ path: "zero", mode: 0 }]));
+    const extract = vi.fn(native!.extractArchiveNative);
+    __setNativeLoaderForTest(() => ({
+      ...native!,
+      async inspectArchiveNative(...args: Parameters<NativeBinding["inspectArchiveNative"]>) {
+        const manifest = await native!.inspectArchiveNative(...args);
+        const entry = manifest[0]!;
+        if (field === "path") entry.path = "different";
+        else entry[field]++;
+        return manifest;
+      },
+      extractArchiveNative: extract,
+    }));
+    configureFsSafeNative({ mode: "require" });
+    const filter = vi.fn(() => "extract" as const);
+    await expect(extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 10000, entryModes: "preserve", entryFilter: filter }))
+      .rejects.toMatchObject({ code: "archive-header-invalid" });
+    expect(filter).not.toHaveBeenCalled();
+    expect(extract).not.toHaveBeenCalled();
+    expect(await fs.readdir(destDir)).toEqual([]);
+  });
+});

--- a/test/archive-publication-modes.test.ts
+++ b/test/archive-publication-modes.test.ts
@@ -1,0 +1,153 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { extractArchive } from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __loadBundledNativeForTest, __resetNativeLoaderForTest, __setNativeLoaderForTest, type NativeBinding } from "../src/native.js";
+import { modeArchive, type ModeEntry } from "./helpers/archive-modes.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+let native: NativeBinding | undefined;
+try { native = __loadBundledNativeForTest(); }
+catch (error) { if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error; }
+const backends = native ? ["off", "require"] as const : ["off"] as const;
+const nonRootPosix = process.platform !== "win32" && process.getuid?.() !== 0;
+
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+async function fixture(kind: "tar" | "zip", entries: ModeEntry[]) {
+  const base = await tempRoot("fs-safe-publication-modes-");
+  const archivePath = path.join(base, `fixture.${kind}`);
+  const destDir = path.join(base, "output");
+  await fs.mkdir(destDir);
+  await fs.writeFile(archivePath, await modeArchive(kind, entries));
+  return { archivePath, destDir, kind, timeoutMs: 10000 };
+}
+
+// Inspect each owned directory before enabling traversal for child inspection/cleanup.
+async function inspectTree(destDir: string, entries: ModeEntry[]) {
+  const modes = new Map<string, number>();
+  for (const entry of [...entries].sort((a, b) => a.path.split("/").filter(Boolean).length - b.path.split("/").filter(Boolean).length)) {
+    const target = path.join(destDir, entry.path);
+    const stat = await fs.stat(target);
+    modes.set(entry.path, stat.mode & 0o7777);
+    await fs.chmod(target, entry.directory ? 0o700 : 0o600);
+    if (!entry.directory) expect(await fs.readFile(target, "utf8")).toBe("NEW");
+  }
+  return modes;
+}
+
+describe.skipIf(!nonRootPosix).each(backends)("%s real non-root publication modes", (backend) => {
+  function configure() {
+    if (native) __setNativeLoaderForTest(() => native!);
+    configureFsSafeNative({ mode: backend });
+  }
+  it.each([
+    ["tar", 0o022], ["tar", 0o077], ["zip", 0o022], ["zip", 0o077],
+  ] as const)("preserves %s file rwx under umask %s, including zero and special bits", async (kind, umask) => {
+    configure();
+    const previousUmask = process.umask(umask);
+    try {
+      const entries = [0, 0o200, 0o400, 0o710, 0o7777, 0o7000].map((mode) => ({ path: `mode-${mode}`, mode }));
+      const params = await fixture(kind, entries);
+      for (const entry of entries) await fs.writeFile(path.join(params.destDir, entry.path), "OLD");
+      await extractArchive({ ...params, entryModes: "preserve" });
+      const actual = await inspectTree(params.destDir, entries);
+      for (const entry of entries) expect(actual.get(entry.path)).toBe(entry.mode & 0o777);
+    } finally { process.umask(previousUmask); }
+  });
+
+  it.each([
+    ["tar", 0o022, "before"], ["tar", 0o022, "after"],
+    ["tar", 0o077, "before"], ["tar", 0o077, "after"],
+    ["zip", 0o022, "before"], ["zip", 0o022, "after"],
+    ["zip", 0o077, "before"], ["zip", 0o077, "after"],
+  ] as const)("finalizes %s directories under umask %s with explicit entries %s children", async (kind, umask, order) => {
+    configure();
+    const previousUmask = process.umask(umask);
+    try {
+      const dirs: ModeEntry[] = [0, 0o100, 0o500, 0o555].flatMap((mode) => [
+        { path: `dir-${mode}/`, directory: true, mode },
+        { path: `dir-${mode}/nested/`, directory: true, mode: 0 },
+        { path: `empty-${mode}/`, directory: true, mode },
+      ]);
+      const files: ModeEntry[] = [0, 0o100, 0o500, 0o555].map((mode) => ({ path: `dir-${mode}/nested/value`, mode: 0o200 }));
+      files.push({ path: "bin/tool", mode: 0o755 });
+      const entries = order === "before" ? [...dirs, ...files] : [...files, ...dirs];
+      const params = await fixture(kind, entries);
+      await extractArchive({ ...params, entryModes: "preserve" });
+      const expected = [...entries, { path: "bin/", directory: true, mode: 0o755 }];
+      const actual = await inspectTree(params.destDir, expected);
+      for (const entry of expected) expect(actual.get(entry.path)).toBe(entry.mode! & 0o777);
+    } finally { process.umask(previousUmask); }
+  });
+
+  it.each(["tar", "zip"] as const)("clamps %s files and implicit parents and calls strip/filter policy once", async (kind) => {
+    configure();
+    const entries = [
+      { path: "pkg/bin/tool", mode: 0o710 }, { path: "pkg/value", mode: 0 },
+      { path: "pkg/skip", mode: 0o200 },
+    ];
+    const params = await fixture(kind, entries);
+    const seen: string[] = [];
+    await extractArchive({ ...params, stripComponents: 1, onFiltered: "skip-entry", entryFilter: ({ path }) => {
+      seen.push(path); return path === "pkg/skip" ? "skip" : "extract";
+    } });
+    expect(seen).toEqual(entries.map((entry) => entry.path));
+    const actual = await inspectTree(params.destDir, [
+      { path: "bin/", directory: true }, { path: "bin/tool" }, { path: "value" },
+    ]);
+    expect(Object.fromEntries(actual)).toEqual({ "bin/": 0o755, value: 0o644, "bin/tool": 0o755 });
+    await expect(fs.stat(path.join(params.destDir, "skip"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("distinguishes absent ZIP metadata from explicit UNIX zero", async () => {
+    configure();
+    const entries: ModeEntry[] = [
+      { path: "absent", mode: null }, { path: "zero", mode: 0 },
+      { path: "absent-dir/", directory: true, mode: null }, { path: "zero-dir/", directory: true, mode: 0 },
+    ];
+    const params = await fixture("zip", entries);
+    await extractArchive({ ...params, entryModes: "preserve" });
+    const actual = await inspectTree(params.destDir, entries);
+    expect(Object.fromEntries(actual)).toEqual({ absent: 0o644, zero: 0, "absent-dir/": 0o755, "zero-dir/": 0 });
+  });
+
+  it.each(["tar", "zip"] as const)("keeps %s explicit directory modes after strip/filter admission", async (kind) => {
+    configure();
+    const entries: ModeEntry[] = [
+      { path: "pkg/restricted/", directory: true, mode: 0 },
+      { path: "pkg/restricted/value", mode: 0o400 },
+      { path: "pkg/skipped/", directory: true, mode: 0 },
+      { path: "pkg/skipped/value", mode: 0o200 },
+    ];
+    const params = await fixture(kind, entries);
+    const seen: string[] = [];
+    await extractArchive({ ...params, stripComponents: 1, entryModes: "preserve", onFiltered: "skip-entry", entryFilter: (entry) => {
+      seen.push(entry.path);
+      return entry.path === "pkg/skipped" ? "skip" : "extract";
+    } });
+    expect(seen).toEqual(["pkg/restricted", "pkg/restricted/value", "pkg/skipped", "pkg/skipped/value"]);
+    const actual = await inspectTree(params.destDir, entries.map((entry) => ({ ...entry, path: entry.path.slice(4) })));
+    expect(Object.fromEntries(actual)).toEqual({ "restricted/": 0, "restricted/value": 0o400, "skipped/": 0o755, "skipped/value": 0o200 });
+  });
+
+  it.each(["tar", "zip"] as const)("associates %s modes with staged Unicode and case identity", async (kind) => {
+    configure();
+    const params = await fixture(kind, [
+      { path: "Dir/é", mode: 0o200 }, { path: "dir/", directory: true, mode: 0o500 },
+    ]);
+    await extractArchive({ ...params, entryModes: "preserve" });
+    const parents = await fs.readdir(params.destDir);
+    const mergedCase = parents.length === 1;
+    expect((await fs.stat(path.join(params.destDir, "Dir"))).mode & 0o777).toBe(mergedCase ? 0o500 : 0o755);
+    expect((await fs.stat(path.join(params.destDir, "dir"))).mode & 0o777).toBe(0o500);
+    await fs.chmod(path.join(params.destDir, "dir"), 0o700);
+    const actual = await inspectTree(params.destDir, [{ path: "Dir/é" }]);
+    expect(actual.get("Dir/é")).toBe(0o200);
+  });
+});

--- a/test/archive-tar-mode-fields.test.ts
+++ b/test/archive-tar-mode-fields.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as zlib from "node:zlib";
+import { afterEach, describe, expect, it } from "vitest";
+import { extractArchive } from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __resetNativeLoaderForTest, __setNativeLoaderForTest } from "../src/native.js";
+import { paxNative } from "./helpers/archive-pax-native.js";
+import { tarFixture } from "./helpers/archive-fuzz.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+function binaryMode(value: bigint): Buffer {
+  const field = Buffer.alloc(8);
+  field.writeBigUInt64BE(BigInt.asUintN(64, value));
+  if (value >= 0) field[0] = 0x80;
+  return field;
+}
+
+const fields = [
+  { name: "blank NUL", field: Buffer.alloc(8), mode: undefined },
+  { name: "blank spaces", field: Buffer.alloc(8, 0x20), mode: undefined },
+  { name: "mixed blank padding", field: Buffer.from([0x20, 0, 0x20, 0, 0, 0, 0, 0]), mode: undefined },
+  { name: "octal zero", field: Buffer.from("0000000\0"), mode: 0 },
+  { name: "binary zero", field: binaryMode(0n), mode: 0 },
+  { name: "binary executable", field: binaryMode(0o755n), mode: 0o755 },
+  { name: "binary above u32", field: binaryMode(2n ** 32n + 0o755n), mode: 0o755 },
+  { name: "binary max safe integer", field: binaryMode(2n ** 53n - 1n), mode: 0o777 },
+  { name: "binary negative one", field: binaryMode(-1n), mode: 0o777 },
+  { name: "binary negative readonly", field: binaryMode(-256n), mode: 0o400 },
+  { name: "binary negative special bits", field: binaryMode(-512n), mode: 0 },
+  { name: "binary min safe integer", field: binaryMode(-(2n ** 53n - 1n)), mode: 1 },
+];
+const routes = [
+  { backend: "off", codec: "tar" }, { backend: "off", codec: "gzip" },
+  ...(paxNative ? [{ backend: "require", codec: "tar" }, { backend: "require", codec: "gzip" }] : []),
+  ...(paxNative && typeof zlib.zstdCompressSync === "function" ? [{ backend: "require", codec: "zstd" }] : []),
+] as const;
+
+describe.skipIf(process.platform === "win32" || process.getuid?.() === 0).each(routes)(
+  "real non-root TAR fields $backend/$codec", ({ backend, codec }) => {
+    it.each(fields)("preserves $name for regular, contiguous, directory and GNUDumpDir entries", async ({ field, mode }) => {
+      configureFsSafeNative({ mode: backend as "off" | "require" });
+      if (backend === "require") __setNativeLoaderForTest(() => paxNative!);
+      const base = await tempRoot("fs-safe-tar-mode-fields-");
+      const archivePath = path.join(base, "fixture.bin");
+      const destDir = path.join(base, "out");
+      await fs.mkdir(destDir);
+      const entries = [
+        { path: "file", type: "0" }, { path: "contiguous", type: "7" },
+        { path: "directory/", type: "5" }, { path: "dump/", type: "D" },
+      ];
+      const tar = tarFixture(entries.map((entry) => ({
+        ...entry, body: entry.type === "0" || entry.type === "7" ? "DATA" : "",
+        mutateHeader: (header: Buffer) => { field.copy(header, 100); },
+      })));
+      const bytes = codec === "gzip" ? zlib.gzipSync(tar) : codec === "zstd" ? zlib.zstdCompressSync(tar) : tar;
+      await fs.writeFile(archivePath, bytes);
+      try {
+        await extractArchive({ archivePath, destDir, kind: codec === "zstd" ? "tar-zstd" : "tar", tarGzip: codec === "gzip", entryModes: "preserve", timeoutMs: 10000 });
+        for (const entry of entries) {
+          const output = path.join(destDir, entry.path);
+          const stat = await fs.stat(output);
+          expect(stat.isDirectory()).toBe(entry.type === "5" || entry.type === "D");
+          expect(stat.mode & 0o7777).toBe(mode ?? (stat.isDirectory() ? 0o755 : 0o644));
+          if (stat.isFile()) {
+            await fs.chmod(output, 0o600);
+            expect(await fs.readFile(output, "utf8")).toBe("DATA");
+          }
+        }
+      } finally {
+        // Only owned synthetic fixtures are made traversable for cleanup, after mode inspection.
+        for (const entry of entries) await fs.chmod(path.join(destDir, entry.path), 0o700).catch(() => undefined);
+      }
+    });
+  },
+);

--- a/test/directory-mode-owner.test.ts
+++ b/test/directory-mode-owner.test.ts
@@ -1,0 +1,107 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pinNodeDirectoryForMode } from "../src/directory-mode-node.js";
+import { applyDirectoryMode } from "../src/replace-file-descriptor.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+describe.skipIf(process.platform === "win32")("directory mode ownership", () => {
+  it("keeps partial injected adapters on descriptor chmod without host fd operations", async () => {
+    const dir = await tempRoot("fs-safe-mode-adapter-");
+    const identity = await fs.stat(dir);
+    let mode = 0o300;
+    const descriptorChmod = vi.fn(async (next: number) => { mode = next; });
+    const close = vi.fn(async () => undefined);
+    const fake = { fd: 1234567, stat: async () => ({ ...identity, mode, isDirectory: () => true, isSymbolicLink: () => false }), chmod: descriptorChmod, close };
+    const adapter = {
+      lstat: vi.fn(async () => identity), open: vi.fn(async () => fake), writeFile: vi.fn(),
+    } as unknown as Pick<typeof fs, "lstat" | "open" | "writeFile">;
+    const hostOpen = vi.spyOn(fs, "open");
+    const hostChmod = vi.spyOn(fs, "chmod");
+    const hostStatfs = vi.spyOn(fs, "statfs");
+    await applyDirectoryMode({ fsModule: adapter, dirPath: dir, mode: 0o755 });
+    expect(descriptorChmod).toHaveBeenCalledExactlyOnceWith(0o755);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(hostOpen).not.toHaveBeenCalled();
+    expect(hostChmod).not.toHaveBeenCalled();
+    expect(hostStatfs).not.toHaveBeenCalled();
+  });
+
+  it("uses no procfs for readable directories and skips an already verified mode", async () => {
+    const dir = await tempRoot("fs-safe-mode-readable-");
+    await fs.chmod(dir, 0o700);
+    const proc = vi.spyOn(fs, "statfs").mockRejectedValue(new Error("procfs unavailable"));
+    const pathChmod = vi.spyOn(fs, "chmod").mockRejectedValue(new Error("unexpected pathname chmod"));
+    const owner = await pinNodeDirectoryForMode(dir);
+    try {
+      await owner.apply(0o700);
+      await owner.apply(0o750);
+      expect((await fs.stat(dir)).mode & 0o777).toBe(0o750);
+      expect(proc).not.toHaveBeenCalled();
+      expect(pathChmod).not.toHaveBeenCalled();
+    } finally { await owner.close(); }
+  });
+
+  it("serializes apply and close, rejects later use and closes once", async () => {
+    const dir = await tempRoot("fs-safe-mode-lifetime-");
+    await fs.chmod(dir, 0o700);
+    const entered = deferred();
+    const release = deferred();
+    const realOpen = fs.open.bind(fs);
+    let fd = -1;
+    let closes = 0;
+    vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+      const handle = await realOpen(...args);
+      fd = handle.fd;
+      const chmod = handle.chmod.bind(handle);
+      const close = handle.close.bind(handle);
+      handle.chmod = async (mode) => { entered.resolve(); await release.promise; await chmod(mode); };
+      handle.close = async () => { closes++; await close(); };
+      return handle;
+    });
+    const owner = await pinNodeDirectoryForMode(dir);
+    const apply = owner.apply(0o555);
+    await entered.promise;
+    const closing = owner.close();
+    expect(fsSync.fstatSync(fd).isDirectory()).toBe(true);
+    expect(closes).toBe(0);
+    await expect(owner.apply(0o700)).rejects.toThrow("closed");
+    release.resolve();
+    await apply;
+    await closing;
+    await owner.close();
+    expect(closes).toBe(1);
+    expect((await fs.stat(dir)).mode & 0o777).toBe(0o555);
+    expect(() => fsSync.fstatSync(fd)).toThrow();
+    await fs.chmod(dir, 0o700);
+  });
+
+  it("does not fall back on a descriptor chmod failure", async () => {
+    const dir = await tempRoot("fs-safe-mode-error-");
+    await fs.chmod(dir, 0o700);
+    const realOpen = fs.open.bind(fs);
+    const chmodError = Object.assign(new Error("chmod failed"), { code: "EBADF" });
+    vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+      const handle = await realOpen(...args);
+      handle.chmod = async () => { throw chmodError; };
+      return handle;
+    });
+    const pathname = vi.spyOn(fs, "chmod");
+    const owner = await pinNodeDirectoryForMode(dir);
+    try {
+      await expect(owner.apply(0o755)).rejects.toBe(chmodError);
+      expect(pathname).not.toHaveBeenCalled();
+      expect((await fs.stat(dir)).mode & 0o777).toBe(0o700);
+    } finally { await owner.close(); }
+  });
+});

--- a/test/directory-mode-proc.test.ts
+++ b/test/directory-mode-proc.test.ts
@@ -1,0 +1,180 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { pinNodeDirectoryForMode } from "../src/directory-mode-node.js";
+import { withExtractionDeadline } from "../src/archive-deadline.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+const restoreModes: string[] = [];
+const architecture = Object.getOwnPropertyDescriptor(process, "arch")!;
+afterEach(async () => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+  Object.defineProperty(process, "arch", architecture);
+  for (const dir of restoreModes.splice(0)) await fs.chmod(dir, 0o700).catch(() => undefined);
+});
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+// These are mocked Linux namespace/dispatch tests using a real owned directory fd.
+// The parent separately runs the actual non-root Linux O_PATH/procfs syscall proof.
+async function simulatedProcRoute() {
+  const dir = await tempRoot("fs-safe-mocked-proc-");
+  const target = path.join(dir, "target");
+  await fs.mkdir(target, { mode: 0o700 });
+  restoreModes.push(target);
+  const handle = await fs.open(target, fsSync.constants.O_RDONLY | fsSync.constants.O_DIRECTORY);
+  const fd = handle.fd;
+  await handle.chmod(0o300);
+  Object.defineProperty(process, "platform", { value: "linux" });
+  Object.defineProperty(process, "arch", { value: "x64" });
+  const realOpen = fs.open.bind(fs);
+  const open = vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
+    if (candidate !== target) return await realOpen(candidate, flags, mode);
+    if (typeof flags === "number" && flags & 0x200000) return handle;
+    throw Object.assign(new Error("mocked read denial"), { code: "EACCES" });
+  });
+  const namespace = vi.spyOn(fs, "statfs").mockImplementation(async (candidate) => {
+    expect(candidate).toBe("/proc/self/fd");
+    return { type: 0x9fa0n } as Awaited<ReturnType<typeof fs.statfs>>;
+  });
+  const procPath = `/proc/self/fd/${fd}`;
+  const realStat = fs.stat.bind(fs);
+  vi.spyOn(fs, "stat").mockImplementation((async (candidate: fsSync.PathLike, options?: { bigint?: boolean }) => {
+    if (candidate === procPath) return await handle.stat({ bigint: true });
+    return await realStat(candidate, options as { bigint: true });
+  }) as typeof fs.stat);
+  const realChmod = fs.chmod.bind(fs);
+  const dispatch = vi.spyOn(fs, "chmod").mockImplementation(async (candidate, mode) => {
+    if (candidate === procPath) await handle.chmod(mode);
+    else await realChmod(candidate, mode);
+  });
+  const owner = await pinNodeDirectoryForMode(target);
+  return { dir, target, handle, fd, owner, namespace, dispatch, procPath, open };
+}
+
+describe.skipIf(process.platform === "win32")("mocked Linux directory proc-fd authority", () => {
+  it.each(["preflight", "verification"] as const)("joins timeout during procfs %s without releasing the fd", async (phase) => {
+    const fixture = await simulatedProcRoute();
+    const entered = deferred();
+    const expired = deferred();
+    const release = deferred();
+    let calls = 0;
+    fixture.namespace.mockImplementation(async () => {
+      if (++calls === (phase === "preflight" ? 1 : 2)) {
+        entered.resolve();
+        await release.promise;
+      }
+      return { type: 0x9fa0n } as Awaited<ReturnType<typeof fs.statfs>>;
+    });
+    const close = vi.spyOn(fixture.handle, "close");
+    let settled = false;
+    const operation = withExtractionDeadline(300, "proc chmod", async (deadline) => {
+      deadline.signal.addEventListener("abort", expired.resolve, { once: true });
+      await deadline.ownDestinationMutation(async () => {
+        try { await fixture.owner.apply(0o755, { check: deadline.check }); }
+        finally { await fixture.owner.close(); }
+      });
+    });
+    void operation.then(() => { settled = true; }, () => { settled = true; });
+    try {
+      await entered.promise;
+      await expired.promise;
+      expect(settled).toBe(false);
+      expect(close).not.toHaveBeenCalled();
+      expect(fsSync.fstatSync(fixture.fd).isDirectory()).toBe(true);
+    } finally { release.resolve(); }
+    await expect(operation).rejects.toThrow("proc chmod timed out");
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(fixture.dispatch).toHaveBeenCalledTimes(phase === "preflight" ? 0 : 1);
+    expect((await fs.stat(fixture.target)).mode & 0o777).toBe(phase === "preflight" ? 0o300 : 0o755);
+  });
+
+  it.each(["unavailable", "untrusted"] as const)("rejects %s procfs without mutating", async (condition) => {
+    const fixture = await simulatedProcRoute();
+    if (condition === "unavailable") fixture.namespace.mockRejectedValue(Object.assign(new Error("missing procfs"), { code: "ENOENT" }));
+    else fixture.namespace.mockResolvedValue({ type: 0x1234n } as Awaited<ReturnType<typeof fs.statfs>>);
+    try {
+      await expect(fixture.owner.apply(0o755)).rejects.toThrow(condition === "unavailable" ? "missing procfs" : "trusted procfs");
+      expect(fixture.dispatch).not.toHaveBeenCalled();
+      expect((await fixture.handle.stat()).mode & 0o777).toBe(0o300);
+    } finally { await fixture.owner.close(); }
+  });
+
+  it("does not require procfs when the requested owned mode already matches", async () => {
+    const fixture = await simulatedProcRoute();
+    fixture.namespace.mockRejectedValue(new Error("no procfs"));
+    try {
+      await fixture.owner.apply(0o300);
+      expect(fixture.namespace).not.toHaveBeenCalled();
+      expect(fixture.dispatch).not.toHaveBeenCalled();
+    } finally { await fixture.owner.close(); }
+  });
+
+  it("authenticates the exact followed fd identity before dispatch", async () => {
+    const fixture = await simulatedProcRoute();
+    const wrong = await fs.stat(fixture.dir, { bigint: true });
+    vi.mocked(fs.stat).mockResolvedValue(wrong);
+    try {
+      await expect(fixture.owner.apply(0o755)).rejects.toMatchObject({ code: "path-mismatch" });
+      expect(fixture.dispatch).not.toHaveBeenCalled();
+    } finally { await fixture.owner.close(); }
+  });
+
+  it("holds the descriptor through queued proc chmod and post-operation verification", async () => {
+    const fixture = await simulatedProcRoute();
+    const entered = deferred();
+    const release = deferred();
+    const realClose = fixture.handle.close.bind(fixture.handle);
+    const close = vi.spyOn(fixture.handle, "close").mockImplementation(realClose);
+    fixture.dispatch.mockImplementation(async (candidate, mode) => {
+      expect(candidate).toBe(fixture.procPath);
+      entered.resolve();
+      await release.promise;
+      expect(fsSync.fstatSync(fixture.fd).isDirectory()).toBe(true);
+      await fixture.handle.chmod(mode);
+    });
+    const apply = fixture.owner.apply(0o555);
+    await entered.promise;
+    const closing = fixture.owner.close();
+    expect(close).not.toHaveBeenCalled();
+    release.resolve();
+    await apply;
+    await closing;
+    await fixture.owner.close();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(fixture.namespace).toHaveBeenCalledTimes(2);
+    expect(fixture.dispatch).toHaveBeenCalledExactlyOnceWith(fixture.procPath, 0o555);
+    expect(fixture.open).toHaveBeenCalledTimes(2);
+    vi.restoreAllMocks();
+    expect((await fs.stat(fixture.target)).mode & 0o777).toBe(0o555);
+    await fs.chmod(fixture.target, 0o700);
+  });
+
+  it("preserves a substitution while an active fd chmod finishes on the original", async () => {
+    const fixture = await simulatedProcRoute();
+    const moved = path.join(fixture.dir, "moved");
+    fixture.dispatch.mockImplementation(async (candidate, mode) => {
+      expect(candidate).toBe(fixture.procPath);
+      await fs.rename(fixture.target, moved);
+      await fs.mkdir(fixture.target, { mode: 0o750 });
+      await fixture.handle.chmod(mode);
+    });
+    try {
+      await expect(fixture.owner.apply(0o555)).rejects.toMatchObject({ code: "path-mismatch" });
+      expect((await fixture.handle.stat()).mode & 0o777).toBe(0o555);
+      expect(fixture.dispatch).toHaveBeenCalledTimes(1);
+    } finally { await fixture.owner.close(); }
+    vi.restoreAllMocks();
+    expect((await fs.stat(fixture.target)).mode & 0o777).toBe(0o750);
+    expect((await fs.stat(moved)).mode & 0o777).toBe(0o555);
+    await fs.chmod(moved, 0o700);
+  });
+});

--- a/test/findings-regression.test.ts
+++ b/test/findings-regression.test.ts
@@ -114,7 +114,8 @@ describe("security finding regressions", () => {
     await expect(fsp.stat(path.join(outside, "nested"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  itPosix("does not chmod through an archive entry symlink swap", async () => {
+  itPosix("preserves a substituted archive symlink after publication without changing its target", async () => {
+    configureFsSafeNative({ mode: "off" });
     const base = await tempRoot("fs-safe-archive-chmod-race-");
     const source = path.join(base, "source");
     const dest = path.join(base, "dest");
@@ -126,18 +127,28 @@ describe("security finding regressions", () => {
     await fsp.writeFile(outsideFile, "outside");
     await fsp.chmod(outsideFile, 0o600);
     const destinationRealDir = await prepareArchiveDestinationDir(dest);
+    const target = path.join(destinationRealDir, "payload.txt");
+    const published = path.join(base, "published.txt");
+    let swapped = false;
 
     __setFsSafeTestHooksForTest({
-      async beforeArchiveOutputMutation(operation, targetPath) {
-        if (operation !== "chmod" || !targetPath.endsWith("payload.txt")) return;
-        await fsp.rm(targetPath, { force: true });
+      async afterPinnedWriteFallbackRename(targetPath) {
+        if (targetPath !== target) return;
+        await fsp.rename(targetPath, published);
         await fsp.symlink(outsideFile, targetPath, "file");
+        swapped = true;
       },
     });
 
     await expect(
       mergeExtractedTreeIntoDestination({ sourceDir: source, destinationDir: dest, destinationRealDir }),
-    ).rejects.toBeTruthy();
+    ).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(swapped).toBe(true);
+    expect((await fsp.lstat(target)).isSymbolicLink()).toBe(true);
+    expect(await fsp.readlink(target)).toBe(outsideFile);
+    expect(await fsp.readFile(published, "utf8")).toBe("payload");
+    expect(await fsp.readFile(target, "utf8")).toBe("outside");
+    expect(await fsp.readFile(outsideFile, "utf8")).toBe("outside");
     expect((await fsp.stat(outsideFile)).mode & 0o777).toBe(0o600);
   });
 

--- a/test/helpers/archive-modes.ts
+++ b/test/helpers/archive-modes.ts
@@ -1,0 +1,28 @@
+import JSZip from "jszip";
+import { tarFixture } from "./archive-fuzz.js";
+
+export type ModeEntry = { path: string; mode?: number | null; directory?: boolean };
+
+export async function modeArchive(kind: "tar" | "zip", entries: ModeEntry[]): Promise<Buffer> {
+  if (kind === "tar") {
+    return tarFixture(entries.map((entry) => ({
+      path: entry.path, mode: entry.mode ?? undefined,
+      type: entry.directory ? "5" : "0", body: entry.directory ? "" : "NEW",
+    })));
+  }
+  const zip = new JSZip();
+  for (const entry of entries) {
+    zip.file(entry.path, entry.directory ? "" : "NEW", {
+      dir: entry.directory, createFolders: false,
+    });
+  }
+  const bytes = await zip.generateAsync({ type: "nodebuffer", platform: "UNIX" });
+  let offset = bytes.readUInt32LE(bytes.length - 6);
+  for (const entry of entries) {
+    // JSZip's writer defaults zero modes. Set real central attributes explicitly.
+    bytes[offset + 5] = entry.mode == null ? 0 : 3;
+    bytes.writeUInt32LE((((entry.mode ?? 0) << 16) | (entry.directory ? 0x10 : 0)) >>> 0, offset + 38);
+    offset += 46 + bytes.readUInt16LE(offset + 28) + bytes.readUInt16LE(offset + 30) + bytes.readUInt16LE(offset + 32);
+  }
+  return bytes;
+}


### PR DESCRIPTION
## Summary

Archive extraction applied requested final modes while files and directories were still private staging inputs. A write-only file therefore became unreadable before merge, and a restrictive directory could block extraction of its own children. Separately, zero modes were treated as absent defaults, native implicit parents leaked staging `0700`, and native metadata collapsed missing TAR/ZIP permissions into zero or backend-specific values.

This change separates working and publication permissions:

- stage files as `0600` and directories as `0700`;
- carry admitted post-strip path/kind/final-mode metadata without invoking filters twice;
- publish file modes through `Root.copyIn`'s owned writer descriptor, including exact zero;
- finalize directories postorder through retained, identity-checked authority;
- preserve explicit zero versus absent ZIP/TAR metadata and supported GNU binary TAR modes;
- use ordinary directory descriptors when readable, macOS search descriptors for search-only directories, and an authenticated Linux proc-fd path tied to an owned `O_PATH` descriptor when read access is unavailable;
- reject unsafe/unavailable mode application rather than returning success with the wrong final mode.

The archive layer still owns no path-only rollback. `Root.copyIn` retains publication cleanup ownership from [PR #197](https://github.com/openclaw/fs-safe/pull/197). Merge remains nontransactional, and existing inaccessible directories are never temporarily widened to make child writes succeed.

Public API and native manifest ABI are unchanged. Production delta is +608/−263 (net +345), primarily the shared postorder merge and directory-mode owners; tests are +816/−10.

## Observable before/after

Physical packed consumers used valid independent TAR/UNIX ZIP fixtures, a non-root process, actual final-mode inspection before task-owned cleanup chmod, and both absent/present-`OLD` destinations. Representative Node 24 observations:

```json
{
  "before": [
    {"case":"TAR preserve 0000","mode":"0644","expected":"0000","status":"fail"},
    {"case":"ZIP preserve 0200","error":"EACCES before merge","status":"fail"},
    {"case":"ZIP directory 0555 before child","error":"EACCES while staging child","status":"fail"},
    {"case":"native implicit TAR parent","mode":"0700","expected":"0755","status":"fail"},
    {"case":"UNIX ZIP zero attributes","mode":"0644","expected":"0000","status":"fail"}
  ],
  "after": [
    {"case":"TAR preserve 0000","mode":"0000","bytes":"NEW","status":"pass"},
    {"case":"ZIP preserve 0200","mode":"0200","bytes":"NEW","status":"pass"},
    {"case":"ZIP directory 0555 before child","directoryMode":"0555","childMode":"0200","bytes":"NEW","status":"pass"},
    {"case":"native implicit TAR parent","mode":"0755","status":"pass"},
    {"case":"UNIX ZIP zero attributes","mode":"0000","bytes":"NEW","status":"pass"},
    {"case":"non-UNIX ZIP absent permissions","mode":"0644","bytes":"NEW","status":"pass"}
  ]
}
```

The complete independent matrix covers 49 archive fixtures with absent/exact-zero/write-only/read-only/executable/special-bit files; restrictive, nested, empty, implicit, stripped, filtered and Unicode directories; UNIX-zero and DOS-absent ZIP metadata; existing and absent targets; umasks `0022`/`0077`; and native-only bzip2 controls. A second 96-fixture matrix exercises blank NUL/space TAR modes, octal zero, positive/negative GNU binary modes, regular/contiguous/directory/GNUDumpDir records and plain/gzip decoding.

Across Node 22.0.0, 22.23.2 and 24.20.0 in `off`/`require`, plus Node 24 `auto`, **2,008 observations pass** and nine bzip2 cases are correctly out of scope in `off`. Required/automatic lanes recorded the freshly built candidate native binary; `off` loaded none. Candidate tree: `85fce4775717414b037eae7b3125c609282d822b`. Root artifact integrity: `sha512-kmi1wZIT96a85zEECOgj/IdKFN3/0bpHqqSBgiz2HiZdK9X/ktQCwE4qJSjfN/GJHVJIf2sR86GuhA1WCd5Wtw==`; host-native artifact integrity: `sha512-RcrjLJ899MtcDwqSEHSBVQ/CEU7TjOCI8z9Ir0fLbF3iNOaFn9F27EBpKC/7DcOicLIkHHLVWezn7DwrazcaaQ==`.

## Authority and race proof

Real non-root Linux proof confirmed that `O_RDONLY` fails on an existing `0300` directory, while `O_PATH | O_DIRECTORY | O_NOFOLLOW` retains its inode. Chmod through the authenticated `/proc/self/fd/<owned-fd>` path changed that retained inode even after its original pathname was replaced; the replacement remained unchanged. macOS Node 22.0/22.23/24 on arm64 and x64 under Rosetta confirmed `O_SEARCH` can retain chmod authority for `0300` directories while read/event-only opens fail. This is translated x64 execution, not physical Intel hardware proof.

Tests cover destination/root/ancestor substitutions, named association and ancestry checks, adapter isolation, untrusted/unavailable procfs, active chmod/deadline joining, close-once behavior, no late mode mutation, existing search-only/inaccessible destinations, and preservation of substituted files/symlinks/hardlinks. A genuine procfs capability remains required only for Linux search-only directories whose mode actually must change; readable or already-correct directories do not acquire that dependency.

## Validation

- Focused archive/mode-owner/native matrix: 3,692 passed / 48 skipped; targeted final set: 146 passed.
- Rust native tests: 69 passed, including all TAR codecs and absent/octal/binary signed mode fields.
- macOS arm64 Node 24: `CI=1 FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm check` — 6,806 passed / 77 skipped; `pnpm test:security` — 84 passed; `pnpm package:smoke` passed physical npm/pnpm and optional/missing-binary controls.
- Independent source review found one native missing-mode issue; it was fixed and the reviewer verified resolution. Independent autoreview is scoped-clean at its P0 threshold (0.94).
- `git diff --check`, build, file-size, filesystem-boundary and docs checks passed.

The first broad local run also hit two unrelated high-concurrency fixture timeouts and exposed an obsolete file-chmod test hook; the initial Linux candidate exposed that hook plus an ambient-umask assertion. The tests were moved to active owner boundaries/captured modes rather than restoring deleted production behavior or changing timeouts. The bounded final local gate is green. A fresh task-owned Linux runner could not be acquired after the prior lease expired: the broker returned an uncertain-create HTTP 500 and recorded cancellation, so that separate lane remains unavailable. Exact-head CI passed the actual Linux non-root archive tests (including the procfs-backed `0300` directory route), Linux musl native checks, macOS and Windows native checks, Node 22/24 checks, and bundled-package smoke.

This PR does not release or publish a package.
