### PR TITLE
fix(path): reject unresolved strict aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Reject dangling symlink leaves and ancestors under strict absolute-write and missing local-root resolution instead of treating unresolved aliases as safe missing paths.
 - Accept canonical in-root absolute paths in `Root.readAbsolute()` and `Root.reader()` when the Root was configured through a directory symlink or Windows junction.
 - Bound callback staging components to 255 NFC/NFD bytes so filesystem-valid long destination names work without changing final names or short callback paths.
 - End `Root.walk()` immediately after its single truncation marker, including when a nested depth or entry budget is reached.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -49,7 +49,7 @@ root-path result helpers.
 | `assertAbsolutePathInput` | – | Validate a caller-supplied absolute path string. |
 | `ensureAbsoluteDirectory`, `EnsureAbsoluteDirectoryOptions`, `EnsureAbsoluteDirectoryResult` | – | Create a trusted absolute directory path one segment at a time, rejecting symlink or non-directory segments. |
 | `canonicalPathFromExistingAncestor`, `findExistingAncestor` | – | Canonicalize without requiring the leaf to exist. |
-| `resolveAbsolutePathForRead`, `resolveAbsolutePathForWrite`, `ResolvedAbsolutePath`, `ResolvedWritableAbsolutePath`, `AbsolutePathSymlinkPolicy` | – | Validate an absolute path against a symlink policy before opening. |
+| `resolveAbsolutePathForRead`, `resolveAbsolutePathForWrite`, `ResolvedAbsolutePath`, `ResolvedWritableAbsolutePath`, `AbsolutePathSymlinkPolicy` | – | Validate an absolute path against a symlink policy before opening; strict writes reject dangling symlink components rather than treating them as missing. |
 
 `ensureAbsoluteDirectory()` is for paths you already intend to trust as absolute
 locations, such as a configured output root. It does not enforce a root boundary;

--- a/docs/local-roots.md
+++ b/docs/local-roots.md
@@ -66,9 +66,10 @@ console.log(r.root); // canonical /srv/uploads
 By default the candidate must exist. `allowMissing: true` instead canonicalizes
 the nearest existing ancestor and validates the missing tail, which is useful
 when selecting a future output location. `requireFile: true` rejects existing
-directories and other non-file leaves. Dangling symlinks and candidates whose
-ancestors cannot be canonicalized are rejected rather than treated as safe
-missing paths.
+directories and other non-file leaves. A missing suffix begins only at a
+component that does not exist: dangling symlinks, descendants of dangling
+symlinks, and candidates whose existing ancestors cannot be canonicalized are
+rejected rather than treated as safe missing paths.
 
 ## `readLocalFileFromRoots(options)`
 

--- a/src/absolute-path.ts
+++ b/src/absolute-path.ts
@@ -8,6 +8,7 @@ import {
 } from "./directory-guard.js";
 import { FsSafeError, type FsSafeErrorCode } from "./errors.js";
 import { pathExists } from "./fs.js";
+import { resolveRootPath } from "./root-path.js";
 
 export type AbsolutePathSymlinkPolicy = "reject" | "follow";
 
