### PR TITLE
fix(path): reject reserved device names on Windows and guard secret reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Check JavaScript fallback
         run: pnpm check
 
+      - name: Prove archive device admission and secret reads
+        if: matrix.node == 24
+        run: node scripts/device-path-proof.mjs off
+
       - name: Prove slow package-copy fixture lifetime on Windows
         if: matrix.os == 'windows-latest'
         run: pnpm test --config scripts/slow-package-copy.config.ts
@@ -126,6 +130,9 @@ jobs:
 
       - name: Build and stage host binding
         run: pnpm native:build
+
+      - name: Prove archive device admission and secret reads with native binding
+        run: node scripts/device-path-proof.mjs require
 
       - name: Prove temp workspace quarantine swap at native removal
         run: node scripts/temp-workspace-quarantine-swap-proof.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Highlights:** TAR/gzip extraction now shares one parser across native and fallback modes, improving compatibility with system-tar output while keeping admission and publication guarded.
 
+- Reject reserved archive device names and ignored-space aliases on Windows while preserving ordinary POSIX members, and guard secret reads with the documented `device-path` rejection. Thanks @SebTardif.
 - Unify native and guarded JavaScript TAR admission on one Rust core, bundle its WASM build, and accept strict UTF-8/newline PAX paths without a runtime `tar` dependency; retain bounded framing, raw-field validation, and guarded publication.
 - Accept bounded all-zero gzip container padding from system-tar stdout after validated member trailers, and reject nonzero data hidden after padding on both native and guarded JavaScript TAR routes.
 - Fix `replaceFileAtomic({ dirMode })` rejecting a raw `fs.stat` mode: directory modes are masked to permission bits (`0o7777`) before application and verification, matching chmod semantics; 0.8.0 regressed this input tolerance with `directory final mode could not be verified`.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -124,6 +124,12 @@ Unicode Path names use the same canonicalization.
 Raw paths undergo traversal, absolute/drive-path, and NUL validation **before**
 canonicalization; normalization cannot turn an unsafe path into an accepted
 one. Stripping and output collision checks use this same canonical identity.
+On Windows, archive admission also rejects reserved device segments such as
+`NUL`, `CON.txt`, and `nul .txt` with `ArchiveSecurityError("entry-path")`,
+before extraction or bounded member reads. Ignored trailing spaces in the stem
+before an extension do not bypass this check. Ordinary members with these names
+remain valid on POSIX; this is a host-specific device guard, not a portable-name
+restriction.
 Filters that compare exact strings should use canonical pre-strip paths,
 including directory names without a trailing `/`.
 Returning `"skip"` rejects the whole archive unless `onFiltered` is

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -87,6 +87,14 @@ The `require` command must resolve the freshly packed native binding; the
 
 ### Native consumer installs
 
+The CI Node 24 and native jobs also run `node scripts/device-path-proof.mjs off`
+and `node scripts/device-path-proof.mjs require` against the built package.
+This extracts real ZIP files and checks bounded member reads, preserving reserved
+device-like names on POSIX while rejecting them and ignored-space aliases on
+Windows. It also verifies ordinary secret reads and typed device-path rejection
+without replacing filesystem functions. Run after `pnpm build`, and build the
+host binding with `pnpm native:build` before the `require` case.
+
 After `pnpm build` and a fresh `pnpm native:build`, run `pnpm package:smoke`.
 It packs the real root and host binding, then runs root-only npm and the
 declared pnpm version against a disposable loopback registry. The root's exact

--- a/docs/secret-file.md
+++ b/docs/secret-file.md
@@ -91,6 +91,11 @@ credential must also fail on broad permissions or unexpected ownership.
 the same pinned-handle validation, byte cap, trimming, error codes, and strict
 versus missing-is-undefined naming semantics.
 
