### PR TITLE
test(lock): let contention watchdog own liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Assign cross-platform sidecar contention proof liveness to its whole-worker watchdog instead of false-failing healthy unfair acquisition; production lock timeout behavior is unchanged.
 - Enforce portable FileStore keys consistently across methods: async reads, `exists`, and `remove` now reject parent-segment and backslash aliases with `invalid-path` for existing roots, matching sync and write methods while preserving missing-root error precedence and Root's confined existing-object compatibility.
 - Resync durable queue acknowledgement retries after final marker unlink before reporting completion or a newer-generation mismatch.
 - Propagate durable queue batch claim and migration failures instead of returning empty or partial success, and strictly sync migration publication in both loaders while preserving retry state.

--- a/scripts/sidecar-contention-proof.mjs
+++ b/scripts/sidecar-contention-proof.mjs
@@ -28,10 +28,10 @@ const safeLabel = (value) => typeof value === "string" && /^[a-zA-Z][a-zA-Z0-9_-
 // Never forward error messages, paths, stacks, sidecar bytes, or child output.
 const errorShape = (error) => ({ name: safeLabel(error?.name), code: safeLabel(error?.code) });
 const absent = (file) => assert.throws(() => fs.lstatSync(file), { code: "ENOENT" });
-const lockOptions = () => ({
+const lockOptions = (timeoutMs = 15_000) => ({
   staleMs: 60_000,
-  timeoutMs: 15_000,
-  retry: { retries: 15_000, factor: 1, minTimeout: 1, maxTimeout: 5, randomize: true },
+  timeoutMs,
+  retry: { factor: 1, minTimeout: 1, maxTimeout: 5, randomize: true },
   staleRecovery: "fail-closed",
   // Deliberately omit createdAt: contention must use the snapshot-mtime fallback.
   payload: () => ({ pid: process.pid }),
@@ -53,7 +53,8 @@ async function runWorker(test, directory) {
   const marker = path.join(directory, "critical");
   // Both APIs accept the documented Root capability; there is no RootSync API.
   const lockRoot = test.rooted ? await root(directory) : undefined;
-  const options = { ...lockOptions(), lockRoot };
+  // A per-acquisition deadline would mistake unfair but progressing contention for lock failure.
+  const options = { ...lockOptions(Infinity), lockRoot };
   phase = "start-barrier";
   await parentBarrier("ready", "start");
   const waitWord = new Int32Array(new SharedArrayBuffer(4));

--- a/test/sidecar-contention-proof-contract.test.ts
+++ b/test/sidecar-contention-proof-contract.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+
+// Read only: importing this standalone proof would launch its worker suite.
+const source = fs.readFileSync(new URL("../scripts/sidecar-contention-proof.mjs", import.meta.url), "utf8")
+  .replace(/\/\/[^\n]*|\/\*[\s\S]*?\*\//gu, "");
+
+function functionSource(name: string): string {
+  const match = source.match(new RegExp(
+    `^(?:async\\s+)?function\\s+${name}\\s*\\([\\s\\S]*?(?=^(?:async\\s+)?function\\s|^try\\s*\\{)`,
+    "mu",
+  ));
+  expect(match, `missing proof function ${name}`).not.toBeNull();
+  return match![0];
+}
+
+describe("sidecar contention proof contract", () => {
+  it("keeps a finite default and unlimited retries with the same backoff and jitter", () => {
+    const options = source.match(
+      /const\s+lockOptions\s*=\s*\(\s*timeoutMs\s*=\s*15_?000\s*\)\s*=>\s*\(\s*\{(?<body>[\s\S]*?)\}\s*\)\s*;/u,
+    )?.groups?.body;
+    expect(options).toBeDefined();
+    expect(options).toMatch(/(?:^|,)\s*timeoutMs\s*,/u);
+    expect(options).not.toMatch(/\btimeoutMs\s*:/u);
+    const retry = options?.match(/\bretry\s*:\s*\{(?<body>[^}]+)\}/u)?.groups?.body;
+    expect(retry?.split(",").map((entry) => entry.replace(/\s/gu, "")).filter(Boolean).sort()).toEqual([
+      "factor:1", "maxTimeout:5", "minTimeout:1", "randomize:true",
+    ]);
+    expect(options).not.toMatch(/\bretries\b/u);
+    expect(options).toMatch(/\bstaleRecovery\s*:\s*["']fail-closed["']/u);
+  });
+
+  it("gives both child acquisition APIs only the unbounded contention options", () => {
+    const worker = functionSource("runWorker");
+    expect(worker).toMatch(
+      /const\s+options\s*=\s*\{\s*\.\.\.lockOptions\s*\(\s*Infinity\s*\)\s*,\s*lockRoot\s*,?\s*\}\s*;/u,
+    );
+    expect([...worker.matchAll(/\bacquireFileLock(?:Sync)?\s*\([^)]*\)/gu)].map(([call]) =>
+      call.replace(/\s/gu, ""))).toEqual([
+      "acquireFileLockSync(target,options)", "acquireFileLock(target,options)",
+    ]);
+    // Catch overrides/mutations as well as changing the helper's Infinity argument.
+    expect(worker.match(/\boptions\b/gu)).toHaveLength(3);
+    expect(worker).not.toMatch(/\b(?:timeoutMs|retry|retries)\b/u);
+    expect(worker.match(/\blockOptions\s*\(/gu)).toHaveLength(1);
+  });
+
+  it("keeps both parent permission acquisitions on the finite default", () => {
+    const permission = functionSource("runPermissionCase");
+    expect(permission.match(/\bacquireFileLockSync\s*\(\s*target\s*,\s*lockOptions\s*\(\s*\)\s*\)/gu))
+      .toHaveLength(2);
+    expect(permission.match(/\bacquireFileLock(?:Sync)?\s*\(/gu)).toHaveLength(2);
+    expect(permission).not.toMatch(/\bInfinity\b/u);
+    expect(source.match(/\blockOptions\s*\(/gu)).toHaveLength(3);
+  });
+
+  it("preserves all four cases and the four-by-25 workload with 2ms critical sections", () => {
+    expect(source).toMatch(/const\s+processes\s*=\s*4\s*;/u);
+    expect(source).toMatch(/const\s+acquisitionsPerProcess\s*=\s*25\s*;/u);
+    expect([...source.matchAll(/name:\s*["']((?:pathname|root)-(?:async|sync))["']/gu)]
+      .map((match) => match[1])).toEqual(["pathname-async", "pathname-sync", "root-async", "root-sync"]);
+    const worker = functionSource("runWorker");
+    expect(worker).toMatch(/index\s*<\s*acquisitionsPerProcess/u);
+    expect(worker).toMatch(/Atomics\.wait\s*\(\s*waitWord\s*,\s*0\s*,\s*0\s*,\s*2\s*\)/u);
+    expect(worker).toMatch(/await\s+pause\s*\(\s*2\s*\)/u);
+    expect(functionSource("runContentionCase")).toMatch(/index\s*<\s*processes/u);
+  });
+
+  it("keeps the parent's 60-second watchdog wired to kill and reap workers", () => {
+    expect(source).toMatch(/const\s+childDeadlineMs\s*=\s*60_?000\s*;/u);
+    const launch = functionSource("launchWorker");
+    expect(launch).toMatch(
+      /const\s+deadline\s*=\s*setTimeout\s*\(\s*\(\s*\)\s*=>\s*\{\s*timedOut\s*=\s*true\s*;\s*stop\s*\(\s*\)\s*;\s*\}\s*,\s*childDeadlineMs\s*\)/u,
+    );
+    expect(launch).toMatch(/const\s+stop\s*=\s*\(\s*\)\s*=>\s*\{\s*if\s*\(\s*!closed\s*\)\s*\{\s*try\s*\{\s*child\.kill\s*\(\s*["']SIGKILL["']\s*\)/u);
+    expect(launch).toMatch(/const\s+done\s*=\s*new\s+Promise\s*\(\s*\(\s*resolve\s*\)\s*=>\s*\{\s*child\.once\s*\(\s*["']close["']/u);
+    expect(launch).toMatch(/child\.once\s*\(\s*["']close["']\s*,\s*\(\s*exitCode\s*,\s*signal\s*\)\s*=>\s*\{\s*closed\s*=\s*true\s*;\s*clearTimeout\s*\(\s*deadline\s*\)/u);
+    expect(launch).toMatch(/const\s+passed\s*=\s*exitCode\s*===\s*0\s*&&\s*!signal\s*&&\s*!timedOut/u);
+    expect(launch).toMatch(/return\s*\{\s*ready\s*,\s*released\s*,\s*done\s*,\s*stop\s*,/u);
+    expect(functionSource("runContentionCase")).toMatch(
+      /finally\s*\{\s*for\s*\(\s*const\s+child\s+of\s+children\s*\)\s*child\.stop\s*\(\s*\)\s*;\s*const\s+settled\s*=\s*await\s+Promise\.allSettled\s*\(\s*children\.map\s*\(\s*\(\s*child\s*\)\s*=>\s*child\.done\s*\)\s*\)/u,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- make the whole-worker watchdog the sole liveness budget for sidecar contention proof children;
- remove the proof's accidental per-acquisition fairness requirement while preserving every mutual-exclusion, ownership, cleanup, and workload assertion;
- keep the un-watched POSIX permission case on its existing finite acquisition budget;
- add a static proof-contract guard and an operational 0.7.3 changelog entry.

## Root cause

The contention proof launches four processes and requires each to complete 25 acquisitions. Every acquisition previously had a 15-second timeout and a finite retry count, while the parent independently enforced a 60-second whole-worker watchdog.

Actual Windows native proof reproduced the mismatch:

- pathname async/sync and Root async completed 300/300;
- Root sync made healthy progress but completed 71/100;
- two workers completed all 25 acquisitions, a third completed 21, and a fourth completed none;
- the latter two reported `file_lock_timeout` in acquisition;
- no 60-second child watchdog fired; the case failed after about 30 seconds;
- the unchanged failed job reran successfully, and many surrounding exact-head runs passed.

Cross-process locks promise exclusion, exact ownership, fail-closed stale behavior, and caller-selected waiting budgets—not FIFO fairness. A releasing worker can reacquire while another process sleeps or inspects the old record. Requiring every contender to win within 15 seconds can therefore false-fail while other workers are safely progressing.

## Repair

Contention children now use `lockOptions(Infinity)` with no retry-count limit. The existing 60-second parent watchdog owns liveness for their whole workload. It starts at child launch, kills a stuck child, resolves failed barriers on child closure, and reaps every sibling before scratch cleanup.

The finite 15-second default remains in `lockOptions()` and is still used by the POSIX permission/release case, which has no child watchdog. Backoff/jitter, stale timeout, and fail-closed recovery are unchanged.

The proof still requires:

- four cases, four workers each, 25 acquisitions per worker;
- 400 exact contention acquisitions;
- a 2 ms critical section;
- live ownership and payload verification;
- an exclusive marker and exact shared counter;
- release completion plus marker/sidecar/reclaim absence;
- the two-acquisition POSIX release-retry proof where supported.

No production source, lock API/default, fairness behavior, denial cap, test timeout, workflow timeout, workload size, native code, exports, or types changed. Production LOC delta: zero.

## Regression guard

A new static contract test reads the standalone proof without importing or launching it and pins:

- finite `lockOptions()` default;
- worker-only `Infinity` and omitted retry count;
- unchanged backoff/jitter and fail-closed recovery;
- finite permission-case calls;
- four-by-25 workload and 2 ms critical section;
- 60-second watchdog, `SIGKILL`, child-close settlement, sibling kill, and `Promise.allSettled` reaping.

## Local validation

- focused proof-contract test: 5 passed;
- relevant lock suites: 163 passed / 6 skipped;
- complete macOS arm64 Node.js 24.20.0 proof, native `off`: 400/400 contention plus 2/2 permission acquisitions;
- complete macOS arm64 Node.js 24.20.0 proof, native `require`: 400/400 contention plus 2/2 permission acquisitions;
- build and host native binding staging: passed;
- full `CI=1 pnpm check`: 202 test files passed / 2 skipped, 7,085 tests passed / 80 skipped;
- security suite: 84 passed;
- release-package smoke: passed;
- `git diff --check`: passed;
- Codex autoreview: no accepted/actionable finding, patch correct at 0.99.

Neither local proof hit the watchdog or failed an exclusion, identity, counter, release, or cleanup assertion.

## Windows validation results

The standalone PR run passed 400/400 in both [Windows fallback](https://github.com/openclaw/fs-safe/actions/runs/33767135233/job/100687782016) and [Windows required-native](https://github.com/openclaw/fs-safe/actions/runs/33767135233/job/100687781679) modes. Four of the original five whole workflow runs passed. The fifth, [33767148513](https://github.com/openclaw/fs-safe/actions/runs/33767148513/job/100687834460), failed with a separate Root async `EPERM`; it remains preserved and was not retried away. That discovery prompted the separate production repair in [#218](https://github.com/openclaw/fs-safe/pull/218), rather than broadening this harness-only PR.

[Complete combined after-fix proof](https://github.com/openclaw/fs-safe/pull/217#issuecomment-5528920170) now records five independent Windows x64 / Node 24.19.0 fallback/native pairs at frozen integration head `dab64dbb922afb5a86cd2fb782544d9d334a3052`, tree `0e27501c81d73003da4a05c48df6e7d1fbc30e3d`: ten successful 400/400 invocations, 4,000 acquisitions, exact counters, marker/sidecar absence, and no watchdog expiry. Checkout SHAs were verified from job logs. This is the combined validation tree, not this PR's standalone head; this PR's script and guard are byte-identical in that tree.

Six combined workflows were launched: five completed both proofs, while [33777327817](https://github.com/openclaw/fs-safe/actions/runs/33777327817/job/100722191744) failed an existing private-store stress test before its fallback proof. The additional independent run supplied the missing executed pair; the failed workflow is retained, not counted as passing. No dedicated physical Windows provider is claimed: these are actual Windows GitHub Actions executions.

Disposable local negative controls also verified that four deliberately blocked sync children were killed and reaped at the existing 60-second watchdog, and that retained sidecars fail the proof despite complete counters. Both exited nonzero and left their scratch roots empty. Local combined full-check attempts separately stalled in a workflow-dispatch fixture and are preserved as failures, not represented as successful checks.
