### PR TITLE
test(ci): bound dispatch fixture subprocess lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Bound workflow-dispatch test subprocesses and terminate their process groups before fixture cleanup, so stuck shell descendants fail validation instead of hanging the suite.
 - Enforce portable FileStore keys consistently across methods: async reads, `exists`, and `remove` now reject parent-segment and backslash aliases with `invalid-path` for existing roots, matching sync and write methods while preserving missing-root error precedence and Root's confined existing-object compatibility.
 - Resync durable queue acknowledgement retries after final marker unlink before reporting completion or a newer-generation mismatch.
 - Propagate durable queue batch claim and migration failures instead of returning empty or partial success, and strictly sync migration publication in both loaders while preserving retry state.

--- a/test/clawsweeper-dispatch-workflow.test.ts
+++ b/test/clawsweeper-dispatch-workflow.test.ts
@@ -1,4 +1,5 @@
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
@@ -10,9 +11,56 @@ import {
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const behaviorIt = process.platform === "win32" ? it.skip : it;
+const fixtureTimeoutMs = 10_000;
+
+function startFixture(
+  scriptPath: string,
+  env: NodeJS.ProcessEnv,
+  armDeadline: (callback: () => void, ms: number) => NodeJS.Timeout = setTimeout,
+) {
+  const child = spawn("bash", [scriptPath], {
+    cwd: process.cwd(), env, detached: true, stdio: ["ignore", "pipe", "pipe"],
+  });
+  let closed = false;
+  let stopping = false;
+  let timedOut = false;
+  let error: Error | undefined;
+  let bytes = 0;
+  const output = { stdout: [] as Buffer[], stderr: [] as Buffer[] };
+  const stop = () => {
+    if (closed || stopping || child.pid === undefined) return;
+    stopping = true;
+    try { process.kill(-child.pid, "SIGKILL"); }
+    catch (reason) {
+      if ((reason as NodeJS.ErrnoException).code !== "ESRCH") error = reason as Error;
+    }
+  };
+  const deadline = armDeadline(() => { timedOut = true; stop(); }, fixtureTimeoutMs);
+  for (const name of ["stdout", "stderr"] as const) {
+    child[name].on("data", (chunk: Buffer) => {
+      bytes += chunk.length;
+      if (bytes <= 1_048_576) output[name].push(chunk);
+      else { error ??= new Error("dispatch fixture output exceeded 1 MiB"); stop(); }
+    });
+  }
+  child.on("error", (reason) => { error = reason; stop(); });
+  // A descendant may hold the pipes after Bash exits; keep the deadline until close.
+  const result = new Promise<{
+    status: number | null; signal: NodeJS.Signals | null; timedOut: boolean;
+    error?: Error; stdout: string; stderr: string;
+  }>((resolve) => child.once("close", (status, signal) => {
+    closed = true;
+    clearTimeout(deadline);
+    resolve({ status, signal, timedOut, error,
+      stdout: Buffer.concat(output.stdout).toString("utf8"),
+      stderr: Buffer.concat(output.stderr).toString("utf8"),
+    });
+  }));
+  return { child, result, stop };
+}
 
 function exactReviewBlock(workflow: string) {
   const start = workflow.indexOf("      - name: Dispatch exact ClawSweeper review");
@@ -32,7 +80,7 @@ function exactReviewRun(workflow: string) {
     .trimEnd();
 }
 
-function executeExactReview(run: string, event: object, environment: Record<string, string>) {
+async function executeExactReview(run: string, event: object, environment: Record<string, string>) {
   const directory = mkdtempSync(join(tmpdir(), "fs-safe-clawsweeper-dispatch-"));
   const eventPath = join(directory, "event.json");
   const capturePath = join(directory, "dispatch.json");
@@ -61,19 +109,17 @@ function executeExactReview(run: string, event: object, environment: Record<stri
     chmodSync(scriptPath, 0o755);
     chmodSync(ghPath, 0o755);
 
-    const result = spawnSync("bash", [scriptPath], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        ...environment,
-        GH_CAPTURE: capturePath,
-        GH_TOKEN: "proof-token",
-        GITHUB_EVENT_PATH: eventPath,
-        PATH: `${directory}:${process.env.PATH ?? ""}`,
-        SUPERSEDES_IN_PROGRESS: "false",
-      },
-    });
+    const result = await startFixture(scriptPath, {
+      ...process.env,
+      ...environment,
+      GH_CAPTURE: capturePath,
+      GH_TOKEN: "proof-token",
+      GITHUB_EVENT_PATH: eventPath,
+      PATH: `${directory}:${process.env.PATH ?? ""}`,
+      SUPERSEDES_IN_PROGRESS: "false",
+    }).result;
+    expect(result.timedOut, `dispatch fixture timed out after ${fixtureTimeoutMs}ms (${result.status}/${result.signal}): ${result.stdout}\n${result.stderr}`).toBe(false);
+    expect(result.error).toBeUndefined();
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     return JSON.parse(readFileSync(capturePath, "utf8")) as {
       event_type: string;
@@ -124,7 +170,7 @@ describe("ClawSweeper dispatch workflow", () => {
       updated_at: "2026-08-10T22:00:00Z",
       body: "proof body",
     };
-    const prPayload = executeExactReview(
+    const prPayload = await executeExactReview(
       run,
       { pull_request: pullRequest, label: { name: "proof: sufficient" } },
       {
@@ -165,7 +211,7 @@ describe("ClawSweeper dispatch workflow", () => {
       },
     });
 
-    const issuePayload = executeExactReview(
+    const issuePayload = await executeExactReview(
       run,
       { issue: { number: 446 } },
       {
@@ -186,5 +232,52 @@ describe("ClawSweeper dispatch workflow", () => {
       source_action: "opened",
       supersedes_in_progress: false,
     });
-  });
+  }, 2 * fixtureTimeoutMs + 1_000);
+
+  behaviorIt("kills descendants holding pipes after the shell exits and reports a timeout", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "fs-safe-dispatch-watchdog-"));
+    const scriptPath = join(directory, "hang.sh");
+    writeFileSync(scriptPath, '\"$FIXTURE_NODE\" -e \'process.on("SIGTERM", () => {}); console.log("READY"); setInterval(() => {}, 1000)\' &\n');
+    let expire = () => {};
+    const armDeadline = vi.fn((callback: () => void, ms: number) => {
+      expire = callback;
+      return setTimeout(callback, ms);
+    });
+    const fixture = startFixture(scriptPath, { ...process.env, FIXTURE_NODE: process.execPath }, armDeadline);
+    try {
+      await Promise.race([
+        Promise.all([once(fixture.child, "exit"), once(fixture.child.stdout, "data")]),
+        fixture.result.then(() => { throw new Error("fixture closed before readiness"); }),
+      ]);
+      expect(fixture.child.exitCode).toBe(0);
+      expect(armDeadline).toHaveBeenCalledWith(expect.any(Function), fixtureTimeoutMs);
+      expire();
+      const result = await fixture.result;
+      expect(result.timedOut).toBe(true);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("READY");
+      expect(result.error).toBeUndefined();
+    } finally {
+      fixture.stop();
+      await fixture.result;
+      rmSync(directory, { recursive: true, force: true });
+    }
+  }, fixtureTimeoutMs + 1_000);
+
+  behaviorIt("bounds fixture output and reaps an overflowing child", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "fs-safe-dispatch-output-"));
+    const scriptPath = join(directory, "overflow.sh");
+    writeFileSync(scriptPath, '\"$FIXTURE_NODE\" -e \'process.stdout.write("x".repeat(2 * 1024 * 1024)); setInterval(() => {}, 1000)\'\n');
+    const fixture = startFixture(scriptPath, { ...process.env, FIXTURE_NODE: process.execPath });
+    try {
+      const result = await fixture.result;
+      expect(result.error?.message).toBe("dispatch fixture output exceeded 1 MiB");
+      expect(result.timedOut).toBe(false);
+      expect(Buffer.byteLength(result.stdout)).toBeLessThanOrEqual(1_048_576);
+    } finally {
+      fixture.stop();
+      await fixture.result;
+      rmSync(directory, { recursive: true, force: true });
+    }
+  }, fixtureTimeoutMs + 1_000);
 });


