### PR TITLE
fix(atomic): move dangling symlinks through fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Move dangling symlink sources through staged and cross-device fallback without dereferencing their absent referents, while retaining same-entry, descendant, and source-substitution guards.
 - Retire every copied source name after cross-device moves with allowed in-tree hardlink aliases, while preserving `ESTALE` fences for unverified external mutations.
 - Reject dangling symlink leaves and ancestors under strict absolute-write and missing local-root resolution instead of treating unresolved aliases as safe missing paths.
 - Accept canonical in-root absolute paths in `Root.readAbsolute()` and `Root.reader()` when the Root was configured through a directory symlink or Windows junction.

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -184,7 +184,9 @@ an identity-bound process-exit cleanup retry.
 On POSIX, staged directory modes are applied through no-follow directory
 descriptors; on Windows, Node cannot portably open those descriptors and no
 pathname `chmod` fallback is attempted, so directory modes remain subject to
-Windows' `mkdir(mode)` behavior.
+Windows' `mkdir(mode)` behavior. Symlink sources are copied as links rather than
+followed, including when the referent is absent; only a source proven to be a
+directory is dereferenced for the destination-descendant guard.
 
 ```ts
 import { movePathWithCopyFallback } from "@openclaw/fs-safe/atomic";

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -87,14 +87,34 @@ function isSameOrDescendant(parentPath: string, candidatePath: string): boolean 
   );
 }
 
-async function assertCopyDestinationOutsideSource(sourcePath: string, targetPath: string) {
-  const sourceReal = await fs.realpath(sourcePath);
+async function assertCopyDestinationOutsideSource(
+  sourcePath: string,
+  targetPath: string,
+  expectedIdentity?: EntryIdentity,
+): Promise<EntryIdentity> {
+  const sourceStat = await fs.lstat(sourcePath);
+  const sourceIdentity = entryIdentity(sourceStat);
+  if (expectedIdentity && !sameIdentity(expectedIdentity, sourceIdentity)) {
+    throw sourceChangedError(sourcePath);
+  }
+  const normalizedSource = path.resolve(sourcePath);
   const normalizedTarget = path.resolve(targetPath);
-  const targetParentReal = await fs.realpath(path.dirname(normalizedTarget));
+  const [sourceParentReal, targetParentReal] = await Promise.all([
+    fs.realpath(path.dirname(normalizedSource)),
+    fs.realpath(path.dirname(normalizedTarget)),
+  ]);
+  const sourceCandidate = path.join(sourceParentReal, path.basename(normalizedSource));
   const targetCandidate = path.join(targetParentReal, path.basename(normalizedTarget));
-  if (isSameOrDescendant(sourceReal, targetCandidate)) {
+  const sourceBoundary = sourceStat.isDirectory()
+    ? await fs.realpath(sourcePath)
+    : sourceCandidate;
+  const unsafeTarget = sourceStat.isDirectory()
+    ? isSameOrDescendant(sourceBoundary, targetCandidate)
+    : path.relative(sourceBoundary, targetCandidate) === "";
+  if (unsafeTarget) {
     throw new FsSafeError("invalid-path", "Move destination must not be inside the source");
   }
+  return sourceIdentity;
 }
 
 function modeBits(mode: number): number {
@@ -199,9 +219,13 @@ async function copyEntryWithManifest(
     sourceHardlinks: "allow" | "reject";
     budget?: { discovered: number };
   },
+  expectedIdentity?: EntryIdentity,
 ): Promise<CopiedEntryManifest> {
   const sourceStat = await fs.lstat(from);
   const identity = entryIdentity(sourceStat);
+  if (expectedIdentity && !sameIdentity(expectedIdentity, identity)) {
+    throw sourceChangedError(from);
+  }
 
   if (sourceStat.isSymbolicLink()) {
     await fs.symlink(await fs.readlink(from), to);
@@ -295,19 +319,24 @@ export async function movePathWithCopyFallback(
     // Commit a fresh inode through the copy path so a post-scan hardlink can
     // never become the published target; the copy loop fences nlink again.
   }
-  await assertCopyDestinationOutsideSource(sourcePath, targetPath);
+  const sourceIdentity = await assertCopyDestinationOutsideSource(sourcePath, targetPath);
   const targetDir = path.dirname(targetPath);
   const staged = path.join(targetDir, `.fs-safe-move-${process.pid}-${randomUUID()}.tmp`);
   const unregisterStaged = registerTempPathForExit(staged, { recursive: true });
   let stagedCommitted = false;
   try {
-    const manifest = await copyEntryWithManifest(sourcePath, staged, {
-      sourceHardlinks: options.sourceHardlinks ?? "allow",
-      ...(rejectHardlinks ? { budget: { discovered: 1 } } : {}),
-    });
+    const manifest = await copyEntryWithManifest(
+      sourcePath,
+      staged,
+      {
+        sourceHardlinks: options.sourceHardlinks ?? "allow",
+        ...(rejectHardlinks ? { budget: { discovered: 1 } } : {}),
+      },
+      sourceIdentity,
+    );
     const cleanupState = createCleanupCopiedEntryState(sourcePath, manifest);
     unregisterStaged.setIdentity(await fs.lstat(staged, { bigint: true }));
-    await assertCopyDestinationOutsideSource(sourcePath, targetPath);
+    await assertCopyDestinationOutsideSource(sourcePath, targetPath, manifest);
     await guardedRename({ from: staged, to: targetPath, assertBeforeRename });
     stagedCommitted = true;
     unregisterStaged();

--- a/test/move-path-dangling-symlink.test.ts
+++ b/test/move-path-dangling-symlink.test.ts
@@ -1,0 +1,103 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { movePathWithCopyFallback } from "../src/move-path.js";
+import { expectFsSafeError } from "./helpers/security.js";
+import { itPosix, useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function expectMovedDanglingLink(source: string, target: string): Promise<void> {
+  await expect(fs.lstat(source)).rejects.toMatchObject({ code: "ENOENT" });
+  await expect(fs.readlink(target)).resolves.toBe("absent-referent");
+  await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+}
+
+describe("dangling symlink move fallback", () => {
+  itPosix("moves the link itself through the forced staged route", async () => {
+    const root = await tempRoot("fs-safe-move-dangling-staged-");
+    const source = path.join(root, "source-link");
+    const target = path.join(root, "target-link");
+    await fs.symlink("absent-referent", source, "file");
+
+    await movePathWithCopyFallback({
+      from: source,
+      sourceHardlinks: "reject",
+      to: target,
+    });
+
+    await expectMovedDanglingLink(source, target);
+  });
+
+  itPosix("moves the link itself after an EXDEV rename failure", async () => {
+    const root = await tempRoot("fs-safe-move-dangling-exdev-");
+    const source = path.join(root, "source-link");
+    const target = path.join(root, "target-link");
+    await fs.symlink("absent-referent", source, "file");
+    const rename = fs.rename.bind(fs);
+    vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+      if (from === source && to === target) {
+        throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+      }
+      await rename(from, to);
+    });
+
+    await movePathWithCopyFallback({ from: source, to: target });
+
+    await expectMovedDanglingLink(source, target);
+  });
+
+  itPosix("still rejects the same entry through an aliased parent", async () => {
+    const root = await tempRoot("fs-safe-move-dangling-same-entry-");
+    const realParent = path.join(root, "real");
+    const aliasParent = path.join(root, "alias");
+    const realPath = path.join(realParent, "source-link");
+    await fs.mkdir(realParent);
+    await fs.symlink(realParent, aliasParent, "dir");
+    await fs.symlink("absent-referent", realPath, "file");
+
+    await expectFsSafeError(
+      movePathWithCopyFallback({
+        from: path.join(aliasParent, "source-link"),
+        sourceHardlinks: "reject",
+        to: realPath,
+      }),
+      "invalid-path",
+    );
+    await expect(fs.readlink(realPath)).resolves.toBe("absent-referent");
+  });
+});
+
+const hasLinuxSharedMemory = process.platform === "linux" && fsSync.existsSync("/dev/shm");
+
+describe.runIf(hasLinuxSharedMemory)("real cross-device dangling symlink move", () => {
+  it("moves the link without dereferencing its absent referent", async () => {
+    const sourceRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-dangling-source-")),
+    );
+    const targetRoot = await fs.realpath(
+      await fs.mkdtemp(path.join("/dev/shm", "fs-safe-dangling-target-")),
+    );
+    try {
+      expect((await fs.stat(sourceRoot)).dev).not.toBe((await fs.stat(targetRoot)).dev);
+      const source = path.join(sourceRoot, "source-link");
+      const target = path.join(targetRoot, "target-link");
+      await fs.symlink("absent-referent", source, "file");
+
+      await movePathWithCopyFallback({ from: source, to: target });
+
+      await expectMovedDanglingLink(source, target);
+    } finally {
+      await Promise.all([
+        fs.rm(sourceRoot, { force: true, recursive: true }),
+        fs.rm(targetRoot, { force: true, recursive: true }),
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The staged-copy path already copies symlink entries with `readlink()`/`symlink()`, but its destination-descendant guard called `realpath()` on every top-level source first. A dangling symlink therefore failed with raw `ENOENT` before the copy branch could move the link itself. This affected both forced staging (`sourceHardlinks: "reject"`) and genuine cross-device fallback.

Canonicalize source and target parents to detect the same directory entry without dereferencing the source leaf. Only a source proven by `lstat` to be a directory is dereferenced for descendant containment. Carry that initial source identity into the root copy and compare the copied manifest again during the pre-commit descendant check, so a source substituted after the new guard still fails `ESTALE` before publication.

Same-entry paths through aliased parents and directory descendants remain `invalid-path`; ordinary direct rename behavior is unchanged. No raw fallback or weakened symlink policy is added. Production delta is +39/−10 (net +29); focused tests add 103 lines.

## Real cross-device proof

Physical Linux baseline showed ordinary same-device rename moving the dangling link, while the forced staged route failed with `ENOENT` from source `realpath()` and left the source untouched.

A fresh physical install of the packed candidate passes 36 observations across Linux arm64, exact Node 22.0.0, 22.23.2, and 24.20.0, and native configuration `off`/`require`. Every run confirms distinct `/tmp` and `/dev/shm` devices and exercises:

- direct same-device rename;
- forced same-device staging with `sourceHardlinks: "reject"`;
- actual cross-device fallback under default and explicit allow policies;
- exact dangling link text, removed source entry, and still-absent referent;
- same-entry rejection through an aliased parent;
- unchanged directory-descendant rejection.

The move path is pure JavaScript and all runs recorded zero loaded native objects; `require` therefore proves configuration compatibility, not native dispatch. Root artifact integrity: `sha512-amszG2LlYW+A2xZg3XOdZ+Dy+61SsLcTXT8P9eO5NIRz1eooCm0uhkmG/TiiQnyksCpqAoNqm4pKtPbF3iRWHQ==`. Package version remains 0.7.2; no release is included.

Candidate tree: `b0c0073323c9138ed62fd44f74c8b4dc874cebb3`.

## Validation

- Focused dangling, substitution, authority, and mode suites: 43 passed / 2 platform skips on macOS.
- Clean Linux Node 22 and Node 24 containers: 21 passed / 1 Windows-only skip each; all four dangling-link tests ran, including real `/tmp` → `/dev/shm` fallback.
- `CI=1 pnpm check`: 6,826 passed / 80 skipped on macOS (the Linux-only real-device case is an explicit skip).
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: physical npm/pnpm consumers, optional omission, and missing-binary behavior passed.
- Build, docs, file-size, filesystem-boundary, package, and `git diff --check` gates passed.
- Independent Codex autoreview was scoped-clean at P0 (0.97).

Exact-head cross-platform CI and ClawSweeper review are required before merge. Linux CI reruns the real distinct-device case; other platforms cover the forced staging and source-substitution paths where symlink support is available.
