### PR TITLE
fix(walk): stop after nested truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- End `Root.walk()` immediately after its single truncation marker, including when a nested depth or entry budget is reached.
 - Close a selected archive input if private staging allocation fails, preventing `readArchiveEntry()` setup errors from retaining file descriptors until garbage collection.
 - Avoid opening the TAR metadata stream until preflight setup succeeds, and always destroy it after pipeline completion, preventing descriptor leaks on setup failures. Thanks @SebTardif.
 - Separate archive staging permissions from final publication modes so zero/write-only files and restrictive directories extract correctly; finalize explicit and implicit directory modes through retained, verified authority and reject unsafe mode application instead of silently skipping it.

--- a/src/root-walk.ts
+++ b/src/root-walk.ts
@@ -83,11 +83,13 @@ export async function* walkRoot(
   const maxEntries = validateBudget("maxEntries", options.maxEntries);
   const visitedDirectories = new Set<string>();
   let examined = 0;
+  let truncated = false;
 
   const onLimit = (atPath: string): RootWalkEntry => {
     if ((options.limitBehavior ?? "truncate") === "throw") {
       throw new FsSafeError("too-large", `root walk budget exceeded at ${atPath || "."}`);
     }
+    truncated = true;
     return limitEntry(atPath);
   };
 
@@ -175,6 +177,7 @@ export async function* walkRoot(
         return;
       }
       yield* visit(child, depth + 1);
+      if (truncated) return;
     }
   }
 

--- a/test/root-walk-options.test.ts
+++ b/test/root-walk-options.test.ts
@@ -78,6 +78,32 @@ it("counts skipped entries against the traversal budget", async () => {
   ]);
 });
 
+it.each([
+  { name: "depth", options: { maxDepth: 1 }, marker: "a/inner" },
+  { name: "entry", options: { maxEntries: 2 }, marker: "a/inner/file.txt" },
+])("ends every generator frame after a nested $name limit", async ({ options, marker }) => {
+  const directory = await tempRoot();
+  await fs.mkdir(path.join(directory, "a", "inner"), { recursive: true });
+  await fs.writeFile(path.join(directory, "a", "inner", "file.txt"), "nested");
+  await fs.writeFile(path.join(directory, "z.txt"), "later sibling");
+  const capability = await root(directory);
+  const entries: RootWalkEntry[] = [];
+
+  for await (const entry of capability.walk("", {
+    ...options,
+    symlinkPolicy: "skip",
+  })) {
+    entries.push(entry);
+  }
+
+  expect(entries.map(({ relativePath, kind }) => ({ relativePath, kind }))).toEqual([
+    { relativePath: "a", kind: "directory" },
+    { relativePath: "a/inner", kind: "directory" },
+    { relativePath: marker, kind: "truncated" },
+  ]);
+  expect(entries.at(-1)).toEqual({ relativePath: marker, kind: "truncated", size: 0 });
+});
+
 it("reports failed directory subtrees and continues when requested", async () => {
   const directory = await tempRoot();
   await fs.mkdir(path.join(directory, "broken"));


### PR DESCRIPTION
## Summary

A nested `Root.walk()` frame returned after yielding a truncation marker, but its parent generator resumed scanning later siblings. Depth limits could therefore yield normal entries after the marker, and entry limits could yield more than one marker, contradicting the documented “one marker and ends” contract.

Track the first truncation globally for the walk and return from each parent frame after its child generator completes. `limitBehavior: "throw"` still throws immediately; filtering, symlink, abort and directory-error behavior are unchanged. Production delta: +3 lines.

## Real consumer proof

A physical pre-fix consumer contains `a/inner/file.txt` and later root sibling `z.txt`:

```json
{
  "before": [
    {
      "case":"depth",
      "entries":["a","a/inner","truncated:a/inner","z.txt"],
      "markerIsLast":false,
      "markerCount":1
    },
    {
      "case":"entries",
      "entries":["a","a/inner","truncated:a/inner/file.txt","truncated:z.txt"],
      "markerCount":2
    }
  ],
  "after": [
    {"case":"depth","entries":["a","a/inner","truncated:a/inner"],"markerIsLast":true,"markerCount":1},
    {"case":"entries","entries":["a","a/inner","truncated:a/inner/file.txt"],"markerIsLast":true,"markerCount":1},
    {"case":"throw","errorCode":"too-large"}
  ]
}
```

The packed candidate passed all 18 observations across Node22.0.0,22.23.2,24.20.0 under native `off` and `require` configuration. `Root.walk()` is pure Node behavior and loaded no native binary in either mode; this is configuration coverage, not a native-branch claim.

Candidate tree: `3037a1f763e05bb3cdcc1e0cc697ca38c9facb79`. Root artifact integrity: `sha512-zqp5IGsZe17R8bbksvQUoSH60429DkRK23FJa46RS3JiA+U61SG/b3aOag9C2EVuzoiDbxFdEqZl5TnbNTf2/g==`. Package version remains0.7.2; no release is included.

## Validation

- Focused Root walk/options suites passed.
- `CI=1 pnpm check`: 6,811 passed / 77 skipped.
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: physical npm/pnpm consumers, omitted optionals and missing-binary behavior passed.
- Build, docs, file-size, filesystem-boundary and `git diff --check` passed.
- Independent Codex autoreview: scoped-clean at P0, confidence0.99.

Exact-head cross-platform CI and review are required before merge.