+Both readers reject known unsafe device and process-fd paths with `device-path`
+before inspection, and check the resolved target before opening it. This includes
+Windows reserved device names and ignored-space aliases such as `nul .txt`.
+Optional readers propagate this error instead of treating the secret as missing.
+
 Both sync and async readers compare lossless bigint identities from the preview,
 opened descriptor, resolved target, and current input path before reading. POSIX
 opens are nonblocking, so a raced FIFO is rejected by descriptor type instead of

--- a/scripts/device-path-proof.mjs
+++ b/scripts/device-path-proof.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import JSZip from "jszip";
+import { configureFsSafeNative } from "../dist/index.js";
+import { extractArchive, readArchiveEntry } from "../dist/archive.js";
+import { readSecretFile, readSecretFileSync, tryReadSecretFile, tryReadSecretFileSync } from "../dist/secret.js";
+
+const mode = process.argv[2];
+assert.ok(mode === "off" || mode === "require", "usage: device-path-proof.mjs <off|require>");
+configureFsSafeNative({ mode });
+const directory = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-device-proof-"));
+const payload = Buffer.from("synthetic archive member\n");
+const cases = [
+  ["NUL", true],
+  ["CON.txt", true],
+  ["nul .txt", true],
+  ["nested/COM1 .log", true],
+  ["NUL/leaf.txt", true],
+  ["console.txt", false],
+  ["content.txt", false],
+];
+
+try {
+  for (const [index, [member, reserved]] of cases.entries()) {
+    const zip = new JSZip();
+    zip.file(member, payload);
+    const archivePath = path.join(directory, `${index}.zip`);
+    const destDir = path.join(directory, `out-${index}`);
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+    await fs.mkdir(destDir);
+    const rejected = process.platform === "win32" && reserved;
+    const extract = () => extractArchive({ archivePath, destDir, kind: "zip", timeoutMs: 10_000 });
+    const read = () => readArchiveEntry(archivePath, member, { kind: "zip", maxBytes: payload.length });
+    if (rejected) {
+      await assert.rejects(extract, { code: "entry-path" });
+      await assert.rejects(read, { code: "entry-path" });
+      assert.deepEqual(await fs.readdir(destDir), []);
+    } else {
+      await extract();
+      assert.deepEqual(await fs.readFile(path.join(destDir, member)), payload);
+      assert.deepEqual(await read(), payload);
+    }
+    console.log(JSON.stringify({ platform: process.platform, mode, member,
+      extraction: rejected ? "entry-path; destination empty" : "exact payload",
+      boundedRead: rejected ? "entry-path" : "exact payload" }));
+  }
+
+  const regular = path.join(directory, "secret.txt");
+  await fs.writeFile(regular, " synthetic token\n", { mode: 0o600 });
+  assert.equal(await readSecretFile(regular, "proof"), "synthetic token");
+  assert.equal(readSecretFileSync(regular, "proof"), "synthetic token");
+  const devices = process.platform === "win32"
+    ? [path.join(directory, "NUL"), path.join(directory, "nul .txt")]
+    : ["/dev/urandom", "/dev/fd/99"];
+  for (const device of devices) {
+    await assert.rejects(() => readSecretFile(device, "proof"), { code: "device-path" });
+    await assert.rejects(() => tryReadSecretFile(device, "proof"), { code: "device-path" });
+    assert.throws(() => readSecretFileSync(device, "proof"), { code: "device-path" });
+    assert.throws(() => tryReadSecretFileSync(device, "proof"), { code: "device-path" });
+  }
+  console.log(JSON.stringify({ platform: process.platform, mode,
+    secretReads: "regular file accepted; async/sync strict/optional device paths rejected", result: "PASS" }));
+} finally {
+  await fs.rm(directory, { recursive: true, force: true });
+}

--- a/src/archive-entry.ts
+++ b/src/archive-entry.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { ArchiveSecurityError } from "./archive-errors.js";
+import { isWindowsReservedDeviceName } from "./device-path.js";
 import { formatErrorDetail } from "./error-detail.js";
 import { resolveSafeBaseDir } from "./path.js";
 
