### PR TITLE
fix(write): preserve final modes and cleanup ownership

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Test native Root publication verification
         env:
           FS_SAFE_NATIVE_MODE: require
-        run: pnpm test test/root-write-mode.test.ts test/root-write-verification.test.ts test/root-write-lifetime.test.ts test/root-write-exact-identity.test.ts
+        run: pnpm test test/root-write-mode.test.ts test/root-write-verification.test.ts test/root-write-lifetime.test.ts test/root-write-exact-identity.test.ts test/secret-write-publication.test.ts test/native-write-mode-ownership.test.ts test/native-created-cleanup.test.ts test/file-mode-facades.test.ts
 
       - name: Test Root sidecar admission with required native binding
         env:
@@ -182,7 +182,7 @@ jobs:
             node scripts/sidecar-contention-proof.mjs require
             FS_SAFE_NATIVE_MODE=require pnpm test test/root-create-only-preflight.test.ts test/sidecar-lock-root-admission.test.ts test/sidecar-lock-root-ancestry.test.ts test/sidecar-lock-root-budget.test.ts test/sidecar-lock-root-resolver.test.ts test/sidecar-lock-root-unlink.test.ts test/sidecar-lock-unlink-siblings.test.ts test/file-lock-sync-stale.test.ts test/file-lock-sync-release.test.ts
             FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm test test/native-owned-tree.test.ts test/native-write-containment.test.ts test/native-staging-regression.test.ts test/staged-file.test.ts test/staged-file-failures.test.ts test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts test/archive-pax.test.ts test/archive-pax-security.test.ts test/archive-pax-compressed.test.ts test/archive-tar-strip.test.ts test/archive-tar-framing.test.ts test/archive-tar-framing-compressed.test.ts test/archive-gzip-integrity.test.ts
-            FS_SAFE_NATIVE_MODE=require pnpm test test/root-write-mode.test.ts test/root-write-verification.test.ts test/root-write-lifetime.test.ts test/root-write-exact-identity.test.ts
+            FS_SAFE_NATIVE_MODE=require pnpm test test/root-write-mode.test.ts test/root-write-verification.test.ts test/root-write-lifetime.test.ts test/root-write-exact-identity.test.ts test/secret-write-publication.test.ts test/native-write-mode-ownership.test.ts test/native-created-cleanup.test.ts test/file-mode-facades.test.ts
             FS_SAFE_NATIVE_MODE=require pnpm test test/archive-zip-admission.test.ts test/archive-zip-metadata.test.ts test/archive-zip-integrity.test.ts
             FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm test test/archive-filter-paths.test.ts test/archive-filter-compressed.test.ts test/archive-tar-gnu.test.ts test/archive-tar-gnu-meter.test.ts test/archive-tar-ignored.test.ts test/archive-tar-ignored-meter.test.ts test/archive-tar-admission.test.ts test/archive-tar-manifest.test.ts
           '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.7.3 - Unreleased
 
+- Finalize explicit file modes after content writes across pinned writers, verify all `0o7777` POSIX bits for secret publication, and use exact identities before native Windows mode changes and failed-write cleanup; JavaScript fallback cleanup preserves unverified replacements.
+- Complete short synchronous regular-file appends and preserve explicitly requested special mode bits in both append helpers, retaining permission tightening before any data is written.
 - Preserve existing secret-directory permissions instead of repairing them; retain lossless directory identities through private locks and native writes, initialize new directories through guarded descriptor authority, honor full directory mode bits, and fail closed for unpinnable parents, including non-root macOS directories created under `umask(0o777)`.
 - Keep async Root-backed lock normalization read-only, rejecting deleted or replaced admitted parents without recreating them while preserving explicit in-root sidecars for external target keys.
 - Exercise secret-directory admission from isolated npm/pnpm consumer installs, retain real-identity and native-load proof, and honor explicit package-proof output paths.

--- a/docs/regular-file.md
+++ b/docs/regular-file.md
@@ -116,9 +116,17 @@ stalling admission. A confirmed non-regular target is refused before chmod or
 append; other open errors propagate unchanged. This safeguard does not change
 ordinary regular-file append semantics or require read permission.
 
+The requested mode is applied through the admitted descriptor **before** any
+content is appended, so an existing file is tightened first. On successful
+completion, explicitly requested POSIX special bits are reapplied after the
+content write, which can otherwise clear set-ID bits. An initial chmod failure
+leaves the content untouched; a write or final chmod failure can leave appended
+content and is not rolled back. Windows does not enforce POSIX mode semantics.
+
 ### `appendRegularFileSync(options)`
 
-Synchronous. Same options.
+Synchronous. Same options and mode ordering. Writes the complete input through
+the already-open descriptor, including when an individual write is short.
 
 ### `resolveRegularFileAppendFlags()`
 

--- a/docs/secret-file.md
+++ b/docs/secret-file.md
@@ -123,7 +123,7 @@ startWebhookVerifier(signingKey);
 
 ### `writeSecretFileAtomic(params)`
 
-Async. Creates the parent directory at `dirMode` (default `0o700`) if missing, writes content to a sibling temp file at `mode` (default `0o600`), atomically renames over the destination, and re-asserts the file mode after rename.
+Async. Creates the parent directory at `dirMode` (default `0o700`) if missing, writes content to a sibling temp file, finalizes `mode` (default `0o600`) through an owned descriptor after content writes, and atomically renames over the destination. Publication verification checks the final file identity and mode.
 
 Concurrent writes to distinct leaves may share creation of a missing parent.
 After a parent-creation race, the helper re-inspects the entry and requires a
@@ -132,10 +132,21 @@ the requested directory mode before writing either leaf.
 
 Publication verification borrows the writer's still-open descriptor to check
 the exact file identity, regular-file and link policy, requested POSIX mode,