### PR DESCRIPTION
## Summary

Bound the POSIX workflow-dispatch test fixture's subprocess lifetime without changing the workflow or production code.

The fixture used `spawnSync("bash", ...)` with no subprocess deadline. During local validation it stalled inside Node's synchronous process runner while Bash descendants waited, so Vitest's own timer could not interrupt it. That attempt required stopping the task-owned child and is preserved as a failed run. The underlying shell scheduling cause has not been conclusively identified.

The fixture now uses asynchronous `spawn` in a dedicated POSIX process group, a 10-second deadline, and a 1 MiB output bound. On failure it signals its owned process group once and awaits `close` before temporary-directory cleanup. The deadline stays active after the shell's `exit` event because a descendant can keep the pipes open. A timeout cannot be treated as success merely because the shell exited zero.

The behavioral test's outer budget covers its two sequential bounded fixture invocations plus cleanup margin; no repository-wide test timeout, production timeout, workflow timeout, or workload was changed. Windows retains the existing skip for the POSIX behavioral fixture.

## Regression proof

- Normal workflow serialization still verifies the exact PR ingress fingerprint, branch authority, and issue payload.
- A real Node descendant holds inherited pipes open after Bash exits successfully and ignores `SIGTERM`. The test waits for readiness and the parent's exit, invokes the registered deadline callback, and verifies timeout failure plus closure after process-group `SIGKILL`. A real timer remains as a cleanup backstop.
- A real child overflowing output is terminated and reaped; captured output stays bounded.
- Group termination is idempotent, including when additional buffered output arrives after the first kill.

