### PR TITLE
docs(archive): correct helper signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Correct lower-level archive helper signatures in the reference docs and guard them against drifting from the public declarations.
 - Retry and fully revalidate raced secret-parent creation so concurrent writes to distinct leaves succeed without leaking `EEXIST` or reporting a false `secret-exists` collision.
 - Release asynchronously acquired Root-backed sidecar locks on natural event-loop shutdown through their retained ownership receipts, preserving changed sidecars and avoiding cleanup retry loops.
 - Prevent no-reader FIFOs from stalling POSIX `Root.openWritable()` and async/sync regular-file append admission, preserving regular-file write semantics and existing-target cleanup fencing.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -502,9 +502,9 @@ The archive subpath also exports the helpers `extractArchive` is built on. Most 
 | `withStagedArchiveDestination(opts)` | Creates a private staging dir outside the destination, calls your `run(stagingDir)`, then cleans it up. |
 | `mergeExtractedTreeIntoDestination(opts)` | The merge step alone — staged tree → destination through boundary checks. |
 | `prepareArchiveDestinationDir(destDir)` | Canonicalizes and asserts the destination directory. |
-| `prepareArchiveOutputPath(opts)` | Resolves a single entry's output path against the staging dir. |
-| `loadZipArchiveWithPreflight(opts)` | Loads a JSZip with size/entry-count preflight before unzipping. |
-| `readZipCentralDirectoryEntryCount(path)` | Returns the entry count from a ZIP's central directory without reading any payloads. |
+| `prepareArchiveOutputPath({ destinationDir, destinationRealDir, relPath, outPath, originalPath, isDirectory, deadline? })` | Validates and prepares parents for an already-resolved entry output path. |
+| `loadZipArchiveWithPreflight(buffer, limits?)` | Loads a JSZip from a `Buffer` or `Uint8Array` with size/entry-count preflight before unzipping. |
+| `readZipCentralDirectoryEntryCount(buffer)` | Returns the entry count from an already-loaded ZIP `Buffer` or `Uint8Array` without decoding payloads. |
 | `createTarEntryPreflightChecker(opts)` | Returns a per-entry checker for use as a `tar.x` `onReadEntry` hook. |
 
 These let you build custom extractors that share the same safety machinery — for example, a streaming uploader that wants to refuse archives with too many entries before reading any payloads.
