### PR TITLE
fix(writes): prevent FIFO admission stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Prevent no-reader FIFOs from stalling POSIX `Root.openWritable()` and async/sync regular-file append admission, preserving regular-file write semantics and existing-target cleanup fencing.
 - Normalize every exclusive-copy target to mode `0o600` through its owned descriptor, including under restrictive umasks and native macOS clone staging.
 - Move dangling symlink sources through staged and cross-device fallback without dereferencing their absent referents, while retaining same-entry, descendant, and source-substitution guards.
 - Retire every copied source name after cross-device moves with allowed in-tree hardlink aliases, while preserving `ESTALE` fences for unverified external mutations.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ await using opened = await fs.openWritable("logs/current.log", { writeMode: "app
 
 `nonBlockingRead` remains as a compatibility hint in `RootDefaults`. Safe read/open operations already use nonblocking descriptor opens where the platform supports them so a raced FIFO cannot pin a worker; filesystem safety policy remains explicit through `hardlinks`, `symlinks`, and `denyMutations`.
 
+On POSIX, `openWritable()` also uses nonblocking admission for existing targets
+so a no-reader FIFO cannot stall validation. Ordinary regular-file write
+semantics are unchanged; see [writing](docs/writing.md#openwritable-for-streaming).
+
 ```ts
 const locked = await root("/srv/workspace", {
   denyMutations: {

--- a/docs/regular-file.md
+++ b/docs/regular-file.md
@@ -111,6 +111,11 @@ append boundary; rounded-equal replacements and persistent unknown Windows
 identities reject before chmod or writing bytes. With
 `rejectSymlinkParents: true`, it also rejects symlinked ancestor directories.
 
+On POSIX, `O_NONBLOCK` prevents a no-reader FIFO substituted before open from
+stalling admission. A confirmed non-regular target is refused before chmod or
+append; other open errors propagate unchanged. This safeguard does not change
+ordinary regular-file append semantics or require read permission.
+
 ### `appendRegularFileSync(options)`
 
 Synchronous. Same options.
@@ -118,7 +123,8 @@ Synchronous. Same options.
 ### `resolveRegularFileAppendFlags()`
 
 Helper that returns the append helpers' `O_WRONLY | O_APPEND | O_CREAT` flags,
-plus `O_NOFOLLOW` where the platform provides it:
+plus `O_NOFOLLOW` where the platform provides it and `O_NONBLOCK` on POSIX
+where available. Windows flags are unchanged:
 
 ```ts
 import { resolveRegularFileAppendFlags } from "@openclaw/fs-safe/advanced";

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -207,6 +207,13 @@ destination — there is no atomic-rename step. If you need both streaming and
 atomicity, write to a sibling temp yourself and rename when done; the
 [`atomic`](atomic.md) helpers can do this for you.
 
+On POSIX, existing-target opens use `O_NONBLOCK` as an admission safeguard so
+a no-reader FIFO cannot stall regular-file validation. This does not change
+ordinary regular-file write semantics. `replace` and `update` remain write-only
+opens, including for mode `0o200` files; replacement truncation happens only
+after type, identity, and boundary checks pass. Rejected existing paths are
+never cleanup-owned or unlinked.
+
 ## Write defaults vs per-call options
 
 Set `mkdir: true` once on `root()`; pass text encodings per call when needed:

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -12,6 +12,11 @@ import { isNotFoundPathError } from "./path.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { assertNoSymlinkParents, assertNoSymlinkParentsSync } from "./symlink-parents.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
+import {
+  isNonRegularWriteOpenError,
+  isNonRegularWriteOpenErrorSync,
+  resolveNonblockingWriteFlag,
+} from "./write-open-flags.js";
 
 export type RegularFileStatResult = { missing: true } | { missing: false; stat: Stats };
 
@@ -19,7 +24,7 @@ type RegularFileAppendFlagConstants = Pick<
   typeof fsSync.constants,
   "O_APPEND" | "O_CREAT" | "O_WRONLY"
 > &
-  Partial<Pick<typeof fsSync.constants, "O_NOFOLLOW">>;
+  Partial<Pick<typeof fsSync.constants, "O_NOFOLLOW" | "O_NONBLOCK">>;
 
 export type AppendRegularFileOptions = {
   filePath: string;
@@ -38,7 +43,8 @@ export function resolveRegularFileAppendFlags(
     constants.O_CREAT |
     constants.O_APPEND |
     constants.O_WRONLY |
-    (typeof noFollow === "number" ? noFollow : 0)
+    (typeof noFollow === "number" ? noFollow : 0) |
+    resolveNonblockingWriteFlag(constants)
   );
 }
 
@@ -306,11 +312,16 @@ export async function appendRegularFile(options: AppendRegularFileOptions): Prom
   }
 
   await getFsSafeTestHooks()?.beforeRegularFileAppendOpen?.(options.filePath);
-  const handle = await fs.open(
-    options.filePath,
-    resolveRegularFileAppendFlags(),
-    options.mode ?? 0o600,
-  );
+  const flags = resolveRegularFileAppendFlags();
+  let handle: FileHandle;
+  try {
+    handle = await fs.open(options.filePath, flags, options.mode ?? 0o600);
+  } catch (error) {
+    if (await isNonRegularWriteOpenError(error, options.filePath, flags)) {
+      throw new Error(`Refusing to append to non-file: ${options.filePath}`);
+    }
+    throw error;
+  }
   try {
     let identity: BigIntStats;
     try {
@@ -381,11 +392,16 @@ export function appendRegularFileSync(options: AppendRegularFileOptions): void {
   }
 
   getFsSafeTestHooks()?.beforeRegularFileAppendOpenSync?.(options.filePath);
-  const fd = fsSync.openSync(
-    options.filePath,
-    resolveRegularFileAppendFlags(),
-    options.mode ?? 0o600,
-  );
+  const flags = resolveRegularFileAppendFlags();
+  let fd: number;
+  try {
+    fd = fsSync.openSync(options.filePath, flags, options.mode ?? 0o600);
+  } catch (error) {
+    if (isNonRegularWriteOpenErrorSync(error, options.filePath, flags)) {
+      throw new Error(`Refusing to append to non-file: ${options.filePath}`);
+    }
+    throw error;
+  }
   try {
     let identity: BigIntStats;
     try {

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -41,6 +41,7 @@ import {
 } from "./path.js";
 import { readOpenedFileSafely, type ReadResult } from "./read-opened-file.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
+import { isNonRegularWriteOpenError, resolveNonblockingWriteFlag } from "./write-open-flags.js";
 import { resolveRootPath } from "./root-path.js";
 import {
   assertRootIdentityCurrent,
@@ -156,14 +157,16 @@ const SUPPORTS_NOFOLLOW = process.platform !== "win32" && "O_NOFOLLOW" in fsCons
 const OPEN_READ_FLAGS = resolveReadOpenFlags();
 const OPEN_READ_FOLLOW_FLAGS = resolveReadOpenFlags({ followSymlinks: true });
 const OPEN_WRITE_EXISTING_FLAGS =
-  fsConstants.O_WRONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+  fsConstants.O_WRONLY | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0) |
+  resolveNonblockingWriteFlag();
 const OPEN_WRITE_CREATE_FLAGS =
   fsConstants.O_WRONLY |
   fsConstants.O_CREAT |
   fsConstants.O_EXCL |
   (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
 const OPEN_APPEND_EXISTING_FLAGS =
-  fsConstants.O_RDWR | fsConstants.O_APPEND | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
+  fsConstants.O_RDWR | fsConstants.O_APPEND | (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0) |
+  resolveNonblockingWriteFlag();
 const OPEN_APPEND_CREATE_FLAGS =
   fsConstants.O_RDWR |
   fsConstants.O_APPEND |
@@ -908,6 +911,9 @@ async function openWritableFileInRoot(
     try {
       handle = await fs.open(ioPath, existingFlags, mode);
     } catch (err) {
+      if (await isNonRegularWriteOpenError(err, ioPath, existingFlags)) {
+        throw new FsSafeError("not-file", "path is not a regular file under root");
+      }
       if (!isNotFoundPathError(err)) {
         throw err;
       }

--- a/src/write-open-flags.ts
+++ b/src/write-open-flags.ts
@@ -1,0 +1,45 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import { hasNodeErrorCode } from "./path.js";
+
+export function resolveNonblockingWriteFlag(
+  constants: Partial<Pick<typeof fsSync.constants, "O_NONBLOCK">> = fsSync.constants,
+): number {
+  return process.platform !== "win32" && typeof constants.O_NONBLOCK === "number"
+    ? constants.O_NONBLOCK
+    : 0;
+}
+
+function isNonblockingWriteEnxio(error: unknown, flags: number): boolean {
+  return hasNodeErrorCode(error, "ENXIO") &&
+    (flags & (fsSync.constants.O_WRONLY | fsSync.constants.O_RDWR)) === fsSync.constants.O_WRONLY &&
+    (flags & resolveNonblockingWriteFlag()) !== 0;
+}
+
+// A no-reader FIFO rejects a nonblocking write-only open before fstat is possible.
+// Reclassify only a confirmed non-regular path; inconclusive races keep the errno.
+export async function isNonRegularWriteOpenError(
+  error: unknown,
+  filePath: string,
+  flags: number,
+): Promise<boolean> {
+  if (!isNonblockingWriteEnxio(error, flags)) return false;
+  try {
+    return !(await fs.lstat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function isNonRegularWriteOpenErrorSync(
+  error: unknown,
+  filePath: string,
+  flags: number,
+): boolean {
+  if (!isNonblockingWriteEnxio(error, flags)) return false;
+  try {
+    return !fsSync.lstatSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/test/nonblocking-write-admission.test.ts
+++ b/test/nonblocking-write-admission.test.ts
@@ -1,0 +1,317 @@
+import { spawnSync } from "node:child_process";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FsSafeError } from "../src/errors.js";
+import {
+  appendRegularFile,
+  appendRegularFileSync,
+  resolveRegularFileAppendFlags,
+} from "../src/regular-file.js";
+import { root as openRoot } from "../src/root.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import {
+  isNonRegularWriteOpenError,
+  isNonRegularWriteOpenErrorSync,
+  resolveNonblockingWriteFlag,
+} from "../src/write-open-flags.js";
+import { itPosix, useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const constants = fsSync.constants;
+afterEach(() => {
+  __setFsSafeTestHooksForTest(undefined);
+  vi.restoreAllMocks();
+});
+
+function makeFifo(filePath: string): fsSync.Stats {
+  expect(spawnSync("mkfifo", [filePath]).status).toBe(0);
+  return fsSync.lstatSync(filePath);
+}
+
+function expectNonblocking(flags: string | number): void {
+  expect(typeof flags).toBe("number");
+  expect(Number(flags) & constants.O_NONBLOCK).toBe(constants.O_NONBLOCK);
+}
+
+function expectWriteOnly(flags: string | number): void {
+  expect(Number(flags) & (constants.O_WRONLY | constants.O_RDWR)).toBe(constants.O_WRONLY);
+}
+
+describe("nonblocking writable admission", () => {
+  itPosix.each(["replace", "update", "append"] as const)(
+    "rejects a stable no-reader FIFO in Root %s without changing it",
+    async (writeMode) => {
+      const dir = await tempRoot("fs-safe-root-write-fifo-");
+      const filePath = path.join(dir, "fifo");
+      const before = makeFifo(filePath);
+      const scoped = await openRoot(dir);
+      const realOpen = fs.open.bind(fs);
+      const mutations: ReturnType<typeof vi.spyOn>[] = [];
+      const open = vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+        expect(candidate).toBe(filePath);
+        // Fail before the real syscall if the admission safeguard is missing.
+        expectNonblocking(flags);
+        expect(Number(flags) & (constants.O_TRUNC | constants.O_CREAT | constants.O_EXCL)).toBe(0);
+        if (writeMode !== "append") expectWriteOnly(flags);
+        const handle = await realOpen(candidate, flags, mode);
+        mutations.push(vi.spyOn(handle, "chmod"), vi.spyOn(handle, "truncate"),
+          vi.spyOn(handle, "write"), vi.spyOn(handle, "appendFile"));
+        return handle;
+      });
+
+      const pending = scoped.openWritable("fifo", { writeMode, mkdir: false });
+      await expect(pending).rejects.toBeInstanceOf(FsSafeError);
+      await expect(pending).rejects.toMatchObject({
+        code: "not-file", message: "path is not a regular file under root",
+      });
+      expect(open).toHaveBeenCalledTimes(1);
+      for (const mutation of mutations) expect(mutation).not.toHaveBeenCalled();
+      expect(fsSync.lstatSync(filePath)).toEqual(before);
+      expect(fsSync.readdirSync(dir)).toEqual(["fifo"]);
+    },
+  );
+
+  itPosix.each(["async", "sync"] as const)(
+    "rejects a no-reader FIFO swapped in before %s advanced append",
+    async (variant) => {
+      const dir = await tempRoot("fs-safe-append-write-fifo-");
+      const filePath = path.join(dir, "value");
+      const displaced = `${filePath}.displaced`;
+      await fs.writeFile(filePath, "ORIGINAL");
+      const probe = await fs.open(filePath, "r");
+      const prototype = Object.getPrototypeOf(probe);
+      await probe.close();
+      const chmod = vi.spyOn(prototype, "chmod");
+      const append = vi.spyOn(prototype, "appendFile");
+      const fchmod = vi.spyOn(fsSync, "fchmodSync");
+      const write = vi.spyOn(fsSync, "writeSync");
+      let fifoStat: fsSync.Stats | undefined;
+      const swap = (candidate: string) => {
+        expect(candidate).toBe(filePath);
+        fsSync.renameSync(filePath, displaced);
+        fifoStat = makeFifo(filePath);
+      };
+      __setFsSafeTestHooksForTest({
+        beforeRegularFileAppendOpen: swap,
+        beforeRegularFileAppendOpenSync: swap,
+      });
+      const refusal = new Error(`Refusing to append to non-file: ${filePath}`);
+      if (variant === "async") {
+        const realOpen = fs.open.bind(fs);
+        const open = vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+          expectNonblocking(flags);
+          expectWriteOnly(flags);
+          return await realOpen(candidate, flags, mode);
+        });
+        await expect(appendRegularFile({ filePath, content: "MUTATED" })).rejects.toEqual(refusal);
+        expect(open).toHaveBeenCalledTimes(1);
+      } else {
+        const realOpen = fsSync.openSync.bind(fsSync);
+        const open = vi.spyOn(fsSync, "openSync").mockImplementationOnce((candidate, flags, mode) => {
+          expectNonblocking(flags);
+          expectWriteOnly(flags);
+          return realOpen(candidate, flags, mode);
+        });
+        expect(() => appendRegularFileSync({ filePath, content: "MUTATED" }))
+          .toThrow(expect.objectContaining({ message: refusal.message }));
+        expect(open).toHaveBeenCalledTimes(1);
+      }
+      expect(fifoStat).toBeDefined();
+      expect(fsSync.lstatSync(filePath)).toEqual(fifoStat);
+      expect(chmod).not.toHaveBeenCalled();
+      expect(append).not.toHaveBeenCalled();
+      expect(fchmod).not.toHaveBeenCalled();
+      expect(write).not.toHaveBeenCalled();
+      expect(fsSync.readFileSync(displaced, "utf8")).toBe("ORIGINAL");
+      expect(fsSync.readdirSync(dir).sort()).toEqual(["value", "value.displaced"]);
+    },
+  );
+
+  itPosix.each(["replace", "update", "append", "async", "sync"] as const)(
+    "preserves ordinary %s writes and required access modes",
+    async (operation) => {
+      const dir = await tempRoot("fs-safe-write-only-control-");
+      const filePath = path.join(dir, "value");
+      const mode = operation === "append" ? 0o600 : 0o200;
+      await fs.writeFile(filePath, "ORIGINAL", { mode });
+      await fs.chmod(filePath, mode);
+      const scoped = await openRoot(dir);
+      const realOpen = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, permissions) => {
+        expectNonblocking(flags);
+        if (operation !== "append") expectWriteOnly(flags);
+        expect(Number(flags) & constants.O_TRUNC).toBe(0);
+        return await realOpen(candidate, flags, permissions);
+      });
+      if (operation === "sync") {
+        const realOpenSync = fsSync.openSync.bind(fsSync);
+        vi.spyOn(fsSync, "openSync").mockImplementationOnce((candidate, flags, permissions) => {
+          expectNonblocking(flags);
+          expectWriteOnly(flags);
+          return realOpenSync(candidate, flags, permissions);
+        });
+        appendRegularFileSync({ filePath, content: "X", mode });
+      } else if (operation === "async") {
+        await appendRegularFile({ filePath, content: "X", mode });
+      } else {
+        const opened = await scoped.openWritable("value", { writeMode: operation, mkdir: false });
+        try {
+          expect(opened.createdForWrite).toBe(false);
+          await opened.handle.writeFile("X");
+        } finally {
+          await opened.handle.close();
+        }
+      }
+      expect(fsSync.statSync(filePath).mode & 0o777).toBe(mode);
+      await fs.chmod(filePath, 0o600);
+      const expected = operation === "replace" ? "X" : operation === "update" ? "XRIGINAL" : "ORIGINALX";
+      expect(fsSync.readFileSync(filePath, "utf8")).toBe(expected);
+    },
+  );
+
+  it.each(["replace", "update", "append"] as const)(
+    "keeps Root %s creation exclusive and unchanged",
+    async (writeMode) => {
+      const dir = await tempRoot("fs-safe-write-create-flags-");
+      const scoped = await openRoot(dir);
+      const realOpen = fs.open.bind(fs);
+      const noFollow = process.platform !== "win32" ? constants.O_NOFOLLOW ?? 0 : 0;
+      const access = writeMode === "append" ? constants.O_RDWR | constants.O_APPEND : constants.O_WRONLY;
+      const open = vi.spyOn(fs, "open").mockImplementation(async (candidate, flags, mode) => {
+        const expected = access | noFollow | (open.mock.calls.length === 1
+          ? resolveNonblockingWriteFlag() : constants.O_CREAT | constants.O_EXCL);
+        expect(flags).toBe(expected);
+        return await realOpen(candidate, flags, mode);
+      });
+      const opened = await scoped.openWritable("new", { writeMode, mkdir: false });
+      try {
+        expect(opened.createdForWrite).toBe(true);
+        await opened.handle.writeFile("created");
+      } finally {
+        await opened.handle.close();
+      }
+      expect(open).toHaveBeenCalledTimes(2);
+      expect(await fs.readFile(path.join(dir, "new"), "utf8")).toBe("created");
+    },
+  );
+
+  itPosix("keeps delayed truncation and existing-path cleanup fencing after a regular-file swap", async () => {
+    const dir = await tempRoot("fs-safe-write-truncate-fence-");
+    const filePath = path.join(dir, "value");
+    const displaced = `${filePath}.displaced`;
+    await fs.writeFile(filePath, "ORIGINAL");
+    const scoped = await openRoot(dir);
+    const realOpen = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementationOnce(async (candidate, flags, mode) => {
+      expectNonblocking(flags);
+      expect(Number(flags) & constants.O_TRUNC).toBe(0);
+      const handle = await realOpen(candidate, flags, mode);
+      await fs.rename(filePath, displaced);
+      await fs.writeFile(filePath, "REPLACEMENT");
+      return handle;
+    });
+    await expect(scoped.openWritable("value", { mkdir: false })).rejects.toMatchObject({
+      code: "path-mismatch", message: "path changed during write",
+    });
+    expect(await fs.readFile(filePath, "utf8")).toBe("REPLACEMENT");
+    expect(await fs.readFile(displaced, "utf8")).toBe("ORIGINAL");
+  });
+
+  for (const operation of ["replace", "update", "async", "sync"] as const) {
+    itPosix.each(["regular", "missing", "uninspectable", "other-errno"] as const)(
+      `preserves the original ${operation} error for %s paths`,
+      async (state) => {
+        const dir = await tempRoot("fs-safe-write-enxio-");
+        const filePath = path.join(dir, "value");
+        await fs.writeFile(filePath, "ORIGINAL");
+        const scoped = await openRoot(dir);
+        const failure = Object.assign(new Error("open failed"), {
+          code: state === "other-errno" ? "EIO" : "ENXIO",
+        });
+        const failOpen = () => {
+          if (state === "missing") fsSync.unlinkSync(filePath);
+          if (state === "other-errno") {
+            fsSync.renameSync(filePath, `${filePath}.displaced`);
+            fsSync.mkdirSync(filePath);
+          }
+          if (state === "uninspectable") {
+            const denied = Object.assign(new Error("inspection denied"), { code: "EACCES" });
+            vi.spyOn(fs, "lstat").mockRejectedValueOnce(denied);
+            vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => { throw denied; });
+          }
+          throw failure;
+        };
+        if (operation === "sync") {
+          vi.spyOn(fsSync, "openSync").mockImplementationOnce(failOpen);
+          let caught: unknown;
+          try {
+            appendRegularFileSync({ filePath, content: "X" });
+          } catch (error) {
+            caught = error;
+          }
+          expect(caught).toBe(failure);
+        } else {
+          vi.spyOn(fs, "open").mockImplementationOnce(async () => failOpen());
+          const pending = operation === "async"
+            ? appendRegularFile({ filePath, content: "X" })
+            : scoped.openWritable("value", { writeMode: operation, mkdir: false });
+          await expect(pending).rejects.toBe(failure);
+        }
+      },
+    );
+  }
+
+  itPosix("preserves ENXIO from Root read-write append even for a non-regular path", async () => {
+    const dir = await tempRoot("fs-safe-write-rdwr-enxio-");
+    makeFifo(path.join(dir, "fifo"));
+    const scoped = await openRoot(dir);
+    const failure = Object.assign(new Error("open failed"), { code: "ENXIO" });
+    vi.spyOn(fs, "open").mockRejectedValueOnce(failure);
+    await expect(scoped.openWritable("fifo", { writeMode: "append", mkdir: false }))
+      .rejects.toBe(failure);
+  });
+});
+
+describe("writable admission platform flags", () => {
+  itPosix("classifies ENXIO using the current entry without following symlinks", async () => {
+    const dir = await tempRoot("fs-safe-write-enxio-lstat-");
+    const target = path.join(dir, "target");
+    const link = path.join(dir, "link");
+    await fs.writeFile(target, "ORIGINAL");
+    await fs.symlink(target, link);
+    const error = Object.assign(new Error("open failed"), { code: "ENXIO" });
+    const flags = constants.O_WRONLY | constants.O_NONBLOCK;
+    expect(await isNonRegularWriteOpenError(error, link, flags)).toBe(true);
+    expect(isNonRegularWriteOpenErrorSync(error, link, flags)).toBe(true);
+    expect(await fs.readFile(target, "utf8")).toBe("ORIGINAL");
+    expect(fsSync.lstatSync(link).isSymbolicLink()).toBe(true);
+  });
+
+  it.each(["linux", "darwin", "win32"] as const)("resolves %s append flags", (platform) => {
+    vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+    const base = { O_WRONLY: 1, O_APPEND: 2, O_CREAT: 4 };
+    expect(resolveRegularFileAppendFlags(base)).toBe(7);
+    expect(resolveRegularFileAppendFlags({ ...base, O_NOFOLLOW: 8 })).toBe(15);
+    expect(resolveRegularFileAppendFlags({ ...base, O_NONBLOCK: 16 })).toBe(platform === "win32" ? 7 : 23);
+    expect(resolveRegularFileAppendFlags({ ...base, O_NOFOLLOW: 8, O_NONBLOCK: 16 }))
+      .toBe(platform === "win32" ? 15 : 31);
+  });
+
+  it.each(["linux", "win32"] as const)("does not inspect unrelated %s open errors", async (platform) => {
+    vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+    const lstat = vi.spyOn(fs, "lstat");
+    const lstatSync = vi.spyOn(fsSync, "lstatSync");
+    const enxio = Object.assign(new Error("open failed"), { code: "ENXIO" });
+    const flags = [constants.O_WRONLY, constants.O_RDONLY | constants.O_NONBLOCK,
+      constants.O_RDWR | constants.O_NONBLOCK];
+    if (platform === "win32") flags.push(constants.O_WRONLY | constants.O_NONBLOCK);
+    for (const flag of flags) {
+      expect(await isNonRegularWriteOpenError(enxio, "unused", flag)).toBe(false);
+      expect(isNonRegularWriteOpenErrorSync(enxio, "unused", flag)).toBe(false);
+    }
+    expect(lstat).not.toHaveBeenCalled();
+    expect(lstatSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

POSIX writable admission could block before validation when an attacker-controlled existing path was a FIFO with no reader. `Root.openWritable()` replace/update used blocking `O_WRONLY`, while async and sync `appendRegularFile()` could preview a regular file, lose the race to a FIFO substitution, and block on the actual write-only open. The eventual type and identity checks were correct but unreachable until another process opened the FIFO reader.

Existing-target writable opens now include POSIX `O_NONBLOCK` while preserving their original access modes. A write-only nonblocking `ENXIO` is translated only when a no-follow `lstat` confirms that the current entry is non-regular; unrelated or inconclusive errors remain unchanged. Exclusive creation, delayed truncation, exact identity checks, hardlink/symlink rejection, containment, and cleanup ownership are unchanged.

The shared flag/error helper is internal. No public signature, native ABI, dependency, lockfile, generated output, timeout, or size budget changed. `src/root-impl.ts` remains within its existing 1,750-line limit at 1,749 lines. Production delta is +67 lines; focused tests add 317 lines across 37 parameterized cases.

## Physical behavior proof

Baseline from a fresh packed merged-main consumer on macOS arm64 Node 24.20.0:

```text
Root replace -> O_NONBLOCK false; required a FIFO reader; eventual not-file
Root update  -> O_NONBLOCK false; required a FIFO reader; eventual not-file
Root append  -> O_NONBLOCK false; no reader required; eventual not-file control
append async -> O_NONBLOCK false; required a FIFO reader; original bytes preserved
append sync  -> O_NONBLOCK false; required a FIFO reader; original bytes preserved
```

Fresh physical installs of the packed candidate then passed 50/50 observations:

- macOS arm64: Node 22.0.0, 22.23.2, and 24.20.0; native configuration `off` and `require`; 30/30 operations.
- Linux arm64 local containers: exact Node 22.0.0 and 24.20.0; native configuration `off` and `require`; 20/20 operations.
- Each run exercised Root replace/update/append and advanced async/sync append against actual no-reader FIFOs.
- Every open reported `O_NONBLOCK`; zero calls needed a reader; every FIFO remained present; Root paths returned `not-file`; advanced paths retained `Refusing to append to non-file`; displaced originals remained exactly `ORIGINAL`.
- Candidate root artifact integrity: `sha512-whhQ5I4IMTBeNgIlyPmolBafeEZFDW+47fUyF6dKAyEvJ14saaYW0imLL7UjgbE6LmW+IKJvzfb4w0wXiyEumA==`.

The native mode setting is a configuration-compatibility lane here, not native-dispatch proof: these writable JavaScript paths do not invoke a native operation. Separate package smoke exercised the host native loader. The Linux lane is a real local-container Linux arm64 run, not remote/AWS proof. Windows does not receive `O_NONBLOCK`; exact-head Windows CI is required before merge.

## Validation

- Focused writable-admission/root/regular-file suites: 65 passed / 2 Windows-only skipped, including 37 new cases.
- `CI=1 pnpm check`: 6,869 passed / 80 skipped; 197 files passed / 2 skipped.
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: npm/pnpm physical consumers, optional omission, host native loading, and missing-binary behavior passed.
- File-size, filesystem-boundary, build, docs, package, and `git diff --check` gates passed.
- Independent Codex autoreview was scoped-clean at P0 (0.96).

The first Linux proof invocation was a harness-only failure: an empty tarball lookup produced an invalid Docker mount before any container or product code ran. Repeating with the exact candidate artifact produced the 20/20 Linux result above.

Exact-head cross-platform CI and ClawSweeper review are required before merge. No release or package publication is included.
