### PR TITLE
fix(root): accept canonical absolute alias reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Accept canonical in-root absolute paths in `Root.readAbsolute()` and `Root.reader()` when the Root was configured through a directory symlink or Windows junction.
 - Bound callback staging components to 255 NFC/NFD bytes so filesystem-valid long destination names work without changing final names or short callback paths.
 - End `Root.walk()` immediately after its single truncation marker, including when a nested depth or entry budget is reached.
 - Close a selected archive input if private staging allocation fails, preventing `readArchiveEntry()` setup errors from retaining file descriptors until garbage collection.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Root reads default to `DEFAULT_ROOT_MAX_BYTES` (16 MiB). Pass a larger `maxBytes
 for expected large reads, or `Number.POSITIVE_INFINITY` when the caller has a
 separate size budget.
 
-`reader()` returns a callback that reads absolute or relative paths through the same root boundary. It is useful for APIs that accept a `(path) => Promise<Buffer>` loader. Absolute paths outside the root are rejected with `outside-workspace`. `readAbsolute()` has the same absolute-path behavior directly.
+`reader()` returns a callback that reads absolute or relative paths through the same root boundary. It is useful for APIs that accept a `(path) => Promise<Buffer>` loader. For roots configured through a directory symlink or Windows junction, absolute inputs may use either the configured spelling or the canonical real path. Absolute paths outside the root are rejected with `outside-workspace`. `readAbsolute()` has the same absolute-path behavior directly.
 
 When you need a writable `FileHandle`, use `openWritable()` and prefer `await using` for cleanup:
 

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -102,7 +102,9 @@ fs.readAbsolute(absPath, options?)   // ReadResult, abs path must be inside the 
 fs.reader(options?)              // (path) => Promise<Buffer>
 ```
 
-`readAbsolute` accepts absolute paths. Anything outside the root throws
+`readAbsolute` accepts absolute paths using either the configured root spelling
+or its canonical real path. This includes roots configured through a directory
+symlink or Windows junction. Anything outside the root throws
 `outside-workspace`. It also accepts relative paths for compatibility, but use
 `read()`/`readBytes()` when the input contract is explicitly relative.
 

--- a/docs/root.md
+++ b/docs/root.md
@@ -87,8 +87,10 @@ await using opened = await fs.open("large.log");
 [security model](security-model.md#containment-guarantees-by-platform).
 
 The read methods also accept an absolute spelling that already resolves inside
-the root. `readAbsolute()` and `reader()` make that intent explicit; an absolute
-path outside the root is still rejected.
+the root. `readAbsolute()` and `reader()` make that intent explicit and accept
+both the configured root spelling and its canonical real path when the Root was
+created through a directory symlink or Windows junction. An absolute path
+outside the root is still rejected.
 
 ### Writes
 

--- a/src/root-context.ts
+++ b/src/root-context.ts
@@ -80,6 +80,23 @@ export async function resolveRootContext(rootDir: string): Promise<RootContext> 
   };
 }
 
