### PR TITLE
test: fix Windows fixture lifetimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Check JavaScript fallback
         run: pnpm check
 
+      - name: Prove slow package-copy fixture lifetime on Windows
+        if: matrix.os == 'windows-latest'
+        run: pnpm test --config scripts/slow-package-copy.config.ts
+
       - name: Prove Root sidecar unlinked snapshot handoff and replacement rejection
         if: matrix.node == 24 && (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15')
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Keep slow physical-package fixture setup outside the process-exit test deadline, drain fixture work before teardown, and give each adversarial corpus payload its own test lifetime while retaining Windows boundary assertions.
 - Refresh the Node type definitions, align development and CI on pnpm 11.25.0, and update the pinned Pages deployment action to v5.0.1 for polling backoff and jitter. Thanks @dependabot.
 - Finalize explicit file modes after content writes across pinned writers, verify all `0o7777` POSIX bits for secret publication, and use exact identities before native Windows mode changes and failed-write cleanup; JavaScript fallback cleanup preserves unverified replacements.
 - Complete short synchronous regular-file appends and preserve explicitly requested special mode bits in both append helpers, retaining permission tightening before any data is written.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,6 +35,19 @@ pnpm test test/archive.test.ts
 
 Use `vi.mock` sparingly. Most tests should drive real disk operations in a `mkdtemp`-created scratch directory, asserting on observable behavior. The library has [test hooks](testing.md) for the rare cases where you need to inject a TOCTOU race deterministically.
 
+Vitest timeouts do not cancel filesystem promises. Shared fixtures with expensive
+setup use `useSuiteFixture` from `test/helpers/suite-fixture.ts`: setup has a separate
+30-second hook budget, and teardown waits for tracked setup and test work before
+removing directories. Run shared-state corpora sequentially with a deadline per
+payload. Keep child-process liveness limits separate from fixture preparation.
+The Windows CI slow-copy proof runs the real package-copy process-exit test with a
+six-second copy delay, retaining its four-second child deadline:
+
+```bash
+pnpm build
+pnpm test --config scripts/slow-package-copy.config.ts
+```
+
 ## Checks
 
 Run the complete repository gate before handoff:

--- a/scripts/slow-package-copy.config.ts
+++ b/scripts/slow-package-copy.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import config from "../vitest.config.js";
+
+export default defineConfig({
+  ...config,
+  test: {
+    ...config.test,
+    include: ["test/sidecar-lock-process-exit.test.ts"],
+    testNamePattern: "deduplicates listeners across manager domains and physical package copies",
+    setupFiles: ["scripts/slow-package-copy.setup.ts"],
+  },
+});

--- a/scripts/slow-package-copy.setup.ts
+++ b/scripts/slow-package-copy.setup.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterAll, expect, vi } from "vitest";
+
+const copy = fs.cp.bind(fs);
+const remove = fs.rm.bind(fs);
+let directory: string | undefined;
+let pending: Promise<void> | undefined;
+let copied = false;
+let raced = false;
+let copies = 0;
+
+const copySpy = vi.spyOn(fs, "cp").mockImplementation((source, destination, options) => {
+  if (typeof destination !== "string" || path.basename(destination) !== "dist"
+    || !path.basename(path.dirname(path.dirname(destination))).startsWith("fs-safe-lock-exit-copies-")) {
+    return copy(source, destination, options);
+  }
+  directory = path.dirname(path.dirname(destination));
+  copies++;
+  pending = (async () => {
+    // Exceed the ordinary five-second test deadline, without slowing the child.
+    await delay(6_000);
+    await copy(source, destination, options);
+    copied = true;
+  })();
+  return pending;
+});
+
+const removeSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+  if (target === directory) raced ||= !copied;
+  await remove(target, options);
+});
+
+afterAll(async () => {
+  try {
+    // Drain even the deliberately broken baseline before the proof runner exits.
+    await pending;
+    console.log(JSON.stringify({ slowPackageCopy: { copies, copied, teardownRacedCopy: raced } }));
+    expect(copies).toBe(1);
+    expect(copied).toBe(true);
+    expect(raced).toBe(false);
+    await expect(fs.lstat(directory!)).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    copySpy.mockRestore();
+    removeSpy.mockRestore();
+    // The failing baseline may recreate files after its own early teardown.
+    if (directory) await remove(directory, { recursive: true, force: true });
+  }
+}, 30_000);