@@ -382,16 +383,14 @@ export async function resolveAbsolutePathForWrite(
   const parentDir = path.dirname(normalized);
   const parentExists = await pathExists(parentDir);
   if (symlinks === "reject") {
-    const ancestor = await findExistingAncestor(parentDir);
-    if (ancestor) {
-      const canonicalAncestor = await fs.realpath(ancestor).catch(() => ancestor);
-      if (canonicalAncestor !== ancestor) {
-        const canonicalPath = path.join(canonicalAncestor, path.relative(ancestor, normalized));
-        throw new FsSafeError("symlink", "path traverses a symlink", {
-          cause: { canonicalPath },
-        });
-      }
-    }
+    const filesystemRoot = path.parse(normalized).root;
+    await resolveRootPath({
+      absolutePath: normalized,
+      rootPath: filesystemRoot,
+      rootCanonicalPath: filesystemRoot,
+      boundaryLabel: "absolute path",
+      rejectSymlinks: true,
+    });
   }
   const canonicalPath = await canonicalPathFromExistingAncestor(normalized);
   if (symlinks === "reject" && canonicalPath !== normalized) {

--- a/src/local-roots.ts
+++ b/src/local-roots.ts
@@ -5,6 +5,7 @@ import { FsSafeError } from "./errors.js";
 import { expandHomePrefix, resolveUserPath } from "./home-dir.js";
 import { isFileUrl, safeFileURLToPath } from "./local-file-access.js";
 import { isPathInside } from "./path.js";
+import { resolveRootPathSync } from "./root-path.js";
 import { root, type HardlinkPolicy, type ReadResult, type SymlinkPolicy } from "./root.js";
 
 export type LocalRootsPathResult = {
@@ -66,10 +67,6 @@ function resolveLocalRootInput(input: string, label: string): string {
   return path.resolve(resolved);
 }
 
-function isPathInsideRoot(candidate: string, rootDir: string): boolean {
-  return isPathInside(rootDir, candidate);
-}
-
 function resolveRootRealSync(rootDir: string): string | null {
   try {
     // Configured roots may themselves be symlinks. Follow only this trusted
@@ -81,55 +78,6 @@ function resolveRootRealSync(rootDir: string): string | null {
     return fsSync.realpathSync(rootDir);
   } catch {
     return null;
-  }
-}
-
-function resolveCandidateCanonicalSync(
-  filePath: string,
-): { exists: true; canonicalPath: string; isFile: boolean } | { exists: false; canonicalPath: string } {
-  let sawExistingLeaf = false;
-  try {
-    const stat = fsSync.lstatSync(filePath);
-    sawExistingLeaf = true;
-    return {
-      exists: true,
-      canonicalPath: fsSync.realpathSync(filePath),
-      isFile: stat.isFile(),
-    };
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw err;
-    }
-  }
-  if (sawExistingLeaf) {
-    // lstat succeeded but realpath failed: this is an existing dangling
-    // symlink, not a missing path callers may safely create through.
-    throw new FsSafeError("symlink", "local roots candidate is a dangling symlink");
-  }
-
-  let cursor = filePath;
-  const missingSegments: string[] = [];
-  while (true) {
-    const parent = path.dirname(cursor);
-    if (parent === cursor) {
-      return { exists: false, canonicalPath: filePath };
-    }
-    missingSegments.unshift(path.basename(cursor));
-    cursor = parent;
-    try {
-      fsSync.lstatSync(cursor);
-      const ancestorReal = fsSync.realpathSync(cursor);
-      return {
-        exists: false,
-        canonicalPath: path.join(ancestorReal, ...missingSegments),
-      };
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        // Existing ancestors that cannot be canonicalized are symlink/error
-        // terrain; do not reconstruct a trusted missing path through them.
-        throw err;
-      }
-    }
   }
 }
 
@@ -146,21 +94,30 @@ export function resolveLocalPathFromRootsSync(
       continue;
     }
 
-    let candidate: ReturnType<typeof resolveCandidateCanonicalSync>;
+    let candidate: ReturnType<typeof resolveRootPathSync>;
     try {
-      candidate = resolveCandidateCanonicalSync(requestedPath);
+      candidate = resolveRootPathSync({
+        absolutePath: requestedPath,
+        rootPath: rootDir,
+        rootCanonicalPath: rootReal,
+        boundaryLabel: label,
+      });
     } catch {
       continue;
     }
     if (!candidate.exists && options.allowMissing !== true) {
       continue;
     }
-    if (candidate.exists && options.requireFile === true && !candidate.isFile) {
-      continue;
+    if (candidate.exists && options.requireFile === true) {
+      try {
+        if (!fsSync.lstatSync(requestedPath).isFile()) {
+          continue;
+        }
+      } catch {
+        continue;
+      }
     }
-    if (isPathInsideRoot(candidate.canonicalPath, rootReal)) {
-      return { path: candidate.canonicalPath, root: rootReal };
-    }
+    return { path: candidate.canonicalPath, root: rootReal };
   }
 
   return null;

--- a/src/local-roots.ts
+++ b/src/local-roots.ts
@@ -101,6 +101,7 @@ export function resolveLocalPathFromRootsSync(
         rootPath: rootDir,
         rootCanonicalPath: rootReal,
         boundaryLabel: label,
+        rejectUnresolvedSymlinks: true,
       });
     } catch {
       continue;

--- a/src/root-path-symlink.ts
+++ b/src/root-path-symlink.ts
@@ -8,8 +8,18 @@ import {
   resolvePathViaExistingAncestorSync,
 } from "./root-path-existing.js";
 
-function normalizeSymlinkResolutionError(error: unknown): void {
-  if (isSymlinkOpenError(error)) {
+type ResolveSymlinkHopOptions = {
+  rejectUnresolved?: boolean;
+};
+
+function normalizeSymlinkResolutionError(
+  error: unknown,
+  options: ResolveSymlinkHopOptions,
+): void {
+  if (
+    isSymlinkOpenError(error) ||
+    (options.rejectUnresolved && isNotFoundPathError(error))
+  ) {
     throw new FsSafeError("symlink", "symlink path could not be resolved", {
       cause: error instanceof Error ? error : undefined,
     });
@@ -17,21 +27,27 @@ function normalizeSymlinkResolutionError(error: unknown): void {
   if (!isNotFoundPathError(error)) throw error;
 }
 
-export async function resolveSymlinkHopPath(symlinkPath: string): Promise<string> {
+export async function resolveSymlinkHopPath(
+  symlinkPath: string,
+  options: ResolveSymlinkHopOptions = {},
+): Promise<string> {
   try {
     return path.resolve(await fsp.realpath(symlinkPath));
   } catch (error) {
-    normalizeSymlinkResolutionError(error);
+    normalizeSymlinkResolutionError(error, options);
     const linkTarget = await fsp.readlink(symlinkPath);
     return resolvePathViaExistingAncestor(path.resolve(path.dirname(symlinkPath), linkTarget));
   }
 }
 
-export function resolveSymlinkHopPathSync(symlinkPath: string): string {
+export function resolveSymlinkHopPathSync(
+  symlinkPath: string,
+  options: ResolveSymlinkHopOptions = {},
+): string {
   try {
     return path.resolve(fs.realpathSync(symlinkPath));
   } catch (error) {
-    normalizeSymlinkResolutionError(error);
+    normalizeSymlinkResolutionError(error, options);
     const linkTarget = fs.readlinkSync(symlinkPath);
     return resolvePathViaExistingAncestorSync(path.resolve(path.dirname(symlinkPath), linkTarget));
   }

--- a/src/root-path.ts
+++ b/src/root-path.ts
@@ -44,6 +44,7 @@ type ResolveRootPathParams = {
   intent?: RootPathIntent;
   policy?: RootPathAliasPolicy;
   rejectSymlinks?: boolean;
+  rejectUnresolvedSymlinks?: boolean;
   skipLexicalRootCheck?: boolean;
   rootCanonicalPath?: string;
 };
@@ -469,7 +470,10 @@ async function resolveRootPathLexicalAsync(
     }
 
     await resolveAndApplySymlinkHop(context, {
-      resolveLinkCanonical: (cursor) => resolveSymlinkHopPath(cursor),
+      resolveLinkCanonical: (cursor) =>
+        resolveSymlinkHopPath(cursor, {
+          rejectUnresolved: context.resolveParams.rejectUnresolvedSymlinks,
+        }),
     });
     if (context.resolveParams.rejectSymlinks === true) {
       throw new FsSafeError("symlink", "symlink path component not allowed");
@@ -516,7 +520,10 @@ function resolveRootPathLexicalSync(params: LexicalResolutionParams): ResolvedRo
     }
 
     const maybeApplied = resolveAndApplySymlinkHop(context, {
-      resolveLinkCanonical: (cursor) => resolveSymlinkHopPathSync(cursor),
+      resolveLinkCanonical: (cursor) =>
+        resolveSymlinkHopPathSync(cursor, {
+          rejectUnresolved: context.resolveParams.rejectUnresolvedSymlinks,
+        }),
     });
     if (isPromiseLike<void>(maybeApplied)) {
       throw new Error("Unexpected async symlink resolution");

--- a/test/strict-unresolved-alias.test.ts
+++ b/test/strict-unresolved-alias.test.ts
@@ -14,26 +14,27 @@ describe("strict unresolved alias handling", () => {
     const outside = await fs.realpath(
       await tempRoot("fs-safe-unresolved-alias-outside-"),
     );
-    const dangling = path.join(root, "dangling");
-    const danglingChild = path.join(dangling, "child.txt");
+    const danglingInside = path.join(root, "dangling-inside");
+    const danglingOutside = path.join(root, "dangling-outside");
+    const danglingInsideChild = path.join(danglingInside, "child.txt");
     const missing = path.join(root, "missing", "child.txt");
     const linkType = process.platform === "win32" ? "junction" : "dir";
-    await fs.symlink(path.join(outside, "absent"), dangling, linkType);
+    await fs.symlink(path.join(root, "absent-inside"), danglingInside, linkType);
+    await fs.symlink(path.join(outside, "absent"), danglingOutside, linkType);
 
-    expect(
-      resolveLocalPathFromRootsSync({
-        filePath: dangling,
-        roots: [root],
-        allowMissing: true,
-      }),
-    ).toBeNull();
-    expect(
-      resolveLocalPathFromRootsSync({
-        filePath: danglingChild,
-        roots: [root],
-        allowMissing: true,
-      }),
-    ).toBeNull();
+    for (const filePath of [
+      danglingInside,
+      danglingInsideChild,
+      path.join(danglingOutside, "child.txt"),
+    ]) {
+      expect(
+        resolveLocalPathFromRootsSync({
+          filePath,
+          roots: [root],
+          allowMissing: true,
+        }),
+      ).toBeNull();
+    }
     expect(
       resolveLocalPathFromRootsSync({
         filePath: missing,
@@ -42,10 +43,13 @@ describe("strict unresolved alias handling", () => {
       }),
     ).toEqual({ path: missing, root });
 
-    await expectFsSafeError(resolveAbsolutePathForWrite(dangling), "symlink");
-    await expectFsSafeError(resolveAbsolutePathForWrite(danglingChild), "symlink");
-    await expect(resolveAbsolutePathForWrite(dangling, { symlinks: "follow" }))
-      .resolves.toMatchObject({ path: dangling, canonicalPath: dangling });
+    await expectFsSafeError(resolveAbsolutePathForWrite(danglingInside), "symlink");
+    await expectFsSafeError(resolveAbsolutePathForWrite(danglingInsideChild), "symlink");
+    await expect(resolveAbsolutePathForWrite(danglingInside, { symlinks: "follow" }))
+      .resolves.toMatchObject({
+        path: danglingInside,
+        canonicalPath: danglingInside,
+      });
   });
 
   it("keeps following resolvable in-root aliases for local missing paths", async () => {

--- a/test/strict-unresolved-alias.test.ts
+++ b/test/strict-unresolved-alias.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveAbsolutePathForWrite } from "../src/absolute-path.js";
+import { resolveLocalPathFromRootsSync } from "../src/local-roots.js";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+
+describe("strict unresolved alias handling", () => {
+  it("distinguishes dangling aliases from truly missing suffixes", async () => {
+    const root = await fs.realpath(await tempRoot("fs-safe-unresolved-alias-root-"));
+    const outside = await fs.realpath(
+      await tempRoot("fs-safe-unresolved-alias-outside-"),
+    );
+    const dangling = path.join(root, "dangling");
+    const danglingChild = path.join(dangling, "child.txt");
+    const missing = path.join(root, "missing", "child.txt");
+    const linkType = process.platform === "win32" ? "junction" : "dir";
+    await fs.symlink(path.join(outside, "absent"), dangling, linkType);
+
+    expect(
+      resolveLocalPathFromRootsSync({
+        filePath: dangling,
+        roots: [root],
+        allowMissing: true,
+      }),
+    ).toBeNull();
+    expect(
+      resolveLocalPathFromRootsSync({
+        filePath: danglingChild,
+        roots: [root],
+        allowMissing: true,
+      }),
+    ).toBeNull();
+    expect(
+      resolveLocalPathFromRootsSync({
+        filePath: missing,
+        roots: [root],
+        allowMissing: true,
+      }),
+    ).toEqual({ path: missing, root });
+
+    await expectFsSafeError(resolveAbsolutePathForWrite(dangling), "symlink");
+    await expectFsSafeError(resolveAbsolutePathForWrite(danglingChild), "symlink");
+    await expect(resolveAbsolutePathForWrite(dangling, { symlinks: "follow" }))
+      .resolves.toMatchObject({ path: dangling, canonicalPath: dangling });
+  });
+
+  it("keeps following resolvable in-root aliases for local missing paths", async () => {
+    const root = await fs.realpath(await tempRoot("fs-safe-resolved-alias-root-"));
+    const actual = path.join(root, "actual");
+    const alias = path.join(root, "alias");
+    const linkType = process.platform === "win32" ? "junction" : "dir";
+    await fs.mkdir(actual);
+    await fs.symlink(actual, alias, linkType);
+
+    expect(
+      resolveLocalPathFromRootsSync({
+        filePath: path.join(alias, "future.txt"),
+        roots: [root],
+        allowMissing: true,
+      }),
+    ).toEqual({ path: path.join(actual, "future.txt"), root });
+  });
+
+  itPosix("preserves requireFile semantics for a symlink leaf", async () => {
+    const root = await fs.realpath(await tempRoot("fs-safe-alias-file-root-"));
+    const actual = path.join(root, "actual.txt");
+    const alias = path.join(root, "alias.txt");
+    await fs.writeFile(actual, "value");
+    await fs.symlink(actual, alias, "file");
+
+    expect(resolveLocalPathFromRootsSync({ filePath: alias, roots: [root] })).toEqual({
+      path: actual,
+      root,
+    });
+    expect(
+      resolveLocalPathFromRootsSync({
+        filePath: alias,
+        roots: [root],
+        requireFile: true,
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Two strict path-selection helpers confused an unresolved alias with a genuinely missing suffix. The local-root resolver had a bespoke nearest-ancestor walk where `lstat` could prove a dangling alias existed, but a subsequent `realpath` `ENOENT` was still allowed to walk past it and reconstruct a trusted-looking child path. The absolute-write resolver similarly allowed its canonicalization fallback to erase a dangling final alias under the default strict policy.

Route synchronous local-root candidates through the existing component-wise Root path resolver, which already stops only at a truly absent component and rejects unresolved aliases. Strict absolute-write resolution now uses that same resolver as a no-symlink preflight from the filesystem root before retaining its existing canonical result shape. This removes the duplicated local-root path walk and keeps resolvable in-root aliases, `requireFile` leaf semantics, plain missing paths, and explicit `symlinks: "follow"` behavior unchanged.

No new raw filesystem operation or fallback is added. Public signatures and exports are unchanged. The production delta is +58/−78 (net −20), including the shared unresolved-hop policy and both sync/async resolver wiring.

## Real consumer proof

Physical published/current-main consumers showed the asymmetric strict behavior without performing any write through the returned paths:

```json
{
  "localDanglingLeaf": "rejected",
  "localChildBelowDanglingAncestor": "accepted",
  "strictAbsoluteDanglingLeaf": "accepted"
}
```

A fresh physical install of the corrected packed candidate passes 180 source-blind observations across macOS arm64 and translated x64 Node via Rosetta, Node 22.0.0, 22.23.2, and 24.20.0, with native configuration `off` and `require`. Every run distinguishes a plain missing suffix from dangling leaves and ancestors whose missing targets are both inside and outside the configured root; preserves canonical future paths through resolvable internal and external aliases; keeps prefix siblings outside; retains `requireFile` symlink-leaf behavior; rejects strict absolute dangling/resolvable aliases with `symlink`; and preserves explicit-follow results.

These helpers are pure JavaScript and every run recorded zero loaded native shared objects. The `require` rows therefore prove configuration compatibility, not native dispatch; Rosetta rows prove translated x64 execution, not physical Intel hardware. Root artifact integrity: `sha512-Ug00Ah8UTHhEuyKPOLDg+5887raNUg31H37bpGABKTxss82p2hqLHDUoy3iaCe90XxjIdRXDxXkML6M+6zWaYg==`. Package version remains 0.7.2; no release is included.

Candidate tree: `0b5582c521a316e7f4a6ef05d3577aee1e11a608`.

## Validation

- Focused strict-alias, deep-security, local-root, absolute-path, and coverage suites: 63 passed.
- `CI=1 pnpm check`: 6,821 passed / 77 skipped.
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: physical npm/pnpm consumers, optional omission, and missing-binary behavior passed.
- Build, docs, file-size, filesystem-boundary, package, and `git diff --check` gates passed.
- Initial Codex autoreview was scoped-clean at P0 (0.98); ClawSweeper then identified the missing in-root dangling-target case, which is addressed by the shared unresolved-hop policy and corrected packed proof. Final autoreview was scoped-clean at P0 (0.99).

Exact-head cross-platform CI and ClawSweeper review are required before merge. The regression test uses a Windows junction on Windows CI; this host supplies real POSIX dangling-symlink and Rosetta coverage.
