### PR TITLE
fix(secret): revalidate raced parent creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Retry and fully revalidate raced secret-parent creation so concurrent writes to distinct leaves succeed without leaking `EEXIST` or reporting a false `secret-exists` collision.
 - Release asynchronously acquired Root-backed sidecar locks on natural event-loop shutdown through their retained ownership receipts, preserving changed sidecars and avoiding cleanup retry loops.
 - Prevent no-reader FIFOs from stalling POSIX `Root.openWritable()` and async/sync regular-file append admission, preserving regular-file write semantics and existing-target cleanup fencing.
 - Normalize every exclusive-copy target to mode `0o600` through its owned descriptor, including under restrictive umasks and native macOS clone staging.

--- a/docs/secret-file.md
+++ b/docs/secret-file.md
@@ -125,6 +125,11 @@ startWebhookVerifier(signingKey);
 
 Async. Creates the parent directory at `dirMode` (default `0o700`) if missing, writes content to a sibling temp file at `mode` (default `0o600`), atomically renames over the destination, and re-asserts the file mode after rename.
 
+Concurrent writes to distinct leaves may share creation of a missing parent.
+After a parent-creation race, the helper re-inspects the entry and requires a
+non-symlink directory, then revalidates root/parent guards, containment, and
+the requested directory mode before writing either leaf.
+
 Publication verification borrows the writer's still-open descriptor to check
 the exact file identity, regular-file and link policy, requested POSIX mode,
 and root/parent ancestry before the writer closes it. POSIX mode overrides such
@@ -163,6 +168,10 @@ post-write verification policy. Final materialization uses exclusive create;
 if anything already occupies the target path it throws
 `FsSafeError("secret-exists")` without modifying that entry. Use the distinct
 name when first-writer-wins is part of the credential protocol.