@@ -40,6 +41,15 @@ export function validateArchiveEntryPath(
     throw new ArchiveSecurityError(
       "entry-path",
       `archive entry uses a Windows alternate data stream path: ${formatErrorDetail(entryPath)}`,
+    );
+  }
+  if (
+    process.platform === "win32" &&
+    slashNormalized.split("/").some((segment) => isWindowsReservedDeviceName(segment))
+  ) {
+    throw new ArchiveSecurityError(
+      "entry-path",
+      `archive entry uses a reserved device path: ${formatErrorDetail(entryPath)}`,
     );
   }
   const normalized = path.posix.normalize(slashNormalized);

--- a/src/device-path.ts
+++ b/src/device-path.ts
@@ -127,8 +127,12 @@ function normalizeWindowsDeviceBaseName(filePath: string): string {
   const normalized = trimTrailingWindowsSeparators(filePath.replace(/\//g, "\\"));
   const lastSegment = normalized.split("\\").filter(Boolean).at(-1) ?? normalized;
   const withoutStream = lastSegment.split(":")[0] ?? lastSegment;
-  const withoutTrailingIgnoredChars = trimTrailingWindowsIgnoredChars(withoutStream);
-  return (withoutTrailingIgnoredChars.split(".")[0] ?? withoutTrailingIgnoredChars).toUpperCase();
+  const stem = withoutStream.split(".")[0] ?? withoutStream;
+  return trimTrailingWindowsIgnoredChars(stem).toUpperCase();
+}
+
+export function isWindowsReservedDeviceName(name: string): boolean {
+  return name.length > 0 && WINDOWS_RESERVED_DEVICE_NAMES.has(normalizeWindowsDeviceBaseName(name));
 }
 
 function matchWindowsDeviceReadPath(filePath: string): UnsafeDeviceReadPathMatch | undefined {

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -7,6 +7,7 @@ import { normalizeMaxBytes } from "./byte-budget.js";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard, inspectDirectoryIdentity, type AsyncDirectoryGuard } from "./directory-guard.js";
 import { pinNodeDirectoryForMode } from "./directory-mode-node.js";
 import { assertOwnedDirectory } from "./directory-mode-owner.js";
+import { assertNoUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
 import { resolveHomeRelativePath } from "./home-dir.js";
 import { openPinnedFileSync } from "./pinned-open.js";
@@ -52,6 +53,7 @@ export function readSecretFileSync(
 
   let previewStat: fs.BigIntStats;
   try {
+    assertNoUnsafeDeviceReadPath(resolvedPath);
     previewStat = inspectFileIdentitySync(() =>
       inspectInput(`${label} file at ${resolvedPath} must not be a symlink.`),
     );

--- a/src/secret-read-async.ts
+++ b/src/secret-read-async.ts
@@ -2,6 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { readFileHandleBounded } from "./bounded-read.js";
 import { normalizeMaxBytes } from "./byte-budget.js";
+import { assertNoUnsafeDeviceReadPath } from "./device-path.js";
 import { FsSafeError } from "./errors.js";
 import { resolveHomeRelativePath } from "./home-dir.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
@@ -39,6 +40,7 @@ export async function readSecretFile(
 
   let previewStat;
   try {
+    assertNoUnsafeDeviceReadPath(resolvedPath);
     previewStat = await inspectFileIdentity(() =>
       inspectInput(`${label} file at ${resolvedPath} must not be a symlink.`),
     );
@@ -54,6 +56,7 @@ export async function readSecretFile(
   let raw: string;
   try {
     const realPath = await fs.realpath(resolvedPath);
+    assertNoUnsafeDeviceReadPath(realPath);
     handle = await fs.open(realPath, resolveReadOpenFlags());
     const openedHandle = handle;
     const openedStat = await inspectFileIdentity(async () => {

--- a/test/archive-property-fuzz.test.ts
+++ b/test/archive-property-fuzz.test.ts
@@ -263,7 +263,7 @@ describe.each(["tar", "zip"] as const)("%s Windows-name portability", (kind) => 
         if (process.platform === "win32") {
           expect(outcome, JSON.stringify({ kind, backend, name })).toEqual({
             accepted: false,
-            code: name.includes(":") ? "entry-path" : "device-path",
+            code: "entry-path",
           });
         } else {
           expect(outcome, JSON.stringify({ kind, backend, name })).toEqual({ accepted: true });

--- a/test/device-path.test.ts
+++ b/test/device-path.test.ts
@@ -54,6 +54,9 @@ describe("unsafe device read paths", () => {
     for (const filePath of [
       "NUL",
       "C:\\tmp\\NUL.txt",
+      "C:\\tmp\\nul .txt",
+      "C:\\tmp\\COM1 .log",
+      "C:\\tmp\\LPT³  .txt",
       "C:\\tmp\\con",
       "C:\\tmp\\COM¹.txt",
       "C:\\tmp\\LPT³",
@@ -66,6 +69,7 @@ describe("unsafe device read paths", () => {
       });
     }
     expect(isUnsafeDeviceReadPath("C:\\tmp\\normal.txt", { platform: "win32" })).toBe(false);
+    expect(isUnsafeDeviceReadPath("C:\\tmp\\nulled .txt", { platform: "win32" })).toBe(false);
   });
 
   posixIt("blocks async public file read primitives before open", async () => {

--- a/test/extracted-helpers.test.ts
+++ b/test/extracted-helpers.test.ts
@@ -148,6 +148,20 @@ describe("archive entry helpers", () => {
     }
   });
 
+  it("rejects reserved device segments only on Windows", () => {
+    for (const entryPath of ["CON", "NUL", "CON.txt", "COM1", "nested/LPT1", "CON .", "nul .txt", "nested/COM1 .log", "NUL/leaf.txt"]) {
+      if (process.platform === "win32") {
+        expect(() => validateArchiveEntryPath(entryPath), entryPath).toThrow(
+          "archive entry uses a reserved device path",
+        );
+      } else {
+        expect(() => validateArchiveEntryPath(entryPath), entryPath).not.toThrow();
+      }
+    }
+    expect(() => validateArchiveEntryPath("console.txt")).not.toThrow();
+    expect(() => validateArchiveEntryPath("content.txt")).not.toThrow();
+  });
+
   it("resolves archive output paths under the destination root", () => {
     const rootDir = path.join(path.sep, "tmp", "archive-root");
     expect(

--- a/test/helpers/property.ts
+++ b/test/helpers/property.ts
@@ -15,6 +15,8 @@ export const WINDOWS_ARCHIVE_PORTABILITY_NAMES = [
   ...WINDOWS_RESERVED_ARCHIVE_NAMES.flatMap((name) => [name, `${name}.txt`]),
   "NUL.",
   "NUL ",
+  "nul .txt",
+  "nested/COM1 .log",
   "CON.txt.",
   "CON.txt ",
   "COM1.",

--- a/test/sync-async-contracts.test.ts
+++ b/test/sync-async-contracts.test.ts
@@ -109,6 +109,34 @@ describe("sync and async public contracts", () => {
     expect(await captureRejected(tryReadSecretFile(filePath, "token", options))).toMatchObject(expected);
   });
 
+  it("rejects unsafe device paths with the same device-path code on sync and async", async () => {
+    const devicePath = process.platform === "win32" ? path.resolve("CON") : "/dev/urandom";
+    const inspectBlocked = new Error("inspect should not run for reserved device paths");
+    const openBlocked = new Error("open should not run for reserved device paths");
+    vi.spyOn(fsSync, "statSync").mockImplementation(() => {
+      throw inspectBlocked;
+    });
+    vi.spyOn(fsSync, "lstatSync").mockImplementation(() => {
+      throw inspectBlocked;
+    });
+    vi.spyOn(fsSync, "openSync").mockImplementation(() => {
+      throw openBlocked;
+    });
+    vi.spyOn(fs, "stat").mockRejectedValue(inspectBlocked);
+    vi.spyOn(fs, "lstat").mockRejectedValue(inspectBlocked);
+    vi.spyOn(fs, "realpath").mockRejectedValue(openBlocked);
+    vi.spyOn(fs, "open").mockRejectedValue(openBlocked);
+
+    const syncError = captureThrown(() => readSecretFileSync(devicePath, "token"));
+    const asyncError = await captureRejected(readSecretFile(devicePath, "token"));
+    for (const error of [syncError, asyncError]) {
+      expectFsSafeCode(error, "device-path");
+      expect(error).toMatchObject({
+        message: `Failed to inspect token file at ${devicePath}: FsSafeError: file reads from unsafe device paths are not allowed: ${devicePath}`,
+      });
+    }
+  });
+
   it("does not reclassify path resolution failures as optional missing secrets", async () => {
     const failure = Object.assign(new Error("cwd unavailable"), { code: "ENOENT" });
     const cwd = vi.spyOn(process, "cwd").mockImplementation(() => { throw failure; });


### PR DESCRIPTION
Reject reserved archive device segments on Windows, including ignored-space aliases such as `nul .txt` and `nested/COM1 .log`, before extraction or bounded member reads. Ordinary POSIX members named `NUL` and `CON.txt` remain valid. The shared Windows device matcher trims the stem before its extension, so existing guarded readers also recognize these aliases.

Secret readers enforce the documented `device-path` contract: check the input before inspection and the resolved target before opening, and propagate policy errors through strict and optional readers. Normal secret reads remain unchanged.

This maintainer repair rebases the contribution onto main, preserves POSIX archive compatibility, and places the credited hardening entry immediately after the Unreleased Highlights line.

### Validation

Prepared head: `702634f1b0b2296ef16af1b61831764a53387f04`.

- All 15 [CI jobs](https://github.com/openclaw/fs-safe/actions/runs/33988075104) passed, including Node 22/24 checks on Linux/macOS/Windows, native glibc/musl/macOS/Windows checks, and consumer-install smoke.
- All three platform coverage jobs and [merged coverage](https://github.com/openclaw/fs-safe/actions/runs/33988075051) passed with unchanged thresholds.
- Independent committed-branch review is clean through P2; local build, 38 focused regression tests, and the standalone package/import/API check passed.
- The local full check reported a failure in `api-coverage.test.ts` at `covers JSON success, parse, read, and lock behavior` after 6753 ms and was stopped after failure. A fresh-private-temp retry passed all 22 tests in that file. The interrupted full local run is not claimed as a pass; complete-suite validation is supplied by the successful CI matrix.

### Real filesystem proof

`node scripts/device-path-proof.mjs off` passed locally on macOS 26.6.2 arm64 with Node 24.20.0. The script imports the built public modules and uses unmodified filesystem calls. It extracts real ZIPs, compares exact payloads and bounded member reads, and checks normal and guarded secret reads.

The same script passed in the [Windows Node 24 job](https://github.com/openclaw/fs-safe/actions/runs/33988075104/job/101365211453) with `off`, and the [Windows native job](https://github.com/openclaw/fs-safe/actions/runs/33988075104/job/101365211322) with `require`.

| Cases | macOS `off` | Windows `off` and `require` |
|---|---|---|
| `NUL`, `CON.txt`, `nul .txt`, `nested/COM1 .log`, `NUL/leaf.txt` | Extraction and bounded reads preserve exact payload | Both return `entry-path`; extraction destination stays empty |
| `console.txt`, `content.txt` | Exact payload | Exact payload |
| Regular secret file | Sync and async reads succeed | Sync and async reads succeed |
| Unsafe device paths | Strict/optional sync/async readers return `device-path` | Strict/optional sync/async readers return `device-path` |

No merge, tag, or publication has been performed in this repair turn.

Co-authored-by: Sebastien Tardif <SebTardif@ncf.ca>
