### PR TITLE
fix(atomic): retire copied hardlink aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Retire every copied source name after cross-device moves with allowed in-tree hardlink aliases, while preserving `ESTALE` fences for unverified external mutations.
 - Reject dangling symlink leaves and ancestors under strict absolute-write and missing local-root resolution instead of treating unresolved aliases as safe missing paths.
 - Accept canonical in-root absolute paths in `Root.readAbsolute()` and `Root.reader()` when the Root was configured through a directory symlink or Windows junction.
 - Bound callback staging components to 255 NFC/NFD bytes so filesystem-valid long destination names work without changing final names or short callback paths.

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -207,7 +207,11 @@ the preflight cap fails with `FsSafeError("too-large")`.
 If another writer changes source entries during the fallback, the staged copy
 throws `ESTALE` before commit when possible. If the destination has already
 been committed, cleanup still preserves the changed source entries and throws
-`ESTALE`.
+`ESTALE`. When allowed source names are hardlinks to the same inode, each owned
+unlink is verified through a remaining manifested alias and its exact resulting
+identity becomes the next cleanup receipt. This accounts for the operation's
+own link-count and ctime changes without suppressing unexpected external
+mutations.
 
 ### Final rename authorization
 

--- a/src/move-path-cleanup.ts
+++ b/src/move-path-cleanup.ts
@@ -1,0 +1,230 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type EntryIdentity = {
+  ctimeMs: number;
+  dev: number;
+  ino: number;
+  mode: number;
+  mtimeMs: number;
+  nlink: number;
+  size: number;
+};
+
+export type CopiedEntryManifest =
+  | (EntryIdentity & {
+      children: Array<{ name: string; manifest: CopiedEntryManifest }>;
+      kind: "directory";
+    })
+  | (EntryIdentity & { kind: "leaf" });
+
+type CleanupCopiedEntryResult = "removed" | "stale";
+
+type CleanupAliasGroup = {
+  expected: EntryIdentity;
+  remainingPaths: Set<string>;
+};
+
+export type CleanupCopiedEntryState = {
+  aliasGroups: Map<string, CleanupAliasGroup>;
+};
+
+export function entryIdentity(stat: {
+  ctimeMs: number;
+  dev: number;
+  ino: number;
+  mode: number;
+  mtimeMs: number;
+  nlink: number;
+  size: number;
+}): EntryIdentity {
+  return {
+    ctimeMs: stat.ctimeMs,
+    dev: stat.dev,
+    ino: stat.ino,
+    mode: stat.mode,
+    mtimeMs: stat.mtimeMs,
+    nlink: stat.nlink,
+    size: stat.size,
+  };
+}
+
+export function sameIdentity(a: EntryIdentity, b: EntryIdentity): boolean {
+  return (
+    a.dev === b.dev &&
+    a.ino === b.ino &&
+    a.mode === b.mode &&
+    a.nlink === b.nlink &&
+    a.size === b.size &&
+    a.mtimeMs === b.mtimeMs &&
+    a.ctimeMs === b.ctimeMs
+  );
+}
+
+function sameDirectoryNode(a: EntryIdentity, b: EntryIdentity): boolean {
+  return a.dev === b.dev && a.ino === b.ino;
+}
+
+export function sourceChangedError(sourcePath: string): Error {
+  return Object.assign(new Error(`Source changed during move fallback: ${sourcePath}`), {
+    code: "ESTALE",
+  });
+}
+
+export async function assertSourceStillMatches(
+  sourcePath: string,
+  identity: EntryIdentity,
+): Promise<void> {
+  if (!sameIdentity(identity, entryIdentity(await fs.lstat(sourcePath)))) {
+    throw sourceChangedError(sourcePath);
+  }
+}
+
+function identityKey(identity: EntryIdentity): string {
+  return `${identity.dev}:${identity.ino}`;
+}
+
+function collectAliasCandidates(
+  sourcePath: string,
+  manifest: CopiedEntryManifest,
+  candidates: Map<string, Array<{ manifest: EntryIdentity; path: string }>>,
+): void {
+  if (manifest.kind === "directory") {
+    for (const child of manifest.children) {
+      collectAliasCandidates(path.join(sourcePath, child.name), child.manifest, candidates);
+    }
+    return;
+  }
+  if (manifest.nlink <= 1) {
+    return;
+  }
+  const key = identityKey(manifest);
+  const entries = candidates.get(key) ?? [];
+  entries.push({ manifest, path: sourcePath });
+  candidates.set(key, entries);
+}
+
+export function createCleanupCopiedEntryState(
+  sourcePath: string,
+  manifest: CopiedEntryManifest,
+): CleanupCopiedEntryState {
+  const candidates = new Map<
+    string,
+    Array<{ manifest: EntryIdentity; path: string }>
+  >();
+  collectAliasCandidates(sourcePath, manifest, candidates);
+
+  const aliasGroups = new Map<string, CleanupAliasGroup>();
+  for (const [key, entries] of candidates) {
+    if (entries.length < 2) {
+      continue;
+    }
+    const first = entries[0];
+    if (!first || entries.some((entry) => !sameIdentity(first.manifest, entry.manifest))) {
+      throw sourceChangedError(sourcePath);
+    }
+    aliasGroups.set(key, {
+      expected: first.manifest,
+      remainingPaths: new Set(entries.map((entry) => entry.path)),
+    });
+  }
+  return { aliasGroups };
+}
+
+function sameOwnedUnlinkTransition(before: EntryIdentity, after: EntryIdentity): boolean {
+  return (
+    before.dev === after.dev &&
+    before.ino === after.ino &&
+    before.mode === after.mode &&
+    before.size === after.size &&
+    before.mtimeMs === after.mtimeMs &&
+    before.nlink > 0 &&
+    after.nlink === before.nlink - 1 &&
+    after.ctimeMs >= before.ctimeMs
+  );
+}
+
+async function observeOwnedAliasUnlink(
+  sourcePath: string,
+  group: CleanupAliasGroup,
+): Promise<CleanupCopiedEntryResult> {
+  group.remainingPaths.delete(sourcePath);
+  const remainingPath = group.remainingPaths.values().next().value as string | undefined;
+  if (!remainingPath) {
+    return "removed";
+  }
+
+  let observed: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    observed = await fs.lstat(remainingPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
+      return "stale";
+    }
+    throw error;
+  }
+  const observedIdentity = entryIdentity(observed);
+  if (!sameOwnedUnlinkTransition(group.expected, observedIdentity)) {
+    return "stale";
+  }
+  group.expected = observedIdentity;
+  return "removed";
+}
+
+function mergeCleanupResults(
+  a: CleanupCopiedEntryResult,
+  b: CleanupCopiedEntryResult,
+): CleanupCopiedEntryResult {
+  return a === "stale" || b === "stale" ? "stale" : "removed";
+}
+
+export async function cleanupCopiedEntry(
+  sourcePath: string,
+  manifest: CopiedEntryManifest,
+  state: CleanupCopiedEntryState,
+): Promise<CleanupCopiedEntryResult> {
+  let currentStat: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    currentStat = await fs.lstat(sourcePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
+      return "removed";
+    }
+    throw error;
+  }
+
+  if (manifest.kind === "directory") {
+    if (!currentStat.isDirectory() || !sameDirectoryNode(manifest, entryIdentity(currentStat))) {
+      return "stale";
+    }
+    // A same-inode directory can gain unrelated children after commit. Still
+    // clean manifest children so the fallback does not duplicate copied files.
+    let result: CleanupCopiedEntryResult = "removed";
+    for (const child of manifest.children) {
+      result = mergeCleanupResults(
+        result,
+        await cleanupCopiedEntry(path.join(sourcePath, child.name), child.manifest, state),
+      );
+    }
+    try {
+      await fs.rmdir(sourcePath);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | null)?.code;
+      if (code === "ENOTEMPTY" || code === "EEXIST") {
+        return "stale";
+      }
+      throw error;
+    }
+    return result;
+  }
+
+  const aliasGroup = state.aliasGroups.get(identityKey(manifest));
+  const expected = aliasGroup?.expected ?? manifest;
+  if (!sameIdentity(expected, entryIdentity(currentStat))) {
+    return "stale";
+  }
+  await fs.unlink(sourcePath);
+  return aliasGroup
+    ? await observeOwnedAliasUnlink(sourcePath, aliasGroup)
+    : "removed";
+}