+
+Distinct leaves can share missing-parent creation without a `secret-exists`
+error. Concurrent creates at the same leaf still have exactly one winner;
+the loser receives `secret-exists` and leaves the winner's bytes intact.
 
 For example, two onboarding requests may race to install the first refresh
 token. Exactly one should win, and the loser must not overwrite it:

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -188,21 +188,30 @@ async function ensurePrivateDirectory(
     .filter(Boolean)) {
     current = path.join(current, segment);
     const parentGuard = await createAsyncDirectoryGuard(path.dirname(current));
-    await assertAsyncDirectoryGuard(rootGuard);
-    try {
-      const stat = await fsp.lstat(current);
-      if (stat.isSymbolicLink()) {
-        throw new Error(`Private secret directory component ${current} must not be a symlink.`);
-      }
-      if (!stat.isDirectory()) {
-        throw new Error(`Private secret directory component ${current} must be a directory.`);
-      }
-    } catch (error) {
-      if (!error || typeof error !== "object" || !("code" in error) || error.code !== "ENOENT") {
-        throw error;
-      }
+    while (true) {
+      await assertAsyncDirectoryGuard(rootGuard);
       await assertAsyncDirectoryGuard(parentGuard);
-      await fsp.mkdir(current, { mode });
+      try {
+        const stat = await fsp.lstat(current);
+        if (stat.isSymbolicLink()) {
+          throw new Error(`Private secret directory component ${current} must not be a symlink.`);
+        }
+        if (!stat.isDirectory()) {
+          throw new Error(`Private secret directory component ${current} must be a directory.`);
+        }
+        break;
+      } catch (error) {
+        if (!error || typeof error !== "object" || !("code" in error) || error.code !== "ENOENT") {
+          throw error;
+        }
+        await assertAsyncDirectoryGuard(parentGuard);
+        try {
+          await fsp.mkdir(current, { mode });
+        } catch (mkdirError) {
+          if ((mkdirError as NodeJS.ErrnoException).code !== "EEXIST") throw mkdirError;
+        }
+        // A successful mkdir or a competing creator still requires fresh type checks.
+      }
     }
     const currentReal = await fsp.realpath(current);
     assertRealPathWithinRoot(resolvedRootReal, currentReal);

--- a/test/secret-parent-concurrency.test.ts
+++ b/test/secret-parent-concurrency.test.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FsSafeError } from "../src/errors.js";
+import { createSecretFileAtomic, writeSecretFileAtomic } from "../src/secret.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const writers = [
+  { operation: "write", write: writeSecretFileAtomic },
+  { operation: "create", write: createSecretFileAtomic },
+] as const;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("secret parent creation contention", () => {
+  it.each(writers)("$operation admits distinct leaves racing at the real parent mkdir", async ({ write }) => {
+    const rootDir = await tempRoot("fs-safe-secret-parent-race-");
+    const parent = path.join(rootDir, "shared");
+    const inputs = [
+      { filePath: path.join(parent, "first"), content: Buffer.from([0, 10, 128, 255]) },
+      { filePath: path.join(parent, "second"), content: Buffer.from("second secret\n") },
+    ];
+    const ready = Promise.withResolvers<void>();
+    let arrivals = 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const mkdirErrors: unknown[] = [];
+    const mkdir = fs.mkdir.bind(fs);
+    vi.spyOn(fs, "mkdir").mockImplementation(async (candidate, options) => {
+      if (String(candidate) !== parent) return await mkdir(candidate, options);
+      expect(options).toEqual({ mode: 0o700 });
+      arrivals++;
+      if (arrivals === 1) {
+        timer = setTimeout(() => ready.reject(new Error("both writers must reach parent mkdir")), 2_000);
+      } else if (arrivals === 2) {
+        clearTimeout(timer);
+        ready.resolve();
+      }
+      await ready.promise;
+      try {
+        return await mkdir(candidate, options);
+      } catch (error) {
+        mkdirErrors.push(error);
+        throw error;
+      }
+    });
+
+    try {
+      const results = await Promise.allSettled(inputs.map((input) => write({ rootDir, ...input })));
+      expect(arrivals).toBe(2);
+      expect(mkdirErrors).toEqual([expect.objectContaining({ code: "EEXIST" })]);
+      expect(results).toEqual(inputs.map(() => ({ status: "fulfilled", value: undefined })));
+      for (const input of inputs) {
+        expect(await fs.readFile(input.filePath)).toEqual(input.content);
+        const stat = await fs.lstat(input.filePath);
+        expect(stat.isFile()).toBe(true);
+        expect(stat.nlink).toBe(1);
+        if (process.platform !== "win32") expect(stat.mode & 0o777).toBe(0o600);
+      }
+      if (process.platform !== "win32") expect((await fs.stat(parent)).mode & 0o777).toBe(0o700);
+      expect((await fs.readdir(parent)).sort()).toEqual(["first", "second"]);
+    } finally {
+      clearTimeout(timer);
+    }
+  }, 5_000);
+
+  it("keeps same-leaf creates first-writer-wins under a missing parent", async () => {
+    const rootDir = await tempRoot("fs-safe-secret-same-leaf-");
+    const parent = path.join(rootDir, "shared");
+    const filePath = path.join(parent, "token");
+    const contents = [Buffer.from("first\n"), Buffer.from([0, 127, 255])];
+    const results = await Promise.allSettled(contents.map((content) =>
+      createSecretFileAtomic({ rootDir, filePath, content }),
+    ));
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const failures = results.filter((result) => result.status === "rejected");
+    expect(failures).toHaveLength(1);
+    expect(failures[0]!.reason).toBeInstanceOf(FsSafeError);
+    expect(failures[0]!.reason).toMatchObject({ code: "secret-exists" });
+    const winner = results.findIndex((result) => result.status === "fulfilled");
+    expect(await fs.readFile(filePath)).toEqual(contents[winner]);
+    expect(await fs.readdir(parent)).toEqual(["token"]);
+  });
+
+  for (const outcome of ["EEXIST", "success"] as const) {
+    it.each(writers)(`$operation rejects a file substituted at parent mkdir ${outcome}`, async ({ write }) => {
+      const rootDir = await tempRoot("fs-safe-secret-parent-file-");
+      const parent = path.join(rootDir, "shared");
+      const mkdir = fs.mkdir.bind(fs);
+      let injected = false;
+      vi.spyOn(fs, "mkdir").mockImplementation(async (candidate, options) => {
+        if (String(candidate) !== parent) return await mkdir(candidate, options);
+        if (outcome === "success") {
+          await mkdir(candidate, options);
+          await fs.rmdir(parent);
+        }
+        await fs.writeFile(parent, "keep parent file", { flag: "wx", mode: 0o400 });
+        injected = true;
+        if (outcome === "EEXIST") return await mkdir(candidate, options);
+      });
+
+      await expect(write({ rootDir, filePath: path.join(parent, "token"), content: "secret" }))
+        .rejects.toThrow(`Private secret directory component ${parent} must be a directory.`);
+      expect(injected).toBe(true);
+      expect(await fs.readFile(parent, "utf8")).toBe("keep parent file");
+      if (process.platform !== "win32") expect((await fs.stat(parent)).mode & 0o777).toBe(0o400);
+      await expect(fs.lstat(path.join(parent, "token"))).rejects.toMatchObject({
+        code: expect.stringMatching(/^(ENOENT|ENOTDIR)$/),
+      });
+      expect(await fs.readdir(rootDir)).toEqual(["shared"]);
+    });
+
+    it.each(writers)(`$operation rejects an in-root symlink substituted at parent mkdir ${outcome}`, async ({ write }) => {
+      const rootDir = await tempRoot("fs-safe-secret-parent-link-");
+      const parent = path.join(rootDir, "shared");
+      const referent = path.join(rootDir, "referent");
+      await fs.mkdir(referent, { mode: 0o700 });
+      await fs.writeFile(path.join(referent, "keep"), "untouched");
+      const mkdir = fs.mkdir.bind(fs);
+      let injected = false;
+      vi.spyOn(fs, "mkdir").mockImplementation(async (candidate, options) => {
+        if (String(candidate) !== parent) return await mkdir(candidate, options);
+        if (outcome === "success") {
+          await mkdir(candidate, options);
+          await fs.rmdir(parent);
+        }
+        await fs.symlink(referent, parent, process.platform === "win32" ? "junction" : "dir");
+        injected = true;
+        if (outcome === "EEXIST") return await mkdir(candidate, options);
+      });
+
+      await expect(write({ rootDir, filePath: path.join(parent, "token"), content: "secret" }))
+        .rejects.toThrow(`Private secret directory component ${parent} must not be a symlink.`);
+      expect(injected).toBe(true);
+      expect((await fs.lstat(parent)).isSymbolicLink()).toBe(true);
+      expect(await fs.realpath(parent)).toBe(referent);
+      expect(await fs.readFile(path.join(referent, "keep"), "utf8")).toBe("untouched");
+      expect(await fs.readdir(referent)).toEqual(["keep"]);
+      await expect(fs.lstat(path.join(parent, "token"))).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  }
+
+  for (const ancestor of ["root", "parent"] as const) {
+    it.each(writers)(`$operation retains the ${ancestor} guard across an EEXIST retry`, async ({ write }) => {
+      const sandbox = await tempRoot("fs-safe-secret-parent-guard-");
+      const rootDir = path.join(sandbox, "root");
+      const existing = path.join(rootDir, "existing");
+      const parent = path.join(existing, "shared");
+      const moved = path.join(sandbox, "moved");
+      await fs.mkdir(existing, { recursive: true, mode: 0o700 });
+      const mkdir = fs.mkdir.bind(fs);
+      let injected = false;
+      vi.spyOn(fs, "mkdir").mockImplementation(async (candidate, options) => {
+        if (String(candidate) === parent) {
+          await fs.rename(ancestor === "root" ? rootDir : existing, moved);
+          await mkdir(parent, { recursive: true, mode: 0o700 });
+          injected = true;
+        }
+        return await mkdir(candidate, options);
+      });
+
+      await expect(write({ rootDir, filePath: path.join(parent, "token"), content: "secret" }))
+        .rejects.toMatchObject({ code: "path-mismatch" });
+      expect(injected).toBe(true);
+      expect(await fs.readdir(parent)).toEqual([]);
+      const originalParent = ancestor === "root" ? path.join(moved, "existing") : moved;
+      expect(await fs.readdir(originalParent)).toEqual([]);
+    });
+  }
+
+  it.each(writers)("$operation propagates unexpected parent mkdir errors unchanged", async ({ write }) => {
+    const rootDir = await tempRoot("fs-safe-secret-parent-errno-");
+    const parent = path.join(rootDir, "shared");
+    const failure = Object.assign(new Error("mkdir I/O failure"), { code: "EIO" });
+    const mkdir = fs.mkdir.bind(fs);
+    vi.spyOn(fs, "mkdir").mockImplementation(async (candidate, options) => {
+      if (String(candidate) === parent) throw failure;
+      return await mkdir(candidate, options);
+    });
+
+    await expect(write({ rootDir, filePath: path.join(parent, "token"), content: "secret" }))
+      .rejects.toBe(failure);
+    expect(await fs.readdir(rootDir)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Two legitimate secret writers targeting distinct leaves beneath the same initially missing parent could both observe `ENOENT` and reach the real non-recursive `mkdir`. One created the directory; the other leaked raw `EEXIST`. `createSecretFileAtomic()` then broadly remapped that parent collision to `secret-exists`, even though its distinct final leaf did not exist.

Intermediate parent creation now consumes only `mkdir EEXIST` and loops back through the existing root/parent guards and `lstat` type checks. Both competing creation and this invocation's successful `mkdir` receive fresh validation before realpath containment, requested-mode enforcement, and later publication. `EEXIST` is therefore a reason to re-inspect, never evidence that the raced entry is trustworthy.

Per-leaf write queuing remains unchanged so distinct leaves may proceed concurrently. Final exclusive publication and same-leaf create collisions are unchanged: one same-leaf creator wins and the loser still receives `secret-exists`. Production delta is +23/−14, net +9 lines; focused regressions add 188 lines across 17 cases. No public signature, native ABI, dependency, lockfile, generated output, timeout, or size budget changed.

The separate custom setgid `dirMode` / pre-existing-directory chmod and ownership policy is intentionally excluded and tracked as a distinct follow-up.

## Physical behavior proof

Fresh packed merged-main baseline on macOS arm64 exact Node 24.20.0 in native configuration `off` and `require`:

```text
writeSecretFileAtomic distinct leaves -> one fulfilled; one raw parent mkdir EEXIST; losing leaf absent
createSecretFileAtomic distinct leaves -> one fulfilled; one false secret-exists caused by parent mkdir EEXIST; losing leaf absent
```

Both real writers reached the parent barrier in every case and no barrier timed out.

Fresh physical installs of the packed candidate pass 20/20 public contention cases:

- macOS arm64: exact Node 22.0.0, 22.23.2, and 24.20.0; native configuration `off` and `require`; 12/12 method lanes.
- Linux arm64 local containers: exact Node 22.0.0 and 24.20.0; native configuration `off` and `require`; 8/8 method lanes.
- Each lane ran two concurrent `writeSecretFileAtomic()` calls and two concurrent `createSecretFileAtomic()` calls against distinct leaves beneath one missing shared parent.
- Every method recorded both arrivals, no timeout, both fulfilled operations, and exact bytes at all four leaves.
- Candidate root artifact integrity: `sha512-MDirtAA6cXpHMKZD2EiQAr75FvI7D9ps741yh9yr2iFbaiKeMPNBXtUk4lM85/9Azw/hdzYML1FiviBOWFpxQA==`.

The native setting is a configuration/backend parity lane; the parent retry itself is TypeScript before final backend publication. Separate package smoke exercised host-native loading. Linux evidence is local-container Linux arm64 proof, not remote/AWS proof.

## Adversarial coverage

The focused suite verifies:

- Distinct-leaf write and create races both complete with exact binary/text bytes.
- Concurrent same-leaf create remains first-writer-wins with exactly one `secret-exists` loser and unchanged winner bytes.
- A regular file winning or replacing a parent `mkdir` is rejected and preserved.
- An in-root directory symlink winning or replacing the parent is rejected without writing through it.
- Root and immediate-parent substitutions across the retry reject with `path-mismatch` and leave both old and replacement trees untouched.
- Unexpected parent `mkdir` errors propagate unchanged.

## Validation

- Focused secret/guard/publication suites: 159 passed / 1 Windows-only skipped.
- New concurrency suite independently on exact Node 22.0.0, 22.23.2, and 24.20.0: 17 passed on each runtime.
- `CI=1 pnpm check`: 6,897 passed / 80 skipped; 199 files passed / 2 skipped.
- `pnpm test:security`: 84 passed.
- `pnpm package:smoke`: npm/pnpm physical consumers, host native loading, optional omission, and missing-binary behavior passed.
- File-size, filesystem-boundary, build, docs, package, and `git diff --check` gates passed.
- Independent Codex autoreview was scoped-clean at P0 (0.98). The review harness omitted the then-untracked secret regression file by policy; that file was independently executed across all three exact Node versions and is included in the committed PR for exact-head CI and ClawSweeper review.

Exact-head cross-platform CI and ClawSweeper review are required before merge. No release or package publication is included.