+export function rootRelativeReadPath(root: RootContext, filePath: string): string {
+  const absoluteInput = path.isAbsolute(filePath);
+  const candidatePath = absoluteInput
+    ? path.resolve(filePath)
+    : path.resolve(root.rootDir, filePath);
+  let relativeBase = root.rootDir;
+  if (
+    absoluteInput &&
+    !isPathInside(root.rootDir, candidatePath) &&
+    isPathInside(root.rootReal, candidatePath)
+  ) {
+    // A Root created through an alias has two valid in-root absolute spellings.
+    relativeBase = root.rootReal;
+  }
+  return path.relative(relativeBase, candidatePath);
+}
+
 export async function assertRootIdentityCurrent(root: RootContext): Promise<void> {
   let current: Awaited<ReturnType<typeof fs.lstat>>;
   try {

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -50,6 +50,7 @@ import {
   expandRelativePathWithHome,
   resolvePathInRoot,
   resolveRootContext,
+  rootRelativeReadPath,
   type RootContext,
 } from "./root-context.js";
 import {
@@ -743,11 +744,7 @@ async function readPathInRoot(
     symlinks?: SymlinkPolicy;
   },
 ): Promise<ReadResult> {
-  const rootDir = root.rootDir;
-  const candidatePath = path.isAbsolute(params.filePath)
-    ? path.resolve(params.filePath)
-    : path.resolve(rootDir, params.filePath);
-  const relativePath = path.relative(rootDir, candidatePath);
+  const relativePath = rootRelativeReadPath(root, params.filePath);
   return await readFileInRoot(root, {
     relativePath,
     hardlinks: params.hardlinks,

--- a/test/root-absolute-alias.test.ts
+++ b/test/root-absolute-alias.test.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { root as openRoot } from "../src/index.js";
+import { expectFsSafeError } from "./helpers/security.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+
+describe("Root absolute reads through configured aliases", () => {
+  it("accepts configured and canonical in-root spellings", async () => {
+    const container = await tempRoot("fs-safe-reader-root-alias-");
+    const canonicalRoot = path.join(container, "canonical");
+    const rootAlias = path.join(container, "alias");
+    const outsidePath = path.join(container, "outside.txt");
+    const nestedRoot = path.join(canonicalRoot, "nested");
+    const nestedAlias = path.join(canonicalRoot, "nested-alias");
+    await fs.mkdir(canonicalRoot);
+    await fs.mkdir(nestedRoot);
+    await fs.writeFile(path.join(canonicalRoot, "value.txt"), "inside");
+    await fs.writeFile(path.join(nestedRoot, "value.txt"), "nested");
+    await fs.writeFile(outsidePath, "outside");
+    const directoryLinkType = process.platform === "win32" ? "junction" : "dir";
+    await fs.symlink(canonicalRoot, rootAlias, directoryLinkType);
+    await fs.symlink(nestedRoot, nestedAlias, directoryLinkType);
+
+    const root = await openRoot(rootAlias);
+    const configuredPath = path.join(root.rootDir, "value.txt");
+    const canonicalPath = path.join(root.rootReal, "value.txt");
+    const canonicalAliasPath = path.join(root.rootReal, "nested-alias", "value.txt");
+
+    expect(root.rootDir).not.toBe(root.rootReal);
+    await expect(root.readAbsolute(configuredPath)).resolves.toMatchObject({
+      buffer: Buffer.from("inside"),
+    });
+    await expect(root.readAbsolute(canonicalPath)).resolves.toMatchObject({
+      buffer: Buffer.from("inside"),
+    });
+    await expect(root.reader()(configuredPath)).resolves.toEqual(Buffer.from("inside"));
+    await expect(root.reader()(canonicalPath)).resolves.toEqual(Buffer.from("inside"));
+    await expect(root.readText(canonicalPath)).resolves.toBe("inside");
+
+    await expectFsSafeError(root.readAbsolute(canonicalAliasPath), "symlink");
+    await expect(
+      root.readAbsolute(canonicalAliasPath, { symlinks: "follow-within-root" }),
+    ).resolves.toMatchObject({ buffer: Buffer.from("nested") });
+    await expect(
+      root.reader({ symlinks: "follow-within-root" })(canonicalAliasPath),
+    ).resolves.toEqual(Buffer.from("nested"));
+
+    await expectFsSafeError(root.readAbsolute(outsidePath), "outside-workspace");
+    await expectFsSafeError(root.reader()(outsidePath), "outside-workspace");
+  });
+});


### PR DESCRIPTION
## Summary

A `Root` created through a directory symlink or Windows junction retains both the configured spelling (`rootDir`) and canonical identity path (`rootReal`). Ordinary Root reads already accept the canonical absolute path, but the `readAbsolute()` adapter always computed its relative input against `rootDir`. The canonical spelling therefore became lexical `..` traversal and failed with `outside-workspace`; `reader()` inherited the same defect.

Normalize absolute adapter inputs against the configured root when they are lexically inside that spelling, otherwise against the canonical root when they are lexically inside `rootReal`. Inputs inside neither spelling still flow through the existing guarded reader and reject as outside. Relative inputs, root identity checks, unsafe-device checks, symlink/hardlink policy, descriptor identity verification, and byte caps are unchanged.

The regression is isolated in a dedicated test file so the existing root implementation and broad security suite remain within their file-size budgets. Public signatures and exports are unchanged.

## Real consumer proof

Before the repair, physical published and current-main consumers configured through a real directory symlink produced:

```json
{
  "read": "pass",
  "readAbsolute": {"code": "outside-workspace"},
  "reader": {"code": "outside-workspace"}
}
```

A fresh physical install of the packed candidate passes 132 observable checks: 66 under macOS arm64 and 66 under translated x64 Node via Rosetta, across Node 22.0.0, 22.23.2, and 24.20.0 with native configuration `off` and `require`. Every run verifies relative and canonical ordinary reads; configured and canonical `readAbsolute()`/`reader()` paths; exact fixture bytes; outside-root and prefix-sibling rejection; default inner-symlink refusal; and `follow-within-root` success.

This read path is pure JavaScript, so all runs recorded zero loaded native shared objects. The `require` configuration rows therefore prove configuration compatibility, not native dispatch; Rosetta rows prove translated x64 execution, not physical Intel hardware. Root artifact integrity: `sha512-1oDX2pOx6XLRMSY0x0VQg39xGMtSPYxuODhgo+9Ouo6DEpN0eZjj7tMxWNDLQ9KzzM271oWEFPiKbH6lpvADFQ==`. Package version remains 0.7.2; no release is included.

Candidate tree: `cf945074462371b7919ac00cf3575a0525b1e4ff`.

## Validation

- Focused alias, root-boundary, and Windows-path suites: 45 passed / 2 skipped.
- `CI=1 pnpm check`: 6,818 passed / 77 skipped.
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: physical npm/pnpm consumers, optional omission, and missing-binary behavior passed.
- Build, docs, file-size, filesystem-boundary, package, and `git diff --check` gates passed.
- The first bounded full run encountered two unrelated 5-second TAR fixture timeouts; both files then passed 1,122/1,122 in isolation, and the complete bounded check passed on rerun without code or timeout changes.
- Independent Codex autoreview was scoped-clean at P0 (0.98).

Exact-head cross-platform CI and ClawSweeper review are required before merge; Windows CI supplies the real junction lane unavailable on this host.
