### PR TITLE
fix(output): bound callback staging names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Bound callback staging components to 255 NFC/NFD bytes so filesystem-valid long destination names work without changing final names or short callback paths.
 - End `Root.walk()` immediately after its single truncation marker, including when a nested depth or entry budget is reached.
 - Close a selected archive input if private staging allocation fails, preventing `readArchiveEntry()` setup errors from retaining file descriptors until garbage collection.
 - Avoid opening the TAR metadata stream until preflight setup succeeds, and always destroy it after pipeline completion, preventing descriptor leaks on setup failures. Thanks @SebTardif.

--- a/docs/output.md
+++ b/docs/output.md
@@ -60,7 +60,10 @@ hazards but does not trim Windows-normalized trailing dots or spaces; reject or
 rewrite those when cross-platform filename uniqueness matters.
 `staging: "workspace"` passes the sanitized basename to the producer.
 `staging: "sibling"` embeds that basename in its randomized temporary name.
-The final target and returned `path` use the destination basename, sanitized
+When the complete temporary component would exceed 255 bytes under NFC or NFD,
+only the embedded tail is shortened, preserving its extension when possible;
+short callback paths remain unchanged. The final target and returned `path` use
+the destination basename, sanitized
 when needed as described above. Guarded temporary files used only inside
 fs-safe have independent names so their length does not grow with the
 destination basename.

--- a/docs/temp.md
+++ b/docs/temp.md
@@ -345,7 +345,11 @@ If `replaceFileAtomic` does what you need, prefer that. Use
 the final destination still needs root-boundary checks.
 Its private workspace uses the same identity-aware directory cleanup as
 `tempFile()`: moving and replacing the workspace preserves the replacement.
-This workspace owns its contents, unlike the unadmitted sibling pathname above.
+The callback staging component is capped at 255 bytes under NFC and NFD by
+shortening only an overlong embedded destination tail, while preserving an
+extension when possible. Short callback paths and the final target stay
+unchanged. This workspace owns its contents, unlike the unadmitted sibling
+pathname above.
 
 ## Secure temp root
 

--- a/src/filename.ts
+++ b/src/filename.ts
@@ -26,6 +26,51 @@ function suffixWindowsReservedDeviceName(fileName: string): string {
   return `${baseName}_${fileName.slice(baseNameEnd)}`;
 }
 