--- a/src/move-path-cleanup.ts
+++ b/src/move-path-cleanup.ts
@@ -23,6 +23,7 @@ type CleanupCopiedEntryResult = "removed" | "stale";
 type CleanupAliasGroup = {
   expected: EntryIdentity;
   remainingPaths: Set<string>;
+  stale: boolean;
 };
 
 export type CleanupCopiedEntryState = {
@@ -126,6 +127,7 @@ export function createCleanupCopiedEntryState(
     aliasGroups.set(key, {
       expected: first.manifest,
       remainingPaths: new Set(entries.map((entry) => entry.path)),
+      stale: false,
     });
   }
   return { aliasGroups };
@@ -144,6 +146,11 @@ function sameOwnedUnlinkTransition(before: EntryIdentity, after: EntryIdentity):
   );
 }
 
+function poisonAliasGroup(group: CleanupAliasGroup): CleanupCopiedEntryResult {
+  group.stale = true;
+  return "stale";
+}
+
 async function observeOwnedAliasUnlink(
   sourcePath: string,
   group: CleanupAliasGroup,
@@ -159,13 +166,13 @@ async function observeOwnedAliasUnlink(
     observed = await fs.lstat(remainingPath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
-      return "stale";
+      return poisonAliasGroup(group);
     }
     throw error;
   }
   const observedIdentity = entryIdentity(observed);
   if (!sameOwnedUnlinkTransition(group.expected, observedIdentity)) {
-    return "stale";
+    return poisonAliasGroup(group);
   }
   group.expected = observedIdentity;
   return "removed";
@@ -183,12 +190,18 @@ export async function cleanupCopiedEntry(
   manifest: CopiedEntryManifest,
   state: CleanupCopiedEntryState,
 ): Promise<CleanupCopiedEntryResult> {
+  const aliasGroup =
+    manifest.kind === "leaf" ? state.aliasGroups.get(identityKey(manifest)) : undefined;
+  if (aliasGroup?.stale) {
+    return "stale";
+  }
+
   let currentStat: Awaited<ReturnType<typeof fs.lstat>>;
   try {
     currentStat = await fs.lstat(sourcePath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
-      return "removed";
+      return aliasGroup ? poisonAliasGroup(aliasGroup) : "removed";
     }
     throw error;
   }
@@ -218,10 +231,9 @@ export async function cleanupCopiedEntry(
     return result;
   }
 
-  const aliasGroup = state.aliasGroups.get(identityKey(manifest));
   const expected = aliasGroup?.expected ?? manifest;
   if (!sameIdentity(expected, entryIdentity(currentStat))) {
-    return "stale";
+    return aliasGroup ? poisonAliasGroup(aliasGroup) : "stale";
   }
   await fs.unlink(sourcePath);
   return aliasGroup

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -5,6 +5,16 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { guardedRename } from "./guarded-mutation.js";
+import {
+  assertSourceStillMatches,
+  cleanupCopiedEntry,
+  createCleanupCopiedEntryState,
+  entryIdentity,
+  sameIdentity,
+  sourceChangedError,
+  type CopiedEntryManifest,
+  type EntryIdentity,
+} from "./move-path-cleanup.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { registerTempPathForExit } from "./temp-cleanup.js";
 
@@ -31,25 +41,6 @@ export function moveCopyFallbackReasonForRenameError(
   }
   return undefined;
 }
-
-type EntryIdentity = {
-  ctimeMs: number;
-  dev: number;
-  ino: number;
-  mode: number;
-  mtimeMs: number;
-  nlink: number;
-  size: number;
-};
-
-type CopiedEntryManifest =
-  | (EntryIdentity & {
-      children: Array<{ name: string; manifest: CopiedEntryManifest }>;
-      kind: "directory";
-    })
-  | (EntryIdentity & { kind: "leaf" });
-
-type CleanupCopiedEntryResult = "removed" | "stale";
 
 const MAX_HARDLINK_PREFLIGHT_ENTRIES = 50_000;
 
@@ -106,59 +97,8 @@ async function assertCopyDestinationOutsideSource(sourcePath: string, targetPath
   }
 }
 