The subprocess supervisor and tests are local to this test file; no new exported helper or dependency is introduced.

## Validation and limitations

- Focused suite: 4 passed.
- Complete serial suite: `CI=1 pnpm test --maxWorkers=1` — 201 suites passed / 2 skipped; 7,082 tests passed / 80 skipped.
- Build, boundary/size lint, documentation examples, `pnpm pack:check`, and `git diff --check` passed.
- Codex autoreview: no accepted/actionable P0 findings in the final two-file patch.

Default parallel full checks did **not** pass locally and are not claimed as passing: separate runs hit the fixture deadline, a pre-existing sidecar process-exit test deadline, and varying archive test deadlines. The serial verification changed only test-file concurrency, not test bodies, internal stress concurrency, or product deadlines. All failed attempts remain in the campaign evidence. [Initial exact-head hosted CI](https://github.com/openclaw/fs-safe/actions/runs/33781096701) and [first updated-base CI](https://github.com/openclaw/fs-safe/actions/runs/33783022005) passed the normal repository configuration. The changelog conflicts are resolved. Current head `4178ed22d60f40bfc453cb80bb423d1826817ab0` is based on merged main `9edca2ca1e1708e9536587b221de739b439029e1`; [final exact-head CI](https://github.com/openclaw/fs-safe/actions/runs/33783988003) is running. The supervisor itself is byte-identical to the captured runtime helper.

A later local serial run on the combined base also reached this fixture's deadline (7,107 passed / 1 timeout / 80 skipped), and a paired focused run alternated between passing and timing out. Those failures are retained too. This patch bounds and cleans up such failures; it is not claimed to eliminate or conclusively explain the underlying intermittent local shell stall.

## Inspectable runtime capture

After-fix execution used the exact `startFixture` helper from committed head `408598672aa2936605c6aefcdfa93eced4063abb`, extracted without semantic changes and stripped of TypeScript annotations by Node. Helper SHA-256: `d6ecf91cbb24bb52a6bed8a8e2ff1d3e66e6454b811b4c0ed0e8a00221449ae2`. Environment: physical macOS arm64, Node 24.20.0. Actual Bash/Node processes, the real 10,000ms deadline, and actual process-group signals were used—no mocked timer or signal.

Captured terminal results (only synthetic fixture state):

```json
{"case":"normal","status":0,"signal":null,"timedOut":false,"error":null,"elapsedMs":17,"closeObserved":true,"stdoutBytes":11,"descendantGone":null,"scratchRemoved":true}
{"case":"exited-shell-live-descendant","status":0,"signal":null,"timedOut":true,"error":null,"elapsedMs":10005,"closeObserved":true,"stdoutBytes":27,"descendantGone":true,"scratchRemoved":true}
{"case":"output-overflow","status":null,"signal":"SIGKILL","timedOut":false,"error":"dispatch fixture output exceeded 1 MiB","elapsedMs":57,"closeObserved":true,"stdoutBytes":983040,"descendantGone":true,"scratchRemoved":true}
```

The second case confirms that a successful Bash exit is not mistaken for fixture completion while a live descendant holds the pipes. Its actual deadline fired at approximately ten seconds, closure was observed, the descendant was verified gone, and only then was scratch removed. The overflow case terminated before the deadline, retained less than 1 MiB, and likewise verified closure, descendant termination, and cleanup.

This is a separate validation repair discovered while verifying #217 and #218. Their lock implementations and frozen Windows proof candidate were left unchanged.