+const PORTABLE_FILE_NAME_BYTES = 255;
+
+function normalizedFileNameBytes(value: string): number {
+  return Math.max(
+    Buffer.byteLength(value.normalize("NFC"), "utf8"),
+    Buffer.byteLength(value.normalize("NFD"), "utf8"),
+  );
+}
+
+/** Keeps short names exact and trims only the filename tail of a composite temp name. */
+export function fitFileNameToPortableComponent(params: {
+  prefix: string;
+  fileName: string;
+  suffix: string;
+}): string {
+  const complete = `${params.prefix}${params.fileName}${params.suffix}`;
+  if (normalizedFileNameBytes(complete) <= PORTABLE_FILE_NAME_BYTES) {
+    return params.fileName;
+  }
+  if (normalizedFileNameBytes(`${params.prefix}${params.suffix}`) > PORTABLE_FILE_NAME_BYTES) {
+    throw new RangeError("sibling temp prefix exceeds the portable filename byte limit");
+  }
+
+  const extension = path.extname(params.fileName);
+  const preserveExtension = normalizedFileNameBytes(`${params.prefix}${extension}${params.suffix}`) <=
+    PORTABLE_FILE_NAME_BYTES;
+  const tailSuffix = preserveExtension ? extension : "";
+  const stem = preserveExtension
+    ? params.fileName.slice(0, params.fileName.length - extension.length)
+    : params.fileName;
+  const codePoints = Array.from(stem);
+  let low = 0;
+  let high = codePoints.length;
+  while (low < high) {
+    const length = Math.ceil((low + high) / 2);
+    const candidate = `${params.prefix}${codePoints.slice(0, length).join("")}${tailSuffix}${params.suffix}`;
+    if (normalizedFileNameBytes(candidate) <= PORTABLE_FILE_NAME_BYTES) {
+      low = length;
+    } else {
+      high = length - 1;
+    }
+  }
+  return `${codePoints.slice(0, low).join("")}${tailSuffix}`;
+}
+
 export function sanitizeUntrustedFileName(fileName: string, fallbackName: string): string {
   const trimmed = typeof fileName === "string" ? fileName.trim() : "";
   if (!trimmed) {

--- a/src/filename.ts
+++ b/src/filename.ts
@@ -46,7 +46,8 @@ export function fitFileNameToPortableComponent(params: {
     return params.fileName;
   }
   if (normalizedFileNameBytes(`${params.prefix}${params.suffix}`) > PORTABLE_FILE_NAME_BYTES) {
-    throw new RangeError("sibling temp prefix exceeds the portable filename byte limit");
+    // Preserve the existing OS error for a caller-supplied prefix that cannot fit.
+    return params.fileName;
   }
 
   const extension = path.extname(params.fileName);

--- a/src/output-sibling.ts
+++ b/src/output-sibling.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
-import { sanitizeUntrustedFileName } from "./filename.js";
+import { fitFileNameToPortableComponent, sanitizeUntrustedFileName } from "./filename.js";
 import { writeCallbackSibling } from "./sibling-staged-file.js";
 
 function safeFallbackFileName(fallbackFileName?: string): string {
@@ -8,14 +8,17 @@ function safeFallbackFileName(fallbackFileName?: string): string {
 }
 
 function buildSiblingTempPath(targetPath: string, fallbackFileName?: string): string {
-  const safeTail = sanitizeUntrustedFileName(
-    path.basename(targetPath),
-    safeFallbackFileName(fallbackFileName),
-  );
-  return path.join(
-    path.dirname(targetPath),
-    `.fs-safe-output-${process.pid}-${randomUUID()}-${safeTail}.part`,
-  );
+  const prefix = `.fs-safe-output-${process.pid}-${randomUUID()}-`;
+  const suffix = ".part";
+  const safeTail = fitFileNameToPortableComponent({
+    prefix,
+    fileName: sanitizeUntrustedFileName(
+      path.basename(targetPath),
+      safeFallbackFileName(fallbackFileName),
+    ),
+    suffix,
+  });
+  return path.join(path.dirname(targetPath), `${prefix}${safeTail}${suffix}`);
 }
 
 export async function writeExternalFileViaSibling<T>(params: {

--- a/src/sibling-temp.ts
+++ b/src/sibling-temp.ts
@@ -2,7 +2,7 @@ import crypto, { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard } from "./directory-guard.js";
-import { sanitizeUntrustedFileName } from "./filename.js";
+import { fitFileNameToPortableComponent, sanitizeUntrustedFileName } from "./filename.js";
 import { applyDirectoryMode } from "./replace-file-descriptor.js";
 import { root } from "./root.js";
 import { assertSafePathPrefix } from "./safe-path-segment.js";
@@ -71,11 +71,17 @@ function buildSiblingTempPath(params: {
   const safePrefix = assertSafePathPrefix(params.tempPrefix, {
     label: "sibling temp prefix",
   });
-  const safeTail = sanitizeUntrustedFileName(
-    path.basename(params.targetPath),
-    params.fallbackFileName,
-  );
-  return path.join(path.dirname(params.targetPath), `${safePrefix}${id}-${safeTail}.part`);
+  const prefix = `${safePrefix}${id}-`;
+  const suffix = ".part";
+  const safeTail = fitFileNameToPortableComponent({
+    prefix,
+    fileName: sanitizeUntrustedFileName(
+      path.basename(params.targetPath),
+      params.fallbackFileName,
+    ),
+    suffix,
+  });
+  return path.join(path.dirname(params.targetPath), `${prefix}${safeTail}${suffix}`);
 }
 
 export async function writeViaSiblingTempPath(params: {

--- a/test/filename.test.ts
+++ b/test/filename.test.ts
@@ -34,14 +34,6 @@ describe("fitFileNameToPortableComponent", () => {
     expect(normalizedBytes(`${prefix}${fitted}${suffix}`)).toBeLessThanOrEqual(255);
     expect(fitted.length).toBeLessThan(fileName.length);
   });
-
-  it("rejects a fixed prefix and suffix that cannot fit", () => {
-    expect(() => fitFileNameToPortableComponent({
-      prefix: "x".repeat(251),
-      fileName: "name.txt",
-      suffix,
-    })).toThrow(RangeError);
-  });
 });
 
 describe("sanitizeUntrustedFileName", () => {

--- a/test/filename.test.ts
+++ b/test/filename.test.ts
@@ -3,13 +3,46 @@ import {
   isUnsafeDeviceReadPath,
   WINDOWS_RESERVED_DEVICE_NAMES,
 } from "../src/device-path.js";
-import { sanitizeUntrustedFileName } from "../src/filename.js";
+import { fitFileNameToPortableComponent, sanitizeUntrustedFileName } from "../src/filename.js";
 
 function mixedCase(value: string): string {
   return Array.from(value, (character, index) =>
     index % 2 === 0 ? character : character.toLowerCase()
   ).join("");
 }
+
+function normalizedBytes(value: string): number {
+  return Math.max(Buffer.byteLength(value.normalize("NFC")), Buffer.byteLength(value.normalize("NFD")));
+}
+
+describe("fitFileNameToPortableComponent", () => {
+  const prefix = `.fs-safe-output-12345-${"a".repeat(36)}-`;
+  const suffix = ".part";
+
+  it("keeps short callback names exact", () => {
+    expect(fitFileNameToPortableComponent({ prefix, fileName: "report.tar.gz", suffix }))
+      .toBe("report.tar.gz");
+  });
+
+  it.each([
+    `${"a".repeat(195)}.json`,
+    `${"é".repeat(100)}.json`,
+    `${"가".repeat(65)}.json`,
+  ])("fits %s under NFC and NFD byte limits while preserving the extension", (fileName) => {
+    const fitted = fitFileNameToPortableComponent({ prefix, fileName, suffix });
+    expect(fitted).toMatch(/\.json$/u);
+    expect(normalizedBytes(`${prefix}${fitted}${suffix}`)).toBeLessThanOrEqual(255);
+    expect(fitted.length).toBeLessThan(fileName.length);
+  });
+
+  it("rejects a fixed prefix and suffix that cannot fit", () => {
+    expect(() => fitFileNameToPortableComponent({
+      prefix: "x".repeat(251),
+      fileName: "name.txt",
+      suffix,
+    })).toThrow(RangeError);
+  });
+});
 
 describe("sanitizeUntrustedFileName", () => {
   it("keeps only the basename and strips control characters", () => {

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -62,6 +62,30 @@ describe("writeExternalFileWithinRoot", () => {
     await expect(fs.stat(stagedPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("bounds sibling staging names without changing a valid long destination", async () => {
+    const rootDir = await tempRoot("fs-safe-output-long-sibling-");
+    const fileName = `${"a".repeat(195)}.json`;
+    let stagedName = "";
+
+    const result = await writeExternalFileWithinRoot({
+      rootDir,
+      path: fileName,
+      staging: "sibling",
+      write: async (candidate) => {
+        stagedName = path.basename(candidate);
+        await fs.writeFile(candidate, "long", "utf8");
+      },
+    });
+
+    expect(Math.max(
+      Buffer.byteLength(stagedName.normalize("NFC")),
+      Buffer.byteLength(stagedName.normalize("NFD")),
+    )).toBeLessThanOrEqual(255);
+    expect(stagedName).toMatch(/\.json\.part$/u);
+    expect(path.basename(result.path)).toBe(fileName);
+    await expect(fs.readFile(path.join(rootDir, fileName), "utf8")).resolves.toBe("long");
+  });
+
   it("creates missing target parents for sibling staging", async () => {
     const rootDir = await tempRoot("fs-safe-output-sibling-parent-");
 

--- a/test/sibling-temp-write.test.ts
+++ b/test/sibling-temp-write.test.ts
@@ -35,6 +35,30 @@ describe("writeViaSiblingTempPath", () => {
     });
   });
 
+  it("bounds private staging names without changing a valid long destination", async () => {
+    await withTempDir(async (root) => {
+      const fileName = `${"é".repeat(97)}.json`;
+      const targetPath = path.join(root, fileName);
+      let stagedName = "";
+
+      await writeViaSiblingTempPath({
+        rootDir: root,
+        targetPath,
+        writeTemp: async (candidate) => {
+          stagedName = path.basename(candidate);
+          await fs.writeFile(candidate, "ok", "utf8");
+        },
+      });
+
+      expect(Math.max(
+        Buffer.byteLength(stagedName.normalize("NFC")),
+        Buffer.byteLength(stagedName.normalize("NFD")),
+      )).toBeLessThanOrEqual(255);
+      expect(stagedName).toMatch(/\.json\.part$/u);
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("ok");
+    });
+  });
+
   it("rejects targets outside the root", async () => {
     await withTempDir(async (root) => {
       await expect(


### PR DESCRIPTION
## Summary

Valid long destination basenames already work as final files and in private-workspace staging, but two callback paths embedded the entire sanitized basename after a randomized prefix. A 200-byte destination therefore produced 263-byte output-sibling and 258-byte private-staging components, both failing with `ENAMETOOLONG` before the producer could write.

Fit only the embedded filename tail when the complete randomized component would exceed a conservative 255-byte limit under either NFC or NFD. Short callback names remain byte-for-byte unchanged, destination extensions are preserved when possible, and the final destination path is never shortened. Caller-supplied fixed prefixes that cannot fit by themselves retain their prior OS-level failure rather than receiving a new compatibility behavior.

The shared helper is internal; public exports and signatures are unchanged. Production delta is +70/−15 (net +55), primarily the NFC/NFD byte fitter and two owner integrations.

## Real consumer proof

Physical pre-fix consumers with a valid 200-byte final basename showed:

```json
{
  "workspace":{"producerNameBytes":200,"bytes":"VALUE","verdict":"pass"},
  "outputSibling":{"producerNameBytes":263,"errorCode":"ENAMETOOLONG","verdict":"fail"},
  "writeViaSiblingTempPath":{"producerNameBytes":258,"errorCode":"ENAMETOOLONG","verdict":"fail"}
}
```

Fresh packed-candidate consumers exercise ASCII 200-byte names, Latin characters that expand under NFD, Hangul, extensionless names, and a short-name control through both callback owners. Representative repaired rows:

```json
[
  {"case":"ASCII output sibling","finalNameBytes":200,"callbackNfcNfdBytes":255,"extensionPreserved":true,"bytes":"VALUE"},
  {"case":"ASCII private sibling","finalNameBytes":200,"callbackNfcNfdBytes":255,"extensionPreserved":true,"bytes":"VALUE"},
  {"case":"Latin NFD expansion","finalNfcNfdBytes":200,"callbackNfcNfdBytes":255,"extensionPreserved":true,"bytes":"VALUE"},
  {"case":"short control","callbackTail":"short.json.part","unchanged":true}
]
```

All 54 observations pass across Node 22.0.0, 22.23.2, and 24.20.0 under native `off` and `require` configuration. Required runs recorded the actual `fs-safe-darwin-arm64` binary because final publication uses the guarded Root copy path; off loaded none. Each fixture first creates and removes the requested final path as a positive control, then verifies the final name/content and absence of extra entries.

Candidate tree: `aed705b87d2284822dea427a3cdfffb3f1c88d36`. Root artifact integrity: `sha512-lwwzoFSsEd6iWJwmkCHG5MYmFEF5R+jEpSl2qJoijWx9JSpxPEVpxZ5sVpcNOZD7ItGc9S0mXd7l0PvHbvzeaw==`. Package version remains 0.7.2; no release is included.

## Validation

- Focused filename/output/sibling/platform suites passed; final focused subset: 72 passed.
- Unit coverage checks short-name identity, ASCII/Latin/Hangul NFC/NFD byte bounds, extension preservation, long valid final names, publication and cleanup.
- `CI=1 pnpm check`: 6,817 passed / 77 skipped.
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: physical npm/pnpm consumers, optional omission and missing-binary behavior passed.
- Build, docs, file-size, filesystem-boundary and `git diff --check` passed.
- Two independent Codex autoreview passes, including the complete final branch, were scoped-clean at P0 (0.99).

Exact-head cross-platform CI and review are required before merge.