-function entryIdentity(stat: {
-  ctimeMs: number;
-  dev: number;
-  ino: number;
-  mode: number;
-  mtimeMs: number;
-  nlink: number;
-  size: number;
-}): EntryIdentity {
-  return {
-    ctimeMs: stat.ctimeMs,
-    dev: stat.dev,
-    ino: stat.ino,
-    mode: stat.mode,
-    mtimeMs: stat.mtimeMs,
-    nlink: stat.nlink,
-    size: stat.size,
-  };
-}
-
-function sameIdentity(a: EntryIdentity, b: EntryIdentity): boolean {
-  return (
-    a.dev === b.dev &&
-    a.ino === b.ino &&
-    a.mode === b.mode &&
-    a.nlink === b.nlink &&
-    a.size === b.size &&
-    a.mtimeMs === b.mtimeMs &&
-    a.ctimeMs === b.ctimeMs
-  );
-}
-
-function sameDirectoryNode(a: EntryIdentity, b: EntryIdentity): boolean {
-  return a.dev === b.dev && a.ino === b.ino;
-}
-
 function modeBits(mode: number): number {
   return mode & 0o777;
-}
-
-function sourceChangedError(sourcePath: string): Error {
-  return Object.assign(new Error(`Source changed during move fallback: ${sourcePath}`), {
-    code: "ESTALE",
-  });
-}
-
-async function assertSourceStillMatches(
-  sourcePath: string,
-  identity: EntryIdentity,
-): Promise<void> {
-  if (!sameIdentity(identity, entryIdentity(await fs.lstat(sourcePath)))) {
-    throw sourceChangedError(sourcePath);
-  }
 }
 
 async function chmodDirectoryPinned(directoryPath: string, mode: number): Promise<void> {
@@ -314,59 +254,6 @@ async function copyEntryWithManifest(
   return { ...identity, kind: "leaf" };
 }
 
-function mergeCleanupResults(
-  a: CleanupCopiedEntryResult,
-  b: CleanupCopiedEntryResult,
-): CleanupCopiedEntryResult {
-  return a === "stale" || b === "stale" ? "stale" : "removed";
-}
-
-async function cleanupCopiedEntry(
-  sourcePath: string,
-  manifest: CopiedEntryManifest,
-): Promise<CleanupCopiedEntryResult> {
-  let currentStat: Awaited<ReturnType<typeof fs.lstat>>;
-  try {
-    currentStat = await fs.lstat(sourcePath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
-      return "removed";
-    }
-    throw error;
-  }
-
-  if (manifest.kind === "directory") {
-    if (!currentStat.isDirectory() || !sameDirectoryNode(manifest, entryIdentity(currentStat))) {
-      return "stale";
-    }
-    // A same-inode directory can gain unrelated children after commit. Still
-    // clean manifest children so the fallback does not duplicate copied files.
-    let result: CleanupCopiedEntryResult = "removed";
-    for (const child of manifest.children) {
-      result = mergeCleanupResults(
-        result,
-        await cleanupCopiedEntry(path.join(sourcePath, child.name), child.manifest),
-      );
-    }
-    try {
-      await fs.rmdir(sourcePath);
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException | null)?.code;
-      if (code === "ENOTEMPTY" || code === "EEXIST") {
-        return "stale";
-      }
-      throw error;
-    }
-    return result;
-  }
-
-  if (!sameIdentity(manifest, entryIdentity(currentStat))) {
-    return "stale";
-  }
-  await fs.unlink(sourcePath);
-  return "removed";
-}
-
 export async function movePathWithCopyFallback(
   options: MovePathWithCopyFallbackOptions,
 ): Promise<void> {
@@ -418,12 +305,13 @@ export async function movePathWithCopyFallback(
       sourceHardlinks: options.sourceHardlinks ?? "allow",
       ...(rejectHardlinks ? { budget: { discovered: 1 } } : {}),
     });
