### PR TITLE
fix(durability): normalize exclusive copy modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Normalize every exclusive-copy target to mode `0o600` through its owned descriptor, including under restrictive umasks and native macOS clone staging.
 - Move dangling symlink sources through staged and cross-device fallback without dereferencing their absent referents, while retaining same-entry, descendant, and source-substitution guards.
 - Retire every copied source name after cross-device moves with allowed in-tree hardlink aliases, while preserving `ESTALE` fences for unverified external mutations.
 - Reject dangling symlink leaves and ancestors under strict absolute-write and missing local-root resolution instead of treating unresolved aliases as safe missing paths.

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -142,8 +142,9 @@ success. `parentReceipt`, when supplied, must name the target's direct parent.
 With a native binding, the copy fallback first attempts a copy-on-write clone
 (`fclonefileat` on macOS, `FICLONE` on Linux), then Linux
 `copy_file_range`, and finally the existing JavaScript byte loop. Every route
-creates the target exclusively, normalizes its mode to `0o600`, and goes
-through the same post-copy identity and SHA-256 fencing. Hashing uses an async
+creates the target exclusively, applies mode `0o600` through its owned
+descriptor independently of the process umask, and goes through the same
+post-copy identity and SHA-256 fencing. Hashing uses an async
 native task when available, so large verification reads do not occupy the
 JavaScript event loop.
 

--- a/native/src/unix.rs
+++ b/native/src/unix.rs
@@ -691,6 +691,19 @@ pub fn clone_file_exclusive(
             }
         })
         .ok_or_else(|| native_error("EIO", "create private clone staging directory"))?;
+    if let Err(error) = rustix::fs::chmodat(
+        borrowed(target_root_fd),
+        stage_path.as_str(),
+        Mode::from_bits_retain(0o700),
+        AtFlags::SYMLINK_NOFOLLOW,
+    ) {
+        let _ = rustix::fs::unlinkat(
+            borrowed(target_root_fd),
+            stage_path.as_str(),
+            AtFlags::REMOVEDIR,
+        );
+        return Err(os_error(error, "normalize private clone staging directory"));
+    }
     let stage_fd = match open_beneath(
         target_root_fd,
         &stage_path,
@@ -709,6 +722,14 @@ pub fn clone_file_exclusive(
             return Err(error);
         }
     };
+    if let Err(error) = rustix::fs::fchmod(stage_fd.as_fd(), Mode::from_bits_retain(0o700)) {
+        let _ = rustix::fs::unlinkat(
+            borrowed(target_root_fd),
+            stage_path.as_str(),
+            AtFlags::REMOVEDIR,
+        );
+        return Err(os_error(error, "normalize private clone staging directory"));
+    }
 
     let payload = CString::new("payload").unwrap();
     // SAFETY: descriptors are borrowed for this call and payload is NUL-terminated.

