### PR TITLE
feat(root): add durable option to Root write methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `durable` to Root write/create/writeJson/createJson/append options and Root defaults; `durable: false` skips file and parent fsync for reconstructible data (default unchanged: durable).
 - Simplify internals without changing public behavior: remove unused string/home helpers, `resolveUserPath`, `createBoundedReadStream`, `sidecarLockPayloadIsStale`, and `tarManifestEntryCost`; share filesystem utilities and merge private modules.
 - Reduce filesystem calls per read and write while retaining boundary, hardlink, hook, retry, and post-mutation identity checks.
 - Skip native publication's extra mode-only file fsync for modes that retain owner read/write when staging permissions have not widened; after a crash, a file may retain staged `0o600` instead of the wider requested mode, while restrictive modes retain the extra fsync.

--- a/docs/root.md
+++ b/docs/root.md
@@ -18,6 +18,7 @@ const fs = await root("/srv/workspace", {
 function root(rootDir: string, defaults?: RootDefaults): Promise<Root>;
 
 type RootDefaults = {
+  durable?: boolean;               // fsync write/create/writeJson/createJson/append; default true
   hardlinks?: "reject" | "allow";  // refuse files with nlink > 1 on read; defaults to "reject"
   denyMutations?: DenyMutationPolicy; // absolute paths/prefixes mutation methods may not change
   maxBytes?: number;               // refuse reads larger than this many bytes; defaults to 16 MiB
@@ -99,7 +100,7 @@ fs.write(rel, data, options?)            // overwrite-ok atomic write
 fs.create(rel, data, options?)           // throws "already-exists" if target exists
 fs.writeJson(rel, value, options?)       // JSON.stringify + atomic write
 fs.createJson(rel, value, options?)      // create() variant of writeJson
-fs.append(rel, data, options?)           // append text/buffer; syncs before close
+fs.append(rel, data, options?)           // append text/buffer; syncs before close by default
 fs.copyIn(rel, sourceAbsPath, options?)  // copy from outside the root, atomically, with size cap
 fs.openWritable(rel, options?)           // FileHandle for streaming writes; supports await using
 fs.move(from, to, options?)              // rename within the root; defaults to no clobber
@@ -109,6 +110,14 @@ fs.ensureRoot(options?)                  // accepts "" / "." as the root itself
 ```
 
 `write`, `create`, `append`, `writeJson`, and `createJson` accept `mode?: number`; use `0o600` for credentials and other private state. `writeJson` also accepts the same options as `JSON.stringify` plus `trailingNewline?: boolean` (defaults `true` so the file ends in `\n`).
+
+These five methods also accept `durable?: boolean`: the per-call value overrides
+`Root.defaults.durable`, which defaults to `true` when omitted. An explicitly
+`undefined` per-call value preserves the root default. `durable: false` keeps
+the existing publication behavior, modes, and identity checks but skips file
+and parent-directory fsync calls. Use it only for reconstructible data: a crash
+may lose the write or leave the previous file. See [Writing](writing.md#write-options)
+for platform details.
 
 `copyIn` is a one-shot ingest from a trusted absolute source path: it streams the source through the boundary, atomically renames into the root, and respects `maxBytes`.
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -100,6 +100,7 @@ type RenameIdentityPolicy = "strict" | "verify-content-with-lock";
 
 type RootDefaults = {
   denyMutations?: DenyMutationPolicy;
+  durable?: boolean; // default true for write/create/writeJson/createJson/append
   hardlinks?: "reject" | "allow";
   maxBytes?: number;
   mkdir?: boolean; // default true for mutation methods
@@ -126,7 +127,7 @@ type RootOptions = {
 
 ```ts
 type RootReadOptions = Pick<RootDefaults, "hardlinks" | "maxBytes" | "nonBlockingRead" | "symlinks">;
-type RootWriteOptions = Pick<RootDefaults, "denyMutations" | "mkdir" | "mode" | "renameIdentity"> & {
+type RootWriteOptions = Pick<RootDefaults, "denyMutations" | "durable" | "mkdir" | "mode" | "renameIdentity"> & {
   encoding?: BufferEncoding;
   overwrite?: boolean;
 };

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -77,14 +77,37 @@ await fs.write("state/last-run.json", JSON.stringify(run));
 await fs.write("notes/today.txt", "hello\n", { encoding: "utf8" });
 ```
 
-`data` accepts `string | Buffer`. `options` are `{ denyMutations?: DenyMutationPolicy; encoding?: BufferEncoding; mkdir?: boolean; mode?: number; overwrite?: boolean; renameIdentity?: RenameIdentityPolicy }`. `mode` sets the file's POSIX mode. If neither the call nor `RootDefaults` supplies it, a replacement preserves the existing file mode and a new file uses `0o600`. `mkdir` and `overwrite` both default to `true`; set `overwrite: false` for the same no-clobber behavior as `create()`.
+`data` accepts `string | Buffer`. `mode` sets the file's POSIX mode. If neither the call nor `RootDefaults` supplies it, a replacement preserves the existing file mode and a new file uses `0o600`. `mkdir` and `overwrite` both default to `true`; set `overwrite: false` for the same no-clobber behavior as `create()`.
+
+#### Write options
+
+| Option | Type | Default / behavior |
+|---|---|---|
+| `denyMutations` | `DenyMutationPolicy` | Merged with root-level denies. |
+| `durable` | `boolean` | `true`; use `false` to skip file and parent fsync. |
+| `encoding` | `BufferEncoding` | `"utf8"` for strings. |
+| `mkdir` | `boolean` | `true`; creates missing parents. |
+| `mode` | `number` | Inherited on replacement, otherwise `0o600`. |
+| `overwrite` | `boolean` | `true`; `false` is create-only. |
+| `renameIdentity` | `RenameIdentityPolicy` | `"strict"`. |
+
+`write`, `create`, `writeJson`, `createJson`, and `append` accept `durable`.
+Precedence is per-call option, then `Root.defaults.durable`, then `true`;
+an explicitly `undefined` call option preserves the root default.
+`durable: false` keeps the sibling-temp replace/rename behavior of replacement
+writes but skips file and parent-directory fsync calls. Create-only and append
+publication behavior, permissions, identity checks, and error codes are unchanged.
+Use it only for reconstructible data: a crash may lose the write or leave the
+previous file. `copyIn`, `move`, and streaming `openWritable` do not use this option.
+The existing pure-JavaScript Windows writer performs no fsync calls in either
+setting; native Windows writes honor the option. Directory sync remains best-effort.
 
 POSIX modes without read permission, including `0o000` and `0o200`, succeed:
 final verification uses a descriptor retained by the writer rather than reopening
 the published file. The requested mode is not relaxed for verification.
 Publication verification compares exact bigint descriptor and pathname identities,
 including large file indexes that cannot be represented by a JavaScript number.
-Native publication syncs content before rename and always syncs the parent directory.
+With durability enabled (the default), native publication syncs content before rename and syncs the parent directory.
 Modes that retain owner read/write skip the extra mode-only file sync: after a
 crash, the file may retain staged mode `0o600` instead of the wider requested mode.
 Modes that remove owner read or write, and corrections of observed wider staging
@@ -143,7 +166,7 @@ type RootWriteJsonOptions = RootWriteOptions & {
 
 ### `fs.append(rel, data, options?)`
 
-Open in append mode, write, sync the file handle, and close. Honors `mkdir` for the parent directory and syncs the parent directory when the append creates the file. Pass `prependNewlineIfNeeded: true` to insert a `\n` if the file does not already end in one.
+Open in append mode, write, sync the file handle, and close. Honors `mkdir` for the parent directory and syncs the parent directory when the append creates the file. `durable: false` skips both syncs. Pass `prependNewlineIfNeeded: true` to insert a `\n` if the file does not already end in one.
 
 ```ts
 await fs.append("logs/today.log", `[${ts}] ${line}\n`);

--- a/scripts/benchmark.mjs
+++ b/scripts/benchmark.mjs
@@ -223,6 +223,13 @@ async function main() {
         },
       },
       {
+        group: "write file",
+        name: "root.write durable:false",
+        run: async (i) => {
+          await safe.write("root-write-nondurable.txt", `${i}:${payload.toString("utf8")}`, { durable: false });
+        },
+      },
+      {
         group: "read json",
         name: "raw readFile + JSON.parse",
         baseline: true,

--- a/src/native-pinned-write-windows.ts
+++ b/src/native-pinned-write-windows.ts
@@ -60,7 +60,7 @@ export async function runPinnedWriteWindows(
     // reopenable until the published name has been identity-fenced.
     fsSync.fchmodSync(tempFd, 0o600);
     await writeNativeInput(tempFd, params.input, params.maxBytes);
-    syncFileBestEffortSync(tempFd);
+    if (params.sync !== false) syncFileBestEffortSync(tempFd);
     if (params.overwrite === false) {
       binding.renameNoReplace(parentFd, tempName, parentFd, params.basename);
     } else {
@@ -84,7 +84,7 @@ export async function runPinnedWriteWindows(
     // verifiable and so broader modes are never exposed before that fence.
     try {
       fsSync.fchmodSync(targetFd, params.mode);
-      syncFileBestEffortSync(targetFd);
+      if (params.sync !== false) syncFileBestEffortSync(targetFd);
     } catch (error) {
       closeWriteFd(targetFd);
       targetFd = undefined;
@@ -96,7 +96,7 @@ export async function runPinnedWriteWindows(
       });
       throw error;
     }
-    syncFileBestEffortSync(parentFd);
+    if (params.sync !== false) syncFileBestEffortSync(parentFd);
     // Verification follows publication and final chmod, outside rollback handling.
     await params.verifyPublished?.(targetFd, verificationIdentity, parentGuard);
     completed = true;

--- a/src/native-staged-file.ts
+++ b/src/native-staged-file.ts
@@ -69,6 +69,7 @@ class NativeStagedFile implements StagedFile {
   readonly #directory: StagedFileReceipt["directory"];
   readonly #portableNames: boolean;
   readonly #publishedMode: number;
+  readonly #sync: boolean;
   readonly #name = `.fs-safe-${randomUUID()}.tmp`;
   #state: State = { status: "open", publication: NOT_PUBLISHED };
   #receipt?: StagedFileReceipt;
@@ -79,12 +80,14 @@ class NativeStagedFile implements StagedFile {
     directory: StagedFileReceipt["directory"],
     portableNames: boolean,
     publishedMode: number,
+    sync: boolean,
   ) {
     this.#binding = binding;
     this.#parentFd = parentFd;
     this.#directory = directory;
     this.#portableNames = portableNames;
     this.#publishedMode = publishedMode;
+    this.#sync = sync;
   }
 
   // Takes ownership of parentFd, including all construction and preparation failures.
@@ -97,10 +100,11 @@ class NativeStagedFile implements StagedFile {
     maxBytes?: number,
     // Public staging uses portable names; existing POSIX writes accept literal names.
     portableNames = true,
+    sync = true,
   ): Promise<NativeStagedFile> {
     let staged: NativeStagedFile;
     try {
-      staged = new NativeStagedFile(binding, parentFd, directory, portableNames, mode);
+      staged = new NativeStagedFile(binding, parentFd, directory, portableNames, mode, sync);
     } catch (error) {
       try {
         fs.closeSync(parentFd);
@@ -123,7 +127,7 @@ class NativeStagedFile implements StagedFile {
     // This owner never escapes. Only the internal verifier borrows its fd;
     // public descriptor methods remain await-free and cannot race disposal.
     await using staged = await NativeStagedFile.create(
-      binding, parentFd, directory, params.input, params.mode, params.maxBytes, false,
+      binding, parentFd, directory, params.input, params.mode, params.maxBytes, false, params.sync,
     );
     const published = await staged.publish(params.basename, { overwrite: params.overwrite !== false });
     const identity = published.staged.identity;
@@ -185,7 +189,7 @@ class NativeStagedFile implements StagedFile {
       const fd = state.fileFd;
       fs.fchmodSync(fd, 0o600);
       await writeNativeInput(fd, input, maxBytes);
-      syncFileBestEffortSync(fd);
+      if (this.#sync) syncFileBestEffortSync(fd);
       const stat = fs.fstatSync(fd, { bigint: true });
       this.#receipt = Object.freeze({
         directory: this.#directory,
@@ -260,13 +264,13 @@ class NativeStagedFile implements StagedFile {
       // fence. Mode changes use the owned fd, including for final mode 000.
       const fd = this.#file();
       if (this.#publishedMode !== 0o600 || stagedMode !== 0o600) fs.fchmodSync(fd, this.#publishedMode);
-      // Content was synced before rename. A lost chmod leaves staged 0600,
+      // With sync enabled, content was synced before rename. A lost chmod leaves staged 0600,
       // no wider than modes retaining owner rw. Restrictive modes and observed
       // widening of the stage still need the permission correction made durable.
-      if ((this.#publishedMode & 0o600) !== 0o600 || (stagedMode & ~this.#publishedMode) !== 0) {
+      if (this.#sync && ((this.#publishedMode & 0o600) !== 0o600 || (stagedMode & ~this.#publishedMode) !== 0)) {
         syncFileBestEffortSync(fd);
       }
-      syncFileBestEffortSync(this.#parentFd);
+      if (this.#sync) syncFileBestEffortSync(this.#parentFd);
       this.#assertNamed(basename);
       assertStagedDirectoryCurrent(this.#directory);
       return receipt;

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -87,6 +87,7 @@ export type PinnedWriteParams = {
   basename: string;
   mkdir: boolean;
   mode: number;
+  sync?: boolean;
   overwrite?: boolean;
   maxBytes?: number;
   input: PinnedWriteInput;
@@ -213,9 +214,9 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
       }
       // Content writes may clear set-ID bits; finalize them through the owned fd.
       await handle.chmod(params.mode);
-      await syncFileBestEffort(handle);
+      if (params.sync !== false) await syncFileBestEffort(handle);
       const stat = await handle.stat();
-      await syncDirectoryBestEffort(parentPath);
+      if (params.sync !== false) await syncDirectoryBestEffort(parentPath);
       // Publication is complete. A failed outer check must not remove its target.
       created = false;
       await params.verifyPublished?.(handle.fd, verificationIdentity, parentGuard);
@@ -269,13 +270,13 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
     }
     const expectedTempStat = tempStat;
     await handle.chmod(params.mode);
-    await syncFileBestEffort(handle);
+    if (params.sync !== false) await syncFileBestEffort(handle);
     let verifiedIdentity: FileIdentityStat = expectedTempStat;
     await withAsyncDirectoryGuards([parentGuard], async () => {
       await fs.rename(tempPath, targetPath);
       renamed = true;
       await getFsSafeTestHooks()?.afterPinnedWriteFallbackRename?.(targetPath);
-      await syncDirectoryBestEffort(parentPath);
+      if (params.sync !== false) await syncDirectoryBestEffort(parentPath);
       const targetStat = await fs.lstat(targetPath);
       if (targetStat.isSymbolicLink()) {
         throw new FsSafeError("path-mismatch", "fallback target changed during write");

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -96,6 +96,7 @@ export type HardlinkPolicy = "reject" | "allow";
 export type WritableOpenMode = "replace" | "append" | "update";
 
 export type RootDefaults = {
+  durable?: boolean;
   hardlinks?: HardlinkPolicy;
   maxBytes?: number;
   mkdir?: boolean;
@@ -113,7 +114,7 @@ export type RootReadOptions = Pick<
 
 export type RootOpenOptions = Omit<RootReadOptions, "maxBytes">;
 
-export type RootWriteOptions = Pick<RootDefaults, "denyMutations" | "mkdir" | "mode" | "renameIdentity"> & {
+export type RootWriteOptions = Pick<RootDefaults, "denyMutations" | "durable" | "mkdir" | "mode" | "renameIdentity"> & {
   encoding?: BufferEncoding;
   overwrite?: boolean;
 };
@@ -514,6 +515,7 @@ export class RootHandle implements Root {
       mkdir: this.defaults.mkdir,
       mode: this.defaults.mode,
       ...this.mutationOptions(options),
+      durable: options.durable ?? this.defaults.durable ?? true,
     });
   }
 
@@ -554,6 +556,7 @@ export class RootHandle implements Root {
       mode: this.defaults.mode,
       renameIdentity: this.defaults.renameIdentity,
       ...this.mutationOptions(options),
+      durable: options.durable ?? this.defaults.durable ?? true,
     });
   }
 
@@ -569,6 +572,7 @@ export class RootHandle implements Root {
       mkdir: this.defaults.mkdir,
       mode: this.defaults.mode,
       ...this.mutationOptions(options),
+      durable: options.durable ?? this.defaults.durable ?? true,
       overwrite: false,
     });
   }
@@ -1004,6 +1008,7 @@ async function appendFileInRoot(
   params: {
     relativePath: string;
     data: string | Buffer;
+    durable?: boolean;
     encoding?: BufferEncoding;
     mkdir?: boolean;
     mode?: number;
@@ -1042,8 +1047,8 @@ async function appendFileInRoot(
         prefix.length > 0 ? Buffer.concat([Buffer.from(prefix, "utf8"), params.data]) : params.data;
       await target.handle.appendFile(payload);
     }
-    await target.handle.sync();
-    if (target.createdForWrite) {
+    if (params.durable !== false) await target.handle.sync();
+    if (params.durable !== false && target.createdForWrite) {
       await syncDirectoryBestEffort(path.dirname(target.realPath));
     }
   } finally {
@@ -1127,6 +1132,7 @@ async function commitPinnedWriteInRoot(
       renameIdentity: params.renameIdentity,
       mkdir: params.mkdir !== false,
       mode: params.mode ?? pinned.mode,
+      sync: params.durable !== false,
       overwrite: params.overwrite,
       input: { kind: "buffer", data: params.data, encoding: params.encoding },
       rootIdentity: root.rootIdentity,

--- a/test/root-durable-option.test.ts
+++ b/test/root-durable-option.test.ts
@@ -1,0 +1,188 @@
+import fsSync from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeNative, root, type RootWriteOptions } from "../src/index.js";
+import { __loadBundledNativeForTest, __resetNativeLoaderForTest, __setNativeLoaderForTest } from "../src/native.js";
+import { runPinnedWriteHelper } from "../src/pinned-write.js";
+import * as verification from "../src/root-write-verification.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+const verifyPublished = verification.verifyAtomicWriteResult;
+let nativeAvailable = false;
+try {
+  __loadBundledNativeForTest();
+  nativeAvailable = true;
+} catch (error) {
+  if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platformDescriptor);
+  configureFsSafeNative({ mode: "auto" });
+  __resetNativeLoaderForTest();
+});
+
+async function observeSyncs(directory: string) {
+  const probePath = path.join(directory, "probe");
+  const probe = await fs.open(probePath, "w");
+  const prototype = Object.getPrototypeOf(probe) as FileHandle;
+  await probe.close();
+  await fs.unlink(probePath);
+  const events: string[] = [];
+  const record = (fd: number) => events.push(fsSync.fstatSync(fd).isFile() ? "file" : "parent");
+  const asyncSync = prototype.sync;
+  const syncSync = fsSync.fsyncSync;
+  const asyncSpy = vi.spyOn(prototype, "sync").mockImplementation(async function (this: FileHandle) {
+    record(this.fd);
+    await asyncSync.call(this);
+  });
+  // Native writers share this sync helper's fs.fsyncSync path.
+  const syncSpy = vi.spyOn(fsSync, "fsyncSync").mockImplementation((fd) => {
+    record(fd);
+    syncSync(fd);
+  });
+  return { events, asyncSpy, syncSpy };
+}
+
+const policies: { name: string; rootDefault?: boolean; options?: RootWriteOptions; sync: boolean }[] = [
+  { name: "default", sync: true },
+  { name: "per-call false", options: { durable: false }, sync: false },
+  { name: "root false", rootDefault: false, sync: false },
+  { name: "undefined preserves root false", rootDefault: false, options: { durable: undefined }, sync: false },
+  { name: "per-call true overrides root false", rootDefault: false, options: { durable: true }, sync: true },
+  { name: "per-call false overrides root true", rootDefault: true, options: { durable: false }, sync: false },
+];
+
+for (const backend of ["auto", "off"] as const) {
+  describe.skipIf(backend === "auto" && !nativeAvailable)(`Root durable option: native ${backend}`, () => {
+    for (const method of ["write", "create", "writeJson", "createJson", "append"] as const) {
+      it.each(policies.flatMap((policy) => [0o640, 0o400].map((mode) => ({ ...policy, mode }))))(
+        `${method}: $name, mode $mode`,
+        async ({ rootDefault, options, sync, mode }) => {
+          configureFsSafeNative({ mode: backend });
+          const directory = await tempRoot("fs-safe-durable-");
+          const safe = await root(directory, { durable: rootDefault });
+          expect(safe.defaults.durable).toBe(rootDefault);
+          const { events, asyncSpy, syncSpy } = await observeSyncs(directory);
+          const isJson = method === "writeJson" || method === "createJson";
+          if (isJson) {
+            await safe[method]("target", { value: "payload" }, { ...options, mode });
+          } else {
+            await safe[method]("target", "payload", { ...options, mode });
+          }
+          if (!sync || (process.platform === "win32" && backend === "off" && method !== "append")) {
+            expect(asyncSpy).not.toHaveBeenCalled();
+            expect(syncSpy).not.toHaveBeenCalled();
+          } else if (process.platform === "win32") {
+            // Windows directory sync may be unavailable; the file sync is observable.
+            expect(events).toContain("file");
+          } else {
+            expect(events).toEqual(backend === "auto" && method !== "append" && mode === 0o400
+              ? ["file", "file", "parent"] : ["file", "parent"]);
+            expect(backend === "auto" && method !== "append" ? syncSpy : asyncSpy).toHaveBeenCalled();
+          }
+          const target = path.join(directory, "target");
+          if (process.platform !== "win32") expect((await fs.stat(target)).mode & 0o777).toBe(mode);
+          await fs.chmod(target, 0o600);
+          expect(await fs.readFile(target, "utf8")).toBe(isJson ? '{"value":"payload"}\n' : "payload");
+          expect(await fs.readdir(directory)).toEqual(["target"]);
+        },
+      );
+    }
+
+    it.each([true, false])("replaces an existing inode and preserves its mode with durable %s", async (durable) => {
+      configureFsSafeNative({ mode: backend });
+      const directory = await tempRoot("fs-safe-durable-replace-");
+      const target = path.join(directory, "target");
+      await fs.writeFile(target, "old bytes", { mode: 0o640 });
+      const before = await fs.stat(target);
+      const safe = await root(directory);
+      const { events } = await observeSyncs(directory);
+      await safe.write("target", "new bytes", { durable });
+      expect(await fs.readFile(target, "utf8")).toBe("new bytes");
+      const after = await fs.stat(target);
+      expect(after.ino).not.toBe(before.ino);
+      expect(after.mode).toBe(before.mode);
+      if (!durable) expect(events).toEqual([]);
+    });
+
+    it.each([true, false])("appends in place with durable %s and no parent sync", async (durable) => {
+      configureFsSafeNative({ mode: backend });
+      const directory = await tempRoot("fs-safe-durable-append-");
+      const target = path.join(directory, "target");
+      await fs.writeFile(target, "old", { mode: 0o600 });
+      const before = await fs.stat(target);
+      const safe = await root(directory);
+      const { events } = await observeSyncs(directory);
+      await safe.append("target", Buffer.from("new"), { durable, prependNewlineIfNeeded: true });
+      expect(events).toEqual(durable ? ["file"] : []);
+      expect(await fs.readFile(target, "utf8")).toBe("old\nnew");
+      expect((await fs.stat(target)).ino).toBe(before.ino);
+    });
+
+    it.each(["write", "create"] as const)("%s retains post-publication identity rejection without sync", async (method) => {
+      configureFsSafeNative({ mode: backend });
+      const directory = await tempRoot("fs-safe-durable-fence-");
+      const target = path.join(directory, "target");
+      const safe = await root(directory, { durable: false });
+      vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+        await fs.rename(target, path.join(directory, "published"));
+        await fs.writeFile(target, "substitute");
+        await verifyPublished(params);
+      });
+      const { events } = await observeSyncs(directory);
+      await expect(safe[method]("target", "payload")).rejects.toMatchObject({ code: "path-mismatch" });
+      expect(events).toEqual([]);
+      expect(await fs.readFile(target, "utf8")).toBe("substitute");
+      expect(await fs.readFile(path.join(directory, "published"), "utf8")).toBe("payload");
+    });
+
+    it("retains create-only errors and copyIn durability with a false root default", async () => {
+      configureFsSafeNative({ mode: backend });
+      const directory = await tempRoot("fs-safe-durable-copy-");
+      const source = path.join(directory, "source");
+      await fs.writeFile(source, "payload");
+      const safe = await root(directory, { durable: false });
+      await expect(safe.create("source", "replacement")).rejects.toMatchObject({ code: "already-exists" });
+      await expect(safe.write("../escape", "payload")).rejects.toMatchObject({ code: "outside-workspace" });
+      const { events } = await observeSyncs(directory);
+      await safe.copyIn("target", source);
+      expect(events).toContain("file");
+      expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("payload");
+    });
+  });
+}
+
+describe.skipIf(process.platform === "win32")("Windows writer branch simulation", () => {
+  it.each([true, false])("preserves the unsynced JS writer with durable %s", async (durable) => {
+    configureFsSafeNative({ mode: "off" });
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const directory = await tempRoot("fs-safe-durable-win-js-");
+    const safe = await root(directory, { durable });
+    const { events } = await observeSyncs(directory);
+    await safe.create("created", "created");
+    await safe.write("created", "replaced");
+    expect(events).toEqual([]);
+    expect(await fs.readFile(path.join(directory, "created"), "utf8")).toBe("replaced");
+  });
+
+  it.skipIf(!nativeAvailable).each([true, false])("gates every Windows native sync with sync %s", async (sync) => {
+    const binding = __loadBundledNativeForTest();
+    __setNativeLoaderForTest(() => binding);
+    configureFsSafeNative({ mode: "auto" });
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const directory = await tempRoot("fs-safe-durable-win-native-");
+    const { events } = await observeSyncs(directory);
+    await runPinnedWriteHelper({
+      rootPath: directory, relativeParentPath: "", basename: "target", mkdir: false,
+      mode: 0o400, sync, input: { kind: "buffer", data: "payload" },
+    });
+    expect(events).toEqual(sync ? ["file", "file", "parent"] : []);
+    expect((await fs.stat(path.join(directory, "target"))).mode & 0o777).toBe(0o400);
+    expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("payload");
+  });
+});

--- a/test/root-durable-option.test.ts
+++ b/test/root-durable-option.test.ts
@@ -60,7 +60,9 @@ const policies: { name: string; rootDefault?: boolean; options?: RootWriteOption
 for (const backend of ["auto", "off"] as const) {
   describe.skipIf(backend === "auto" && !nativeAvailable)(`Root durable option: native ${backend}`, () => {
     for (const method of ["write", "create", "writeJson", "createJson", "append"] as const) {
-      it.each(policies.flatMap((policy) => [0o640, 0o400].map((mode) => ({ ...policy, mode }))))(
+      // The Windows JavaScript fallback cannot rename over a read-only destination.
+      const modes = process.platform === "win32" && backend === "off" && method !== "append" ? [0o640] : [0o640, 0o400];
+      it.each(policies.flatMap((policy) => modes.map((mode) => ({ ...policy, mode }))))(
         `${method}: $name, mode $mode`,
         async ({ rootDefault, options, sync, mode }) => {
           configureFsSafeNative({ mode: backend });


### PR DESCRIPTION
Root writes always paid for file and parent-directory fsync, even for reconstructible state. In the motivating macOS workload, one fsync costs 6–8 ms and Root writes take roughly 15–17 ms versus about 0.5 ms for `replaceFileAtomic`.

Add `durable?: boolean` to `RootDefaults` and `RootWriteOptions`, inherited by `write`, `create`, `writeJson`, `createJson`, and `append`. Precedence is per-call option > root default > `true`; an explicitly undefined per-call value preserves the root default. `Root.defaults` exposes the supplied setting. `durable: false` only skips fsync. Use it only for reconstructible data: a crash may lose the write or leave the previous file.

The native staged writer gates its content, conditional mode-only, and parent syncs. The guarded JavaScript writer gates file and parent syncs in both exclusive-create and temp/rename paths. The Windows native writer gates all three existing syncs; its existing pure-JavaScript Root fallback already performs no fsync and retains that behavior. Append gates its file sync and its parent sync when creating a file. Every chmod, publication step, identity fence, verification, and cleanup remains in place. `copyIn`, `move`, and public staging retain their existing policies.

Documentation updates cover `docs/root.md`, the write-options table and durability explanation in `docs/writing.md`, and `docs/types.md`; `CHANGELOG.md` records the additive option. README has no write-options table. The public API gains the optional field on the existing types, with no new export names or error codes. Regenerating `test/public-api.json` produced no diff because the current snapshot records exported names and error-code members, not option fields.

Validation:

- TypeScript compilation passed, including a separate type check of the new tests.
- `pnpm lint:file-size`, `pnpm lint:fs-boundary`, `pnpm docs:check`, `node scripts/check-pack.mjs`, and `git diff --check` passed.
- Focused durability and native-staging tests: 148 passed. Coverage includes auto/off, all five methods, precedence, zero fsync with the opt-out, content/modes, replacement and append behavior, post-publication identity rejection, copyIn policy, and Windows branch simulations.
- `pnpm test --maxWorkers=1`: 7,938 passed, 80 skipped, and two known local failures in `test/consumer-pnpm-lifecycle.test.ts` caused by the local pnpm executable not being a JavaScript lifecycle CLI. No archive timeout failures.
- `pnpm test:security --maxWorkers=1`: 226 passed.
- `pnpm check` and `pnpm public-api:update` passed their TypeScript step but stopped at the known missing `wasm32-unknown-unknown` target. Restored the prepared WASM artifact, completed snapshot regeneration with `node scripts/check-pack.mjs --update-public-api`, and ran the remaining checks separately. Generated dist output is not committed.
- Independent autoreview against the base: scoped-clean through P2, no actionable findings.

Benchmarks: `node scripts/benchmark.mjs --iterations 300 --samples 3`, once with `FS_SAFE_NATIVE_MODE=auto` and once with `FS_SAFE_NATIVE_MODE=off`. Node v26.8.1 on darwin/arm64; 128-byte payload, three samples per case. These are report-only microbenchmarks.

| Native mode | Write-file case | Best 300 operations (ms) | Best ms/operation |
|---|---|---:|---:|
| auto | `replaceFileAtomic` | 725.63 | 2.42 |
| auto | `root.write` | 5647.89 | 18.83 |
| auto | `root.write durable:false` | 836.71 | 2.79 |
| off | `replaceFileAtomic` | 1988.82 | 6.63 |
| off | `root.write` | 7010.28 | 23.37 |
| off | `root.write durable:false` | 1483.92 | 4.95 |

The opt-out was approximately 6.8× faster in auto and 4.7× faster with native mode off, comparing best samples within each run.