--- a/test/adversarial-boundary-payloads.test.ts
+++ b/test/adversarial-boundary-payloads.test.ts
@@ -2,6 +2,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { expectNoOutsideWrite, makeTempLayout } from "./helpers/security.js";
+import { useSuiteFixture } from "./helpers/suite-fixture.js";
 import { useTempDirs } from "./helpers/vitest.js";
 import { root as openRoot } from "../src/index.js";
 
@@ -71,18 +72,24 @@ async function attemptAll(rootDir: Awaited<ReturnType<typeof openRoot>>, payload
 }
 
 describe("adversarial boundary payloads", () => {
-  it("never reads, writes, or deletes outside the root for a generated traversal corpus", async () => {
-    const layout = await makeTempLayout("fs-safe-adversarial-corpus", tempDirs);
-    await fsp.mkdir(path.join(layout.root, "nested"), { recursive: true });
-    await fsp.mkdir(path.join(layout.root, "safe"), { recursive: true });
-    const safeRoot = await openRoot(layout.root);
+  describe.sequential("generated traversal corpus", () => {
+    const directories: string[] = [];
+    const run = useSuiteFixture(async () => {
+      const layout = await makeTempLayout("fs-safe-adversarial-corpus", directories);
+      await fsp.mkdir(path.join(layout.root, "nested"), { recursive: true });
+      await fsp.mkdir(path.join(layout.root, "safe"), { recursive: true });
+      return { layout, safeRoot: await openRoot(layout.root) };
+    }, async () => {
+      await Promise.all(directories.map((directory) => fsp.rm(directory, { recursive: true, force: true })));
+    });
 
-    const payloads = buildPayloadCorpus().slice(0, 96);
-    for (const payload of payloads) {
-      await attemptAll(safeRoot, payload);
-      await expectNoOutsideWrite(layout);
-    }
-  }, 30_000);
+    // Keep the accumulated fixture state and corpus order, with a deadline per payload.
+    it.each(buildPayloadCorpus().slice(0, 96))("keeps reads and writes inside the root: %j", (payload) =>
+      run(async ({ layout, safeRoot }) => {
+        await attemptAll(safeRoot, payload);
+        await expectNoOutsideWrite(layout);
+      }), 30_000);
+  });
 
   it("rejects chained symlink parent escapes across read and write surfaces", async () => {
     const layout = await makeTempLayout("fs-safe-symlink-chain", tempDirs);
@@ -99,24 +106,29 @@ describe("adversarial boundary payloads", () => {
     await expectNoOutsideWrite(layout);
   });
 
-  it("does not clobber outside files when copy and move payloads mix source and destination attacks", async () => {
-    const layout = await makeTempLayout("fs-safe-copy-move-corpus", tempDirs);
-    const source = path.join(layout.root, "source.txt");
-    await fsp.writeFile(source, "source");
-    await fsp.symlink(layout.outsideFile, path.join(layout.root, "outside-link.txt"), "file");
-    const safeRoot = await openRoot(layout.root);
-    const payloads = buildPayloadCorpus().slice(0, 48);
-
-    for (const payload of payloads) {
-      await Promise.allSettled([
-        safeRoot.copyIn(payload, source),
-        safeRoot.copyIn("copied.txt", layout.outsideFile),
-        safeRoot.move("source.txt", payload, { overwrite: true }),
-        safeRoot.move(payload, "moved.txt", { overwrite: true }),
-        safeRoot.move("outside-link.txt", "moved-link.txt", { overwrite: true }),
-      ]);
-      await expectNoOutsideWrite(layout);
+  describe.sequential("copy and move source and destination attacks", () => {
+    const directories: string[] = [];
+    const run = useSuiteFixture(async () => {
+      const layout = await makeTempLayout("fs-safe-copy-move-corpus", directories);
+      const source = path.join(layout.root, "source.txt");
       await fsp.writeFile(source, "source");
-    }
-  }, 30_000);
+      await fsp.symlink(layout.outsideFile, path.join(layout.root, "outside-link.txt"), "file");
+      return { layout, source, safeRoot: await openRoot(layout.root) };
+    }, async () => {
+      await Promise.all(directories.map((directory) => fsp.rm(directory, { recursive: true, force: true })));
+    });
+
+    it.each(buildPayloadCorpus().slice(0, 48))("does not clobber outside files: %j", (payload) =>
+      run(async ({ layout, source, safeRoot }) => {
+        await Promise.allSettled([
+          safeRoot.copyIn(payload, source),
+          safeRoot.copyIn("copied.txt", layout.outsideFile),
+          safeRoot.move("source.txt", payload, { overwrite: true }),
+          safeRoot.move(payload, "moved.txt", { overwrite: true }),
+          safeRoot.move("outside-link.txt", "moved-link.txt", { overwrite: true }),
+        ]);
+        await expectNoOutsideWrite(layout);
+        await fsp.writeFile(source, "source");
+      }), 30_000);
+  });
 });

--- a/test/helpers/suite-fixture.ts
+++ b/test/helpers/suite-fixture.ts
@@ -1,0 +1,30 @@
+import { afterAll, beforeAll } from "vitest";
+
+/** Keep setup and test work alive until it is safe to remove a shared fixture. */
+export function useSuiteFixture<Fixture>(
+  prepare: () => Promise<Fixture>,
+  cleanup: () => Promise<void>,
+  setupTimeoutMs = 30_000,
+): <Result>(operation: (fixture: Fixture) => Promise<Result>) => Promise<Result> {
+  let fixture: Fixture;
+  let pending: Promise<unknown> = Promise.resolve();
+  let closing = false;
+
+  function track<Result>(operation: () => Promise<Result>): Promise<Result> {
+    if (closing) return Promise.reject(new Error("suite fixture is closing"));
+    const result = pending.then(operation);
+    // Return the rejection to Vitest, but still allow teardown to drain it.
+    pending = result.catch(() => undefined);
+    return result;
+  }
+
+  beforeAll(() => track(async () => { fixture = await prepare(); }), setupTimeoutMs);
+  afterAll(async () => {
+    closing = true;
+    // Vitest timeouts do not cancel fs.cp or pending filesystem operations.
+    await pending;
+    await cleanup();
+  }, setupTimeoutMs);
+
+  return (operation) => track(() => operation(fixture));
+}

--- a/test/sidecar-lock-process-exit.test.ts
+++ b/test/sidecar-lock-process-exit.test.ts
@@ -1,9 +1,11 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { useTempDirs } from "./helpers/vitest.js";
+import { useSuiteFixture } from "./helpers/suite-fixture.js";
 
 const { tempRoot } = useTempDirs();
 const exec = promisify(execFile);
@@ -133,28 +135,37 @@ describe("sidecar lock natural process exit", () => {
     await expectAbsent(directory);
   });
 
-  it("deduplicates listeners across manager domains and physical package copies", async () => {
-    const directory = await tempRoot("fs-safe-lock-exit-copies-");
-    const copy = path.join(directory, "copy");
-    await fs.mkdir(copy);
-    await fs.copyFile(new URL("../package.json", import.meta.url), path.join(copy, "package.json"));
-    await fs.cp(new URL("../dist", import.meta.url), path.join(copy, "dist"), { recursive: true });
-    const output = await runChild(directory, `
-      const { createRequire } = await import("node:module");
-      const { pathToFileURL } = await import("node:url");
-      const copyRequire = createRequire(path.join(directory, "copy", "package.json"));
-      const other = await import(pathToFileURL(copyRequire.resolve("@openclaw/fs-safe/file-lock")));
-      assert.notEqual(other.createFileLockManager, createFileLockManager);
-      const before = process.listenerCount("beforeExit");
-      for (let index = 0; index < 12; index++) {
-        const api = index % 2 ? other : { createFileLockManager };
-        await api.createFileLockManager("domain-" + index)
-          .acquire(path.join(directory, index + ".json"), options);
-      }
-      console.log(process.listenerCount("beforeExit") - before);
-    `);
-    expect(output).toBe("1");
-    for (let index = 0; index < 12; index++) await expectAbsent(directory, `${index}.json.lock`);
+  describe("physical package copies", () => {
+    let directory: string | undefined;
+    const run = useSuiteFixture(async () => {
+      directory = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-lock-exit-copies-"));
+      const copy = path.join(directory, "copy");
+      await fs.mkdir(copy);
+      await fs.copyFile(new URL("../package.json", import.meta.url), path.join(copy, "package.json"));
+      await fs.cp(new URL("../dist", import.meta.url), path.join(copy, "dist"), { recursive: true });
+      return directory;
+    }, async () => {
+      if (directory) await fs.rm(directory, { recursive: true, force: true });
+    });
+
+    it("deduplicates listeners across manager domains and physical package copies", () => run(async (directory) => {
+      const output = await runChild(directory, `
+        const { createRequire } = await import("node:module");
+        const { pathToFileURL } = await import("node:url");
+        const copyRequire = createRequire(path.join(directory, "copy", "package.json"));
+        const other = await import(pathToFileURL(copyRequire.resolve("@openclaw/fs-safe/file-lock")));
+        assert.notEqual(other.createFileLockManager, createFileLockManager);
+        const before = process.listenerCount("beforeExit");
+        for (let index = 0; index < 12; index++) {
+          const api = index % 2 ? other : { createFileLockManager };
+          await api.createFileLockManager("domain-" + index)
+            .acquire(path.join(directory, index + ".json"), options);
+        }
+        console.log(process.listenerCount("beforeExit") - before);
+      `);
+      expect(output).toBe("1");
+      for (let index = 0; index < 12; index++) await expectAbsent(directory, `${index}.json.lock`);
+    }));
   });
 
   it("registers beforeExit when an older copy already registered exit cleanup", async () => {

--- a/test/suite-fixture.test.ts
+++ b/test/suite-fixture.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSuiteFixture } from "./helpers/suite-fixture.js";
+
+const hooks = vi.hoisted(() => ({
+  setup: undefined as (() => Promise<unknown>) | undefined,
+  cleanup: undefined as (() => Promise<void>) | undefined,
+}));
+
+vi.mock("vitest", async (importOriginal) => ({
+  ...await importOriginal<typeof import("vitest")>(),
+  beforeAll: (callback: () => Promise<unknown>) => { hooks.setup = callback; },
+  afterAll: (callback: () => Promise<void>) => { hooks.cleanup = callback; },
+}));
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  hooks.setup = undefined;
+  hooks.cleanup = undefined;
+});
+
+describe("suite fixture lifetime", () => {
+  it("drains unfinished setup before removing a partially prepared fixture", async () => {
+    const gate = deferred();
+    const cleanup = vi.fn(async () => {});
+    const failure = new Error("copy failed");
+    useSuiteFixture(async () => { await gate.promise; }, cleanup);
+    const setup = hooks.setup!();
+    const rejected = expect(setup).rejects.toBe(failure);
+    const teardown = hooks.cleanup!();
+    await Promise.resolve();
+    expect(cleanup).not.toHaveBeenCalled();
+    gate.reject(failure);
+    await rejected;
+    await teardown;
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("serializes unfinished test work and drains it before teardown", async () => {
+    const gate = deferred();
+    const events: string[] = [];
+    const run = useSuiteFixture(async () => "fixture", async () => { events.push("cleanup"); });
+    await hooks.setup!();
+    const first = run(async (fixture) => {
+      expect(fixture).toBe("fixture");
+      events.push("first");
+      await gate.promise;
+      events.push("settled");
+    });
+    const second = run(async () => { events.push("second"); });
+    const teardown = hooks.cleanup!();
+    await Promise.resolve();
+    expect(events).toEqual(["first"]);
+    await expect(run(async () => {})).rejects.toThrow("suite fixture is closing");
+    gate.resolve();
+    await Promise.all([first, second, teardown]);
+    expect(events).toEqual(["first", "settled", "second", "cleanup"]);
+  });
+
+  it("preserves a test failure while still waiting for its work before cleanup", async () => {
+    const gate = deferred();
+    const cleanup = vi.fn(async () => {});
+    const failure = new Error("operation failed");
+    const run = useSuiteFixture(async () => undefined, cleanup);
+    await hooks.setup!();
+    const operation = run(async () => { await gate.promise; });
+    const rejected = expect(operation).rejects.toBe(failure);
+    const teardown = hooks.cleanup!();
+    await Promise.resolve();
+    expect(cleanup).not.toHaveBeenCalled();
+    gate.reject(failure);
+    await rejected;
+    await teardown;
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Windows CI exposed two fixture-lifetime failures: recursively copying the built package consumed the process-exit test's five-second deadline, and large traversal/copy-move corpora shared one 30-second deadline. Vitest does not cancel timed-out filesystem promises, so teardown could remove directories while those operations were still running, producing `ENOTEMPTY`.

Move physical-package setup into a separately budgeted suite hook, and serialize/drain suite-owned work before removing its directories. Preserve the independent physical package import, all twelve manager domains, every lock-cleanup assertion, and the child's four-second liveness guard. Run all 96 traversal and 48 copy/move payloads in their original order with shared fixture state and a deadline per payload. Production code, permission checks, native boundaries, global test timeouts, and coverage thresholds are unchanged.

Validation:
- Focused suite: 159 tests passed, including fixture setup failure, operation failure, serialization, and teardown ordering.
- Injecting a six-second package copy into the unchanged baseline reproduces its five-second timeout and confirms teardown races the copy. The candidate passes the same probe, reports no cleanup race, removes the fixture, and executes the real built-package child in 344 ms.
- Windows Node 22 and 24 CI now run that deterministic slow-copy proof in addition to the complete checks.
- `CI=1 pnpm check`, `pnpm docs:site`, and `git diff --check` passed. The complete local fallback check passed 5,038 tests (2,427 platform/native-dependent cases skipped); hosted CI covers native and Windows paths.
- Full candidate P2 autoreview: scoped-clean, no actionable findings.

This is a focused follow-up to the postmerge Windows failures after #220. The earlier PowerShell permission-inspection timeout passed its retry; its production deadline and fail-closed behavior remain intact. No further blind retry was used for the known fixture failure.

Exact-head validation at `d263be6bc84eda96e6a84e34c7b3e87ac03ee9c3`:

- [CI: all 15 jobs passed](https://github.com/openclaw/fs-safe/actions/runs/33856907949), including native and bundled-package checks.
- [Windows Node 22](https://github.com/openclaw/fs-safe/actions/runs/33856907949/job/100972219871) and [Windows Node 24](https://github.com/openclaw/fs-safe/actions/runs/33856907949/job/100972219957) both passed the injected six-second copy proof, reporting `teardownRacedCopy: false`. Node 22's actual child case took 346 ms.
- [Coverage](https://github.com/openclaw/fs-safe/actions/runs/33856907970): all three platforms and merged thresholds passed.
- [CodeQL](https://github.com/openclaw/fs-safe/actions/runs/33856908074): passed.

Observed Windows proof (open step 7 in each linked job):

| Runtime | Real delayed-copy run | Observed result |
| --- | --- | --- |
| [Node 22 terminal log](https://github.com/openclaw/fs-safe/actions/runs/33856907949/job/100972219871#step:7:11) | 7.45 s, including the injected 6 s delay; child case 346 ms | One physical copy completed; `copied: true`, `teardownRacedCopy: false`; test passed. |
| [Node 24 terminal log](https://github.com/openclaw/fs-safe/actions/runs/33856907949/job/100972219957#step:7:11) | 7.21 s, including the injected 6 s delay | One physical copy completed; `copied: true`, `teardownRacedCopy: false`; test passed. |

Both successful runs include the [fixture-absence assertion after teardown](https://github.com/openclaw/fs-safe/blob/d263be6bc84eda96e6a84e34c7b3e87ac03ee9c3/scripts/slow-package-copy.setup.ts#L43), independent-package assertion, twelve lock-domain cleanup assertions, and unchanged four-second child deadline. These completed Windows logs supply the runtime evidence requested in the earlier automated review.

No failures or reruns on this repair candidate. Prepared for maintainer review; not merged.
