### PR TITLE
fix(archive): close input when staging allocation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Close a selected archive input if private staging allocation fails, preventing `readArchiveEntry()` setup errors from retaining file descriptors until garbage collection.
 - Avoid opening the TAR metadata stream until preflight setup succeeds, and always destroy it after pipeline completion, preventing descriptor leaks on setup failures. Thanks @SebTardif.
 - Separate archive staging permissions from final publication modes so zero/write-only files and restrictive directories extract correctly; finalize explicit and implicit directory modes through retained, verified authority and reject unsafe mode application instead of silently skipping it.
 - Decode absent TAR modes and supported signed GNU binary permission bits in native manifests, matching JavaScript defaults without changing the native ABI.

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -106,8 +106,9 @@ async function stageArchiveInput(archivePath: string): Promise<{
     return stat;
   });
   const handle = await fs.open(resolved, resolveReadOpenFlags());
-  const staged = await tempFile({ prefix: "fs-safe-archive-read", fileName: "archive.bin" });
+  let staged: Awaited<ReturnType<typeof tempFile>> | undefined;
   try {
+    staged = await tempFile({ prefix: "fs-safe-archive-read", fileName: "archive.bin" });
     const opened = await inspectFileIdentity(async () => {
       const stat = await handle.stat({ bigint: true });
       if (!stat.isFile()) throw new Error("archive changed during validation");
@@ -123,7 +124,7 @@ async function stageArchiveInput(archivePath: string): Promise<{
     await fs.writeFile(staged.path, buffer, { flag: "wx", mode: 0o600 });
     return { path: staged.path, buffer, cleanup: staged.cleanup };
   } catch (error) {
-    await staged.cleanup().catch(() => undefined);
+    await staged?.cleanup().catch(() => undefined);
     if (error instanceof FsSafeError && error.code === "path-mismatch") {
       throw new FsSafeError("path-mismatch", "archive changed during validation", { cause: error });
     }

--- a/test/archive-read-boundaries.test.ts
+++ b/test/archive-read-boundaries.test.ts
@@ -30,6 +30,18 @@ function rawHeader(type = "0", size = 0): Buffer {
   return tarFixture([{ path: "entry", type, body: Buffer.alloc(size) }], false).subarray(0, 512);
 }
 
+function descriptorsForFile(filePath: string): number[] {
+  const expected = fsSync.statSync(filePath, { bigint: true });
+  return Array.from({ length: 4096 }, (_, fd) => fd).filter((fd) => {
+    try {
+      const current = fsSync.fstatSync(fd, { bigint: true });
+      return current.dev === expected.dev && current.ino === expected.ino;
+    } catch {
+      return false;
+    }
+  });
+}
+
 beforeEach(() => {
   configureFsSafeNative({ mode: "off" });
 });
@@ -222,6 +234,38 @@ describe("bounded archive reads", () => {
     await expect(readArchiveEntry("missing.zip", "dir/", { maxBytes: 1 }))
       .rejects.toThrow("archive entry is not a file");
   });
+
+  it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+    "closes the selected archive when private staging allocation fails",
+    async () => {
+      const root = await tempRoot("fs-safe-archive-read-staging-failure-");
+      const archivePath = path.join(root, "fixture.zip");
+      const privateTmp = path.join(root, "private-tmp");
+      await fs.mkdir(privateTmp, { mode: 0o700 });
+      const zip = new JSZip();
+      zip.file("value", "ok");
+      await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+      await fs.writeFile(path.join(privateTmp, `fs-safe-${process.getuid!()}`), "synthetic blocker", {
+        flag: "wx",
+        mode: 0o600,
+      });
+      const saved = new Map(["TMPDIR", "TMP", "TEMP"].map((name) => [name, process.env[name]]));
+      for (const name of saved.keys()) process.env[name] = privateTmp;
+      try {
+        expect(descriptorsForFile(archivePath)).toEqual([]);
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          await expect(readArchiveEntry(archivePath, "value", { maxBytes: 2 }))
+            .rejects.toThrow("Unsafe fallback secure temp dir");
+          expect(descriptorsForFile(archivePath)).toEqual([]);
+        }
+      } finally {
+        for (const [name, value] of saved) {
+          if (value === undefined) delete process.env[name];
+          else process.env[name] = value;
+        }
+      }
+    },
+  );
 
   it("rejects non-file archive inputs", async () => {
     const root = await tempRoot("fs-safe-read-input-");


### PR DESCRIPTION
## Summary

`readArchiveEntry()` pins the selected archive input before allocating a private staged copy. That allocation occurred before the handle's cleanup `try/finally`, so a secure-temp-root refusal could reject after opening the archive and leave the descriptor alive until garbage collection.

Move staging allocation inside the selected handle's existing lifetime. If allocation or any later setup step fails, the archive handle now closes in `finally`; a staged directory is cleaned only when allocation returned its ownership receipt. The initiating error and all existing path/identity checks remain unchanged. Production delta is +3/−2 (net +1).

This is distinct from [PR #196](https://github.com/openclaw/fs-safe/pull/196): that contributor fix owns the TAR metadata `ReadStream`; this change owns the earlier selected input `FileHandle` used by bounded archive-entry reads.

## Real descriptor proof

The physical consumer harness uses a valid ZIP and an owned private `TMPDIR`. A regular file is placed at that fixture's `fs-safe-<uid>` fallback-root pathname, causing the real secure-temp resolver to reject allocation. No filesystem error is fabricated. Open descriptors are counted by exact bigint file identity.

Representative observations:

```json
{
  "before": {
    "macOS": {
      "off": [1, 2, 2],
      "require": [1, 2, 2]
    },
    "Linux": {
      "off": [1, 1, 2],
      "require": [1, 2, 3]
    }
  },
  "afterPackedInstall": {
    "node22.0": {"off": [0, 0, 0], "require": [0, 0, 0]},
    "node22.23": {"off": [0, 0, 0], "require": [0, 0, 0]},
    "node24.20": {"off": [0, 0, 0], "require": [0, 0, 0]}
  }
}
```

Each after run also includes readable-temp controls that return the exact `NEW` bytes with zero descriptors afterward. The required-native success controls recorded the actual `fs-safe-darwin-arm64` binary. The allocation-failure cases correctly occur before native dispatch, so they load no native binary even in `require` configuration.

Candidate tree: `4d66a1826b517a65f567593c3fa4000074fc19f3`. Root artifact integrity: `sha512-1m5FXxD30y8t1FLdCZYZjt5oeG7QkUmL7Kk0Fylj/t2tqtjK78ihx6CAkMQ2QIuPhm1ghErcnoYmUxI92Bkfug==`. Package version remains 0.7.2; this PR does not publish a release.

## Validation

- Focused archive-read boundaries: 16 passed; the new regression runs three real allocation failures and requires an empty descriptor census after each.
- `CI=1 pnpm check`: 6,809 passed / 77 skipped.
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: physical npm/pnpm consumers, optional-dependency omission and missing-binary behavior passed.
- Build, docs, file-size, filesystem-boundary and `git diff --check` passed.
- Independent Codex autoreview: scoped-clean at the P0 threshold, confidence 0.99.

Exact-head cross-platform CI is required before merge. No release or registry publication is included.