@@ -526,7 +526,7 @@ import {
 - `validateArchiveEntryPath(raw, opts)` — throws `ArchiveSecurityError` for `..`, absolute, NUL-containing, drive-relative, or otherwise unsafe entry paths, including alternate data stream names on Windows.
 - `normalizeArchiveEntryPath(raw)` — converts backslashes in the entry path to forward slashes.
 - `stripArchivePath(entryPath, n)` — normalize separators, drop empty and `.` components, then strip the leading N components, returning `null` if none remain.
-- `resolveArchiveOutputPath({ destDir, entryPath })` — combines the entry path with the destination, after validation.
+- `resolveArchiveOutputPath({ rootDir, relPath, originalPath, escapeLabel? })` — combines the validated relative path with the root and rejects escapes using the original archive path for diagnostics.
 - `isWindowsDrivePath(value)` — detects drive-relative segments such as `C:secret` or `nested/C:secret` that should be rejected.
 
 Validate attacker-controlled paths before calling normalization or stripping

--- a/test/documentation-contract.test.ts
+++ b/test/documentation-contract.test.ts
@@ -166,8 +166,13 @@ describe("documentation contract", () => {
     expect(archiveDoc).toContain("loadZipArchiveWithPreflight(buffer, limits?)");
     expect(archiveDoc).toContain("readZipCentralDirectoryEntryCount(buffer)");
     expect(archiveDoc).toContain(
+      "prepareArchiveOutputPath({ destinationDir, destinationRealDir, relPath, outPath, originalPath, isDirectory, deadline? })",
+    );
+    expect(archiveDoc).toContain(
       "resolveArchiveOutputPath({ rootDir, relPath, originalPath, escapeLabel? })",
     );
+    expect(archiveDoc).not.toContain("prepareArchiveOutputPath(opts)");
+    expect(archiveDoc).not.toContain("Resolves a single entry's output path against the staging dir");
     expect(archiveDoc).not.toContain("loadZipArchiveWithPreflight(opts)");
     expect(archiveDoc).not.toContain("readZipCentralDirectoryEntryCount(path)");
     expect(archiveDoc).not.toContain("resolveArchiveOutputPath({ destDir, entryPath })");

--- a/test/documentation-contract.test.ts
+++ b/test/documentation-contract.test.ts
@@ -161,6 +161,18 @@ describe("documentation contract", () => {
     expect(archiveDoc).not.toContain("Returns `undefined` for unknown extensions");
   });
 
+  it("documents the actual lower-level archive helper signatures", () => {
+    const archiveDoc = readRepoFile("docs/archive.md");
+    expect(archiveDoc).toContain("loadZipArchiveWithPreflight(buffer, limits?)");
+    expect(archiveDoc).toContain("readZipCentralDirectoryEntryCount(buffer)");
+    expect(archiveDoc).toContain(
+      "resolveArchiveOutputPath({ rootDir, relPath, originalPath, escapeLabel? })",
+    );
+    expect(archiveDoc).not.toContain("loadZipArchiveWithPreflight(opts)");
+    expect(archiveDoc).not.toContain("readZipCentralDirectoryEntryCount(path)");
+    expect(archiveDoc).not.toContain("resolveArchiveOutputPath({ destDir, entryPath })");
+  });
+
   it("keeps every public error category aligned with observed FsSafeError behavior", () => {
     const operational = new Set<FsSafeErrorCode>([
       "helper-failed",


### PR DESCRIPTION
## Summary

The lower-level archive reference documented three public helpers with argument shapes that do not match their exported declarations, and described `prepareArchiveOutputPath()` as resolving a path even though it validates/prepares an already-resolved output and returns `Promise<void>`.

The reference now shows the exact public shapes:

- `loadZipArchiveWithPreflight(buffer, limits?)`
- `readZipCentralDirectoryEntryCount(buffer)`
- `prepareArchiveOutputPath({ destinationDir, destinationRealDir, relPath, outPath, originalPath, isDirectory, deadline? })`
- `resolveArchiveOutputPath({ rootDir, relPath, originalPath, escapeLabel? })`

A documentation-contract regression asserts the corrected signatures and rejects the stale spellings. This is docs/test-only: no production, declaration, public API, dependency, lockfile, generated output, or native change.

## Executed proof

The stale packed-main example:

```ts
resolveArchiveOutputPath({ destDir, entryPath });
```

fails against the actual package declaration with TS2353 because `destDir` is not a property of `{ rootDir, relPath, originalPath, escapeLabel? }`. The corrected object shape compiles.

A fresh physical install of the packed candidate then compiled one TypeScript consumer using all four corrected documented calls with strict NodeNext settings and no emit. The installed package's packed `docs/archive.md` was also inspected and contained the corrected signatures at the expected reference rows.

Candidate root artifact integrity: `sha512-ldSf9cyntfns1/A1HPdn7aUIoqLq9wxj9R3VVR1Rs3l0cO75baX4rKXlXlOvEjng7pzKA2IwYpH9J80QikUN7g==`.

## Validation

- Focused documentation/API/archive suites: 76 passed.
- `pnpm docs:check`: passed.
- Strict external TypeScript declaration compile: passed.
- Packed documentation signature inspection: passed.
- `CI=1 pnpm check`: 6,898 passed / 80 skipped; 199 files passed / 2 skipped.
- Build, file-size, filesystem-boundary, package, and `git diff --check` gates passed.
- Independent Codex autoreview was scoped-clean at P0 (0.99).

Current docs validation checks imported names but does not type-check inline reference-table signatures; the added regression protects these exact public shapes without introducing a broad Markdown compiler.

Exact-head CI and ClawSweeper review are required before merge. No release or package publication is included.