-and root/parent ancestry before the writer closes it. POSIX mode overrides such
-as `0o000` and `0o200` do not require read permission or a readonly reopen, and
-verification does not widen the final mode. Windows retains its existing
-pathname-identity verification policy without enforcing POSIX mode bits.
+and root/parent ancestry before the writer closes it. All `0o7777` mode bits
+must match, including explicitly requested special bits; unexpected special
+bits are rejected. POSIX mode overrides such as `0o000` and `0o200` do not
+require read permission or a readonly reopen, and verification does not widen
+the final mode. Windows retains pathname-identity verification without enforcing
+POSIX mode bits; its native writer checks the reopened descriptor against the
+original lossless file identity before changing the final mode.
+
+Failed JavaScript fallback writes attempt cleanup while retaining the original
+descriptor and only after checking parent and file identities. Native cleanup
+also compares lossless parent and file identities. Unverifiable paths are left
+for caller-managed cleanup, and cleanup failures do not replace the original
+write error. These are best-effort identity checks followed by name-based
+removal, not atomic conditional unlink. A publication-verification failure
+after a completed write does not authorize deleting the published file.
 
 ```ts
 import { writeSecretFileAtomic } from "@openclaw/fs-safe/secret";

--- a/src/native-operations.ts
+++ b/src/native-operations.ts
@@ -1,4 +1,4 @@
-import fsSync, { type Stats } from "node:fs";
+import fsSync, { type BigIntStats, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { ContainmentGuarantee } from "./containment.js";
@@ -78,25 +78,23 @@ function wrapNativeFd(fd: number, containment: ContainmentGuarantee): NativeFile
 }
 
 export function removeNativeCreatedFileIfStillPinned(params: {
-  binding: NativeBinding;
   parentPath: string;
   parentFd: number;
   basename: string;
-  created?: Stats;
+  created?: BigIntStats;
 }): void {
   if (!params.created) {
     return;
   }
   try {
-    const parentPathStat = fsSync.lstatSync(params.parentPath);
-    const parentFdStat = params.binding.fstatIdentity(params.parentFd);
+    const parentPathStat = fsSync.lstatSync(params.parentPath, { bigint: true });
+    const parentFdStat = fsSync.fstatSync(params.parentFd, { bigint: true });
     const targetPath = path.join(params.parentPath, params.basename);
-    const target = fsSync.lstatSync(targetPath);
+    const target = fsSync.lstatSync(targetPath, { bigint: true });
     if (
-      !parentPathStat.isSymbolicLink() &&
-      parentPathStat.dev === parentFdStat.dev &&
-      parentPathStat.ino === parentFdStat.ino &&
-      !target.isSymbolicLink() &&
+      !parentPathStat.isSymbolicLink() && parentPathStat.isDirectory() &&
+      sameFileIdentityForCleanup(parentPathStat, parentFdStat) &&
+      !target.isSymbolicLink() && target.isFile() &&
       sameFileIdentityForCleanup(target, params.created)
     ) {
       fsSync.rmSync(targetPath);
@@ -123,7 +121,7 @@ export async function createNativeExclusiveFile(
       (typeof fsSync.constants.O_DIRECTORY === "number" ? fsSync.constants.O_DIRECTORY : 0),
   );
   let fd: number | undefined;
-  let created: Stats | undefined;
+  let created: BigIntStats | undefined;
   try {
     let opened: ReturnType<NativeBinding["openBeneath"]>;
     try {
@@ -146,7 +144,7 @@ export async function createNativeExclusiveFile(
     }
     fd = opened.fd;
     fsSync.fchmodSync(fd, mode);
-    created = fsSync.fstatSync(fd);
+    created = fsSync.fstatSync(fd, { bigint: true });
     return wrapNativeFd(fd, opened.containment);
   } catch (error) {
     if (fd !== undefined) {
@@ -156,7 +154,6 @@ export async function createNativeExclusiveFile(
         // Preserve the original error.
       }
       removeNativeCreatedFileIfStillPinned({
-        binding,
         parentPath,
         parentFd: parent.fd,
         basename,

--- a/src/native-pinned-write-windows.ts
+++ b/src/native-pinned-write-windows.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import fsSync, { type Stats } from "node:fs";
+import fsSync, { type BigIntStats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import type { AnyAsyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
@@ -12,6 +12,7 @@ import {
 } from "./native-operations.js";
 import type { NativeBinding } from "./native.js";
 import type { PinnedWriteParams } from "./pinned-write.js";
+import { inspectFileIdentitySync } from "./strict-file-identity.js";
 
 export function sameNativeIdentity(
   left: Pick<FileIdentityStat, "dev" | "ino">,
@@ -39,7 +40,7 @@ export async function runPinnedWriteWindows(
   const parentPath = parentGuard.realPath;
   let tempFd: number | undefined;
   let targetFd: number | undefined;
-  let tempIdentity: Stats | undefined;
+  let tempIdentity: BigIntStats | undefined;
   let tempName = "";
   let renamed = false;
   let completed = false;
@@ -52,8 +53,8 @@ export async function runPinnedWriteWindows(
         fsSync.constants.O_WRONLY | fsSync.constants.O_CREAT | fsSync.constants.O_EXCL,
       ),
     ).fd;
-    tempIdentity = fsSync.fstatSync(tempFd);
-    const verificationIdentity = fsSync.fstatSync(tempFd, { bigint: true });
+    const verificationIdentity = inspectFileIdentitySync(() => fsSync.fstatSync(tempFd!, { bigint: true }));
+    tempIdentity = verificationIdentity;
     // Creation is requested at 0600 in the binding, but a restrictive umask
     // can remove owner access. Keep the unpublished inode private and
     // reopenable until the published name has been identity-fenced.
@@ -71,8 +72,11 @@ export async function runPinnedWriteWindows(
       params.basename,
       nativeOpenFlags(fsSync.constants.O_RDONLY),
     ).fd;
+    const targetStat = inspectFileIdentitySync(
+      () => fsSync.fstatSync(targetFd!, { bigint: true }), verificationIdentity,
+    );
     const targetIdentity = binding.fstatIdentity(targetFd);
-    if (!targetIdentity.isFile || !sameNativeIdentity(tempIdentity, targetIdentity)) {
+    if (!targetStat.isFile()) {
       throw new FsSafeError("path-mismatch", "native write target changed after rename");
     }
     // Native exclusive creation starts at 0600. Apply the requested mode only
@@ -85,7 +89,6 @@ export async function runPinnedWriteWindows(
       closeWriteFd(targetFd);
       targetFd = undefined;
       removeNativeCreatedFileIfStillPinned({
-        binding,
         parentPath,
         parentFd,
         basename: params.basename,
@@ -103,7 +106,6 @@ export async function runPinnedWriteWindows(
     const tempCloseError = closeWriteFd(tempFd);
     if (!renamed) {
       removeNativeCreatedFileIfStillPinned({
-        binding,
         parentPath,
         parentFd,
         basename: tempName,

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import fsSync from "node:fs";
+import fsSync, { type BigIntStats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -16,6 +16,7 @@ import { runPinnedWriteNative } from "./native-pinned-write.js";
 import { getNativeBinding } from "./native.js";
 import { validatePinnedOperationPayload } from "./pinned-operation.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
+import { cleanupPinnedFilePath } from "./replace-file-temp-owner.js";
 import { withSidecarLock } from "./sidecar-lock.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
 
@@ -204,9 +205,10 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
       },
     );
     let created = true;
+    let createdIdentity: BigIntStats | undefined;
     try {
       const verificationIdentity = await handle.stat({ bigint: true });
-      await handle.chmod(params.mode);
+      createdIdentity = verificationIdentity;
       if (params.input.kind === "buffer") {
         assertWithinMaxBytes(
           byteLength(params.input.data, params.input.encoding),
@@ -220,6 +222,8 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
       } else {
         await writeStreamToHandle(params.input.stream, handle, params.maxBytes);
       }
+      // Content writes may clear set-ID bits; finalize them through the owned fd.
+      await handle.chmod(params.mode);
       await syncFileBestEffort(handle);
       const stat = await handle.stat();
       await syncDirectoryBestEffort(parentPath);
@@ -228,9 +232,12 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
       await params.verifyPublished?.(handle.fd, verificationIdentity, parentGuard);
       return { dev: stat.dev, ino: stat.ino };
     } finally {
-      await handle.close().catch(() => undefined);
-      if (created) {
-        await fs.rm(targetPath, { force: true }).catch(() => undefined);
+      try {
+        if (created) {
+          await cleanupPinnedFilePath({ pathname: targetPath, handle, identity: createdIdentity, parentGuard });
+        }
+      } finally {
+        await handle.close().catch(() => undefined);
       }
     }
   }
@@ -246,12 +253,13 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
       : 0);
   let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
   let tempStat: Awaited<ReturnType<NonNullable<typeof handle>["stat"]>> | undefined;
+  let tempIdentity: BigIntStats | undefined;
   let readHandle: FileHandle | undefined;
   let renamed = false;
   try {
     handle = await fs.open(tempPath, tempFlags, params.mode);
     let verificationIdentity = await handle.stat({ bigint: true });
-    await handle.chmod(params.mode);
+    tempIdentity = verificationIdentity;
     if (params.input.kind === "buffer") {
       assertWithinMaxBytes(
         byteLength(params.input.data, params.input.encoding),
@@ -271,6 +279,7 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
       throw new FsSafeError("path-mismatch", "fallback temp path changed during write");
     }
     const expectedTempStat = tempStat;
+    await handle.chmod(params.mode);
     await syncFileBestEffort(handle);
     let verifiedIdentity: FileIdentityStat = expectedTempStat;
     await withAsyncDirectoryGuards([parentGuard], async () => {
@@ -309,10 +318,13 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
     await params.verifyPublished?.((readHandle ?? handle).fd, verificationIdentity, parentGuard);
     return { dev: verifiedIdentity.dev, ino: verifiedIdentity.ino };
   } finally {
-    await readHandle?.close().catch(() => undefined);
-    await handle?.close().catch(() => undefined);
-    if (!renamed) {
-      await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    try {
+      if (!renamed && handle) {
+        await cleanupPinnedFilePath({ pathname: tempPath, handle, identity: tempIdentity, parentGuard });
+      }
+    } finally {
+      await readHandle?.close().catch(() => undefined);
+      await handle?.close().catch(() => undefined);
     }
   }
 }

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -344,8 +344,11 @@ export async function appendRegularFile(options: AppendRegularFileOptions): Prom
     ) {
       return;
     }
-    await handle.chmod(options.mode ?? 0o600);
+    const mode = options.mode ?? 0o600;
+    // Tighten before writing; restore explicit special bits only after content is complete.
+    await handle.chmod(mode);
     await handle.appendFile(options.content, options.encoding ?? "utf8");
+    if (mode & 0o7000) await handle.chmod(mode);
   } finally {
     await handle.close();
   }
@@ -424,8 +427,10 @@ export function appendRegularFileSync(options: AppendRegularFileOptions): void {
     ) {
       return;
     }
-    fsSync.fchmodSync(fd, options.mode ?? 0o600);
-    fsSync.writeSync(fd, contentBuffer, 0, contentBuffer.byteLength);
+    const mode = options.mode ?? 0o600;
+    fsSync.fchmodSync(fd, mode);
+    fsSync.appendFileSync(fd, contentBuffer);
+    if (mode & 0o7000) fsSync.fchmodSync(fd, mode);
   } finally {
     fsSync.closeSync(fd);
   }

--- a/src/replace-file-temp-owner.ts
+++ b/src/replace-file-temp-owner.ts
@@ -1,5 +1,6 @@
 import syncFs, { type BigIntStats } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
+import { assertAsyncDirectoryGuard, type AnyAsyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentityForCleanup, sha256Hex } from "./file-identity.js";
 import { inspectFileIdentity, inspectFileIdentitySync } from "./strict-file-identity.js";
@@ -74,6 +75,37 @@ async function cleanupOwnedPath(params: {
       throw cleanupFailure(params.originalError, cleanupError);
     }
     return false;
+  }
+}
+
+// Borrowed handle: the caller retains it until this best-effort cleanup finishes.
+export async function cleanupPinnedFilePath(params: {
+  pathname: string;
+  handle: FileHandle;
+  identity?: BigIntStats;
+  parentGuard: AnyAsyncDirectoryGuard;
+}): Promise<void> {
+  if (!params.identity) return;
+  try {
+    const guard = params.parentGuard;
+    if ([guard.stat.dev, guard.stat.ino].some(
+      (value) => typeof value === "number" && !Number.isSafeInteger(value),
+    )) return;
+    await assertAsyncDirectoryGuard(guard);
+    const parent = await fs.lstat(guard.dir, { bigint: true });
+    if (parent.isSymbolicLink() || !parent.isDirectory() ||
+      !sameFileIdentityForCleanup(parent, guard.stat)) return;
+    const opened = await params.handle.stat({ bigint: true });
+    if (!opened.isFile() || opened.nlink !== 1n ||
+      !sameFileIdentityForCleanup(opened, params.identity)) return;
+    await cleanupOwnedPath({
+      fsModule: fs,
+      pathname: params.pathname,
+      identity: params.identity,
+      throwOnCleanupError: false,
+    });
+  } catch {
+    // Unverifiable authority must preserve the path and the original write failure.
   }
 }
 

--- a/src/root-write-verification.ts
+++ b/src/root-write-verification.ts
@@ -45,7 +45,7 @@ export async function verifyAtomicWriteResult(params: {
     }
     assertFile(stat);
     if (process.platform !== "win32" && params.expectedMode !== undefined) {
-      const actualMode = Number(stat.mode & 0o777n);
+      const actualMode = Number(stat.mode & 0o7777n);
       if (actualMode !== params.expectedMode) {
         throw new Error(
           `Private secret file ${params.targetPath} has insecure permissions ${actualMode.toString(8)}.`,

--- a/test/fallback-write-mode-cleanup.test.ts
+++ b/test/fallback-write-mode-cleanup.test.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeNative } from "../src/config.js";
+import { createSecretFileAtomic, writeSecretFileAtomic } from "../src/secret.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  configureFsSafeNative({ mode: "auto" });
+});
+
+describe("fallback mode-failure cleanup ownership", () => {
+  it.each([
+    { operation: "write", write: writeSecretFileAtomic },
+    { operation: "create", write: createSecretFileAtomic },
+  ])("$operation preserves a replacement after final chmod fails", async ({ write, operation }) => {
+    configureFsSafeNative({ mode: "off" });
+    const rootDir = await tempRoot("fs-safe-fallback-mode-cleanup-");
+    const filePath = path.join(rootDir, "target");
+    const saved = path.join(rootDir, "original");
+    const failure = Object.assign(new Error("synthetic mode failure"), { code: "EIO" });
+    const open = fs.open.bind(fs);
+    let replacedPath: string | undefined;
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      if (!(await handle.stat()).isFile()) return handle;
+      vi.spyOn(handle, "chmod").mockImplementationOnce(async () => {
+        replacedPath = String(args[0]);
+        await fs.rename(replacedPath, saved);
+        await fs.writeFile(replacedPath, "replacement", { mode: 0o600 });
+        throw failure;
+      });
+      return handle;
+    });
+
+    await expect(write({ rootDir, filePath, content: "owned bytes", mode: 0o600 })).rejects.toBe(failure);
+
+    expect(replacedPath).toBeDefined();
+    expect(await fs.readFile(replacedPath!, "utf8")).toBe("replacement");
+    expect(await fs.readFile(saved, "utf8")).toBe("owned bytes");
+    if (operation === "write") await expect(fs.lstat(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/test/file-mode-facades.test.ts
+++ b/test/file-mode-facades.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import { configureFsSafeNative } from "../src/config.js";
+import { __loadBundledNativeForTest, __resetNativeLoaderForTest } from "../src/native.js";
+import { root } from "../src/root.js";
+import { fileStore, fileStoreSync } from "../src/store.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+let nativeAvailable = false;
+try {
+  __loadBundledNativeForTest();
+  nativeAvailable = true;
+} catch (error) {
+  if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error;
+}
+afterEach(() => {
+  configureFsSafeNative({ mode: "auto" });
+  __resetNativeLoaderForTest();
+});
+
+async function fixture() {
+  const directory = await tempRoot("fs-safe-mode-facade-");
+  const rootDir = path.join(directory, "root");
+  const source = path.join(directory, "source");
+  await fs.mkdir(rootDir, { mode: 0o700 });
+  await fs.writeFile(source, "synthetic facade", { mode: 0o600 });
+  return { rootDir, source, target: path.join(rootDir, "target") };
+}
+
+for (const backend of ["off", "require"] as const) {
+  describe.skipIf(process.platform === "win32" || (backend === "require" && !nativeAvailable))(
+    `explicit file modes through ${backend} facades`,
+    () => {
+      it.each(["write", "create", "copyIn"].flatMap((operation) => [0o600, 0o4600].map((mode) => ({ operation, mode }))))(
+        "Root.$operation preserves $mode",
+        async ({ operation, mode }) => {
+          configureFsSafeNative({ mode: backend });
+          const { rootDir, source, target } = await fixture();
+          const capability = await root(rootDir);
+          if (operation === "copyIn") await capability.copyIn("target", source, { mode });
+          else if (operation === "create") await capability.create("target", "synthetic facade", { mode });
+          else await capability.write("target", "synthetic facade", { mode });
+          expect((await fs.stat(target)).mode & 0o7777).toBe(mode);
+          expect(await fs.readFile(target, "utf8")).toBe("synthetic facade");
+        },
+      );
+
+      it.each([false, true].flatMap((privateMode) => ["write", "copyIn", "writeStream"].flatMap((operation) =>
+        [0o600, 0o4600].map((mode) => ({ privateMode, operation, mode })),
+      )))("FileStore.$operation preserves $mode (private=$privateMode)", async ({ privateMode, operation, mode }) => {
+        configureFsSafeNative({ mode: backend });
+        const { rootDir, source, target } = await fixture();
+        const store = fileStore({ rootDir, private: privateMode, mode });
+        if (operation === "copyIn") await store.copyIn("target", source);
+        else if (operation === "writeStream") await store.writeStream("target", Readable.from(["synthetic ", "facade"]));
+        else await store.write("target", "synthetic facade");
+        expect((await fs.stat(target)).mode & 0o7777).toBe(mode);
+        expect(await fs.readFile(target, "utf8")).toBe("synthetic facade");
+      });
+    },
+  );
+}
+
+describe.skipIf(process.platform === "win32")("existing synchronous mode finalization", () => {
+  it.each([false, true].flatMap((privateMode) => [0o600, 0o4600].map((mode) => ({ privateMode, mode }))))(
+    "FileStoreSync preserves $mode (private=$privateMode)",
+    async ({ privateMode, mode }) => {
+      const { rootDir, target } = await fixture();
+      fileStoreSync({ rootDir, private: privateMode, mode }).write("target", "synthetic facade");
+      expect((await fs.stat(target)).mode & 0o7777).toBe(mode);
+      expect(await fs.readFile(target, "utf8")).toBe("synthetic facade");
+    },
+  );
+});

--- a/test/native-created-cleanup.test.ts
+++ b/test/native-created-cleanup.test.ts
@@ -1,0 +1,49 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { removeNativeCreatedFileIfStillPinned } from "../src/native-operations.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+});
+
+describe("native created-file cleanup authority", () => {
+  it.each(["matching", "parent-path", "parent-fd", "target", "created"])(
+    "handles Windows identity observation: %s",
+    async (scenario) => {
+      const parentPath = await tempRoot("fs-safe-native-cleanup-identity-");
+      const targetPath = path.join(parentPath, "target");
+      await fs.writeFile(targetPath, "owned", { mode: 0o600 });
+      const created = await fs.lstat(targetPath, { bigint: true });
+      const parent = await fs.open(parentPath, fsSync.constants.O_RDONLY | (fsSync.constants.O_DIRECTORY ?? 0));
+      Object.defineProperty(process, "platform", { value: "win32" });
+      const lstat = fsSync.lstatSync.bind(fsSync);
+      const fstat = fsSync.fstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) => {
+        const stat = lstat(...args);
+        const selected = scenario === "parent-path" ? parentPath : scenario === "target" ? targetPath : undefined;
+        return String(args[0]) === selected ? Object.assign(Object.create(stat), { ino: 0n }) : stat;
+      }) as typeof fsSync.lstatSync);
+      vi.spyOn(fsSync, "fstatSync").mockImplementation(((...args: Parameters<typeof fsSync.fstatSync>) => {
+        const stat = fstat(...args);
+        return scenario === "parent-fd" && args[0] === parent.fd
+          ? Object.assign(Object.create(stat), { ino: 0n }) : stat;
+      }) as typeof fsSync.fstatSync);
+      try {
+        removeNativeCreatedFileIfStillPinned({
+          parentPath, parentFd: parent.fd, basename: "target",
+          created: scenario === "created" ? Object.assign(Object.create(created), { ino: 0n }) : created,
+        });
+        expect(fsSync.existsSync(targetPath)).toBe(scenario !== "matching");
+        if (scenario !== "matching") expect(await fs.readFile(targetPath, "utf8")).toBe("owned");
+      } finally {
+        await parent.close();
+      }
+    },
+  );
+});

--- a/test/native-write-mode-ownership.test.ts
+++ b/test/native-write-mode-ownership.test.ts
@@ -1,0 +1,122 @@
+import fsSync, { type BigIntStats, type Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeNative } from "../src/config.js";
+import { __loadBundledNativeForTest, __resetNativeLoaderForTest, __setNativeLoaderForTest } from "../src/native.js";
+import { createSecretFileAtomic, writeSecretFileAtomic } from "../src/secret.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+let nativeAvailable = false;
+try {
+  __loadBundledNativeForTest();
+  nativeAvailable = true;
+} catch (error) {
+  if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error;
+}
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+  configureFsSafeNative({ mode: "auto" });
+  __resetNativeLoaderForTest();
+});
+
+const writers = [
+  { operation: "write", write: writeSecretFileAtomic },
+  { operation: "create", write: createSecretFileAtomic },
+];
+
+describe.skipIf(!nativeAvailable)("native Windows final-mode ownership", () => {
+  it.each(writers.flatMap((writer) => ["stable", "before-open", "mode-error"].map((scenario) => ({ ...writer, scenario }))))(
+    "$operation retains final-mode ownership through $scenario",
+    async ({ write, scenario }) => {
+      const rootDir = await tempRoot("fs-safe-native-mode-owner-");
+      const target = path.join(rootDir, "token");
+      const saved = path.join(rootDir, "published");
+      const binding = __loadBundledNativeForTest();
+      const fstat = fsSync.fstatSync.bind(fsSync);
+      const identities = new Map<string, bigint>();
+      const base = 1n << 53n;
+      expect(Number(base)).toBe(Number(base + 1n));
+      const key = (stat: BigIntStats) => `${stat.dev}:${stat.ino}`;
+      const projectedInode = (stat: BigIntStats) => {
+        const id = key(stat);
+        if (!identities.has(id)) identities.set(id, base + BigInt(identities.size));
+        return identities.get(id)!;
+      };
+      // Only inode values are projected; descriptors, bytes, replacement and chmod are real.
+      const project = <T extends Stats | BigIntStats>(stat: T, exact: BigIntStats): T => {
+        if (!stat.isFile()) return stat;
+        const ino = projectedInode(exact);
+        return Object.assign(Object.create(stat), { ino: typeof stat.ino === "bigint" ? ino : Number(ino) });
+      };
+      vi.spyOn(fsSync, "fstatSync").mockImplementation(((...args: Parameters<typeof fsSync.fstatSync>) =>
+        project(fstat(...args), fstat(args[0], { bigint: true }))) as typeof fsSync.fstatSync);
+      for (const method of ["lstat", "stat"] as const) {
+        const original = fs[method].bind(fs);
+        vi.spyOn(fs, method).mockImplementation((async (...args: Parameters<typeof fs.stat>) => {
+          const stat = await original(...args);
+          if (!stat.isFile()) return stat;
+          return project(stat, await original(args[0], { bigint: true }));
+        }) as typeof fs.stat);
+      }
+      const lstatSync = fsSync.lstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) =>
+        project(lstatSync(...args), lstatSync(args[0], { bigint: true }))) as typeof fsSync.lstatSync);
+      let published = false;
+      let replaced = false;
+      let replacementIdentity: string | undefined;
+      const swap = () => {
+        fsSync.renameSync(target, saved);
+        fsSync.writeFileSync(target, "replacement", { mode: 0o600 });
+        fsSync.chmodSync(target, 0o600);
+        replacementIdentity = key(fsSync.statSync(target, { bigint: true }));
+        replaced = true;
+      };
+      const modeFailure = Object.assign(new Error("synthetic final chmod failure"), { code: "EIO" });
+      const chmod = fsSync.fchmodSync.bind(fsSync);
+      const changes: Array<{ identity: string; mode: number }> = [];
+      vi.spyOn(fsSync, "fchmodSync").mockImplementation((fd, mode) => {
+        if (scenario === "mode-error" && Number(mode) === 0o400) {
+          swap();
+          throw modeFailure;
+        }
+        chmod(fd, mode);
+        changes.push({ identity: key(fstat(fd, { bigint: true })), mode: Number(mode) });
+      });
+      __setNativeLoaderForTest(() => ({
+        ...binding,
+        renameReplace(...args) { binding.renameReplace(...args); published = true; },
+        renameNoReplace(...args) { binding.renameNoReplace(...args); published = true; },
+        openBeneath(...args) {
+          if (scenario === "before-open" && published && args[1] === "token" && !replaced) swap();
+          return binding.openBeneath(...args);
+        },
+        fstatIdentity(fd) {
+          const stat = binding.fstatIdentity(fd);
+          return stat.isFile ? { ...stat, ino: Number(projectedInode(fstat(fd, { bigint: true }))) } : stat;
+        },
+      }));
+      // POSIX hosts exercise the Windows branch; Windows CI uses its actual native mechanism.
+      Object.defineProperty(process, "platform", { value: "win32" });
+      configureFsSafeNative({ mode: "require" });
+      const pending = write({ rootDir, filePath: target, content: "original", mode: 0o400 });
+      if (scenario !== "stable") {
+        if (scenario === "mode-error") await expect(pending).rejects.toBe(modeFailure);
+        else await expect(pending).rejects.toMatchObject({ code: "path-mismatch" });
+        expect(replaced).toBe(true);
+        expect(changes.filter((change) => change.identity === replacementIdentity)).toEqual([]);
+        expect(fsSync.existsSync(target)).toBe(true);
+        expect(fsSync.statSync(target).mode & 0o200).toBe(0o200);
+        expect(fsSync.readFileSync(target, "utf8")).toBe("replacement");
+        expect(fsSync.readFileSync(saved, "utf8")).toBe("original");
+      } else {
+        await expect(pending).resolves.toBeUndefined();
+        expect(fsSync.statSync(target).mode & 0o200).toBe(0);
+        expect(fsSync.readFileSync(target, "utf8")).toBe("original");
+      }
+    },
+  );
+});

--- a/test/pinned-write-cleanup-authority.test.ts
+++ b/test/pinned-write-cleanup-authority.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createAsyncDirectoryGuard } from "../src/directory-guard.js";
+import { cleanupPinnedFilePath } from "../src/replace-file-temp-owner.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+
+describe("pinned failure cleanup authority", () => {
+  it.each(["owned", "replacement", "stale-parent", "missing-identity"])(
+    "borrows the retained descriptor and handles %s",
+    async (scenario) => {
+      const directory = await tempRoot("fs-safe-pinned-cleanup-authority-");
+      const parent = path.join(directory, "parent");
+      await fs.mkdir(parent, { mode: 0o700 });
+      const parentGuard = await createAsyncDirectoryGuard(parent, { bigint: true });
+      if (scenario === "stale-parent") {
+        await fs.rename(parent, path.join(directory, "old-parent"));
+        await fs.mkdir(parent, { mode: 0o700 });
+      }
+      const pathname = path.join(parent, "target");
+      const handle = await fs.open(pathname, "wx", 0o600);
+      try {
+        await handle.writeFile("owned");
+        const identity = await handle.stat({ bigint: true });
+        if (scenario === "replacement") {
+          await fs.rename(pathname, path.join(parent, "saved"));
+          await fs.writeFile(pathname, "replacement", { mode: 0o600 });
+        }
+        const listeners = process.listenerCount("exit");
+        await cleanupPinnedFilePath({
+          pathname, handle, parentGuard,
+          identity: scenario === "missing-identity" ? undefined : identity,
+        });
+        expect(process.listenerCount("exit")).toBe(listeners);
+        expect((await handle.stat({ bigint: true })).ino).toBe(identity.ino);
+        if (scenario === "owned") {
+          await expect(fs.lstat(pathname)).rejects.toMatchObject({ code: "ENOENT" });
+        } else {
+          expect(await fs.readFile(pathname, "utf8")).toBe(scenario === "replacement" ? "replacement" : "owned");
+        }
+      } finally {
+        await handle.close();
+      }
+    },
+  );
+});

--- a/test/pinned-write-file-mode.test.ts
+++ b/test/pinned-write-file-mode.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeNative } from "../src/config.js";
+import { runPinnedWriteHelper } from "../src/pinned-write.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  configureFsSafeNative({ mode: "auto" });
+});
+
+describe.skipIf(process.platform === "win32")("fallback final file mode", () => {
+  it.each([false, true].flatMap((overwrite) => ["buffer", "stream"].map((kind) => ({ overwrite, kind }))))(
+    "applies mode after $kind content and before syncing (overwrite=$overwrite)",
+    async ({ overwrite, kind }) => {
+      configureFsSafeNative({ mode: "off" });
+      const rootPath = await tempRoot("fs-safe-pinned-file-mode-");
+      await fs.chown(rootPath, process.geteuid!(), process.getegid!());
+      const target = path.join(rootPath, "target");
+      const events: string[] = [];
+      const open = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const handle = await open(...args);
+        if (!(await handle.stat()).isFile()) return handle;
+        const chmod = handle.chmod.bind(handle);
+        const writeFile = handle.writeFile.bind(handle);
+        const write = handle.write.bind(handle);
+        const sync = handle.sync.bind(handle);
+        vi.spyOn(handle, "chmod").mockImplementation(async (mode) => {
+          events.push("chmod");
+          await chmod(mode);
+        });
+        vi.spyOn(handle, "writeFile").mockImplementation(async (...args) => {
+          events.push("write");
+          await writeFile(...args);
+        });
+        vi.spyOn(handle, "write").mockImplementation((async (...args: Parameters<typeof handle.write>) => {
+          events.push("write");
+          return await write(...args);
+        }) as typeof handle.write);
+        vi.spyOn(handle, "sync").mockImplementation(async () => {
+          events.push("sync");
+          await sync();
+        });
+        return handle;
+      });
+
+      await runPinnedWriteHelper({
+        rootPath, relativeParentPath: "", basename: "target", mkdir: false, overwrite,
+        mode: 0o4600,
+        input: kind === "buffer" ? { kind: "buffer", data: "synthetic mode" }
+          : { kind: "stream", stream: Readable.from(["synthetic ", "mode"]) },
+      });
+
+      expect((await fs.stat(target)).mode & 0o7777).toBe(0o4600);
+      expect(events.filter((event) => event === "chmod")).toHaveLength(1);
+      expect(events.lastIndexOf("write")).toBeGreaterThanOrEqual(0);
+      expect(events.indexOf("chmod")).toBeGreaterThan(events.lastIndexOf("write"));
+      expect(events.indexOf("sync")).toBeGreaterThan(events.indexOf("chmod"));
+      expect(await fs.readFile(target, "utf8")).toBe("synthetic mode");
+    },
+  );
+});

--- a/test/regular-file-mode.test.ts
+++ b/test/regular-file-mode.test.ts
@@ -1,0 +1,122 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { appendRegularFile, appendRegularFileSync } from "../src/regular-file.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+const append = async (kind: string, options: Parameters<typeof appendRegularFile>[0]) => {
+  if (kind === "async") await appendRegularFile(options);
+  else appendRegularFileSync(options);
+};
+
+describe.skipIf(process.platform === "win32")("regular append final file mode", () => {
+  it.each(["async", "sync"].flatMap((kind) => ["", "added"].flatMap((content) =>
+    [0o600, 0o4600].map((mode) => ({ kind, content, mode })),
+  )))("$kind append '$content' preserves explicit mode $mode", async ({ kind, content, mode }) => {
+    const directory = await tempRoot("fs-safe-append-mode-");
+    const filePath = path.join(directory, "target");
+    await fs.writeFile(filePath, "initial", { mode: 0o600 });
+    await fs.chown(filePath, process.geteuid!(), process.getegid!());
+    await append(kind, { filePath, content, mode });
+    expect((await fs.stat(filePath)).mode & 0o7777).toBe(mode);
+    expect(await fs.readFile(filePath, "utf8")).toBe(`initial${content}`);
+  });
+
+  it.each(["async", "sync"])("%s tightens existing permissions before appending", async (kind) => {
+    const directory = await tempRoot("fs-safe-append-private-first-");
+    const filePath = path.join(directory, "target");
+    await fs.writeFile(filePath, "initial", { mode: 0o644 });
+    await fs.chmod(filePath, 0o644);
+    let observed = false;
+    if (kind === "async") {
+      const open = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const handle = await open(...args);
+        const appendFile = handle.appendFile.bind(handle);
+        vi.spyOn(handle, "appendFile").mockImplementation(async (...args) => {
+          expect((await handle.stat()).mode & 0o7777).toBe(0o600);
+          observed = true;
+          await appendFile(...args);
+        });
+        return handle;
+      });
+    } else {
+      const write = fsSync.writeSync.bind(fsSync);
+      vi.spyOn(fsSync, "writeSync").mockImplementation(((...args: Parameters<typeof fsSync.writeSync>) => {
+        expect(fsSync.fstatSync(args[0]).mode & 0o7777).toBe(0o600);
+        observed = true;
+        return write(...args);
+      }) as typeof fsSync.writeSync);
+    }
+    await append(kind, { filePath, content: "private", mode: 0o600 });
+    expect(observed).toBe(true);
+    expect(await fs.readFile(filePath, "utf8")).toBe("initialprivate");
+  });
+
+  it.each(["async", "sync"])("%s does not append when initial mode tightening fails", async (kind) => {
+    const directory = await tempRoot("fs-safe-append-mode-refusal-");
+    const filePath = path.join(directory, "target");
+    await fs.writeFile(filePath, "initial", { mode: 0o644 });
+    const failure = Object.assign(new Error("mode denied"), { code: "EIO" });
+    if (kind === "async") {
+      const open = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const handle = await open(...args);
+        vi.spyOn(handle, "chmod").mockRejectedValue(failure);
+        return handle;
+      });
+    } else {
+      vi.spyOn(fsSync, "fchmodSync").mockImplementation(() => { throw failure; });
+    }
+    await expect(append(kind, { filePath, content: "private", mode: 0o600 })).rejects.toBe(failure);
+    expect(await fs.readFile(filePath, "utf8")).toBe("initial");
+  });
+  it.each(["async", "sync"])("%s closes after final chmod failure without rolling back bytes", async (kind) => {
+    const directory = await tempRoot("fs-safe-append-final-mode-refusal-");
+    const filePath = path.join(directory, "target");
+    await fs.writeFile(filePath, "initial", { mode: 0o600 });
+    const failure = Object.assign(new Error("final mode denied"), { code: "EIO" });
+    let openedFd = -1;
+    let chmodCalls = 0;
+    if (kind === "async") {
+      const open = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const handle = await open(...args);
+        openedFd = handle.fd;
+        const chmod = handle.chmod.bind(handle);
+        vi.spyOn(handle, "chmod").mockImplementation(async (mode) => {
+          if (++chmodCalls === 2) throw failure;
+          await chmod(mode);
+        });
+        return handle;
+      });
+    } else {
+      const chmod = fsSync.fchmodSync.bind(fsSync);
+      vi.spyOn(fsSync, "fchmodSync").mockImplementation((fd, mode) => {
+        openedFd = fd;
+        if (++chmodCalls === 2) throw failure;
+        chmod(fd, mode);
+      });
+    }
+    await expect(append(kind, { filePath, content: "added", mode: 0o4600 })).rejects.toBe(failure);
+    expect(chmodCalls).toBe(2);
+    expect(() => fsSync.fstatSync(openedFd)).toThrow(expect.objectContaining({ code: "EBADF" }));
+    expect(await fs.readFile(filePath, "utf8")).toBe("initialadded");
+  });
+});
+
+it("completes short synchronous writes before finalizing an append", async () => {
+  const directory = await tempRoot("fs-safe-append-short-write-");
+  const filePath = path.join(directory, "target");
+  await fs.writeFile(filePath, "initial", { mode: 0o600 });
+  const write = fsSync.writeSync.bind(fsSync);
+  const calls = vi.spyOn(fsSync, "writeSync").mockImplementation(((
+    fd: number, buffer: Uint8Array, offset: number, length: number, position?: number | null,
+  ) => write(fd, buffer, offset, Math.min(2, length), position)) as typeof fsSync.writeSync);
+  appendRegularFileSync({ filePath, content: "abcdef", mode: 0o600 });
+  expect(await fs.readFile(filePath, "utf8")).toBe("initialabcdef");
+  expect(calls).toHaveBeenCalledTimes(3);
+});

--- a/test/root-write-exact-identity.test.ts
+++ b/test/root-write-exact-identity.test.ts
@@ -155,7 +155,9 @@ for (const route of routes) {
         const binding = route.includes("native") ? __loadBundledNativeForTest() : undefined;
         if (route.startsWith("windows")) Object.defineProperty(process, "platform", { value: "win32" });
         let published = false;
-        const currentInode = () => changed && published ? inode - 1n : inode;
+        let callbackStarted = false;
+        // Windows now fences exact fd identity before chmod; keep this fault at the callback boundary.
+        const currentInode = () => changed && published && (route !== "windows native" || callbackStarted) ? inode - 1n : inode;
         const fstat = fsSync.fstatSync.bind(fsSync);
         vi.spyOn(fsSync, "fstatSync").mockImplementation(((...args: Parameters<typeof fsSync.fstatSync>) =>
           project(fstat(...args), currentInode())) as typeof fsSync.fstatSync);
@@ -196,6 +198,7 @@ for (const route of routes) {
           fd = params.fd;
           expect(params.expectedIdentity).toMatchObject({ dev: device, ino: inode });
           // Direct-create paths have no rename; mutate only after their expected snapshot.
+          callbackStarted = true;
           published = true;
           await verify(params);
         };

--- a/test/secret-write-publication.test.ts
+++ b/test/secret-write-publication.test.ts
@@ -20,7 +20,7 @@ const writers = [
   { operation: "write", write: writeSecretFileAtomic },
   { operation: "create", write: createSecretFileAtomic },
 ] as const;
-const modes = [0o000, 0o200, 0o400, 0o600];
+const modes = [0o000, 0o200, 0o400, 0o600, 0o1600, 0o2600, 0o4600, 0o6600];
 const verify = verification.verifyAtomicWriteResult;
 
 afterEach(() => {
@@ -39,6 +39,7 @@ for (const backend of ["off", "require"] as const) {
         configureFsSafeNative({ mode: backend });
         expect(process.getuid?.()).toBeGreaterThan(0);
         const rootDir = await tempRoot("fs-safe-secret-mode-");
+        await fs.chown(rootDir, process.geteuid!(), process.getegid!());
         const filePath = path.join(rootDir, "token");
         const content = Uint8Array.from([0, 10, 127, 128, 255]);
         const open = vi.spyOn(fs, "open");
@@ -58,7 +59,7 @@ for (const backend of ["off", "require"] as const) {
         const stat = await fs.lstat(filePath);
         expect(stat.isFile()).toBe(true);
         expect(stat.nlink).toBe(1);
-        expect(stat.mode & 0o777).toBe(mode);
+        expect(stat.mode & 0o7777).toBe(mode);
         if ((mode & 0o400) === 0) {
           await expect(fs.readFile(filePath)).rejects.toMatchObject({ code: "EACCES" });
         }
@@ -73,13 +74,14 @@ for (const backend of ["off", "require"] as const) {
         const rootDir = await tempRoot("fs-safe-secret-default-");
         const filePath = path.join(rootDir, "token");
         await write({ rootDir, filePath, content: "synthetic default\n" });
-        expect((await fs.stat(filePath)).mode & 0o777).toBe(0o600);
+        expect((await fs.stat(filePath)).mode & 0o7777).toBe(0o600);
         expect(await fs.readFile(filePath, "utf8")).toBe("synthetic default\n");
       });
 
       it.each(modes)("overwrites restrictive files and preserves create collisions at mode %i", async (mode) => {
         configureFsSafeNative({ mode: backend });
         const rootDir = await tempRoot("fs-safe-secret-overwrite-");
+        await fs.chown(rootDir, process.geteuid!(), process.getegid!());
         const filePath = path.join(rootDir, "token");
         await createSecretFileAtomic({ rootDir, filePath, content: "original", mode });
         const original = await fs.stat(filePath, { bigint: true });
@@ -87,18 +89,37 @@ for (const backend of ["off", "require"] as const) {
           .rejects.toMatchObject({ code: "secret-exists" });
         const collided = await fs.stat(filePath, { bigint: true });
         expect(collided.ino).toBe(original.ino);
-        expect(collided.mode & 0o777n).toBe(BigInt(mode));
+        expect(collided.mode & 0o7777n).toBe(BigInt(mode));
         await fs.chmod(filePath, 0o600);
         expect(await fs.readFile(filePath, "utf8")).toBe("original");
         await fs.chmod(filePath, mode);
         await writeSecretFileAtomic({ rootDir, filePath, content: "overwritten", mode });
         const overwritten = await fs.stat(filePath, { bigint: true });
         expect(overwritten.ino).not.toBe(original.ino);
-        expect(overwritten.mode & 0o777n).toBe(BigInt(mode));
+        expect(overwritten.mode & 0o7777n).toBe(BigInt(mode));
         await fs.chmod(filePath, 0o600);
         expect(await fs.readFile(filePath, "utf8")).toBe("overwritten");
         expect(await fs.readdir(rootDir)).toEqual(["token"]);
       });
+
+      it.each(writers.flatMap((writer) => [0o1000, 0o2000, 0o4000].map((extra) => ({ ...writer, extra }))))(
+        "$operation rejects unexpected special mode bits $extra after publication",
+        async ({ write, extra }) => {
+          configureFsSafeNative({ mode: backend });
+          const rootDir = await tempRoot("fs-safe-secret-extra-mode-");
+          await fs.chown(rootDir, process.geteuid!(), process.getegid!());
+          const filePath = path.join(rootDir, "token");
+          const checked = vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+            fsSync.fchmodSync(params.fd, 0o600 | extra);
+            await verify(params);
+          });
+          await expect(write({ rootDir, filePath, content: "synthetic", mode: 0o600 }))
+            .rejects.toThrow(/insecure permissions/);
+          expect(checked).toHaveBeenCalledOnce();
+          expect((await fs.stat(filePath)).mode & 0o7777).toBe(0o600 | extra);
+          expect(await fs.readFile(filePath, "utf8")).toBe("synthetic");
+        },
+      );
 
       const attacks = [
         "none", "same bytes", "symlink", "hardlink replacement", "late hardlink",
@@ -134,7 +155,7 @@ for (const backend of ["off", "require"] as const) {
             borrowedFd = params.fd;
             const stat = fsSync.fstatSync(params.fd, { bigint: true });
             expect(params.expectedIdentity).toMatchObject({ dev: stat.dev, ino: stat.ino });
-            expect(stat.mode & 0o777n).toBe(0n);
+            expect(stat.mode & 0o7777n).toBe(0n);
             if (["same bytes", "symlink", "hardlink replacement"].includes(attack)) {
               publishedPath = path.join(parent, "published");
               await fs.rename(filePath, publishedPath);
@@ -200,13 +221,13 @@ for (const backend of ["off", "require"] as const) {
             + handles.filter(({ fd }) => fd === borrowedFd).reduce((sum, { close }) => sum + close.mock.calls.length, 0);
           expect(closes).toBe(1);
           vi.restoreAllMocks();
-          expect((await fs.stat(publishedPath)).mode & 0o777).toBe(attack === "late mode" ? 0o644 : 0o000);
+          expect((await fs.stat(publishedPath)).mode & 0o7777).toBe(attack === "late mode" ? 0o644 : 0o000);
           await fs.chmod(publishedPath, 0o600);
           expect(await fs.readFile(publishedPath, "utf8")).toBe(payload);
           expect(await fs.readFile(outsideFile, "utf8")).toBe("outside");
-          expect((await fs.stat(outsideFile)).mode & 0o777).toBe(0o600);
+          expect((await fs.stat(outsideFile)).mode & 0o7777).toBe(0o600);
           if (attack === "same bytes") {
-            expect((await fs.stat(filePath)).mode & 0o777).toBe(0o400);
+            expect((await fs.stat(filePath)).mode & 0o7777).toBe(0o400);
             expect(await fs.readFile(filePath, "utf8")).toBe(payload);
           } else if (attack === "symlink") expect((await fs.lstat(filePath)).isSymbolicLink()).toBe(true);
           else if (attack === "hardlink replacement") {


### PR DESCRIPTION
## Summary

Preserve explicitly requested file modes after content writes, and keep final mode changes and failed-write cleanup within the original file's ownership boundary. Content writes can clear set-ID bits: the JavaScript pinned writer previously applied chmod too early, while secret publication verification inspected only `0777` and therefore both rejected valid special modes and missed unexpected special bits.

The pinned fallback now finalizes mode after content, secret publication compares all `07777` bits, and native Windows checks lossless descriptor identity before final chmod. Native failure cleanup compares bigint parent/file receipts. JavaScript fallback cleanup borrows the existing guarded atomic-owner leaf cleanup while retaining its original FileHandle, instead of removing an unverified pathname. Completed publication remains outside failure cleanup.

The adjacent regular-file append helpers retain permission tightening **before** data and restore explicitly requested special bits afterward. Synchronous append now uses the already-open descriptor's complete-write primitive rather than accepting one short write. Raw Root append/writable lifecycles, inherited-mode policy, archive special-bit stripping, public numeric Stats shapes, defaults, and error contracts are unchanged. Runtime source delta: **+48 net lines**.

## Regression evidence

- Requested-mode and unexpected-special-bit regressions reproduced before their fixes. Buffer/stream and write/create paths are covered, including zero/write-only modes and create collisions.
- Real native file substitutions reproduced chmod of a replacement before refusal and deletion of a replacement after a mode error. The colliding inode observations are deliberately projected synthetic conditions; this is **not** a claim of naturally occurring Windows collisions. Actual Windows native execution is required by the expanded CI selection.
- Real JavaScript fallback substitutions reproduced replacement deletion after a chmod error, without identity projection. Cleanup retains original errors and preserves unverifiable paths.
- Async/sync nonempty appends reproduced cleared requested set-ID bits. A real two-byte-per-call synchronous write reproduced truncated output; the fixed append completes all six requested bytes in three writes. Tests retain pre-data privacy and verify descriptor closure after final chmod refusal.

## Validation

- Existing append/nonblocking/atomic neighborhood: **200 passed, 6 skipped**.
- Full serial suite: **7,347 passed, 80 skipped**, 219 passing suites and two skipped suites.
- Required-native publication/mode selection: **453 passed, 2 skipped**.
- Security suite: **84 passed**.
- File-size/boundary lint, build, documentation examples, package contract checks, and fresh native build passed.
- Root-only npm/pnpm package smoke passed, including **36 secret-directory observations** with real identities and actual native-load receipts.
- Fresh npm/pnpm root+host tarball consumers: **696 observations passed** across Node **22.0.0, 22.23.2, and 24.20.0**, each in separate off/require processes. This covers explicit secret modes through `07777`, Root/store buffer/copy/stream facades, async/sync appends, short sync writes, and fallback mode-failure cleanup. All six changed compiled module hashes match a fresh build of clean commit `02cfad0bc08c4430fe97cf6e7a8e5f8adbcdd2f7`; the artifact itself was packed before commit and records dirty-base provenance.
- Native-load receipts verify the actual fresh binary, not merely configured require mode. Two earlier fixture attempts failed this assertion because pnpm resolved the registry native package transitively; a fixture-only pnpm 11 workspace override pins the fresh host tarball. Failed attempts are retained. Node 22.0.0 executes already-installed consumers; pnpm 11 is not claimed to run on that minimum Node version.
- Complete candidate, including native CI wiring: Codex autoreview **scoped-clean at P0**, no accepted findings. This is a scoped review result, not an exhaustive correctness certificate.

The ordinary parallel `pnpm check` attempt is retained as **failed**: 7,339 passed, eight test timeouts, 80 skips, plus two accompanying archive cleanup errors. The separate serial result is not a retroactive pass for that attempt.

**[Inspectable after-fix runtime proof](https://github.com/openclaw/fs-safe/pull/223#issuecomment-5536174793)** includes captured consumer receipt rows, per-process outcomes, compiled-module hashes, the actual Windows native execution trace, and hosted artifact links. The Windows required-native selection passed **52 tests with 403 platform skips**, including all **six mode-ownership and five cleanup-identity cases**. Those built-source/native mutation regressions are distinguished from the separately installed Windows package controls. Hosted root-only package proof covers **144 observations** across Windows, macOS, glibc Linux, and musl Linux.

Exact-head [CI](https://github.com/openclaw/fs-safe/actions/runs/33839987256), [coverage](https://github.com/openclaw/fs-safe/actions/runs/33839987304), [benchmarks](https://github.com/openclaw/fs-safe/actions/runs/33839987326), and [CodeQL](https://github.com/openclaw/fs-safe/actions/runs/33839987173) all passed. Optional skipped service/dispatch checks are not counted as test passes.

## Boundaries

Cleanup remains best-effort identity checking followed by name-based unlink, not atomic conditional deletion. Unknown or changed authority can leave artifacts for caller-managed cleanup. Windows does not enforce POSIX modes. Append failures may leave appended bytes; no rollback guarantee is added. Documentation and Unreleased changelog entries are included. No version bump, release, or publication.
