### PR TITLE
perf: cut redundant syscalls and fsyncs in read/write hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Reduce filesystem calls per read and write while retaining boundary, hardlink, hook, retry, and post-mutation identity checks.
+- Skip native publication's extra mode-only file fsync for modes that retain owner read/write when staging permissions have not widened; after a crash, a file may retain staged `0o600` instead of the wider requested mode, while restrictive modes retain the extra fsync.
+- Add 1 MiB read/write and existing-mode inheritance benchmarks, with native-mode metadata and per-case iteration counts.
+
 ## 0.8.2 - 2026-09-05
 
 **Highlights:** TAR/gzip extraction now shares one parser across native and fallback modes, improving compatibility with system-tar output while keeping admission and publication guarded.

--- a/docs/staged-file.md
+++ b/docs/staged-file.md
@@ -66,8 +66,12 @@ Strings are UTF-8. `mode` is the requested **published** mode and defaults to
 `0600`; exact final modes, including `000`, are supported. The unpublished file
 stays at `0600` throughout preparation and any awaited application checks.
 After rename succeeds and the published entry passes identity validation, the
-owner applies the requested mode through its retained file descriptor and
-synchronizes the file. No parent is created or chmodded.
+owner applies the requested mode through its retained file descriptor. Content
+was synchronized during preparation; publication always synchronizes the parent.
+Modes retaining owner read/write skip the extra mode-only file sync, so a crash
+may leave the tighter staged `0600` instead of the wider requested mode. Modes
+removing owner read or write, and corrections of an observed wider staged mode,
+retain the post-chmod file sync. No parent is created or chmodded.
 Creation uses an exclusive, no-follow, close-on-exec open of a generated direct
 child name. Writes use that descriptor. Inspection uses non-following metadata
 operations, never a potentially blocking reopen of the leaf.

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -84,6 +84,11 @@ final verification uses a descriptor retained by the writer rather than reopenin
 the published file. The requested mode is not relaxed for verification.
 Publication verification compares exact bigint descriptor and pathname identities,
 including large file indexes that cannot be represented by a JavaScript number.
+Native publication syncs content before rename and always syncs the parent directory.
+Modes that retain owner read/write skip the extra mode-only file sync: after a
+crash, the file may retain staged mode `0o600` instead of the wider requested mode.
+Modes that remove owner read or write, and corrections of observed wider staging
+permissions, keep the post-chmod file sync.
 Later reads still obey OS permissions, and access checks on a pre-existing
 destination are unchanged. The explicit FUSE compatibility policy still requires
 a readable destination to prove matching content when rename changes its identity.