+    const cleanupState = createCleanupCopiedEntryState(sourcePath, manifest);
     unregisterStaged.setIdentity(await fs.lstat(staged, { bigint: true }));
     await assertCopyDestinationOutsideSource(sourcePath, targetPath);
     await guardedRename({ from: staged, to: targetPath, assertBeforeRename });
     stagedCommitted = true;
     unregisterStaged();
-    const cleanupResult = await cleanupCopiedEntry(sourcePath, manifest);
+    const cleanupResult = await cleanupCopiedEntry(sourcePath, manifest, cleanupState);
     if (cleanupResult === "stale") {
       throw sourceChangedError(sourcePath);
     }

--- a/test/move-path-cross-device-hardlinks.test.ts
+++ b/test/move-path-cross-device-hardlinks.test.ts
@@ -1,0 +1,62 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { movePathWithCopyFallback } from "../src/move-path.js";
+
+const hasLinuxSharedMemory = process.platform === "linux" && fsSync.existsSync("/dev/shm");
+
+describe.runIf(hasLinuxSharedMemory)("real cross-device hardlink retirement", () => {
+  it.each([
+    ["default", undefined],
+    ["allow", "allow"],
+  ] as const)("retires every in-tree alias with sourceHardlinks=%s", async (_label, policy) => {
+    const sourceRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-hardlink-source-")),
+    );
+    const targetRoot = await fs.realpath(
+      await fs.mkdtemp(path.join("/dev/shm", "fs-safe-hardlink-target-")),
+    );
+    try {
+      expect((await fs.stat(sourceRoot)).dev).not.toBe((await fs.stat(targetRoot)).dev);
+      const source = path.join(sourceRoot, "source");
+      const target = path.join(targetRoot, "target");
+      const first = path.join(source, "a.txt");
+      const second = path.join(source, "b.txt");
+      const nested = path.join(source, "nested");
+      const third = path.join(nested, "c.txt");
+      const external = path.join(sourceRoot, "external.txt");
+      await fs.mkdir(source);
+      await fs.mkdir(nested);
+      await fs.writeFile(first, "shared");
+      await fs.link(first, second);
+      await fs.link(first, third);
+      await fs.link(first, external);
+
+      await movePathWithCopyFallback({
+        from: source,
+        ...(policy ? { sourceHardlinks: policy } : {}),
+        to: target,
+      });
+
+      await expect(fs.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readFile(path.join(target, "a.txt"), "utf8")).resolves.toBe(
+        "shared",
+      );
+      await expect(fs.readFile(path.join(target, "b.txt"), "utf8")).resolves.toBe(
+        "shared",
+      );
+      await expect(
+        fs.readFile(path.join(target, "nested", "c.txt"), "utf8"),
+      ).resolves.toBe("shared");
+      await expect(fs.readFile(external, "utf8")).resolves.toBe("shared");
+      expect((await fs.stat(external)).nlink).toBe(1);
+    } finally {
+      await Promise.all([
+        fs.rm(sourceRoot, { force: true, recursive: true }),
+        fs.rm(targetRoot, { force: true, recursive: true }),
+      ]);
+    }
+  });
+});