--- a/src/publish-file.ts
+++ b/src/publish-file.ts
@@ -160,9 +160,11 @@ async function copyPinnedSource(params: {
       }
 
       let target: FileHandle | undefined;
-      const createdIdentity = fsSync.fstatSync(nativeFd, { bigint: true });
+      let createdIdentity = fsSync.fstatSync(nativeFd, { bigint: true });
       rememberCreatedTarget(params.failure, createdIdentity, "copy-verify");
       try {
+        fsSync.fchmodSync(nativeFd, 0o600);
+        createdIdentity = fsSync.fstatSync(nativeFd, { bigint: true });
         await getFsSafeTestHooks()?.afterPublishTargetCreated?.(
           "exclusive-copy",
           params.targetPath,
@@ -198,9 +200,11 @@ async function copyPinnedSource(params: {
   }
 
   const target = await fs.open(params.targetPath, "wx+", 0o600);
-  const exactIdentity = await target.stat({ bigint: true });
-  rememberCreatedTarget(params.failure, exactIdentity, "copy-verify");
+  const createdIdentity = await target.stat({ bigint: true });
+  rememberCreatedTarget(params.failure, createdIdentity, "copy-verify");
   try {
+    await target.chmod(0o600);
+    const exactIdentity = await target.stat({ bigint: true });
     await getFsSafeTestHooks()?.afterPublishTargetCreated?.(
       "exclusive-copy",
       params.targetPath,

--- a/test/native-publish-equivalence.test.ts
+++ b/test/native-publish-equivalence.test.ts
@@ -209,35 +209,46 @@ const publishBackends = native
   : (["javascript"] as const);
 
 describe.each(publishBackends)("%s publication fallback", (backend) => {
-  it("publishes identical bytes with an exclusive 0600 target", async () => {
-    const root = await tempRoot();
-    const sourcePath = path.join(root, "source");
-    const targetPath = path.join(root, "target");
-    const payload = Buffer.alloc(256 * 1024, 0x5a);
-    await fs.writeFile(sourcePath, payload, { mode: 0o644 });
+  it.each([0o022, 0o200, 0o777])(
+    "publishes identical bytes with an exclusive 0600 target under umask %s",
+    async (umask) => {
+      const root = await tempRoot();
+      const sourcePath = path.join(root, "source");
+      const targetPath = path.join(root, "target");
+      const payload = Buffer.alloc(256 * 1024, 0x5a);
+      await fs.writeFile(sourcePath, payload, { mode: 0o644 });
 
-    if (backend === "native") {
-      __setNativeLoaderForTest(() => ({
-        ...native!,
-        linkBeneath() {
-          throw Object.assign(new Error("force copy"), { code: "EXDEV" });
-        },
-      }));
-      configureFsSafeNative({ mode: "require" });
-    } else {
-      configureFsSafeNative({ mode: "off" });
-      vi.spyOn(fs, "link").mockRejectedValue(Object.assign(new Error("force copy"), { code: "EXDEV" }));
-    }
+      if (backend === "native") {
+        __setNativeLoaderForTest(() => ({
+          ...native!,
+          linkBeneath() {
+            throw Object.assign(new Error("force copy"), { code: "EXDEV" });
+          },
+        }));
+        configureFsSafeNative({ mode: "require" });
+      } else {
+        configureFsSafeNative({ mode: "off" });
+        vi.spyOn(fs, "link").mockRejectedValue(
+          Object.assign(new Error("force copy"), { code: "EXDEV" }),
+        );
+      }
 
-    const result = await publishFileExclusive({
-      sourcePath,
-      targetPath,
-      strategy: "link-or-copy",
-    });
-    expect(result.method).toBe("exclusive-copy");
-    await expect(fs.readFile(targetPath)).resolves.toEqual(payload);
-    if (process.platform !== "win32") {
-      expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o600);
-    }
-  });
+      const previousUmask = process.umask(umask);
+      let result: Awaited<ReturnType<typeof publishFileExclusive>>;
+      try {
+        result = await publishFileExclusive({
+          sourcePath,
+          targetPath,
+          strategy: "link-or-copy",
+        });
+      } finally {
+        process.umask(previousUmask);
+      }
+      expect(result.method).toBe("exclusive-copy");
+      await expect(fs.readFile(targetPath)).resolves.toEqual(payload);
+      if (process.platform !== "win32") {
+        expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o600);
+      }
+    },
+  );
 });

--- a/test/publish-file-failure.test.ts
+++ b/test/publish-file-failure.test.ts
@@ -288,6 +288,73 @@ describe("exclusive publication failure fencing", () => {
     await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("rolls back when JavaScript copy mode normalization fails", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const root = await tempRoot("fs-safe-publish-copy-mode-failure-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "content");
+    vi.spyOn(fs, "link").mockRejectedValueOnce(
+      Object.assign(new Error("force copy"), { code: "EXDEV" }),
+    );
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await realOpen(...args);
+      if (String(args[0]) === target && args[1] === "wx+") {
+        vi.spyOn(handle, "chmod").mockRejectedValueOnce(
+          Object.assign(new Error("mode denied"), { code: "EACCES" }),
+        );
+      }
+      return handle;
+    });
+
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-or-copy" }),
+    ).rejects.toMatchObject({
+      code: "helper-failed",
+      details: { phase: "copy-verify", cleanup: "removed" },
+    });
+    await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.runIf(Boolean(native))("rolls back when native copy mode normalization fails", async () => {
+    const root = await tempRoot("fs-safe-publish-native-mode-failure-");
+    const source = path.join(root, "source");
+    const target = path.join(root, "target");
+    await fs.writeFile(source, "content");
+    let targetFd: number | undefined;
+    __setNativeLoaderForTest(() => ({
+      ...native!,
+      linkBeneath() {
+        throw Object.assign(new Error("force clone"), { code: "EXDEV" });
+      },
+      cloneFileExclusive() {
+        fsSync.copyFileSync(source, target, fsSync.constants.COPYFILE_EXCL);
+        targetFd = fsSync.openSync(target, "r+");
+        return targetFd;
+      },
+    }));
+    configureFsSafeNative({ mode: "require" });
+    const realFchmod = fsSync.fchmodSync.bind(fsSync);
+    vi.spyOn(fsSync, "fchmodSync").mockImplementation((fd, mode) => {
+      if (fd === targetFd) {
+        throw Object.assign(new Error("mode denied"), { code: "EACCES" });
+      }
+      return realFchmod(fd, mode);
+    });
+
+    await expect(
+      publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-or-copy" }),
+    ).rejects.toMatchObject({
+      code: "helper-failed",
+      details: { phase: "copy-verify", cleanup: "removed" },
+    });
+    await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(() => fsSync.fstatSync(targetFd!)).toThrow(
+      expect.objectContaining({ code: "EBADF" }),
+    );
+  });
+
   it("rolls back when an exclusive copy cannot make write progress", async () => {
     configureFsSafeNative({ mode: "off" });
     const root = await tempRoot("fs-safe-publish-copy-no-progress-");


### PR DESCRIPTION
## Summary

Every exclusive-copy route is documented to publish mode `0o600`, but JavaScript creation relied only on `open(..., 0o600)`, so a restrictive process umask could produce `0o400` or `0o000`. The owned target descriptor remained writable, yet the result returned success without normalizing its final mode. Native Linux already normalized the returned descriptor; macOS clone staging had a related earlier failure where the private staging directory itself could lose owner permissions to the umask before `fclonefileat` ran.

After exclusive target creation, record the initial identity for rollback, apply `0o600` through the live target descriptor, and capture the normalized exact identity before hooks, hashing, and publication verification. Native results receive the same JavaScript-side descriptor normalization as defense in depth. On macOS, normalize the randomized private clone staging directory relative to the authenticated owned parent before opening it, then reapply `0o700` through its descriptor before cloning.

If descriptor mode normalization fails, the existing exact-identity cleanup removes only the created target and reports cleanup `removed`. Hardlink and rename strategies are unchanged. Production delta is +28/−3 (net +25); focused tests add 78 net lines.

## Physical proof

Actual Linux baseline across distinct `/tmp` and `/dev/shm` devices returned `exclusive-copy` with correct bytes but mode `0o400` under umask `0o200`; the `0o022` control produced `0o600`.

A fresh physical install of the packed candidate passes 24 Linux arm64 observations across exact Node 22.0.0, 22.23.2, and 24.20.0, native `off` and `require`, and umasks `0o022`, `0o077`, `0o200`, and `0o777`. Every target is exactly `0o600`, contains exact bytes, has one link, and leaves the source intact. Off loads no native binary; required runs record the actual Linux arm64 binding.

The rebuilt packed macOS arm64 native binding also passes 9 direct clone observations across the same Node versions and umasks `0o022`, `0o200`, and `0o777`. Every cloned target is `0o600`, preserves exact bytes, and leaves no private clone-stage residue. Root artifact integrity: `sha512-c37OLjM7eRvEBID9sJmjB9fL8+JVqi7bSj57x1/fGtWGtcOJGdQ2LvbBoYCinc1fLFqUp5yCC9pr1SIj3IfD9w==`. Host-native artifact integrity: `sha512-rVagxWQ6WaixgNqa+i+p1lWr7Ivxc6878DB0lxRbvvx4Mb10l1qmJxbxWNMkyPkU4tldezDO7cIqpb3It/WWEA==`. Package version remains 0.7.2; no release is included.

Candidate tree: `ca2c2017c90075afb12ec47f07b00f2be752933c`.

### Inspectable packed-candidate transcript

The source-blind probes imported only the physically installed package subpaths and asserted the public result, exact bytes, source preservation, target mode/link count, distinct source/target devices, loaded shared objects, and clone-stage residue.

Linux arm64, Node 22.0.0, native required, source device 53 and target device 62:

```text
loaded: @openclaw/fs-safe-linux-arm64-gnu/fs-safe-native.node
umask 022 -> method exclusive-copy, mode 600, bytes PAYLOAD, source preserved, pass
umask 077 -> method exclusive-copy, mode 600, bytes PAYLOAD, source preserved, pass
umask 200 -> method exclusive-copy, mode 600, bytes PAYLOAD, source preserved, pass
umask 777 -> method exclusive-copy, mode 600, bytes PAYLOAD, source preserved, pass
```

The native-off lane for the same runtime loaded zero `.node` objects and returned the same four passing rows. The same off/require matrix passed under Node 22.23.2 and 24.20.0: 24/24 total observations.

macOS arm64 direct native clone, Node 24.20.0:

```text
loaded: @openclaw/fs-safe-darwin-arm64/fs-safe-native.node
umask 022 -> mode 600, bytes PAYLOAD, clone-stage residue 0, pass
umask 200 -> mode 600, bytes PAYLOAD, clone-stage residue 0, pass
umask 777 -> mode 600, bytes PAYLOAD, clone-stage residue 0, pass
```

The same three rows passed under Node 22.0.0 and 22.23.2: 9/9 total observations. The JavaScript and native descriptor-chmod failure regressions both returned `helper-failed` at phase `copy-verify`, reported cleanup `removed`, left no target, and verified the native descriptor was closed.

## Validation

- Focused native/JavaScript publication and failure suites: 44 passed / 1 skipped.
- Mode matrices cover both backends under umasks `0o022`, `0o200`, and `0o777`; JavaScript/Linux physical proof additionally covers `0o077`.
- JavaScript and native descriptor-chmod failure tests both verify `copy-verify` failure, exact target rollback, and closed native descriptors.
- Native Rust suite: 69 passed; rebuilt release binding exercised directly.
- `CI=1 pnpm check`: 6,832 passed / 80 skipped.
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: physical npm/pnpm consumers, optional omission, and missing-binary behavior passed.
- Build, docs, file-size, filesystem-boundary, package, and `git diff --check` gates passed.
- Independent Codex autoreview was scoped-clean at P0 (0.98).
- Exact-head CI passed Linux, macOS, Windows, musl, native, package, Cargo clippy/audit, CodeQL, coverage, merged coverage, and benchmarks.