--- a/scripts/benchmark.mjs
+++ b/scripts/benchmark.mjs
@@ -113,19 +113,19 @@ function renderMarkdown(metadata, results) {
   const lines = [
     "# fs-safe benchmark",
     "",
-    `Report-only microbenchmark. Each row times ${metadata.iterations} sequential iterations; lower is better.`,
+    `Report-only microbenchmark. Up to ${metadata.iterations} sequential iterations per row; lower is better.`,
     "",
-    `Node ${metadata.node} on ${metadata.platform}/${metadata.arch}. Samples per case: ${metadata.samples}.`,
+    `Node ${metadata.node} on ${metadata.platform}/${metadata.arch}. Native mode: ${metadata.nativeMode}. Samples per case: ${metadata.samples}.`,
     "",
-    "| Group | Case | Best ms | Median ms | Mean ms | vs raw best | Samples |",
-    "|---|---:|---:|---:|---:|---:|---|",
+    "| Group | Case | Iterations | Best ms | Median ms | Mean ms | vs raw best | Samples |",
+    "|---|---:|---:|---:|---:|---:|---:|---|",
   ];
 
   for (const result of results) {
     const baseline = baselineByGroup.get(result.group) ?? result.bestMs;
     const ratio = baseline > 0 ? result.bestMs / baseline : 1;
     lines.push(
-      `| ${result.group} | ${result.name} | ${formatMs(result.bestMs)} | ${formatMs(result.medianMs)} | ${formatMs(result.meanMs)} | ${formatRatio(ratio)}x | ${result.sampleMs.map(formatMs).join(", ")} |`,
+      `| ${result.group} | ${result.name} | ${result.iterations} | ${formatMs(result.bestMs)} | ${formatMs(result.medianMs)} | ${formatMs(result.meanMs)} | ${formatRatio(ratio)}x | ${result.sampleMs.map(formatMs).join(", ")} |`,
     );
   }
 
@@ -156,6 +156,7 @@ async function main() {
   const warmup = Math.min(args.warmup, iterations);
   const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-benchmark-"));
   const payload = Buffer.from("x".repeat(BYTES_PER_PAYLOAD));
+  const largePayload = Buffer.alloc(1024 * 1024, "x");
   const jsonPayload = { ok: true, count: 42, label: "fs-safe benchmark" };
   const jsonText = `${JSON.stringify(jsonPayload, null, 2)}\n`;
 
@@ -166,6 +167,12 @@ async function main() {
     const jsonPath = path.join(workspace, "state.json");
     await fs.writeFile(readPath, payload);
     await fs.writeFile(jsonPath, jsonText);
+    const largeReadPath = path.join(workspace, "read-1mib.bin");
+    await fs.writeFile(largeReadPath, largePayload);
+    for (const name of ["raw-mode.txt", "atomic-mode.txt", "root-mode.txt"]) {
+      await fs.writeFile(path.join(workspace, name), payload, { mode: 0o640 });
+      await fs.chmod(path.join(workspace, name), 0o640);
+    }
 
     const cases = [
       {
@@ -250,16 +257,53 @@ async function main() {
           });
         },
       },
+      {
+        group: "write file 1 MiB", name: "raw fs.writeFile", baseline: true, iterationsDivisor: 10,
+        run: () => fs.writeFile(path.join(workspace, "raw-write-1mib.bin"), largePayload),
+      },
+      {
+        group: "write file 1 MiB", name: "replaceFileAtomic", iterationsDivisor: 10,
+        run: () => replaceFileAtomic({ filePath: path.join(workspace, "atomic-write-1mib.bin"), content: largePayload }),
+      },
+      {
+        group: "write file 1 MiB", name: "root.write", iterationsDivisor: 10,
+        run: () => safe.write("root-write-1mib.bin", largePayload),
+      },
+      {
+        group: "read file 1 MiB", name: "raw fs.readFile", baseline: true, iterationsDivisor: 10,
+        run: () => fs.readFile(largeReadPath),
+      },
+      {
+        group: "read file 1 MiB", name: "readRegularFile", iterationsDivisor: 10,
+        run: () => readRegularFile({ filePath: largeReadPath }),
+      },
+      {
+        group: "read file 1 MiB", name: "root.readBytes", iterationsDivisor: 10,
+        run: () => safe.readBytes("read-1mib.bin"),
+      },
+      {
+        group: "write inherited mode 0640", name: "raw fs.writeFile", baseline: true,
+        run: () => fs.writeFile(path.join(workspace, "raw-mode.txt"), payload),
+      },
+      {
+        group: "write inherited mode 0640", name: "replaceFileAtomic",
+        run: () => replaceFileAtomic({ filePath: path.join(workspace, "atomic-mode.txt"), content: payload, preserveExistingMode: true }),
+      },
+      {
+        group: "write inherited mode 0640", name: "root.write",
+        run: () => safe.write("root-mode.txt", payload),
+      },
     ];
 
     const results = [];
     for (const benchCase of cases) {
       console.error(`benchmark: ${benchCase.group} / ${benchCase.name}`);
+      const caseIterations = Math.max(1, Math.floor(iterations / (benchCase.iterationsDivisor ?? 1)));
       const result = await timeCase({
         ...benchCase,
-        iterations,
+        iterations: caseIterations,
         samples,
-        warmup,
+        warmup: Math.min(warmup, caseIterations),
       });
       console.error(`benchmark: ${benchCase.name} best=${formatMs(result.bestMs)}ms`);
       results.push(result);
@@ -270,6 +314,8 @@ async function main() {
       samples,
       warmup,
       payloadBytes: payload.byteLength,
+      largePayloadBytes: largePayload.byteLength,
+      nativeMode: process.env.FS_SAFE_NATIVE_MODE ?? "auto",
       node: process.version,
       platform: process.platform,
       arch: process.arch,

--- a/src/directory-mode-owner.ts
+++ b/src/directory-mode-owner.ts
@@ -51,6 +51,7 @@ export function ownDirectoryMode(params: {
       checks.check?.();
       const currentMode = await params.inspect();
       checks.check?.();
+      if (currentMode === mode && !checks.beforeChmod && !checks.check) return;
       if (currentMode !== mode) {
         await params.prepareChmod?.();
         checks.check?.();

--- a/src/native-staged-file.ts
+++ b/src/native-staged-file.ts
@@ -150,14 +150,14 @@ class NativeStagedFile implements StagedFile {
     return state.fileFd;
   }
 
-  #assertNamed(name: string): void {
+  #assertNamed(name: string): number {
     const fd = this.#file();
-    if (
-      !this.#binding.stagedFileMatches(this.#parentFd, name, fd) ||
-      fs.fstatSync(fd, { bigint: true }).nlink !== 1n
-    ) {
+    const stat = this.#binding.stagedFileMatches(this.#parentFd, name, fd)
+      ? fs.fstatSync(fd, { bigint: true }) : undefined;
+    if (!stat || stat.nlink !== 1n) {
       throw new FsSafeError("path-mismatch", "staged entry no longer names the exclusive created file");
     }
+    return Number(stat.mode & 0o7777n);
   }
 
   #assertCurrent(): void {
@@ -251,13 +251,18 @@ class NativeStagedFile implements StagedFile {
         overwrite,
       });
       state.publication = receipt;
-      this.#assertNamed(basename);
+      const stagedMode = this.#assertNamed(basename);
       assertStagedDirectoryCurrent(this.#directory);
       // Keep contents private until the published name passes its identity
       // fence. Mode changes use the owned fd, including for final mode 000.
       const fd = this.#file();
-      fs.fchmodSync(fd, this.#publishedMode);
-      syncNativeFileBestEffort(fd);
+      if (this.#publishedMode !== 0o600 || stagedMode !== 0o600) fs.fchmodSync(fd, this.#publishedMode);
+      // Content was synced before rename. A lost chmod leaves staged 0600,
+      // no wider than modes retaining owner rw. Restrictive modes and observed
+      // widening of the stage still need the permission correction made durable.
+      if ((this.#publishedMode & 0o600) !== 0o600 || (stagedMode & ~this.#publishedMode) !== 0) {
+        syncNativeFileBestEffort(fd);
+      }
       syncNativeFileBestEffort(this.#parentFd);
       this.#assertNamed(basename);
       assertStagedDirectoryCurrent(this.#directory);

--- a/src/opened-realpath.ts
+++ b/src/opened-realpath.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import type { BigIntStats, Stats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { openedPathResolutionError } from "./opened-file-failure.js";
@@ -10,28 +11,36 @@ export async function resolveOpenedFileRealPathForHandle(
   ioPath: string,
 ): Promise<string> {
   const handleStat = await handle.stat();
-  return await resolveOpenedFileRealPathForFd(handle.fd, handleStat, ioPath);
+  return (await resolveOpenedFileRealPathForFd(handle.fd, handleStat, ioPath)).realPath;
 }
 
+export function resolveOpenedFileRealPathForFd(
+  fd: number,
+  handleStat: { dev: bigint; ino: bigint },
+  ioPath: string,
+): Promise<{ realPath: string; stat: BigIntStats }>;
+export function resolveOpenedFileRealPathForFd(
+  fd: number,
+  handleStat: FileIdentityStat,
+  ioPath: string,
+): Promise<{ realPath: string; stat: Stats | BigIntStats }>;
 export async function resolveOpenedFileRealPathForFd(
   fd: number,
   handleStat: FileIdentityStat,
   ioPath: string,
-): Promise<string> {
+): Promise<{ realPath: string; stat: Stats | BigIntStats }> {
   const statOptions = typeof handleStat.dev === "bigint" || typeof handleStat.ino === "bigint"
     ? { bigint: true as const } : undefined;
   const fdCandidates =
     process.platform === "linux"
       ? [`/proc/self/fd/${fd}`, `/dev/fd/${fd}`]
-      : process.platform === "win32"
-        ? []
-        : [`/dev/fd/${fd}`];
+      : [];
   for (const fdPath of fdCandidates) {
     try {
       const fdRealPath = await fs.realpath(fdPath);
       const fdRealStat = statOptions ? await fs.stat(fdRealPath, statOptions) : await fs.stat(fdRealPath);
       if (sameFileIdentity(handleStat, fdRealStat)) {
-        return fdRealPath;
+        return { realPath: fdRealPath, stat: fdRealStat };
       }
     } catch {
       // try next fd path
@@ -42,7 +51,7 @@ export async function resolveOpenedFileRealPathForFd(
     const ioRealPath = await fs.realpath(ioPath);
     const ioRealStat = statOptions ? await fs.stat(ioRealPath, statOptions) : await fs.stat(ioRealPath);
     if (sameFileIdentity(handleStat, ioRealStat)) {
-      return ioRealPath;
+      return { realPath: ioRealPath, stat: ioRealStat };
     }
   } catch (err) {
     if (!isNotFoundPathError(err)) {
@@ -66,7 +75,7 @@ async function resolveOpenedFileRealPathFromParent(
   handleStat: FileIdentityStat,
   ioPath: string,
   statOptions?: { bigint: true },
-): Promise<string | null> {
+): Promise<{ realPath: string; stat: Stats | BigIntStats } | null> {
   let parentReal: string;
   try {
     parentReal = await fs.realpath(path.dirname(ioPath));
@@ -92,7 +101,9 @@ async function resolveOpenedFileRealPathFromParent(
     try {
       const candidateStat = statOptions ? await fs.lstat(candidatePath, statOptions) : await fs.lstat(candidatePath);
       if (candidateStat.isFile() && sameFileIdentity(handleStat, candidateStat)) {
-        return await fs.realpath(candidatePath);
+        const realPath = await fs.realpath(candidatePath);
+        const stat = statOptions ? await fs.stat(realPath, statOptions) : await fs.stat(realPath);
+        if (sameFileIdentity(handleStat, stat)) return { realPath, stat };
       }
     } catch (err) {
       if (!isNotFoundPathError(err)) {

--- a/src/replace-file.ts
+++ b/src/replace-file.ts
@@ -143,7 +143,7 @@ async function renameWithRetry(params: {
   syncFallback: boolean;
 }): Promise<ReplaceFileAtomicResult> {
   for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
-    await params.assertSourceCurrent();
+    if (attempt > 0) await params.assertSourceCurrent();
     try {
       await params.fsModule.rename(params.src, params.dest);
       return { method: "rename" };
@@ -187,7 +187,7 @@ function renameWithRetrySync(params: {
   syncFallback: boolean;
 }): ReplaceFileAtomicResult {
   for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
-    params.assertSourceCurrent();
+    if (attempt > 0) params.assertSourceCurrent();
     try {
       params.fsModule.renameSync(params.src, params.dest);
       return { method: "rename" };
@@ -331,9 +331,12 @@ async function replaceFileAtomicUnserialized(
     await tempOwner.assertCurrent(fsModule);
     if (options.beforeRename) {
       await options.beforeRename({ filePath, tempPath });
+      await tempOwner.assertCurrent(fsModule);
     }
-    await tempOwner.assertCurrent(fsModule);
-    await assertDestinationHardlinkPolicy(fsModule, filePath, options.destinationHardlinks);
+    if (options.destinationHardlinks === "reject") {
+      await assertDestinationHardlinkPolicy(fsModule, filePath, options.destinationHardlinks);
+      await tempOwner.assertCurrent(fsModule);
+    }
     const result = await renameWithRetry({
       fsModule,
       src: tempPath,
@@ -354,12 +357,15 @@ async function replaceFileAtomicUnserialized(
     } else {
       await tempOwner.assertCurrent(fsModule);
     }
+    let didSyncParent = false;
     if (syncParent) {
       await syncParent(dir);
+      didSyncParent = true;
     } else if (options.syncParentDir) {
       await syncDirectoryBestEffort(fsModule, dir);
+      didSyncParent = true;
     }
-    if (result.method === "rename") {
+    if (result.method === "rename" && didSyncParent) {
       await tempOwner.assertPublished(fsModule, filePath, expectedHash);
     }
     return result;
@@ -432,9 +438,12 @@ function replaceFileAtomicSyncUnserialized(
     tempOwner.assertCurrent(fsModule);
     if (options.beforeRename) {
       options.beforeRename({ filePath, tempPath });
+      tempOwner.assertCurrent(fsModule);
     }
-    tempOwner.assertCurrent(fsModule);
-    assertDestinationHardlinkPolicySync(fsModule, filePath, options.destinationHardlinks);
+    if (options.destinationHardlinks === "reject") {
+      assertDestinationHardlinkPolicySync(fsModule, filePath, options.destinationHardlinks);
+      tempOwner.assertCurrent(fsModule);
+    }
     const result = renameWithRetrySync({
       fsModule,
       src: tempPath,
@@ -456,10 +465,12 @@ function replaceFileAtomicSyncUnserialized(
     } else {
       tempOwner.assertCurrent(fsModule);
     }
+    let didSyncParent = false;
     if (options.syncParentDir) {
       syncDirectoryBestEffortSync(fsModule, dir);
+      didSyncParent = true;
     }
-    if (result.method === "rename") {
+    if (result.method === "rename" && didSyncParent) {
       tempOwner.assertPublished(fsModule, filePath, expectedHash);
     }
     return result;

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -71,6 +71,7 @@ import { walkRoot, type RootWalkEntry, type RootWalkOptions } from "./root-walk.
 import { registerTempPathForExit, type TempPathRegistration } from "./temp-cleanup.js";
 import { serializePathWrite } from "./write-queue.js";
 import { verifyAtomicWriteResult } from "./root-write-verification.js";
+import { inheritWriteTargetMode } from "./root-write-mode.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
 
 export type { DenyMutationPolicy } from "./deny-mutations.js";
@@ -1293,29 +1294,9 @@ async function resolvePinnedWriteTargetInRoot(
       if (!isNotFoundPathError(error)) throw error;
     }
   }
-  let mode = requestedMode ?? 0o600;
-  try {
-    if (overwrite) {
-      const opened = await openFileInRoot(root, {
-        relativePath,
-        hardlinks: "reject",
-        nonBlockingRead: true,
-        symlinks: "follow-within-root",
-      });
-      try {
-        mode = requestedMode ?? (opened.stat.mode & 0o777);
-        if (!isPathInside(rootWithSep, opened.realPath)) {
-          throw outsideWorkspaceError();
-        }
-      } finally {
-        await opened.handle.close().catch(() => {});
-      }
-    }
-  } catch (err) {
-    if (!(err instanceof FsSafeError) || err.code !== "not-found") {
-      throw err;
-    }
-  }
+  const mode = overwrite
+    ? await inheritWriteTargetMode({ targetPath: resolved, rootWithSep, requestedMode })
+    : requestedMode ?? 0o600;
 
   return {
     rootReal,

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -305,15 +305,20 @@ async function openVerifiedLocalFile(
     });
 
     await fsSafeTestHooks?.afterOpenedPathIdentityCheck?.(filePath, handle);
-    const realPath = await resolveOpenedFileRealPathForFd(handle.fd, identity, filePath)
+    const resolved = await resolveOpenedFileRealPathForFd(handle.fd, identity, filePath)
       .catch(async (error: unknown) => {
         if (stat.nlink <= 1 && (!preOpenStat || preOpenStat.nlink <= 1n)) {
           await recordOpenedFileFailure(error, handle, filePath, identity);
         }
         throw error;
       });
+    const { realPath } = resolved;
+    let resolvedStat: BigIntStats | undefined = resolved.stat;
     await inspectPathIdentity(async () => {
-      const realStat = await fs.stat(realPath, { bigint: true });
+      // Reuse the post-realpath observation; unknown Windows identities still
+      // get a fresh observation on inspectFileIdentity's retry.
+      const realStat = resolvedStat ?? await fs.stat(realPath, { bigint: true });
+      resolvedStat = undefined;
       if (options?.hardlinks === "reject" && realStat.nlink > 1n) {
         throw hardlinkedPathNotAllowedError();
       }

--- a/src/root-write-mode.ts
+++ b/src/root-write-mode.ts
@@ -1,0 +1,52 @@
+import { constants } from "node:fs";
+import fs from "node:fs/promises";
+import { FsSafeError } from "./errors.js";
+import { isNotFoundPathError, isPathInside } from "./path.js";
+import { resolveReadOpenFlags } from "./read-open-flags.js";
+import { hardlinkedPathNotAllowedError, outsideWorkspaceError } from "./root-errors.js";
+import { inspectFileIdentity } from "./strict-file-identity.js";
+
+// The caller has already resolved and guarded this write target.
+export async function inheritWriteTargetMode(params: {
+  targetPath: string;
+  rootWithSep: string;
+  requestedMode?: number;
+}): Promise<number> {
+  try {
+    const existing = await inspectFileIdentity(() => fs.lstat(params.targetPath, { bigint: true }));
+    if (existing.isSymbolicLink()) throw new FsSafeError("path-alias", "path alias escape blocked");
+    if (!existing.isFile()) throw new FsSafeError("not-file", "not a file");
+    if (existing.nlink > 1n) throw hardlinkedPathNotAllowedError();
+    if (!isPathInside(params.rootWithSep, params.targetPath)) throw outsideWorkspaceError();
+    // Preserve destination readability. Windows access() does not check ACLs;
+    // POSIX access() uses real IDs, so credential-switched processes still open.
+    if (process.platform === "win32" || process.getuid?.() !== process.geteuid?.() ||
+      process.getgid?.() !== process.getegid?.()) {
+      const handle = await fs.open(params.targetPath, resolveReadOpenFlags());
+      await handle.close().catch(() => undefined);
+    } else {
+      await fs.access(params.targetPath, constants.R_OK);
+    }
+    try {
+      // A parent can change after guarded resolution. Do not inherit metadata
+      // from an outside inode, even if the parent is restored before publication.
+      const realPath = await fs.realpath(params.targetPath);
+      if (!isPathInside(params.rootWithSep, realPath)) throw outsideWorkspaceError();
+      await inspectFileIdentity(async () => {
+        const current = await fs.stat(realPath, { bigint: true });
+        if (!current.isFile()) throw new FsSafeError("not-file", "not a file");
+        if (current.nlink > 1n) throw hardlinkedPathNotAllowedError();
+        return current;
+      }, existing);
+    } catch (error) {
+      if (isNotFoundPathError(error)) {
+        throw new FsSafeError("path-mismatch", "write target changed during mode inheritance", { cause: error });
+      }
+      throw error;
+    }
+    return params.requestedMode ?? Number(existing.mode & 0o777n);
+  } catch (error) {
+    if (!isNotFoundPathError(error)) throw error;
+    return params.requestedMode ?? 0o600;
+  }
+}

--- a/src/root-write-mode.ts
+++ b/src/root-write-mode.ts
@@ -1,4 +1,3 @@
-import { constants } from "node:fs";
 import fs from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { isNotFoundPathError, isPathInside } from "./path.js";
@@ -18,15 +17,10 @@ export async function inheritWriteTargetMode(params: {
     if (!existing.isFile()) throw new FsSafeError("not-file", "not a file");
     if (existing.nlink > 1n) throw hardlinkedPathNotAllowedError();
     if (!isPathInside(params.rootWithSep, params.targetPath)) throw outsideWorkspaceError();
-    // Preserve destination readability. Windows access() does not check ACLs;
-    // POSIX access() uses real IDs, so credential-switched processes still open.
-    if (process.platform === "win32" || process.getuid?.() !== process.geteuid?.() ||
-      process.getgid?.() !== process.getegid?.()) {
-      const handle = await fs.open(params.targetPath, resolveReadOpenFlags());
-      await handle.close().catch(() => undefined);
-    } else {
-      await fs.access(params.targetPath, constants.R_OK);
-    }
+    // Preserve read-open admission of the pre-existing destination. access(2)
+    // is not equivalent: it ignores ACLs on Windows and capabilities on Linux.
+    const handle = await fs.open(params.targetPath, resolveReadOpenFlags());
+    await handle.close().catch(() => undefined);
     try {
       // A parent can change after guarded resolution. Do not inherit metadata
       // from an outside inode, even if the parent is restored before publication.

--- a/src/root-write-mode.ts
+++ b/src/root-write-mode.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
+import { sameFileIdentity } from "./file-identity.js";
 import { isNotFoundPathError, isPathInside } from "./path.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { hardlinkedPathNotAllowedError, outsideWorkspaceError } from "./root-errors.js";
@@ -20,7 +21,14 @@ export async function inheritWriteTargetMode(params: {
     // Preserve read-open admission of the pre-existing destination. access(2)
     // is not equivalent: it ignores ACLs on Windows and capabilities on Linux.
     const handle = await fs.open(params.targetPath, resolveReadOpenFlags());
-    await handle.close().catch(() => undefined);
+    try {
+      // Bind admission to the inode whose metadata is inherited.
+      if (!sameFileIdentity(await handle.stat({ bigint: true }), existing)) {
+        throw new FsSafeError("path-mismatch", "write target changed during mode inheritance");
+      }
+    } finally {
+      await handle.close().catch(() => undefined);
+    }
     try {
       // A parent can change after guarded resolution. Do not inherit metadata
       // from an outside inode, even if the parent is restored before publication.

--- a/src/root-write-verification.ts
+++ b/src/root-write-verification.ts
@@ -58,7 +58,7 @@ export async function verifyAtomicWriteResult(params: {
     // This descriptor remains owned by the writer, even when final mode forbids opens.
     const stat = assertDescriptor();
     assertPath(await fs.lstat(params.targetPath, { bigint: true }));
-    const realPath = await resolveOpenedFileRealPathForFd(params.fd, stat, params.targetPath);
+    const { realPath } = await resolveOpenedFileRealPathForFd(params.fd, stat, params.targetPath);
     assertPath(await fs.stat(realPath, { bigint: true }));
     if (!isPathInside(params.root.rootWithSep, realPath)) {
       throw outsideWorkspaceError();
@@ -85,7 +85,7 @@ export async function verifyAtomicWriteResult(params: {
       try {
         const reopenedStat = assertDescriptor(opened.fd);
         assertPath(await fs.lstat(params.targetPath, { bigint: true }));
-        const reopenedPath = await resolveOpenedFileRealPathForFd(opened.fd, reopenedStat, params.targetPath);
+        const { realPath: reopenedPath } = await resolveOpenedFileRealPathForFd(opened.fd, reopenedStat, params.targetPath);
         assertPath(await fs.stat(reopenedPath, { bigint: true }));
         if (!isPathInside(params.root.rootWithSep, reopenedPath)) {
           throw outsideWorkspaceError();

--- a/test/atomic-hot-path-fences.test.ts
+++ b/test/atomic-hot-path-fences.test.ts
@@ -1,0 +1,130 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { replaceFileAtomic, replaceFileAtomicSync } from "../src/atomic.js";
+import type { ReplaceFileAtomicOptions, ReplaceFileAtomicSyncOptions } from "../src/replace-file.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+
+describe("atomic publication fences without beforeRename", () => {
+  it("keeps the post-sync check when an async adapter changes the options", async () => {
+    const directory = await tempRoot("fs-safe-atomic-sync-options-");
+    const filePath = path.join(directory, "target");
+    const options: ReplaceFileAtomicOptions = { filePath, content: "intended", syncParentDir: true };
+    options.fileSystem = { promises: { ...fs, open: async (...args) => {
+      const handle = await fs.open(...args);
+      if (String(args[0]) === directory) {
+        const sync = handle.sync.bind(handle);
+        handle.sync = async () => {
+          await sync();
+          options.syncParentDir = false;
+          await fs.rename(filePath, `${filePath}.owned`);
+          await fs.writeFile(filePath, "replacement");
+        };
+      }
+      return handle;
+    } } };
+    await expect(replaceFileAtomic(options)).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(options.syncParentDir).toBe(false);
+    expect(await fs.readFile(filePath, "utf8")).toBe("replacement");
+    expect(await fs.readFile(`${filePath}.owned`, "utf8")).toBe("intended");
+  });
+
+  it("keeps the post-sync check when a sync adapter changes the options", async () => {
+    const directory = await tempRoot("fs-safe-atomic-sync-options-sync-");
+    const filePath = path.join(directory, "target");
+    const options: ReplaceFileAtomicSyncOptions = { filePath, content: "intended", syncParentDir: true };
+    options.fileSystem = { ...fsSync, fsyncSync: (fd) => {
+      fsSync.fsyncSync(fd);
+      if (fsSync.fstatSync(fd).isDirectory()) {
+        options.syncParentDir = false;
+        fsSync.renameSync(filePath, `${filePath}.owned`);
+        fsSync.writeFileSync(filePath, "replacement");
+      }
+    } };
+    expect(() => replaceFileAtomicSync(options)).toThrow(expect.objectContaining({ code: "path-mismatch" }));
+    expect(options.syncParentDir).toBe(false);
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("replacement");
+    expect(fsSync.readFileSync(`${filePath}.owned`, "utf8")).toBe("intended");
+  });
+
+  it.each(["retry", "destination check"])("rejects a temp swap across an async %s", async (boundary) => {
+    const directory = await tempRoot("fs-safe-atomic-fence-");
+    const filePath = path.join(directory, "target");
+    await fs.writeFile(filePath, "original");
+    let temporary = "";
+    let swapped = false;
+    let renames = 0;
+    const swap = async () => {
+      await fs.rename(temporary, `${temporary}.owned`);
+      await fs.writeFile(temporary, "replacement");
+      swapped = true;
+    };
+    await expect(replaceFileAtomic({
+      filePath, content: "intended", renameMaxRetries: 1, renameRetryBaseDelayMs: 0,
+      destinationHardlinks: boundary === "destination check" ? "reject" : undefined,
+      fileSystem: { promises: {
+        ...fs,
+        open: async (...args) => {
+          const handle = await fs.open(...args);
+          if (args[1] === "wx") temporary = String(args[0]);
+          return handle;
+        },
+        lstat: (async (...args: Parameters<typeof fs.lstat>) => {
+          if (boundary === "destination check" && temporary && String(args[0]) === filePath && !swapped) await swap();
+          return await fs.lstat(...args);
+        }) as typeof fs.lstat,
+        rename: async () => {
+          renames++;
+          await swap();
+          throw Object.assign(new Error("busy"), { code: "EBUSY" });
+        },
+      } },
+    })).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(renames).toBe(boundary === "retry" ? 1 : 0);
+    expect(await fs.readFile(filePath, "utf8")).toBe("original");
+    expect(await fs.readFile(temporary, "utf8")).toBe("replacement");
+    expect(await fs.readFile(`${temporary}.owned`, "utf8")).toBe("intended");
+  });
+
+  it.each(["retry", "destination check"])("rejects a temp swap across a sync %s", async (boundary) => {
+    const directory = await tempRoot("fs-safe-atomic-fence-sync-");
+    const filePath = path.join(directory, "target");
+    fsSync.writeFileSync(filePath, "original");
+    let temporary = "";
+    let swapped = false;
+    let renames = 0;
+    const swap = () => {
+      fsSync.renameSync(temporary, `${temporary}.owned`);
+      fsSync.writeFileSync(temporary, "replacement");
+      swapped = true;
+    };
+    expect(() => replaceFileAtomicSync({
+      filePath, content: "intended", renameMaxRetries: 1, renameRetryBaseDelayMs: 0,
+      destinationHardlinks: boundary === "destination check" ? "reject" : undefined,
+      fileSystem: {
+        ...fsSync,
+        openSync: (...args) => {
+          const fd = fsSync.openSync(...args);
+          if (args[1] === "wx") temporary = String(args[0]);
+          return fd;
+        },
+        lstatSync: ((...args: Parameters<typeof fsSync.lstatSync>) => {
+          if (boundary === "destination check" && temporary && String(args[0]) === filePath && !swapped) swap();
+          return fsSync.lstatSync(...args);
+        }) as typeof fsSync.lstatSync,
+        renameSync: () => {
+          renames++;
+          swap();
+          throw Object.assign(new Error("busy"), { code: "EBUSY" });
+        },
+      },
+    })).toThrow(expect.objectContaining({ code: "path-mismatch" }));
+    expect(renames).toBe(boundary === "retry" ? 1 : 0);
+    expect(fsSync.readFileSync(filePath, "utf8")).toBe("original");
+    expect(fsSync.readFileSync(temporary, "utf8")).toBe("replacement");
+    expect(fsSync.readFileSync(`${temporary}.owned`, "utf8")).toBe("intended");
+  });
+});

--- a/test/atomic-hot-path-fences.test.ts
+++ b/test/atomic-hot-path-fences.test.ts
@@ -9,7 +9,7 @@ import { useRealTempDirs } from "./helpers/vitest.js";
 const { tempRoot } = useRealTempDirs();
 
 describe("atomic publication fences without beforeRename", () => {
-  it("keeps the post-sync check when an async adapter changes the options", async () => {
+  it.skipIf(process.platform === "win32")("keeps the post-sync check when an async adapter changes the options", async () => {
     const directory = await tempRoot("fs-safe-atomic-sync-options-");
     const filePath = path.join(directory, "target");
     const options: ReplaceFileAtomicOptions = { filePath, content: "intended", syncParentDir: true };
@@ -32,7 +32,7 @@ describe("atomic publication fences without beforeRename", () => {
     expect(await fs.readFile(`${filePath}.owned`, "utf8")).toBe("intended");
   });
 
-  it("keeps the post-sync check when a sync adapter changes the options", async () => {
+  it.skipIf(process.platform === "win32")("keeps the post-sync check when a sync adapter changes the options", async () => {
     const directory = await tempRoot("fs-safe-atomic-sync-options-sync-");
     const filePath = path.join(directory, "target");
     const options: ReplaceFileAtomicSyncOptions = { filePath, content: "intended", syncParentDir: true };

--- a/test/directory-mode-observations.test.ts
+++ b/test/directory-mode-observations.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { ownDirectoryMode } from "../src/directory-mode-owner.js";
+
+describe("directory mode owner observations", () => {
+  it("inspects an unchanged mode once and keeps verify independent", async () => {
+    const inspect = vi.fn(async () => 0o700);
+    const chmod = vi.fn(async () => undefined);
+    const prepareChmod = vi.fn(async () => undefined);
+    const owner = ownDirectoryMode({ inspect, chmod, prepareChmod, close: async () => undefined });
+    await owner.apply(0o40700);
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(chmod).not.toHaveBeenCalled();
+    expect(prepareChmod).not.toHaveBeenCalled();
+    await owner.verify();
+    expect(inspect).toHaveBeenCalledTimes(2);
+    await owner.close();
+  });
+
+  it.each(["beforeChmod", "check"] as const)("re-inspects after a %s callback changes the observed mode", async (hook) => {
+    let mode = 0o700;
+    const inspect = vi.fn(async () => mode);
+    let checks = 0;
+    const owner = ownDirectoryMode({ inspect, chmod: async () => undefined, close: async () => undefined });
+    const callback = () => { mode = 0o755; };
+    await expect(owner.apply(0o700, hook === "beforeChmod"
+      ? { beforeChmod: async () => callback() }
+      : { check: () => { if (++checks === 2) callback(); } },
+    )).rejects.toMatchObject({ code: "path-mismatch" });
+    expect(inspect.mock.calls.length).toBeGreaterThan(1);
+    await owner.close();
+  });
+
+  it("retains the checks after preparation, user code, and chmod", async () => {
+    let mode = 0o755;
+    const events: string[] = [];
+    const owner = ownDirectoryMode({
+      inspect: async () => { events.push("inspect"); return mode; },
+      prepareChmod: async () => { events.push("prepare"); },
+      chmod: async (value) => { events.push("chmod"); mode = value; },
+      verifyChmod: async () => { events.push("verify chmod"); },
+      close: async () => undefined,
+    });
+    await owner.apply(0o700, { beforeChmod: async () => { events.push("hook"); } });
+    expect(events).toEqual(["inspect", "prepare", "hook", "inspect", "chmod", "verify chmod", "inspect"]);
+    await owner.close();
+  });
+});

--- a/test/fs-call-budget.test.ts
+++ b/test/fs-call-budget.test.ts
@@ -1,0 +1,80 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { replaceFileAtomic } from "../src/atomic.js";
+import { configureFsSafeNative } from "../src/config.js";
+import { tryReadJson, writeJson } from "../src/json.js";
+import { readRegularFile } from "../src/regular-file.js";
+import { root } from "../src/root.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+// Measured fallback calls on macOS; allow two calls for platform variation.
+const budgets = {
+  "root.readBytes": 14, // measured 12
+  readRegularFile: 8, // measured 6
+  tryReadJson: 9, // measured 7
+  replaceFileAtomic: 18, // measured 16
+  "writeJson durable:false": 18, // measured 16
+  "root.write": 56, // measured 54, including canonical mode-inheritance identity
+  "root.exists": 7, // measured 5
+};
+const { tempRoot } = useRealTempDirs();
+
+describe.skipIf(process.platform === "win32")("fallback filesystem call budgets", () => {
+  it("keeps each operation within its syscall budget", async () => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-call-budget-");
+    const safe = await root(directory, { mkdir: true });
+    await fs.writeFile(path.join(directory, "r.txt"), "hi");
+    await fs.writeFile(path.join(directory, "j.json"), "{}");
+    const handle = await fs.open(path.join(directory, "r.txt"), "r");
+    const prototype = Object.getPrototypeOf(handle);
+    await handle.close();
+    const counts = new Map<string, number>();
+    const restore: Array<() => void> = [];
+    let counting = false;
+    const wrap = (object: object, keys: string[], prefix: string) => {
+      for (const key of keys) {
+        const descriptor = Object.getOwnPropertyDescriptor(object, key);
+        if (!descriptor?.writable || typeof descriptor.value !== "function") continue;
+        const original = descriptor.value;
+        Object.defineProperty(object, key, {
+          ...descriptor,
+          value: function (this: unknown, ...args: unknown[]) {
+            if (counting) counts.set(prefix + key, (counts.get(prefix + key) ?? 0) + 1);
+            return Reflect.apply(original, this, args);
+          },
+        });
+        restore.push(() => Object.defineProperty(object, key, descriptor));
+      }
+    };
+    try {
+      wrap(fs, Object.keys(fs), "p.");
+      wrap(fsSync, Object.keys(fsSync).filter((key) => key.endsWith("Sync") && key !== "writeSync"), "s.");
+      wrap(prototype, Object.getOwnPropertyNames(prototype).filter((key) => key !== "constructor" && key !== "fd"), "h.");
+      const operations: Record<keyof typeof budgets, () => Promise<unknown>> = {
+        "root.readBytes": () => safe.readBytes("r.txt"),
+        readRegularFile: () => readRegularFile({ filePath: path.join(directory, "r.txt") }),
+        tryReadJson: () => tryReadJson(path.join(directory, "j.json")),
+        replaceFileAtomic: () => replaceFileAtomic({ filePath: path.join(directory, "a.txt"), content: "x" }),
+        "writeJson durable:false": () => writeJson(path.join(directory, "w.json"), { a: 1 }, { durable: false }),
+        "root.write": () => safe.write("w.txt", "x"),
+        "root.exists": () => safe.exists("r.txt"),
+      };
+      for (const name of Object.keys(budgets) as Array<keyof typeof budgets>) {
+        await operations[name]();
+        counts.clear();
+        counting = true;
+        try { await operations[name](); } finally { counting = false; }
+        const total = [...counts.values()].reduce((sum, count) => sum + count, 0);
+        const breakdown = [...counts].map(([key, count]) => `${key}=${count}`).join(" ");
+        expect.soft(total, `${name}: ${total} calls; ${breakdown}`).toBeLessThanOrEqual(budgets[name]);
+      }
+    } finally {
+      counting = false;
+      for (const undo of restore.reverse()) undo();
+      configureFsSafeNative({ mode: "auto" });
+    }
+  });
+});

--- a/test/native-staging-sync.test.ts
+++ b/test/native-staging-sync.test.ts
@@ -1,0 +1,70 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeNative } from "../src/config.js";
+import { __loadBundledNativeForTest, __resetNativeLoaderForTest } from "../src/native.js";
+import { createNativeStage, assertNativeStaging } from "../src/native-staged-file.js";
+import { openStagedDirectory } from "../src/staged-directory.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+let nativeAvailable = false;
+try {
+  __loadBundledNativeForTest();
+  nativeAvailable = process.platform !== "win32";
+} catch {
+  // Native CI provides the binding; fallback-only installations skip this suite.
+}
+afterEach(() => {
+  vi.restoreAllMocks();
+  configureFsSafeNative({ mode: "auto" });
+  __resetNativeLoaderForTest();
+});
+
+describe.runIf(nativeAvailable)("native staged publication durability", () => {
+  it.each([0o000, 0o200, 0o400, 0o600, 0o644, 0o777])("syncs mode %i according to its owner permissions", async (mode) => {
+    const directory = await tempRoot("fs-safe-staged-sync-");
+    const binding = __loadBundledNativeForTest();
+    assertNativeStaging(binding);
+    const parent = openStagedDirectory(directory);
+    const sync = fsSync.fsyncSync;
+    const events: string[] = [];
+    vi.spyOn(fsSync, "fsyncSync").mockImplementation((fd) => {
+      events.push(fsSync.fstatSync(fd).isFile() ? "file" : "parent");
+      sync(fd);
+    });
+    const chmod = vi.spyOn(fsSync, "fchmodSync");
+    await using staged = await createNativeStage(
+      binding, parent.fd, parent.receipt, { kind: "buffer", data: "payload" }, mode,
+    );
+    expect(events).toEqual(["file"]);
+    chmod.mockClear();
+    await staged.publish("target", { overwrite: true });
+    expect(events).toEqual((mode & 0o600) === 0o600 ? ["file", "parent"] : ["file", "file", "parent"]);
+    expect(chmod).toHaveBeenCalledTimes(mode === 0o600 ? 0 : 1);
+    const target = path.join(directory, "target");
+    expect((await fs.stat(target)).mode & 0o777).toBe(mode);
+    await fs.chmod(target, 0o600);
+    expect(await fs.readFile(target, "utf8")).toBe("payload");
+  });
+
+  it.each([0o600, 0o644].flatMap((mode) => [0o400, 0o666].map((changedMode) => ({ mode, changedMode }))))(
+    "restores mode $mode after staged permissions change to $changedMode",
+    async ({ mode, changedMode }) => {
+      const directory = await tempRoot("fs-safe-staged-mode-drift-");
+      const binding = __loadBundledNativeForTest();
+      assertNativeStaging(binding);
+      const parent = openStagedDirectory(directory);
+      await using staged = await createNativeStage(
+        binding, parent.fd, parent.receipt, { kind: "buffer", data: "payload" }, mode,
+      );
+      await fs.chmod(path.join(directory, staged.receipt.temporaryBasename), changedMode);
+      const sync = vi.spyOn(fsSync, "fsyncSync");
+      await staged.publish("target", { overwrite: true });
+      expect(sync).toHaveBeenCalledTimes(changedMode === 0o666 ? 2 : 1);
+      expect((await fs.stat(path.join(directory, "target"))).mode & 0o777).toBe(mode);
+      expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("payload");
+    },
+  );
+});

--- a/test/opened-realpath-observation.test.ts
+++ b/test/opened-realpath-observation.test.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveOpenedFileRealPathForFd } from "../src/opened-realpath.js";
+import { root } from "../src/root.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+  __setFsSafeTestHooksForTest();
+});
+
+describe("opened realpath observations", () => {
+  it.each(["darwin", "freebsd", "linux"])("uses only supported descriptor aliases on %s", async (host) => {
+    const directory = await tempRoot("fs-safe-realpath-probe-");
+    const target = path.join(directory, "target");
+    await fs.writeFile(target, "payload");
+    const handle = await fs.open(target, "r");
+    try {
+      const identity = await handle.stat({ bigint: true });
+      const realpath = fs.realpath.bind(fs);
+      const calls: string[] = [];
+      vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+        const candidate = String(args[0]);
+        calls.push(candidate);
+        if (candidate.startsWith("/proc/self/fd/")) throw Object.assign(new Error("no procfs"), { code: "ENOENT" });
+        if (candidate.startsWith("/dev/fd/")) return target;
+        return await realpath(...args);
+      });
+      const stat = vi.spyOn(fs, "stat");
+      Object.defineProperty(process, "platform", { value: host });
+      const resolved = await resolveOpenedFileRealPathForFd(handle.fd, identity, target);
+      expect(resolved).toMatchObject({ realPath: target, stat: { dev: identity.dev, ino: identity.ino } });
+      expect(calls).toEqual(host === "linux" ? [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`] : [target]);
+      expect(stat).toHaveBeenCalledExactlyOnceWith(target, { bigint: true });
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it("takes a fresh identity observation after resolving a parent-scan candidate", async () => {
+    const directory = await tempRoot("fs-safe-realpath-scan-");
+    const target = path.join(directory, "target");
+    await fs.writeFile(target, "original");
+    const handle = await fs.open(target, "r");
+    try {
+      const identity = await handle.stat({ bigint: true });
+      const realpath = fs.realpath.bind(fs);
+      let attempts = 0;
+      vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+        if (String(args[0]) === target) {
+          if (++attempts === 1) throw Object.assign(new Error("raced lookup"), { code: "ENOENT" });
+          await fs.rename(target, path.join(directory, "saved"));
+          await fs.writeFile(target, "replacement");
+        }
+        return await realpath(...args);
+      });
+      Object.defineProperty(process, "platform", { value: "darwin" });
+      await expect(resolveOpenedFileRealPathForFd(handle.fd, identity, target)).rejects.toMatchObject({ code: "path-mismatch" });
+      expect(attempts).toBe(2);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it.each(["stable", "hardlink", "windows retry"])("preserves final opened-file checks: %s", async (scenario) => {
+    const directory = await tempRoot("fs-safe-realpath-read-");
+    const safe = await root(directory);
+    const target = path.join(safe.rootReal, "target");
+    await fs.writeFile(target, "payload");
+    Object.defineProperty(process, "platform", { value: scenario === "windows retry" ? "win32" : "darwin" });
+    let resolving = false;
+    let observations = 0;
+    __setFsSafeTestHooksForTest({
+      async afterOpenedPathIdentityCheck() {
+        resolving = true;
+        if (scenario === "hardlink") await fs.link(target, path.join(directory, "alias"));
+      },
+    });
+    const stat = fs.stat.bind(fs);
+    vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
+      const observed = await stat(...args);
+      if (resolving && String(args[0]) === target && args[1]?.bigint) {
+        observations++;
+        if (scenario === "windows retry" && observations === 1) observed.ino = 0n;
+      }
+      return observed;
+    });
+    const pending = scenario === "hardlink"
+      ? safe.copyIn("copy", target, { sourceHardlinks: "reject" })
+      : safe.readText("target");
+    if (scenario === "hardlink") await expect(pending).rejects.toMatchObject({ code: "hardlink" });
+    else await expect(pending).resolves.toBe("payload");
+    expect(observations).toBe(scenario === "windows retry" ? 2 : 1);
+  });
+});

--- a/test/path-stress-regression.test.ts
+++ b/test/path-stress-regression.test.ts
@@ -7,6 +7,7 @@ import { expectFsSafeError, expectFsSafeErrorSync } from "./helpers/security.js"
 import { itPosix, useTempDirs } from "./helpers/vitest.js";
 import { fileStore, fileStoreSync } from "../src/file-store.js";
 import { root as openRoot } from "../src/root.js";
+import * as writeMode from "../src/root-write-mode.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 
 const { tempRoot } = useTempDirs();
@@ -52,37 +53,35 @@ describe("path stress regressions", () => {
     const targetPath = path.join(scoped.rootReal, "state.txt");
     await scoped.write("state.txt", "initial");
 
-    let activeTargetOpens = 0;
-    let maxActiveTargetOpens = 0;
-    let heldFirstOpen = false;
-    let signalFirstOpen!: () => void;
-    const firstOpen = new Promise<void>((resolve) => {
-      signalFirstOpen = resolve;
+    let activeResolutions = 0;
+    let maxActiveResolutions = 0;
+    let heldFirstResolution = false;
+    let signalFirstResolution!: () => void;
+    const firstResolution = new Promise<void>((resolve) => {
+      signalFirstResolution = resolve;
     });
-    __setFsSafeTestHooksForTest({
-      async afterOpen(filePath) {
-        if (filePath !== targetPath) {
-          return;
+    const inheritMode = writeMode.inheritWriteTargetMode;
+    vi.spyOn(writeMode, "inheritWriteTargetMode").mockImplementation(async (params) => {
+      if (params.targetPath !== targetPath) return await inheritMode(params);
+      activeResolutions += 1;
+      maxActiveResolutions = Math.max(maxActiveResolutions, activeResolutions);
+      try {
+        if (!heldFirstResolution) {
+          heldFirstResolution = true;
+          signalFirstResolution();
+          await new Promise((resolve) => setTimeout(resolve, 100));
         }
-        activeTargetOpens += 1;
-        maxActiveTargetOpens = Math.max(maxActiveTargetOpens, activeTargetOpens);
-        try {
-          if (!heldFirstOpen) {
-            heldFirstOpen = true;
-            signalFirstOpen();
-            await new Promise((resolve) => setTimeout(resolve, 100));
-          }
-        } finally {
-          activeTargetOpens -= 1;
-        }
-      },
+        return await inheritMode(params);
+      } finally {
+        activeResolutions -= 1;
+      }
     });
 
     const firstWrite = scoped.write("state.txt", "first");
-    await firstOpen;
+    await firstResolution;
     const secondWrite = scoped.write("state.txt", "second");
     await expect(Promise.all([firstWrite, secondWrite])).resolves.toEqual([undefined, undefined]);
-    expect(maxActiveTargetOpens).toBe(1);
+    expect(maxActiveResolutions).toBe(1);
     await expect(scoped.readText("state.txt")).resolves.toBe("second");
   });
 

--- a/test/root-write-exact-identity.test.ts
+++ b/test/root-write-exact-identity.test.ts
@@ -90,6 +90,7 @@ describe("Root exact publication identity", () => {
     "uses the expected metadata precision for %s realpath resolution",
     async (route) => {
       const directory = await tempRoot("fs-safe-exact-realpath-");
+      if (route === "descriptor") Object.defineProperty(process, "platform", { value: "linux" });
       const target = path.join(directory, "target");
       const handle = await fs.open(target, "wx", 0o600);
       const realpath = fs.realpath.bind(fs);
@@ -129,7 +130,8 @@ describe("Root exact publication identity", () => {
         const pending = route === "numeric handle wrapper"
           ? resolveOpenedFileRealPathForHandle(handle, target)
           : resolveOpenedFileRealPathForFd(handle.fd, { dev: device, ino: inode }, target);
-        await expect(pending).resolves.toBe(target);
+        if (route === "numeric handle wrapper") await expect(pending).resolves.toBe(target);
+        else await expect(pending).resolves.toMatchObject({ realPath: target, stat: { dev: device, ino: inode } });
         expect(sampled.length).toBeGreaterThan(0);
         expect(sampled.every((value) => typeof value === (route === "numeric handle wrapper" ? "number" : "bigint"))).toBe(true);
       } finally {

--- a/test/root-write-inheritance.test.ts
+++ b/test/root-write-inheritance.test.ts
@@ -1,0 +1,108 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeNative } from "../src/config.js";
+import { root } from "../src/root.js";
+import { inheritWriteTargetMode } from "../src/root-write-mode.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => {
+  configureFsSafeNative({ mode: "auto" });
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+});
+
+for (const nativeMode of ["auto", "off"] as const) {
+  describe.skipIf(process.platform === "win32")(`write mode inheritance (${nativeMode})`, () => {
+    it("inherits permissions, honors explicit modes, and defaults new files to 0600", async () => {
+      configureFsSafeNative({ mode: nativeMode });
+      const directory = await tempRoot("fs-safe-mode-inherit-");
+      const safe = await root(directory);
+      const target = path.join(directory, "target");
+      await fs.writeFile(target, "previous");
+      await fs.chmod(target, 0o640);
+      await safe.write("target", "inherited");
+      expect((await fs.stat(target)).mode & 0o777).toBe(0o640);
+      expect(await fs.readFile(target, "utf8")).toBe("inherited");
+      await safe.write("target", "explicit", { mode: 0o600 });
+      expect((await fs.stat(target)).mode & 0o777).toBe(0o600);
+      await safe.write("new", "default");
+      expect((await fs.stat(path.join(directory, "new"))).mode & 0o777).toBe(0o600);
+    });
+
+    it.each(["symlink", "dangling symlink", "hardlink", "directory"])("preserves the existing error code for %s", async (kind) => {
+      configureFsSafeNative({ mode: nativeMode });
+      const directory = await tempRoot("fs-safe-mode-alias-");
+      const source = path.join(directory, "source");
+      const target = path.join(directory, "target");
+      await fs.writeFile(source, "original");
+      if (kind === "symlink") await fs.symlink(source, target);
+      else if (kind === "dangling symlink") await fs.symlink(path.join(directory, "missing"), target);
+      else if (kind === "hardlink") await fs.link(source, target);
+      else await fs.mkdir(target);
+      const safe = await root(directory);
+      await expect(safe.write("target", "replacement")).rejects.toMatchObject({
+        code: kind === "directory" ? "not-file" : "path-alias",
+      });
+      expect(await fs.readFile(source, "utf8")).toBe("original");
+    });
+
+    it.each([false, true])("rejects mode inheritance through a raced parent (restored: %s)", async (restoreParent) => {
+      configureFsSafeNative({ mode: nativeMode });
+      const directory = await tempRoot("fs-safe-inherit-parent-");
+      const outside = await tempRoot("fs-safe-inherit-outside-");
+      const safe = await root(directory);
+      const parent = path.join(safe.rootReal, "parent");
+      const saved = path.join(safe.rootReal, "saved");
+      const target = path.join(parent, "target");
+      await fs.mkdir(parent);
+      await fs.writeFile(target, "original", { mode: 0o600 });
+      await fs.writeFile(path.join(outside, "target"), "outside");
+      await fs.chmod(path.join(outside, "target"), 0o666);
+      const lstat = fs.lstat.bind(fs);
+      let attacked = false;
+      vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+        if (String(args[0]) === target && args[1]?.bigint && !attacked) {
+          attacked = true;
+          await fs.rename(parent, saved);
+          await fs.symlink(outside, parent);
+          const observed = await lstat(...args);
+          if (restoreParent) {
+            await fs.unlink(parent);
+            await fs.rename(saved, parent);
+          }
+          return observed;
+        }
+        return await lstat(...args);
+      });
+      await expect(safe.write("parent/target", "sensitive")).rejects.toMatchObject({
+        code: restoreParent ? "path-mismatch" : "outside-workspace",
+      });
+      expect(attacked).toBe(true);
+      const original = path.join(restoreParent ? parent : saved, "target");
+      expect((await fs.stat(original)).mode & 0o777).toBe(0o600);
+      expect(await fs.readFile(original, "utf8")).toBe("original");
+      expect(await fs.readFile(path.join(outside, "target"), "utf8")).toBe("outside");
+    });
+  });
+}
+
+it.each(["Windows ACL", "effective credentials"])("keeps read-open admission for %s", async (scenario) => {
+  const directory = await tempRoot("fs-safe-inherit-access-");
+  const safe = await root(directory);
+  const targetPath = path.join(safe.rootReal, "target");
+  await fs.writeFile(targetPath, "original");
+  const denied = Object.assign(new Error("read denied"), { code: "EACCES" });
+  const access = vi.spyOn(fs, "access").mockResolvedValue();
+  const open = vi.spyOn(fs, "open").mockRejectedValue(denied);
+  if (scenario === "Windows ACL" || !process.geteuid) {
+    Object.defineProperty(process, "platform", { value: "win32" });
+  } else {
+    vi.spyOn(process, "geteuid").mockReturnValue(process.getuid!() + 1);
+  }
+  await expect(inheritWriteTargetMode({ targetPath, rootWithSep: safe.rootReal + path.sep })).rejects.toBe(denied);
+  expect(open).toHaveBeenCalledTimes(1);
+  expect(access).not.toHaveBeenCalled();
+});

--- a/test/root-write-inheritance.test.ts
+++ b/test/root-write-inheritance.test.ts
@@ -97,3 +97,17 @@ it("keeps read-open admission for the existing destination", async () => {
   await expect(inheritWriteTargetMode({ targetPath, rootWithSep: safe.rootReal + path.sep })).rejects.toBe(denied);
   expect(open).toHaveBeenCalledTimes(1);
 });
+
+it("rejects inheritance when the read-open lands on a different inode", async () => {
+  const directory = await tempRoot("fs-safe-inherit-swap-");
+  const safe = await root(directory);
+  const targetPath = path.join(safe.rootReal, "target");
+  const otherPath = path.join(safe.rootReal, "other");
+  await fs.writeFile(targetPath, "original");
+  await fs.writeFile(otherPath, "other");
+  const realOpen = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation((candidate, ...rest) =>
+    realOpen(String(candidate) === targetPath ? otherPath : candidate, ...rest));
+  await expect(inheritWriteTargetMode({ targetPath, rootWithSep: safe.rootReal + path.sep }))
+    .rejects.toMatchObject({ code: "path-mismatch" });
+});

--- a/test/root-write-inheritance.test.ts
+++ b/test/root-write-inheritance.test.ts
@@ -7,11 +7,9 @@ import { inheritWriteTargetMode } from "../src/root-write-mode.js";
 import { useRealTempDirs } from "./helpers/vitest.js";
 
 const { tempRoot } = useRealTempDirs();
-const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
 afterEach(() => {
   configureFsSafeNative({ mode: "auto" });
   vi.restoreAllMocks();
-  Object.defineProperty(process, "platform", platform);
 });
 
 for (const nativeMode of ["auto", "off"] as const) {
@@ -89,20 +87,13 @@ for (const nativeMode of ["auto", "off"] as const) {
   });
 }
 
-it.each(["Windows ACL", "effective credentials"])("keeps read-open admission for %s", async (scenario) => {
+it("keeps read-open admission for the existing destination", async () => {
   const directory = await tempRoot("fs-safe-inherit-access-");
   const safe = await root(directory);
   const targetPath = path.join(safe.rootReal, "target");
   await fs.writeFile(targetPath, "original");
   const denied = Object.assign(new Error("read denied"), { code: "EACCES" });
-  const access = vi.spyOn(fs, "access").mockResolvedValue();
   const open = vi.spyOn(fs, "open").mockRejectedValue(denied);
-  if (scenario === "Windows ACL" || !process.geteuid) {
-    Object.defineProperty(process, "platform", { value: "win32" });
-  } else {
-    vi.spyOn(process, "geteuid").mockReturnValue(process.getuid!() + 1);
-  }
   await expect(inheritWriteTargetMode({ targetPath, rootWithSep: safe.rootReal + path.sep })).rejects.toBe(denied);
   expect(open).toHaveBeenCalledTimes(1);
-  expect(access).not.toHaveBeenCalled();
 });

--- a/test/sidecar-lock-root-unlink.test.ts
+++ b/test/sidecar-lock-root-unlink.test.ts
@@ -7,9 +7,11 @@ import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 import { useTempDirs } from "./helpers/vitest.js";
 
 const { tempRoot } = useTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
 afterEach(() => {
   __setFsSafeTestHooksForTest();
   vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
 });
 
 // Intercept the actual descriptor resolver; all identities come from the filesystem.
@@ -44,6 +46,8 @@ function atFdResolution(lockPath: string, mutate: (handle: FileHandle) => Promis
 it.skipIf(process.platform === "win32").each(["snapshot"] as const)(
   "completed owner release permits successor at %s FD resolution",
   async (phase) => {
+    // Descriptor-path resolution is Linux-only; exercise that mechanism on POSIX hosts.
+    Object.defineProperty(process, "platform", { value: "linux" });
     const capability = await root(await tempRoot("sidecar-discovery-"));
     const target = path.join(capability.rootReal, "state");
     const relative = "state.lock";

--- a/test/sidecar-lock-root-unlink.test.ts
+++ b/test/sidecar-lock-root-unlink.test.ts
@@ -7,11 +7,9 @@ import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 import { useTempDirs } from "./helpers/vitest.js";
 
 const { tempRoot } = useTempDirs();
-const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
 afterEach(() => {
   __setFsSafeTestHooksForTest();
   vi.restoreAllMocks();
-  Object.defineProperty(process, "platform", platform);
 });
 
 // Intercept the actual descriptor resolver; all identities come from the filesystem.
@@ -22,7 +20,8 @@ function atFdResolution(lockPath: string, mutate: (handle: FileHandle) => Promis
   const realpath = fs.realpath.bind(fs);
   const wrapper = vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
     const candidate = String(args[0]);
-    if (!fired && opened && (candidate === `/dev/fd/${opened.fd}` || candidate === `/proc/self/fd/${opened.fd}`)) {
+    // After afterOpen, the resolver probes procfs on Linux and the lock path elsewhere.
+    if (!fired && opened && candidate === (process.platform === "linux" ? `/proc/self/fd/${opened.fd}` : lockPath)) {
       fired = true;
       __setFsSafeTestHooksForTest();
       mutation = mutate(opened);
@@ -46,8 +45,6 @@ function atFdResolution(lockPath: string, mutate: (handle: FileHandle) => Promis
 it.skipIf(process.platform === "win32").each(["snapshot"] as const)(
   "completed owner release permits successor at %s FD resolution",
   async (phase) => {
-    // Descriptor-path resolution is Linux-only; exercise that mechanism on POSIX hosts.
-    Object.defineProperty(process, "platform", { value: "linux" });
     const capability = await root(await tempRoot("sidecar-discovery-"));
     const target = path.join(capability.rootReal, "state");
     const relative = "state.lock";

--- a/test/staged-file-failures.test.ts
+++ b/test/staged-file-failures.test.ts
@@ -101,7 +101,8 @@ describe.runIf(native)("staged ownership failure boundaries", () => {
         }
       },
     }));
-    const staged = await stageFileInDirectory({ directory, content: "committed", mode: 0o666 });
+    const mode = fault === "file-sync" ? 0o400 : 0o666;
+    const staged = await stageFileInDirectory({ directory, content: "committed", mode });
     if (fault === "chmod") {
       vi.spyOn(fsSync, "fchmodSync").mockImplementation(() => {
         throw failure;
@@ -129,7 +130,7 @@ describe.runIf(native)("staged ownership failure boundaries", () => {
         status: "not-needed", publication: { status: "published" },
       });
       expect(await fs.readFile(final, "utf8")).toBe("committed");
-      expect((await fs.lstat(final)).mode & 0o777).toBe(parentMoved || fault === "chmod" ? 0o600 : 0o666);
+      expect((await fs.lstat(final)).mode & 0o777).toBe(parentMoved || fault === "chmod" ? 0o600 : mode);
       expect(staged.receipt.identity.mode).toBe(0o600);
       if (parentMoved) {
         expect(await fs.readFile(path.join(directory, "final"), "utf8")).toBe("sentinel");


### PR DESCRIPTION
## Problem

Small reads and writes repeated pathname resolution, identity observations, and native file synchronization even when no operation separated the checks. This change reduces the ordinary-path work while retaining root confinement, exact identities, hardlink rejection, and verification after mutations and callbacks.

## Commit summary

1. Inherit replacement modes without a verified read-open. Keep readability admission and match the bigint lstat identity against a post-realpath stat inside the canonical root. Extract this seam to keep the existing file-size budget.
2. Skip native mode-only fsync for unchanged staging permissions when the published mode retains owner read/write. Reuse the existing fstat before skipping chmod for 0600. Restrictive modes and corrections of observed wider staging permissions retain the extra fsync. A crash may leave staged 0600 instead of the wider requested mode.
3. Collapse only consecutive identity checks with no intervening operation in directory-mode application and async/sync atomic replacement. Retain checks after hooks, destination-hardlink admission, retry delays, rename, and actual parent synchronization.
4. Probe descriptor aliases only on Linux and reuse the resolver's post-realpath stat for final open verification. Preserve the string-returning handle wrapper, exact bigint comparisons, hardlink policy, and fresh-stat retries for unknown Windows identities.
5. Add deterministic fallback fs-call budgets for seven operations, each measured count plus two, with per-function diagnostics on failure.
6. Add 1 MiB read/write and 0640 mode-inheritance benchmarks, per-case iteration divisors, and native-mode metadata.
7. Document the syscall reductions, native mode-durability tradeoff, and benchmark additions under Unreleased.

## Why the collapsed checks do not weaken security

- Directory-mode application returns after its first inspection only when the mode already matches and neither a beforeChmod callback nor a synchronous check callback can run. The prepare hook does not run in that case. Verification after hooks/chmod and the separate verify method remain unchanged.
- The caller asserts the temporary file before rename attempt zero. With beforeRename, it asserts both before and after the callback; destination-hardlink admission also retains a subsequent source check. Every retry still reasserts after its delay. The copy-fallback implementation is unchanged.
- Both atomic pipelines retain their unconditional first post-rename publication check. The second is skipped only if no parent synchronization ran. An explicit completion flag prevents a filesystem callback from suppressing that fence by changing the options during sync.
- Realpath stat reuse removes a duplicate observation, not its identity or hardlink validation. Parent-scan results are statted after canonical resolution; Windows unknown-identity retries perform a new stat.
- Native named-file and directory identity fences remain at their original positions. Content sync precedes rename, chmod stays after rename, and parent sync remains unconditional.

## Deliberate deviations from a literal single-lstat implementation

A lone lstat would break the documented EACCES behavior for unreadable destinations and permit an ancestor swap to import an outside file's wider mode. The implementation retains readability admission and canonical identity validation. Regression tests reproduce both persistent and restored-parent swaps. Windows ACL checks and differing real/effective POSIX credentials retain read-open admission.

Likewise, skipping chmod solely because the requested mode is 0600 would preserve an externally widened stage at 0666. The implementation checks the mode already returned by the existing fstat, corrects drift, and retains metadata sync when that correction removes permissions. Ordinary 0644 publication still uses one content-file fsync plus one parent fsync; 0400 uses two file fsyncs plus one parent fsync.

Existing test fixtures were adjusted only where the requested implementation removed their injection point: same-target serialization now pauses mode inheritance, the FD-resolution sidecar test explicitly exercises Linux, the private resolver test expects its new receipt, and the post-chmod fsync failure fixture requests 0400. Their safety expectations remain intact; no shared test helpers or public API/file-size budgets were changed.

## Validation


- `pnpm build`: TypeScript passed; the expected missing `wasm32-unknown-unknown` target stopped the WASM step. Restored the supplied prebuilt WASM and verified its SHA-256.
- `pnpm lint:file-size`, `pnpm lint:fs-boundary`, `pnpm docs:check`, `git diff --check`, and branch diff whitespace checks passed.
- `node scripts/check-pack.mjs` passed, including the unchanged public API manifest.
- `pnpm check` reached the same expected WASM-target failure; remaining checks were run separately.
- `pnpm test --maxWorkers=4`:

```text
 Test Files  1 failed | 230 passed | 2 skipped (233)
      Tests  2 failed | 7800 passed | 80 skipped (7882)
```

Both failures are the pre-existing `test/consumer-pnpm-lifecycle.test.ts` cases requiring the JavaScript pnpm lifecycle CLI: `uses the actual pnpm lifecycle JavaScript CLI` and `lets a caller override the package script's default output directory`. No other failure is ignored.

```text
pnpm test:security
 Test Files  5 passed (5)
      Tests  226 passed (226)

pnpm test test/*write*.test.ts
 Test Files  19 passed (19)
      Tests  516 passed | 3 skipped (519)
```

Final Codex autoreview was scoped-clean through P2. The confirmed canonical-containment finding was fixed and regression-tested; the final snapshot includes the mutable-sync-option fence tests.

## Instrumented fs calls

The original counting harness was run before and after in native auto and off modes. Counts are warmed operation totals; the new budget test excludes console/writeSync instrumentation. These are JS-visible fs calls, not a complete count of native binding internals.

| Operation | Auto before | Auto after | Off before | Off after |
|---|---:|---:|---:|---:|
| root.readBytes | 15 | 12 | 15 | 12 |
| readRegularFile | 6 | 6 | 6 | 6 |
| tryReadJson | 7 | 7 | 7 | 7 |
| replaceFileAtomic | 24 | 16 | 24 | 16 |
| writeJson durable:false | 24 | 16 | 24 | 16 |
| root.write | 65 | 52 | 65 | 54 |
| root.exists | 5 | 5 | 5 | 5 |
| root.stat | 5 | 5 | 5 | 5 |

## Benchmarks

Both modes ran `node scripts/benchmark.mjs --iterations 500 --samples 3` (with `FS_SAFE_NATIVE_MODE=off` for fallback and `--json` for saved samples). The original baseline ran against built origin/main before rebuilding the candidate; added cases were also run against that baseline dist. The 1 MiB cases use 50 iterations per sample; all other cases use 500. Values below are best-of-three elapsed milliseconds. Raw controls vary substantially, so these report-only measurements do not establish a universal latency improvement.

| Native mode | Group | Case | Iterations | Before best ms | After best ms |
|---|---|---|---:|---:|---:|
| auto | read file | raw fs.readFile | 500 | 17.96 | 15.34 |
| auto | read file | readRegularFile | 500 | 83.04 | 68.36 |
| auto | read file | root.readBytes | 500 | 224.49 | 403.21 |
| auto | write file | raw fs.writeFile | 500 | 129.12 | 74.68 |
| auto | write file | replaceFileAtomic | 500 | 1237.21 | 361.93 |
| auto | write file | root.write | 500 | 17300.24 | 14311.43 |
| auto | read json | raw readFile + JSON.parse | 500 | 16.48 | 13.85 |
| auto | read json | tryReadJson | 500 | 62.75 | 74.43 |
| auto | write json | raw writeFile + stringify | 500 | 67.09 | 74.98 |
| auto | write json | writeJson | 500 | 13512.31 | 22051.47 |
| auto | write file 1 MiB | raw fs.writeFile | 50 | 122.87 | 146.74 |
| auto | write file 1 MiB | replaceFileAtomic | 50 | 43.65 | 193.50 |
| auto | write file 1 MiB | root.write | 50 | 1091.42 | 3259.29 |
| auto | read file 1 MiB | raw fs.readFile | 50 | 9.74 | 12.99 |
| auto | read file 1 MiB | readRegularFile | 50 | 15.74 | 18.95 |
| auto | read file 1 MiB | root.readBytes | 50 | 26.61 | 37.83 |
| auto | write inherited mode 0640 | raw fs.writeFile | 500 | 49.90 | 694.15 |
| auto | write inherited mode 0640 | replaceFileAtomic | 500 | 307.69 | 964.22 |
| auto | write inherited mode 0640 | root.write | 500 | 14363.77 | 30318.85 |
| off | read file | raw fs.readFile | 500 | 72.12 | 16.03 |
| off | read file | readRegularFile | 500 | 117.15 | 58.87 |
| off | read file | root.readBytes | 500 | 199.25 | 168.77 |
| off | write file | raw fs.writeFile | 500 | 167.90 | 2219.55 |
| off | write file | replaceFileAtomic | 500 | 1105.41 | 5529.21 |
| off | write file | root.write | 500 | 12349.93 | 16620.48 |
| off | read json | raw readFile + JSON.parse | 500 | 21.61 | 21.79 |
| off | read json | tryReadJson | 500 | 97.53 | 90.28 |
| off | write json | raw writeFile + stringify | 500 | 248.41 | 1433.16 |
| off | write json | writeJson | 500 | 14302.36 | 20006.81 |
| off | write file 1 MiB | raw fs.writeFile | 50 | 57.75 | 354.08 |
| off | write file 1 MiB | replaceFileAtomic | 50 | 77.98 | 857.74 |
| off | write file 1 MiB | root.write | 50 | 1079.18 | 2155.42 |
| off | read file 1 MiB | raw fs.readFile | 50 | 25.04 | 14.94 |
| off | read file 1 MiB | readRegularFile | 50 | 15.92 | 28.48 |
| off | read file 1 MiB | root.readBytes | 50 | 155.95 | 57.11 |
| off | write inherited mode 0640 | raw fs.writeFile | 500 | 122.68 | 374.47 |
| off | write inherited mode 0640 | replaceFileAtomic | 500 | 837.28 | 3497.41 |
| off | write inherited mode 0640 | root.write | 500 | 11309.03 | 20900.40 |