--- a/test/move-path-regression.test.ts
+++ b/test/move-path-regression.test.ts
@@ -219,6 +219,75 @@ describe("movePathWithCopyFallback regressions", () => {
     await expect(fsp.stat(dest)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("retires allowed source aliases after copy fallback", async () => {
+    const base = await tempRoot("fs-safe-move-hardlink-aliases-");
+    const source = path.join(base, "source");
+    const dest = path.join(base, "dest");
+    const first = path.join(source, "a.txt");
+    const second = path.join(source, "b.txt");
+    const external = path.join(base, "external.txt");
+    await fsp.mkdir(source);
+    await fsp.writeFile(first, "shared");
+    await fsp.link(first, second);
+    await fsp.link(first, external);
+    spyOnRename(async (from, to, rename) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+      }
+      await rename(from, to);
+    });
+
+    await movePathWithCopyFallback({
+      from: source,
+      sourceHardlinks: "allow",
+      to: dest,
+    });
+
+    await expect(fsp.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fsp.readFile(path.join(dest, "a.txt"), "utf8")).resolves.toBe("shared");
+    await expect(fsp.readFile(path.join(dest, "b.txt"), "utf8")).resolves.toBe("shared");
+    await expect(fsp.readFile(external, "utf8")).resolves.toBe("shared");
+    expect((await fsp.stat(external)).nlink).toBe(1);
+  });
+
+  it("keeps external hardlink changes stale during alias retirement", async () => {
+    const base = await tempRoot("fs-safe-move-hardlink-alias-race-");
+    const source = path.join(base, "source");
+    const dest = path.join(base, "dest");
+    const first = path.join(source, "a.txt");
+    const second = path.join(source, "b.txt");
+    const external = path.join(base, "external.txt");
+    await fsp.mkdir(source);
+    await fsp.writeFile(first, "shared");
+    await fsp.link(first, second);
+    spyOnRename(async (from, to, rename) => {
+      if (from === source && to === dest) {
+        throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+      }
+      await rename(from, to);
+    });
+    const realUnlink = fsp.unlink.bind(fsp);
+    let remainingPath: string | undefined;
+    vi.spyOn(fsp, "unlink").mockImplementation(async (target) => {
+      const targetPath = String(target);
+      await realUnlink(target);
+      if (!remainingPath && path.dirname(targetPath) === source) {
+        remainingPath = targetPath === first ? second : first;
+        await fsp.link(remainingPath, external);
+      }
+    });
+
+    await expect(
+      movePathWithCopyFallback({ from: source, to: dest }),
+    ).rejects.toMatchObject({ code: "ESTALE" });
+
+    expect(remainingPath).toBeDefined();
+    await expect(fsp.readFile(remainingPath!, "utf8")).resolves.toBe("shared");
+    await expect(fsp.readFile(external, "utf8")).resolves.toBe("shared");
+    await expect(fsp.readFile(path.join(dest, "a.txt"), "utf8")).resolves.toBe("shared");
+    await expect(fsp.readFile(path.join(dest, "b.txt"), "utf8")).resolves.toBe("shared");
+  });
+
   itWin32("falls back to copy/remove when rename is denied with EPERM", async () => {
     const base = await tempRoot("fs-safe-move-eperm-");
     const source = path.join(base, "source.txt");

--- a/test/move-path-regression.test.ts
+++ b/test/move-path-regression.test.ts
@@ -256,10 +256,12 @@ describe("movePathWithCopyFallback regressions", () => {
     const dest = path.join(base, "dest");
     const first = path.join(source, "a.txt");
     const second = path.join(source, "b.txt");
+    const third = path.join(source, "c.txt");
     const external = path.join(base, "external.txt");
     await fsp.mkdir(source);
     await fsp.writeFile(first, "shared");
     await fsp.link(first, second);
+    await fsp.link(first, third);
     spyOnRename(async (from, to, rename) => {
       if (from === source && to === dest) {
         throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
@@ -267,13 +269,17 @@ describe("movePathWithCopyFallback regressions", () => {
       await rename(from, to);
     });
     const realUnlink = fsp.unlink.bind(fsp);
-    let remainingPath: string | undefined;
+    let removedPath: string | undefined;
     vi.spyOn(fsp, "unlink").mockImplementation(async (target) => {
       const targetPath = String(target);
       await realUnlink(target);
-      if (!remainingPath && path.dirname(targetPath) === source) {
-        remainingPath = targetPath === first ? second : first;
-        await fsp.link(remainingPath, external);
+      if (!removedPath && path.dirname(targetPath) === source) {
+        removedPath = targetPath;
+        const remainingPath = [first, second, third].find(
+          (candidate) => candidate !== targetPath,
+        );
+        expect(remainingPath).toBeDefined();
+        await fsp.link(remainingPath!, external);
       }
     });
 
@@ -281,11 +287,18 @@ describe("movePathWithCopyFallback regressions", () => {
       movePathWithCopyFallback({ from: source, to: dest }),
     ).rejects.toMatchObject({ code: "ESTALE" });
 
-    expect(remainingPath).toBeDefined();
-    await expect(fsp.readFile(remainingPath!, "utf8")).resolves.toBe("shared");
+    expect(removedPath).toBeDefined();
+    const remainingNames = (await fsp.readdir(source)).toSorted();
+    expect(remainingNames).toHaveLength(2);
+    expect(remainingNames).not.toContain(path.basename(removedPath!));
+    for (const name of remainingNames) {
+      await expect(fsp.readFile(path.join(source, name), "utf8")).resolves.toBe("shared");
+    }
     await expect(fsp.readFile(external, "utf8")).resolves.toBe("shared");
+    expect((await fsp.stat(external)).nlink).toBe(3);
     await expect(fsp.readFile(path.join(dest, "a.txt"), "utf8")).resolves.toBe("shared");
     await expect(fsp.readFile(path.join(dest, "b.txt"), "utf8")).resolves.toBe("shared");
+    await expect(fsp.readFile(path.join(dest, "c.txt"), "utf8")).resolves.toBe("shared");
   });
 
   itWin32("falls back to copy/remove when rename is denied with EPERM", async () => {


### PR DESCRIPTION
## Summary

Cross-device fallback copies a complete source tree, publishes it, then retires only source entries whose manifest identities still match. When two allowed source names were hardlinks to the same inode, unlinking the first name legitimately reduced the second name's `nlink` and changed its `ctime`. The second manifest then appeared stale, so the move returned `ESTALE` after publishing and left source residue.

Give cleanup an alias-group receipt. Before publication, manifests for repeated in-tree inode identities must agree. After each exact source alias is unlinked, cleanup observes another still-manifested alias, requires the same device/inode/mode/size/mtime, an exact one-link decrement, and nondecreasing ctime, then adopts that complete observed identity for the next retirement. No `nlink` or `ctime` field is globally ignored. Unexpected external link-count, identity, mode, size, or mtime changes poison the alias group, produce `ESTALE`, and preserve every remaining unverified path in that group.

The cleanup owner and manifest identity helpers move into `src/move-path-cleanup.ts`, reducing `move-path.ts` by 112 net lines and keeping both files within size budgets. Overall production delta is +254/−124 (net +130); focused tests add 144 lines, including the terminal stale-group regression.

## Real cross-device proof

Before the repair, actual Linux moves from `/tmp` to `/dev/shm` confirmed distinct device IDs. Both default and explicit `sourceHardlinks: "allow"` published complete destination bytes, then returned `ESTALE` and left one source alias; independent-inode controls passed.

A fresh physical install of the packed candidate passes 24 observations across Linux arm64, exact Node 22.0.0, 22.23.2, and 24.20.0, and native configuration `off`/`require`. Every run confirms distinct source/destination devices and exercises:

- default and explicit allow policies;
- three in-tree hardlink names, including one in a nested directory;
- an external hardlink that remains intact with final link count one;
- complete destination bytes and complete source retirement;
- independent-inode controls under the same devices.

The move path is pure JavaScript and all runs recorded zero loaded native objects; `require` therefore proves configuration compatibility, not native dispatch. Root artifact integrity: `sha512-sP47iS7U1AABLk15ibksdXz6b5OKA4Gx+4LssSxEqdVFd0sz2SJ1EbQzoXoMI5gtzK35wWWKD6CBGYXXLG5JlA==`. Package version remains 0.7.2; no release is included.

Candidate tree: `4b8ed6573d65880f54ddcb8101fd0f00306195f4`.

## Validation

- Complete local move/fallback surface: 47 passed / 3 skipped on macOS.
- Clean Linux Node 22 and Node 24 containers: 19 passed / 1 platform skip each; the two real `/tmp` → `/dev/shm` tests ran and passed.
- Three-alias external hardlink injection during retirement still returns `ESTALE`; only the first exact alias is retired, the poisoned group's two remaining source names and external alias are preserved, and the committed destination remains complete.
- `CI=1 pnpm check`: 6,823 passed / 79 skipped on macOS (the two Linux-only real-device cases are explicit skips).
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: physical npm/pnpm consumers, optional omission, and missing-binary behavior passed.
- Build, docs, file-size, filesystem-boundary, package, and `git diff --check` gates passed.
- Initial Codex autoreview was scoped-clean at P0 (0.93). ClawSweeper then identified stale-receipt reuse after a failed transition; alias groups are now terminally poisoned on any stale member or transition. Final autoreview was scoped-clean at P0 (0.97).

Exact-head cross-platform CI and ClawSweeper review are required before merge. Linux CI reruns the real distinct-device regression; Windows exercises the injected fallback and external-mutation fences.
