### PR TITLE
fix(lock): clean Root sidecars before exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Release asynchronously acquired Root-backed sidecar locks on natural event-loop shutdown through their retained ownership receipts, preserving changed sidecars and avoiding cleanup retry loops.
 - Prevent no-reader FIFOs from stalling POSIX `Root.openWritable()` and async/sync regular-file append admission, preserving regular-file write semantics and existing-target cleanup fencing.
 - Normalize every exclusive-copy target to mode `0o600` through its owned descriptor, including under restrictive umasks and native macOS clone staging.
 - Move dangling symlink sources through staged and cross-device fallback without dereferencing their absent referents, while retaining same-entry, descendant, and source-substitution guards.

--- a/docs/sidecar-lock.md
+++ b/docs/sidecar-lock.md
@@ -21,7 +21,9 @@ try {
 
 The lock file sits next to the protected resource. If a process crashes mid-lock, the next acquirer notices the held entry, inspects its payload (PID, host, acquired-at timestamp), and decides — via `shouldReclaim` (defaulting to "is the lock older than `staleMs`?") — whether it should keep waiting or fail.
 
-The library installs a `process.on("exit")` handler that releases all currently-held locks synchronously, so well-behaved exits leave no stale sidecars. Crashed holders leave their sidecar behind; recover only after an application-owned liveness policy proves the holder cannot still be writing.
+On natural event-loop shutdown, a globally deduplicated `process.on("beforeExit")` handler attempts asynchronous cleanup of held Root-backed locks through their retained Root capability and ownership receipt. The synchronous `process.on("exit")` handler provides last-chance cleanup for raw locks and reclaim guards. Changed sidecars and failed Root cleanup remain in place; cleanup does not keep retrying during shutdown unless another acquisition re-arms it.
+
+Always release locks in a `finally` block. Application-managed graceful shutdown can await `release()` or `manager.drain()` before terminating. Explicit `process.exit()`, uncaught failures, crashes, default signal handling, and fatal termination (including `SIGKILL`) do not reliably run asynchronous Root cleanup and may leave sidecars. Recover only after an application-owned liveness policy proves the holder cannot still be writing.
 
 Each new sidecar also carries an internal random ownership token encoded as JSON trailing whitespace. `JSON.parse()` and every payload callback still see exactly the caller-provided object. Only the process that successfully created the sidecar keeps that token as release authority; merely reading token-shaped bytes from disk does not enable this mode. Release compares the in-memory token and exact serialized bytes, and requires the pathname to remain a regular file, instead of requiring an opened descriptor and pathname lookup to report the same inode identity. This preserves ownership checks on filesystems such as Docker Desktop VirtioFS where those two views can legitimately differ. Sidecars created by older releases have no token and retain the legacy identity-plus-content check.
 
@@ -280,7 +282,7 @@ The sync payload, reclaim, and parsing callbacks must also be synchronous. This
 shape is appropriate for a short boot migration; it is a poor fit for a server
 request because retry backoff uses a blocking wait.
 
-If your process dies before `release()` runs and skips the exit handler, the sidecar remains. Once `staleMs` elapses (or your `shouldReclaim` returns true), acquisition fails closed by default instead of deleting by path.
+If termination skips the relevant cleanup handler or cleanup fails, the sidecar remains. In particular, `process.exit()` skips asynchronous Root cleanup; await explicit release or drain during application-managed graceful shutdown. Once `staleMs` elapses (or your `shouldReclaim` returns true), acquisition fails closed by default instead of deleting by path.
 
 ## `withFileLock` — common shape made one-liner
 

--- a/src/sidecar-lock.ts
+++ b/src/sidecar-lock.ts
@@ -33,6 +33,7 @@ type SidecarLockManagerState = {
 const GLOBAL_STATE_KEY = Symbol.for("fsSafe.sidecarLockManagers");
 const GLOBAL_CLEANUP_KEY = Symbol.for("fsSafe.sidecarLockCleanupRegistered");
 const GLOBAL_CLEANUP_HANDLER_KEY = Symbol.for("fsSafe.sidecarLockCleanupHandler");
+const GLOBAL_BEFORE_EXIT_KEY = Symbol.for("fsSafe.sidecarLockBeforeExitCleanup");
 function getGlobalManagers(): Map<string, SidecarLockManagerState> {
   const globalWithState = globalThis as typeof globalThis & {
     [GLOBAL_STATE_KEY]?: Map<string, SidecarLockManagerState>;
@@ -148,6 +149,33 @@ function ensureGlobalExitCleanupRegistered(): void {
   process.on("exit", cleanup);
 }
 
+function ensureGlobalBeforeExitCleanupRegistered(): { armed: boolean } {
+  const globalWithCleanup = globalThis as typeof globalThis & {
+    [GLOBAL_BEFORE_EXIT_KEY]?: { armed: boolean };
+  };
+  if (globalWithCleanup[GLOBAL_BEFORE_EXIT_KEY]) {
+    return globalWithCleanup[GLOBAL_BEFORE_EXIT_KEY];
+  }
+  // Independent of the exit registration, which an older package copy may own.
+  const lifecycle = { armed: false };
+  globalWithCleanup[GLOBAL_BEFORE_EXIT_KEY] = lifecycle;
+  process.on("beforeExit", () => {
+    if (!lifecycle.armed) return;
+    // Cleanup itself schedules I/O; retry only after another acquisition.
+    lifecycle.armed = false;
+    for (const state of getGlobalManagers().values()) {
+      for (const [normalizedTargetPath, held] of Array.from(state.held.entries())) {
+        if (held.lockRoot) {
+          void releaseHeldLock(state, normalizedTargetPath, held, { force: true }).catch(
+            () => undefined,
+          );
+        }
+      }
+    }
+  });
+  return lifecycle;
+}
+
 async function releaseHeldLock(
   state: SidecarLockManagerState,
   normalizedTargetPath: string,
@@ -197,6 +225,7 @@ function handleForHeldLock(
   normalizedTargetPath: string,
   held: HeldSidecarLock,
 ) {
+  ensureGlobalBeforeExitCleanupRegistered().armed = true;
   return createHeldSidecarLockHandle({
     normalizedTargetPath,
     held,
@@ -212,6 +241,7 @@ export function createSidecarLockManager(key: string) {
     state.cleanupRegistered = true;
     state.reclaimCleanupRegistered = true;
     ensureGlobalExitCleanupRegistered();
+    ensureGlobalBeforeExitCleanupRegistered().armed = true;
   }
 
   async function acquire<TPayload extends Record<string, unknown>>(

--- a/test/sidecar-lock-process-exit.test.ts
+++ b/test/sidecar-lock-process-exit.test.ts
@@ -1,0 +1,198 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+const exec = promisify(execFile);
+const preamble = `
+  import assert from "node:assert/strict";
+  import fs from "node:fs/promises";
+  import path from "node:path";
+  import { root } from "@openclaw/fs-safe/root";
+  import { acquireFileLock, createFileLockManager } from "@openclaw/fs-safe/file-lock";
+  const directory = process.argv[1];
+  const targetPath = path.join(directory, "state.json");
+  const capability = await root(directory);
+  const options = { lockRoot: capability, payload: () => ({ owner: "caller" }) };
+`;
+
+async function runChild(directory: string, script: string): Promise<string> {
+  const { stdout, stderr } = await exec(
+    process.execPath,
+    ["--unhandled-rejections=strict", "--input-type=module", "-e", preamble + script, directory],
+    { cwd: new URL("..", import.meta.url), timeout: 4_000, killSignal: "SIGKILL" },
+  );
+  expect(stderr).toBe("");
+  return stdout.trim();
+}
+
+async function expectAbsent(directory: string, name = "state.json.lock"): Promise<void> {
+  await expect(fs.lstat(path.join(directory, name))).rejects.toMatchObject({ code: "ENOENT" });
+}
+
+describe("sidecar lock natural process exit", () => {
+  it.each(["Root held", "raw held", "Root released"])("cleans %s locks", async (kind) => {
+    const directory = await tempRoot("fs-safe-lock-exit-");
+    await runChild(directory, `
+      const lock = await acquireFileLock(targetPath, {
+        ...options, lockRoot: ${kind === "raw held" ? "undefined" : "capability"},
+      });
+      assert.equal(await lock.verifyStillHeld(), true);
+      ${kind === "Root released" ? "await lock.release();" : ""}
+    `);
+    await expectAbsent(directory);
+  });
+
+  it.each(["rewritten", "replacement"])("preserves a %s Root sidecar", async (kind) => {
+    const directory = await tempRoot("fs-safe-lock-exit-changed-");
+    const replacement = await runChild(directory, `
+      const lock = await acquireFileLock(targetPath, options);
+      const raw = await fs.readFile(lock.lockPath, "utf8");
+      ${kind === "replacement" ? "await fs.unlink(lock.lockPath);" : ""}
+      const changed = raw.trimEnd() + "\\n";
+      await fs.writeFile(lock.lockPath, changed);
+      console.log(JSON.stringify(changed));
+    `);
+    await expect(fs.readFile(path.join(directory, "state.json.lock"), "utf8"))
+      .resolves.toBe(JSON.parse(replacement));
+  });
+
+  it("attempts failed Root cleanup once without an unhandled rejection or shutdown loop", async () => {
+    const directory = await tempRoot("fs-safe-lock-exit-failure-");
+    const output = await runChild(directory, `
+      const lock = await acquireFileLock(targetPath, options);
+      const raw = await fs.readFile(lock.lockPath, "utf8");
+      await acquireFileLock(path.join(directory, "healthy.json"), options);
+      const remove = capability.remove.bind(capability);
+      let removals = 0;
+      let cycles = 0;
+      capability.remove = async (relativePath, ...args) => {
+        if (relativePath !== "state.json.lock") return await remove(relativePath, ...args);
+        removals++;
+        throw Object.assign(new Error("injected Root.remove failure"), { code: "EIO" });
+      };
+      process.on("beforeExit", () => { cycles++; });
+      process.on("exit", () => console.log(JSON.stringify({ removals, cycles, raw })));
+    `);
+    const result = JSON.parse(output);
+    expect(result).toMatchObject({ removals: 1, cycles: 2 });
+    await expect(fs.readFile(path.join(directory, "state.json.lock"), "utf8"))
+      .resolves.toBe(result.raw);
+    await expectAbsent(directory, "healthy.json.lock");
+  });
+
+  it("force-releases a reentrant holder and clears its compromise timer", async () => {
+    const directory = await tempRoot("fs-safe-lock-exit-reentrant-");
+    const output = await runChild(directory, `
+      const manager = createFileLockManager("reentrant");
+      const nestedOptions = {
+        ...options, reentrantOwner: "owner", compromiseCheckIntervalMs: 1_000,
+        onCompromised: () => { throw new Error("unexpected compromise"); },
+      };
+      await manager.acquire(targetPath, nestedOptions);
+      await manager.acquire(targetPath, nestedOptions);
+      const held = [...globalThis[Symbol.for("fsSafe.sidecarLockManagers")]
+        .get("reentrant").held.values()][0];
+      assert.equal(held.refCount, 2);
+      assert.ok(held.compromiseTimer);
+      let closes = 0;
+      const close = held.handle.close.bind(held.handle);
+      held.handle.close = async () => { closes++; await close(); };
+      process.on("exit", () => console.log(JSON.stringify({
+        closes, timerCleared: held.compromiseTimer === undefined,
+      })));
+    `);
+    expect(JSON.parse(output)).toEqual({ closes: 1, timerCleared: true });
+    await expectAbsent(directory);
+  });
+
+  it("joins an explicit release already in flight", async () => {
+    const directory = await tempRoot("fs-safe-lock-exit-in-flight-");
+    const output = await runChild(directory, `
+      const lock = await acquireFileLock(targetPath, options);
+      const remove = capability.remove.bind(capability);
+      let removals = 0;
+      let finish;
+      capability.remove = async (...args) => {
+        removals++;
+        await new Promise(resolve => { finish = resolve; });
+        return await remove(...args);
+      };
+      let released = false;
+      void lock.release().then(() => { released = true; });
+      process.once("beforeExit", () => {
+        assert.equal(removals, 1);
+        setImmediate(finish);
+      });
+      process.on("exit", () => console.log(JSON.stringify({ removals, released })));
+    `);
+    expect(JSON.parse(output)).toEqual({ removals: 1, released: true });
+    await expectAbsent(directory);
+  });
+
+  it("deduplicates listeners across manager domains and physical package copies", async () => {
+    const directory = await tempRoot("fs-safe-lock-exit-copies-");
+    const copy = path.join(directory, "copy");
+    await fs.mkdir(copy);
+    await fs.copyFile(new URL("../package.json", import.meta.url), path.join(copy, "package.json"));
+    await fs.cp(new URL("../dist", import.meta.url), path.join(copy, "dist"), { recursive: true });
+    const output = await runChild(directory, `
+      const { createRequire } = await import("node:module");
+      const { pathToFileURL } = await import("node:url");
+      const copyRequire = createRequire(path.join(directory, "copy", "package.json"));
+      const other = await import(pathToFileURL(copyRequire.resolve("@openclaw/fs-safe/file-lock")));
+      assert.notEqual(other.createFileLockManager, createFileLockManager);
+      const before = process.listenerCount("beforeExit");
+      for (let index = 0; index < 12; index++) {
+        const api = index % 2 ? other : { createFileLockManager };
+        await api.createFileLockManager("domain-" + index)
+          .acquire(path.join(directory, index + ".json"), options);
+      }
+      console.log(process.listenerCount("beforeExit") - before);
+    `);
+    expect(output).toBe("1");
+    for (let index = 0; index < 12; index++) await expectAbsent(directory, `${index}.json.lock`);
+  });
+
+  it("registers beforeExit when an older copy already registered exit cleanup", async () => {
+    const directory = await tempRoot("fs-safe-lock-exit-legacy-");
+    const output = await runChild(directory, `
+      const oldExit = () => {};
+      globalThis[Symbol.for("fsSafe.sidecarLockCleanupRegistered")] = true;
+      globalThis[Symbol.for("fsSafe.sidecarLockCleanupHandler")] = oldExit;
+      process.on("exit", oldExit);
+      const before = process.listenerCount("beforeExit");
+      const exits = process.listenerCount("exit");
+      await acquireFileLock(targetPath, options);
+      assert.equal(process.listenerCount("exit"), exits);
+      assert.equal(globalThis[Symbol.for("fsSafe.sidecarLockCleanupHandler")], oldExit);
+      console.log(process.listenerCount("beforeExit") - before);
+    `);
+    expect(output).toBe("1");
+    await expectAbsent(directory);
+  });
+
+  it("re-arms after a completed cleanup cycle when another listener acquires", async () => {
+    const directory = await tempRoot("fs-safe-lock-exit-rearm-");
+    const output = await runChild(directory, `
+      const manager = createFileLockManager("rearm");
+      await manager.acquire(targetPath, options);
+      let cycles = 0;
+      let acquired = false;
+      process.on("beforeExit", () => {
+        cycles++;
+        if (cycles !== 2) return;
+        assert.equal(manager.heldEntries().length, 0);
+        setImmediate(() => {
+          void manager.acquire(targetPath, options).then(() => { acquired = true; });
+        });
+      });
+      process.on("exit", () => console.log(JSON.stringify({ cycles, acquired })));
+    `);
+    expect(JSON.parse(output)).toEqual({ cycles: 4, acquired: true });
+    await expectAbsent(directory);
+  });
+});


### PR DESCRIPTION
## Summary

Natural event-loop shutdown leaked asynchronously acquired Root-backed sidecar locks. The existing synchronous `exit` hook intentionally skipped `held.lockRoot` because raw pathname deletion would bypass Root confinement and ownership policy, but it then removed the held entry from the manager map. Raw locks cleaned up and explicit Root release worked; only the Root-backed no-release path survived an otherwise clean exit.

A separately registered, globally deduplicated `beforeExit` lifecycle state now force-releases Root-backed holders through the existing `releaseHeldLock()` path. This preserves descriptor closure, exact ownership receipt/token comparison, Root capability enforcement, in-flight release joining, reentrant force release, compromise-timer cleanup, and changed-sidecar preservation. Each quiescent cleanup attempt disarms before scheduling I/O so persistent failures cannot create an endless `beforeExit` loop; a later acquisition re-arms the next cycle.

The synchronous `exit` hook remains unchanged as last-chance cleanup for raw locks and reclaim guards. No raw unlink was added for Root paths, and no signal, uncaught-exception, unhandled-rejection, or termination-delay handler was introduced. Production delta is +30 lines; focused child-process coverage adds 198 lines. No public signature, package export, native ABI, dependency, lockfile, generated output, timeout, or budget changed.

## Physical behavior proof

Fresh packed merged-main baseline on macOS arm64 exact Node 24.20.0, native configuration `off` and `require`:

```text
raw held, no release  -> exit 0, sidecar absent (control)
Root held, no release -> exit 0, sidecar present (defect)
Root explicit release -> exit 0, sidecar absent (control)
```

Fresh physical installs of the packed candidate pass 30/30 natural-exit observations:

- macOS arm64: exact Node 22.0.0, 22.23.2, and 24.20.0; native configuration `off` and `require`; 18/18 observations.
- Linux arm64 local containers: exact Node 22.0.0 and 24.20.0; native configuration `off` and `require`; 12/12 observations.
- Each lane exercised raw held/no release, Root held/no release, and Root explicit release. Every child exited 0 and every sidecar was absent.
- Candidate root artifact integrity: `sha512-V0JGggBYCeaYZ9mZa4Yj4o8MbS8lZrkbbE7RCEuJjTZvZFs6BBd2qOAgdFeJ4wcVn20GNeJcGpuVVqn2Txs7bQ==`.

The native mode is a package-configuration compatibility lane; the lifecycle path itself is JavaScript. Linux evidence is real local-container Linux arm64 proof, not remote/AWS proof.

## Adversarial lifecycle coverage

The new child-process suite also verifies:

- Rewritten and replaced sidecars survive shutdown because the retained ownership receipt no longer matches.
- Injected `Root.remove()` failure is attempted once, produces no unhandled rejection or shutdown loop, preserves the sidecar, and still lets a healthy Root lock clean up.
- A reentrant holder with two logical references closes once, force-releases completely, and clears its compromise timer.
- An explicit release already in flight is joined rather than duplicated.
- Twelve manager domains split across two physical package copies add only one `beforeExit` listener and all clean up.
- A new package copy registers `beforeExit` even when an older copy already owns only the legacy `exit` registration.
- A later acquisition scheduled by another `beforeExit` listener re-arms cleanup for the next quiescent cycle.

## Validation

- Focused sidecar lifecycle/ownership/release/reentrancy suites: 49 passed.
- Lifecycle file independently on exact Node 22.0.0, 22.23.2, and 24.20.0: 11/11 on each runtime.
- `CI=1 pnpm check`: 6,880 passed / 80 skipped; 198 files passed / 2 skipped.
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: npm/pnpm physical consumers, host native loading, optional omission, and missing-binary behavior passed.
- File-size, filesystem-boundary, build, docs, package, and `git diff --check` gates passed.
- Independent Codex autoreview was scoped-clean at P0 (0.98).

Explicit `process.exit()`, uncaught failures, default signal handling, crashes, and fatal termination including `SIGKILL` can still leave Root sidecars. The docs now require explicit release in `finally` and awaited release/drain for application-managed graceful shutdown.

Exact-head cross-platform CI and ClawSweeper review are required before merge. No release or package publication is included.
