### PR TITLE
perf: make metadata observations synchronous inside async hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `durable` to Root write/create/writeJson/createJson/append options and Root defaults; `durable: false` skips file and parent fsync for reconstructible data (default unchanged: durable).
+- Run metadata checks inside async operations synchronously (microseconds each), cutting event-loop round-trips per read/write while data I/O remains asynchronous.
 
 ## 0.8.3 - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add `durable` to Root write/create/writeJson/createJson/append options and Root defaults; `durable: false` skips file and parent fsync for reconstructible data (default unchanged: durable).
-- Run metadata checks inside async operations synchronously (microseconds each), cutting event-loop round-trips per read/write while data I/O remains asynchronous.
+- Run metadata checks inside async operations synchronously (microseconds each), cutting event-loop round-trips per read/write while data I/O remains asynchronous and native canonical path spelling is preserved, including Windows short paths.
 
 ## 0.8.3 - 2026-09-06
 

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -12,7 +12,7 @@ const opened = await fs.open("large.log");               // FileHandle for strea
 
 ## What every read does
 
-Identity and containment checks use brief synchronous metadata calls, like Node's module resolution, while file data is read asynchronously.
+Identity and containment checks use brief synchronous metadata calls, like Node's module resolution, while file data is read asynchronously. Canonical paths retain Node's native realpath spelling, including expansion of Windows short paths.
 
 Regardless of shape, every read goes through the same boundary checks:
 

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -12,6 +12,8 @@ const opened = await fs.open("large.log");               // FileHandle for strea
 
 ## What every read does
 
+Identity and containment checks use brief synchronous metadata calls, like Node's module resolution, while file data is read asynchronously.
+
 Regardless of shape, every read goes through the same boundary checks:
 
 1. Resolve the input lexically against the canonical real root.

--- a/scripts/consumer-secret-probe.mjs
+++ b/scripts/consumer-secret-probe.mjs
@@ -1,11 +1,10 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { promisify } from "node:util";
 import { configureFsSafeNative } from "@openclaw/fs-safe/config";
 import { createSecretFileAtomic, writeSecretFileAtomic } from "@openclaw/fs-safe/secret";
 import { fileStore } from "@openclaw/fs-safe/store";
@@ -17,20 +16,22 @@ configureFsSafeNative({ mode });
 const require = createRequire(import.meta.url);
 const expected = JSON.parse(await fs.readFile("expected.json", "utf8"));
 const sandbox = await fs.realpath(await fs.mkdtemp(path.join(process.cwd(), "secret-proof-")));
-const original = { lstat: fs.lstat, realpath: fs.realpath, open: fs.open };
-const exec = promisify(execFile);
+const original = { open: fs.open };
+const originalSync = { lstatSync: fsSync.lstatSync, realpath: fsSync.realpathSync.native };
 const rows = [];
 
-async function identity(target) {
-  const stat = await original.lstat(target, { bigint: true }).catch((error) => {
+function identity(target) {
+  try {
+    const stat = originalSync.lstatSync(target, { bigint: true });
+    return { dev: String(stat.dev), ino: String(stat.ino), directory: stat.isDirectory() };
+  } catch (error) {
     if (error.code === "ENOENT") return null;
     throw error;
-  });
-  return stat ? { dev: String(stat.dev), ino: String(stat.ino), directory: stat.isDirectory() } : null;
+  }
 }
 
-async function replaceDirectory(target, moved) {
-  await exec(process.execPath, ["-e", `
+function replaceDirectory(target, moved) {
+  execFileSync(process.execPath, ["-e", `
     const fs = require('node:fs');
     fs.renameSync(process.argv[1], process.argv[2]);
     fs.mkdirSync(process.argv[1], { mode: 0o700 });
@@ -67,19 +68,19 @@ try {
       let inspections = 0;
       let swapped = false;
       const events = [];
-      fs.lstat = async (...args) => {
-        const stat = await original.lstat(...args);
+      fsSync.lstatSync = (...args) => {
+        const stat = originalSync.lstatSync(...args);
         if (String(args[0]) === target && args[1]?.bigint) inspections++;
         return stat;
       };
-      fs.realpath = async (...args) => {
+      fsSync.realpathSync.native = (...args) => {
         // Replace after initial inspection and exact guard capture, before write admission.
         if (String(args[0]) === target && inspections >= 2 && !swapped) {
-          await replaceDirectory(target, moved);
+          replaceDirectory(target, moved);
           swapped = true;
-          events.push({ event: "replace-directory", before, after: await identity(target) });
+          events.push({ event: "replace-directory", before, after: identity(target) });
         }
-        return await original.realpath(...args);
+        return originalSync.realpath(...args);
       };
       observeOpens(events);
       let failure;
@@ -89,6 +90,8 @@ try {
         failure = { name: error.name, code: error.code };
       } finally {
         Object.assign(fs, original);
+        fsSync.lstatSync = originalSync.lstatSync;
+        fsSync.realpathSync.native = originalSync.realpath;
       }
       assert.ok(swapped, "replacement witness must execute");
       assert.equal(failure?.code, "path-mismatch");
@@ -111,19 +114,19 @@ try {
     let callbacks = 0;
     // Queue-key inspection plus preparation; Windows skips the POSIX mode inspection.
     const admittedAfter = process.platform === "win32" ? 5 : 6;
-    fs.lstat = async (...args) => {
+    fsSync.lstatSync = (...args) => {
       if (scenario !== "stable" && String(args[0]) === parent && inspections >= admittedAfter && !changed) {
         if (scenario === "deletion") {
-          await exec(process.execPath, ["-e", "require('node:fs').rmdirSync(process.argv[1])", parent], {
+          execFileSync(process.execPath, ["-e", "require('node:fs').rmdirSync(process.argv[1])", parent], {
             timeout: 10_000, killSignal: "SIGKILL",
           });
         } else {
-          await replaceDirectory(parent, `${parent}-admitted`);
+          replaceDirectory(parent, `${parent}-admitted`);
         }
         changed = true;
-        events.push({ event: scenario, before, after: await identity(parent) });
+        events.push({ event: scenario, before, after: identity(parent) });
       }
-      const stat = await original.lstat(...args);
+      const stat = originalSync.lstatSync(...args);
       if (String(args[0]) === parent) inspections++;
       return stat;
     };
@@ -139,6 +142,8 @@ try {
       failure = { name: error.name, code: error.code };
     } finally {
       Object.assign(fs, original);
+      fsSync.lstatSync = originalSync.lstatSync;
+      fsSync.realpathSync.native = originalSync.realpath;
     }
     if (scenario === "stable") {
       assert.equal(failure, undefined);
@@ -175,5 +180,7 @@ try {
   }));
 } finally {
   Object.assign(fs, original);
+  fsSync.lstatSync = originalSync.lstatSync;
+  fsSync.realpathSync.native = originalSync.realpath;
   await fs.rm(sandbox, { recursive: true, force: true });
 }

--- a/src/absolute-path.ts
+++ b/src/absolute-path.ts
@@ -346,7 +346,7 @@ export async function canonicalPathFromExistingAncestor(filePath: string): Promi
   }
   let canonicalAncestor = ancestor;
   try {
-    canonicalAncestor = fsSync.realpathSync(ancestor);
+    canonicalAncestor = fsSync.realpathSync.native(ancestor);
   } catch {
     // Keep lexical path when the existing ancestor cannot be canonicalized.
   }
@@ -362,7 +362,7 @@ export async function resolveAbsolutePathForRead(
   const normalized = assertAbsolutePathInput(filePath);
   let canonicalPath: string;
   try {
-    canonicalPath = fsSync.realpathSync(normalized);
+    canonicalPath = fsSync.realpathSync.native(normalized);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new FsSafeError("not-found", "path not found", { cause: err });

--- a/src/absolute-path.ts
+++ b/src/absolute-path.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -141,7 +142,7 @@ async function directoryGuardFailure(
   }
 
   try {
-    const stat = await fs.lstat(dir);
+    const stat = fsSync.lstatSync(dir);
     const failure = classifyExistingDirectorySegment(stat, scopeLabel);
     if (failure) {
       return failure;
@@ -164,7 +165,7 @@ async function resolveTrustedDirectoryPrefix(
   let current = root;
   let currentStat: Stats;
   try {
-    currentStat = await fs.lstat(current);
+    currentStat = fsSync.lstatSync(current);
   } catch (err) {
     const failure = classifyDirectoryLookupError(err, scopeLabel);
     if (failure) {
@@ -189,7 +190,7 @@ async function resolveTrustedDirectoryPrefix(
     }
     const next = path.join(current, segment);
     try {
-      const nextStat = await fs.lstat(next);
+      const nextStat = fsSync.lstatSync(next);
       const segmentFailure = classifyExistingDirectorySegment(nextStat, scopeLabel);
       if (segmentFailure) {
         return segmentFailure;
@@ -240,7 +241,7 @@ async function findExistingAncestorWithStat(filePath: string): Promise<{
   let current = path.resolve(filePath);
   while (true) {
     try {
-      return { path: current, stat: await fs.lstat(current) };
+      return { path: current, stat: fsSync.lstatSync(current) };
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         throw err;
@@ -288,7 +289,7 @@ export async function ensureAbsoluteDirectory(
         return guardResult;
       }
       try {
-        const stat = await fs.lstat(current);
+        const stat = fsSync.lstatSync(current);
         if (stat.isSymbolicLink()) {
           return ensureDirectoryFailure(
             "symlink",
@@ -345,7 +346,7 @@ export async function canonicalPathFromExistingAncestor(filePath: string): Promi
   }
   let canonicalAncestor = ancestor;
   try {
-    canonicalAncestor = await fs.realpath(ancestor);
+    canonicalAncestor = fsSync.realpathSync(ancestor);
   } catch {
     // Keep lexical path when the existing ancestor cannot be canonicalized.
   }
@@ -361,7 +362,7 @@ export async function resolveAbsolutePathForRead(
   const normalized = assertAbsolutePathInput(filePath);
   let canonicalPath: string;
   try {
-    canonicalPath = await fs.realpath(normalized);
+    canonicalPath = fsSync.realpathSync(normalized);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new FsSafeError("not-found", "path not found", { cause: err });

--- a/src/bounded-read.ts
+++ b/src/bounded-read.ts
@@ -41,11 +41,23 @@ function appendChunk(params: {
 async function readBoundedAsync(
   maxBytes: number,
   readChunk: (scratch: Buffer, length: number) => Promise<number>,
+  observeRegularFileSize?: () => number | undefined,
 ): Promise<Buffer> {
   normalizeMaxBytes(maxBytes);
   const chunks: Buffer[] = [];
-  const scratch = createScratchBuffer(maxBytes);
   let total = 0;
+  const size = observeRegularFileSize?.();
+  if (size !== undefined) {
+    const first = Buffer.allocUnsafe(Math.min(maxBytes, size) + 1);
+    const bytesRead = await readChunk(first, first.length);
+    if (bytesRead === 0) return first.subarray(0, 0);
+    // Short reads can occur before EOF. Only accept one when a fresh fd size
+    // observation proves we consumed at least the entire current file size.
+    const currentSize = bytesRead < first.length ? observeRegularFileSize?.() : undefined;
+    if (currentSize !== undefined && bytesRead >= currentSize) return first.subarray(0, bytesRead);
+    total = appendChunk({ chunks, scratch: first, bytesRead, total, maxBytes });
+  }
+  const scratch = createScratchBuffer(maxBytes);
   while (true) {
     const length = nextReadLength(total, maxBytes, scratch.length);
     const bytesRead = await readChunk(scratch, length);
@@ -65,9 +77,22 @@ export async function readFileHandleBounded(
   handle: ReadableFileHandle,
   maxBytes: number,
 ): Promise<Buffer> {
+  normalizeMaxBytes(maxBytes);
+  const fd = "fd" in handle && typeof handle.fd === "number" ? handle.fd : undefined;
   return await readBoundedAsync(maxBytes, async (scratch, length) => {
     return (await handle.read(scratch, 0, length, null)).bytesRead;
-  });
+  }, fd === undefined ? undefined : () => regularFileSize(fd));
+}
+
+function regularFileSize(fd: number): number | undefined {
+  try {
+    const stat = fs.fstatSync(fd);
+    return stat.isFile() && Number.isSafeInteger(stat.size) && stat.size >= 0
+      ? stat.size : undefined;
+  } catch {
+    // Size is only an optimization hint; retain the reader's original errors.
+    return undefined;
+  }
 }
 
 function readDescriptorChunk(fd: number, scratch: Buffer, length: number): Promise<number> {
@@ -84,9 +109,10 @@ function readDescriptorChunk(fd: number, scratch: Buffer, length: number): Promi
 
 /** Async bounded read from a numeric descriptor. The caller owns the descriptor. */
 export async function readFileDescriptorBounded(fd: number, maxBytes: number): Promise<Buffer> {
+  normalizeMaxBytes(maxBytes);
   return await readBoundedAsync(maxBytes, async (scratch, length) => {
     return await readDescriptorChunk(fd, scratch, length);
-  });
+  }, () => regularFileSize(fd));
 }
 
 /** Sync bounded read from a numeric descriptor. The caller owns the descriptor. */

--- a/src/directory-durability.ts
+++ b/src/directory-durability.ts
@@ -87,7 +87,7 @@ async function createDirectoryReceipt(directoryPath: string, label: string): Pro
   assertDirectory(identity, resolvedPath, label);
   return {
     path: resolvedPath,
-    realPath: fsSync.realpathSync(resolvedPath),
+    realPath: fsSync.realpathSync.native(resolvedPath),
     identity,
   };
 }
@@ -111,7 +111,7 @@ async function assertDirectoryReceiptCurrent(
   assertDirectory(currentIdentity, receipt.path, label);
   if (
     !sameFileIdentity(receipt.identity, currentIdentity) ||
-    (fsSync.realpathSync(receipt.path)) !== receipt.realPath
+    (fsSync.realpathSync.native(receipt.path)) !== receipt.realPath
   ) {
     throw new FsSafeError(
       "path-mismatch",

--- a/src/directory-durability.ts
+++ b/src/directory-durability.ts
@@ -83,11 +83,11 @@ function assertDirectory(identity: Stats, pathname: string, label: string): void
 
 async function createDirectoryReceipt(directoryPath: string, label: string): Promise<DirectoryReceipt> {
   const resolvedPath = path.resolve(directoryPath);
-  const identity = await fs.lstat(resolvedPath);
+  const identity = fsSync.lstatSync(resolvedPath);
   assertDirectory(identity, resolvedPath, label);
   return {
     path: resolvedPath,
-    realPath: await fs.realpath(resolvedPath),
+    realPath: fsSync.realpathSync(resolvedPath),
     identity,
   };
 }
@@ -107,11 +107,11 @@ async function assertDirectoryReceiptCurrent(
   receipt: DirectoryReceipt,
   label: string,
 ): Promise<void> {
-  const currentIdentity = await fs.lstat(receipt.path);
+  const currentIdentity = fsSync.lstatSync(receipt.path);
   assertDirectory(currentIdentity, receipt.path, label);
   if (
     !sameFileIdentity(receipt.identity, currentIdentity) ||
-    (await fs.realpath(receipt.path)) !== receipt.realPath
+    (fsSync.realpathSync(receipt.path)) !== receipt.realPath
   ) {
     throw new FsSafeError(
       "path-mismatch",
@@ -139,7 +139,7 @@ async function assertOpenDirectoryCurrent(
   receipt: DirectoryReceipt,
   label: string,
 ): Promise<void> {
-  const openedIdentity = await handle.stat();
+  const openedIdentity = fsSync.fstatSync(handle.fd);
   assertDirectory(openedIdentity, receipt.path, label);
   if (!sameFileIdentity(receipt.identity, openedIdentity)) {
     throw new FsSafeError(

--- a/src/directory-guard.ts
+++ b/src/directory-guard.ts
@@ -29,7 +29,7 @@ export async function createAsyncDirectoryGuard(dir: string, options?: { bigint?
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw directoryComponentNotDirectoryError();
   }
-  return { dir, realPath: fsSync.realpathSync(dir), stat };
+  return { dir, realPath: fsSync.realpathSync.native(dir), stat };
 }
 
 export async function assertAsyncDirectoryGuard(guard: AnyAsyncDirectoryGuard): Promise<void> {
@@ -39,7 +39,7 @@ export async function assertAsyncDirectoryGuard(guard: AnyAsyncDirectoryGuard): 
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw directoryComponentNotDirectoryError();
   }
-  if (!sameFileIdentity(stat, guard.stat) || fsSync.realpathSync(guard.dir) !== guard.realPath) {
+  if (!sameFileIdentity(stat, guard.stat) || fsSync.realpathSync.native(guard.dir) !== guard.realPath) {
     throw new FsSafeError("path-mismatch", "directory changed during operation");
   }
 }

--- a/src/directory-guard.ts
+++ b/src/directory-guard.ts
@@ -1,6 +1,5 @@
 import type { BigIntStats, Stats } from "node:fs";
 import fsSync from "node:fs";
-import fs from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
@@ -26,21 +25,21 @@ export function createAsyncDirectoryGuard(dir: string, options: { bigint: true }
 export function createAsyncDirectoryGuard(dir: string, options?: { bigint?: false }): Promise<AsyncDirectoryGuard>;
 export function createAsyncDirectoryGuard(dir: string, options: { bigint: boolean }): Promise<AnyAsyncDirectoryGuard>;
 export async function createAsyncDirectoryGuard(dir: string, options?: { bigint?: boolean }): Promise<AnyAsyncDirectoryGuard> {
-  const stat = options?.bigint ? await inspectDirectoryIdentity(dir) : await fs.lstat(dir);
+  const stat = options?.bigint ? await inspectDirectoryIdentity(dir) : fsSync.lstatSync(dir);
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw directoryComponentNotDirectoryError();
   }
-  return { dir, realPath: await fs.realpath(dir), stat };
+  return { dir, realPath: fsSync.realpathSync(dir), stat };
 }
 
 export async function assertAsyncDirectoryGuard(guard: AnyAsyncDirectoryGuard): Promise<void> {
   const stat = typeof guard.stat.dev === "bigint" && typeof guard.stat.ino === "bigint"
     ? await inspectDirectoryIdentity(guard.dir, { dev: guard.stat.dev, ino: guard.stat.ino })
-    : await fs.lstat(guard.dir);
+    : fsSync.lstatSync(guard.dir);
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw directoryComponentNotDirectoryError();
   }
-  if (!sameFileIdentity(stat, guard.stat) || (await fs.realpath(guard.dir)) !== guard.realPath) {
+  if (!sameFileIdentity(stat, guard.stat) || fsSync.realpathSync(guard.dir) !== guard.realPath) {
     throw new FsSafeError("path-mismatch", "directory changed during operation");
   }
 }
@@ -107,7 +106,7 @@ export function createNearestExistingSyncDirectoryGuard(
 // Recovery receipts must retain every identity bit, including on Windows.
 export async function inspectDirectoryIdentity(dir: string, expected?: Pick<BigIntStats, "dev" | "ino">): Promise<BigIntStats> {
   return await inspectFileIdentity(async () => {
-    const stat = await fs.lstat(dir, { bigint: true });
+    const stat = fsSync.lstatSync(dir, { bigint: true });
     if (stat.isSymbolicLink() || !stat.isDirectory()) throw directoryComponentNotDirectoryError();
     return stat;
   }, expected);

--- a/src/file-store-boundary.ts
+++ b/src/file-store-boundary.ts
@@ -76,7 +76,7 @@ async function chmodDirectoryInRootBestEffort(
       : 0;
   const handle = await fs.open(dirPath, syncFs.constants.O_RDONLY | directoryFlag | noFollowFlag);
   try {
-    const stat = await handle.stat();
+    const stat = syncFs.fstatSync(handle.fd);
     if (!stat.isDirectory()) {
       return;
     }

--- a/src/file-store-prune.ts
+++ b/src/file-store-prune.ts
@@ -24,7 +24,7 @@ export async function pruneExpiredStoreEntries(params: {
   const pruneEmptyDirs =
     (recursive || maxDepth !== undefined) && (params.options.pruneEmptyDirs ?? false);
   await fs.mkdir(params.rootDir, { recursive: true, mode: params.dirMode });
-  const rootReal = fsSync.realpathSync(params.rootDir);
+  const rootReal = fsSync.realpathSync.native(params.rootDir);
   const scopedRoot = await root(rootReal);
   const rootGuard = {
     dir: rootReal,
@@ -39,7 +39,7 @@ export async function pruneExpiredStoreEntries(params: {
       !stat.isDirectory() ||
       stat.dev !== rootGuard.stat.dev ||
       stat.ino !== rootGuard.stat.ino ||
-      fsSync.realpathSync(rootGuard.dir) !== rootGuard.realPath
+      fsSync.realpathSync.native(rootGuard.dir) !== rootGuard.realPath
     ) {
       throw new FsSafeError("path-mismatch", "store root changed during prune");
     }
@@ -50,7 +50,7 @@ export async function pruneExpiredStoreEntries(params: {
     if (!before || before.isSymbolicLink() || !before.isDirectory()) {
       return null;
     }
-    const real = observeOrNull(() => fsSync.realpathSync(dir));
+    const real = observeOrNull(() => fsSync.realpathSync.native(dir));
     if (!real || !isPathInside(rootReal, real)) {
       return null;
     }

--- a/src/file-store-prune.ts
+++ b/src/file-store-prune.ts
@@ -1,4 +1,4 @@
-import type { Dirent } from "node:fs";
+import fsSync, { type Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
@@ -24,33 +24,33 @@ export async function pruneExpiredStoreEntries(params: {
   const pruneEmptyDirs =
     (recursive || maxDepth !== undefined) && (params.options.pruneEmptyDirs ?? false);
   await fs.mkdir(params.rootDir, { recursive: true, mode: params.dirMode });
-  const rootReal = await fs.realpath(params.rootDir);
+  const rootReal = fsSync.realpathSync(params.rootDir);
   const scopedRoot = await root(rootReal);
   const rootGuard = {
     dir: rootReal,
     realPath: rootReal,
-    stat: await fs.lstat(rootReal),
+    stat: fsSync.lstatSync(rootReal),
   };
 
   async function assertRootGuard(): Promise<void> {
-    const stat = await fs.lstat(rootGuard.dir);
+    const stat = fsSync.lstatSync(rootGuard.dir);
     if (
       stat.isSymbolicLink() ||
       !stat.isDirectory() ||
       stat.dev !== rootGuard.stat.dev ||
       stat.ino !== rootGuard.stat.ino ||
-      (await fs.realpath(rootGuard.dir)) !== rootGuard.realPath
+      fsSync.realpathSync(rootGuard.dir) !== rootGuard.realPath
     ) {
       throw new FsSafeError("path-mismatch", "store root changed during prune");
     }
   }
 
   async function readStableDirectory(dir: string): Promise<Dirent[] | null> {
-    const before = await fs.lstat(dir).catch(() => null);
+    const before = observeOrNull(() => fsSync.lstatSync(dir));
     if (!before || before.isSymbolicLink() || !before.isDirectory()) {
       return null;
     }
-    const real = await fs.realpath(dir).catch(() => null);
+    const real = observeOrNull(() => fsSync.realpathSync(dir));
     if (!real || !isPathInside(rootReal, real)) {
       return null;
     }
@@ -58,7 +58,7 @@ export async function pruneExpiredStoreEntries(params: {
     if (!entries) {
       return null;
     }
-    const after = await fs.lstat(dir).catch(() => null);
+    const after = observeOrNull(() => fsSync.lstatSync(dir));
     if (!after || before.dev !== after.dev || before.ino !== after.ino) {
       return null;
     }
@@ -73,7 +73,7 @@ export async function pruneExpiredStoreEntries(params: {
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
       const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
-      const stat = await fs.lstat(fullPath).catch(() => null);
+      const stat = observeOrNull(() => fsSync.lstatSync(fullPath));
       if (!stat || stat.isSymbolicLink()) {
         continue;
       }
@@ -103,4 +103,8 @@ export async function pruneExpiredStoreEntries(params: {
   }
 
   await pruneDir(rootReal, "", 0);
+}
+
+function observeOrNull<T>(observe: () => T): T | null {
+  try { return observe(); } catch { return null; }
 }

--- a/src/file-store.ts
+++ b/src/file-store.ts
@@ -162,7 +162,7 @@ async function readFileStoreCopySource(params: {
   sourcePath: string;
   maxBytes?: number;
 }): Promise<Buffer> {
-  const sourceStat = await fs.lstat(params.sourcePath);
+  const sourceStat = syncFs.lstatSync(params.sourcePath);
   if (sourceStat.isSymbolicLink() || !sourceStat.isFile()) {
     throw new FsSafeError("not-file", "source path is not a file");
   }
@@ -197,7 +197,7 @@ async function copyIntoRoot(params: {
 }): Promise<string> {
   const relativePath = assertRelativePath(params.relativePath);
   const destination = resolveStorePath(params.rootDir, relativePath);
-  const sourceStat = await fs.lstat(params.sourcePath);
+  const sourceStat = syncFs.lstatSync(params.sourcePath);
   if (sourceStat.isSymbolicLink() || !sourceStat.isFile()) {
     throw new FsSafeError("not-file", "source path is not a file");
   }

--- a/src/guarded-mkdir.ts
+++ b/src/guarded-mkdir.ts
@@ -13,7 +13,7 @@ function isSameOrChildPath(candidate: string, parent: string): boolean {
 
 async function realpathOrThrowNotFile(target: string): Promise<string> {
   try {
-    return path.resolve(fsSync.realpathSync(target));
+    return path.resolve(fsSync.realpathSync.native(target));
   } catch (error) {
     if (isNotFoundPathError(error)) {
       // A dangling symlink (or a component removed between lstat and
@@ -38,7 +38,7 @@ export async function mkdirPathComponentsWithGuards(params: {
   rejectSymlinks?: boolean;
 }): Promise<string> {
   const root = path.resolve(params.rootReal);
-  const rootCanonical = path.resolve(fsSync.realpathSync(root));
+  const rootCanonical = path.resolve(fsSync.realpathSync.native(root));
   const target = path.resolve(params.targetPath);
   const relative = path.relative(root, target);
   if (isPathRelativeEscape(relative)) {

--- a/src/guarded-mkdir.ts
+++ b/src/guarded-mkdir.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard } from "./directory-guard.js";
@@ -12,7 +13,7 @@ function isSameOrChildPath(candidate: string, parent: string): boolean {
 
 async function realpathOrThrowNotFile(target: string): Promise<string> {
   try {
-    return path.resolve(await fs.realpath(target));
+    return path.resolve(fsSync.realpathSync(target));
   } catch (error) {
     if (isNotFoundPathError(error)) {
       // A dangling symlink (or a component removed between lstat and
@@ -37,7 +38,7 @@ export async function mkdirPathComponentsWithGuards(params: {
   rejectSymlinks?: boolean;
 }): Promise<string> {
   const root = path.resolve(params.rootReal);
-  const rootCanonical = path.resolve(await fs.realpath(root));
+  const rootCanonical = path.resolve(fsSync.realpathSync(root));
   const target = path.resolve(params.targetPath);
   const relative = path.relative(root, target);
   if (isPathRelativeEscape(relative)) {
@@ -56,7 +57,7 @@ export async function mkdirPathComponentsWithGuards(params: {
         throw error;
       }
     }
-    const stat = await fs.lstat(next);
+    const stat = fsSync.lstatSync(next);
     if ((params.rejectSymlinks && stat.isSymbolicLink()) || (!stat.isSymbolicLink() && !stat.isDirectory())) {
       throw directoryComponentNotDirectoryError();
     }
@@ -76,7 +77,7 @@ export async function mkdirPathComponentsWithGuards(params: {
       // every subsequent segment. Callers that need the final directory
       // (e.g. to guard it themselves after this function returns) must use
       // the returned resolved path, not their own lexical parent path.
-      const targetStat = await fs.stat(nextReal);
+      const targetStat = fsSync.statSync(nextReal);
       if (!targetStat.isDirectory()) {
         throw directoryComponentNotDirectoryError();
       }

--- a/src/native-pinned-write.ts
+++ b/src/native-pinned-write.ts
@@ -55,7 +55,7 @@ export async function runPinnedWriteNative(binding: NativeBinding, params: Pinne
       params.relativeParentPath,
       directoryFlags,
     ).fd;
-    const parentPath = fsSync.realpathSync(
+    const parentPath = fsSync.realpathSync.native(
       params.relativeParentPath
         ? path.join(params.rootPath, ...params.relativeParentPath.split("/"))
         : params.rootPath,

--- a/src/native-pinned-write.ts
+++ b/src/native-pinned-write.ts
@@ -55,7 +55,7 @@ export async function runPinnedWriteNative(binding: NativeBinding, params: Pinne
       params.relativeParentPath,
       directoryFlags,
     ).fd;
-    const parentPath = await fs.realpath(
+    const parentPath = fsSync.realpathSync(
       params.relativeParentPath
         ? path.join(params.rootPath, ...params.relativeParentPath.split("/"))
         : params.rootPath,
@@ -63,7 +63,7 @@ export async function runPinnedWriteNative(binding: NativeBinding, params: Pinne
     const directory = windows ? undefined : describeStagedDirectory(parentFd, parentPath);
     const parentPathStat = exactRoot
       ? await inspectDirectoryIdentity(parentPath, inspectFileIdentitySync(() => fsSync.fstatSync(parentFd!, { bigint: true })))
-      : await fs.lstat(parentPath);
+      : fsSync.lstatSync(parentPath);
     if (windows && !exactRoot) {
       const parentIdentity = binding.fstatIdentity(parentFd);
       if (parentPathStat.isSymbolicLink() || !sameNativeIdentity(parentPathStat, parentIdentity)) {
@@ -75,7 +75,7 @@ export async function runPinnedWriteNative(binding: NativeBinding, params: Pinne
     const verificationGuard = { dir: parentPath, realPath: parentPath, stat: parentPathStat };
     if (params.overwrite === false) {
       try {
-        await fs.lstat(path.join(parentPath, params.basename));
+        fsSync.lstatSync(path.join(parentPath, params.basename));
         throw Object.assign(new Error("destination already exists"), { code: "EEXIST" });
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") {

--- a/src/opened-realpath.ts
+++ b/src/opened-realpath.ts
@@ -38,7 +38,7 @@ export async function resolveOpenedFileRealPathForFd(
       : [];
   for (const fdPath of fdCandidates) {
     try {
-      const fdRealPath = fsSync.realpathSync(fdPath);
+      const fdRealPath = fsSync.realpathSync.native(fdPath);
       const fdRealStat = statOptions ? fsSync.statSync(fdRealPath, statOptions) : fsSync.statSync(fdRealPath);
       if (sameFileIdentity(handleStat, fdRealStat)) {
         return { realPath: fdRealPath, stat: fdRealStat };
@@ -49,7 +49,7 @@ export async function resolveOpenedFileRealPathForFd(
   }
 
   try {
-    const ioRealPath = fsSync.realpathSync(ioPath);
+    const ioRealPath = fsSync.realpathSync.native(ioPath);
     const ioRealStat = statOptions ? fsSync.statSync(ioRealPath, statOptions) : fsSync.statSync(ioRealPath);
     if (sameFileIdentity(handleStat, ioRealStat)) {
       return { realPath: ioRealPath, stat: ioRealStat };
@@ -79,7 +79,7 @@ async function resolveOpenedFileRealPathFromParent(
 ): Promise<{ realPath: string; stat: Stats | BigIntStats } | null> {
   let parentReal: string;
   try {
-    parentReal = fsSync.realpathSync(path.dirname(ioPath));
+    parentReal = fsSync.realpathSync.native(path.dirname(ioPath));
   } catch (err) {
     if (isNotFoundPathError(err)) {
       return null;
@@ -102,7 +102,7 @@ async function resolveOpenedFileRealPathFromParent(
     try {
       const candidateStat = statOptions ? fsSync.lstatSync(candidatePath, statOptions) : fsSync.lstatSync(candidatePath);
       if (candidateStat.isFile() && sameFileIdentity(handleStat, candidateStat)) {
-        const realPath = fsSync.realpathSync(candidatePath);
+        const realPath = fsSync.realpathSync.native(candidatePath);
         const stat = statOptions ? fsSync.statSync(realPath, statOptions) : fsSync.statSync(realPath);
         if (sameFileIdentity(handleStat, stat)) return { realPath, stat };
       }

--- a/src/opened-realpath.ts
+++ b/src/opened-realpath.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import type { BigIntStats, Stats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
@@ -10,7 +11,7 @@ export async function resolveOpenedFileRealPathForHandle(
   handle: FileHandle,
   ioPath: string,
 ): Promise<string> {
-  const handleStat = await handle.stat();
+  const handleStat = fsSync.fstatSync(handle.fd);
   return (await resolveOpenedFileRealPathForFd(handle.fd, handleStat, ioPath)).realPath;
 }
 
@@ -37,8 +38,8 @@ export async function resolveOpenedFileRealPathForFd(
       : [];
   for (const fdPath of fdCandidates) {
     try {
-      const fdRealPath = await fs.realpath(fdPath);
-      const fdRealStat = statOptions ? await fs.stat(fdRealPath, statOptions) : await fs.stat(fdRealPath);
+      const fdRealPath = fsSync.realpathSync(fdPath);
+      const fdRealStat = statOptions ? fsSync.statSync(fdRealPath, statOptions) : fsSync.statSync(fdRealPath);
       if (sameFileIdentity(handleStat, fdRealStat)) {
         return { realPath: fdRealPath, stat: fdRealStat };
       }
@@ -48,8 +49,8 @@ export async function resolveOpenedFileRealPathForFd(
   }
 
   try {
-    const ioRealPath = await fs.realpath(ioPath);
-    const ioRealStat = statOptions ? await fs.stat(ioRealPath, statOptions) : await fs.stat(ioRealPath);
+    const ioRealPath = fsSync.realpathSync(ioPath);
+    const ioRealStat = statOptions ? fsSync.statSync(ioRealPath, statOptions) : fsSync.statSync(ioRealPath);
     if (sameFileIdentity(handleStat, ioRealStat)) {
       return { realPath: ioRealPath, stat: ioRealStat };
     }
@@ -78,7 +79,7 @@ async function resolveOpenedFileRealPathFromParent(
 ): Promise<{ realPath: string; stat: Stats | BigIntStats } | null> {
   let parentReal: string;
   try {
-    parentReal = await fs.realpath(path.dirname(ioPath));
+    parentReal = fsSync.realpathSync(path.dirname(ioPath));
   } catch (err) {
     if (isNotFoundPathError(err)) {
       return null;
@@ -99,10 +100,10 @@ async function resolveOpenedFileRealPathFromParent(
   for (const entry of entries.toSorted()) {
     const candidatePath = path.join(parentReal, entry);
     try {
-      const candidateStat = statOptions ? await fs.lstat(candidatePath, statOptions) : await fs.lstat(candidatePath);
+      const candidateStat = statOptions ? fsSync.lstatSync(candidatePath, statOptions) : fsSync.lstatSync(candidatePath);
       if (candidateStat.isFile() && sameFileIdentity(handleStat, candidateStat)) {
-        const realPath = await fs.realpath(candidatePath);
-        const stat = statOptions ? await fs.stat(realPath, statOptions) : await fs.stat(realPath);
+        const realPath = fsSync.realpathSync(candidatePath);
+        const stat = statOptions ? fsSync.statSync(realPath, statOptions) : fsSync.statSync(realPath);
         if (sameFileIdentity(handleStat, stat)) return { realPath, stat };
       }
     } catch (err) {

--- a/src/path-policy.ts
+++ b/src/path-policy.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
 import {
   ROOT_PATH_ALIAS_POLICIES,
   resolveRootPath,
@@ -44,9 +44,9 @@ export async function assertNoHardlinkedFinalPath(params: {
   if (params.allowFinalHardlinkForUnlink) {
     return;
   }
-  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  let stat: fs.Stats;
   try {
-    stat = await fs.stat(params.filePath);
+    stat = fs.statSync(params.filePath);
   } catch (err) {
     if (isNotFoundPathError(err)) {
       return;

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -197,7 +197,7 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
     let created = true;
     let createdIdentity: BigIntStats | undefined;
     try {
-      const verificationIdentity = await handle.stat({ bigint: true });
+      const verificationIdentity = fsSync.fstatSync(handle.fd, { bigint: true });
       createdIdentity = verificationIdentity;
       if (params.input.kind === "buffer") {
         assertWithinMaxBytes(
@@ -215,7 +215,7 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
       // Content writes may clear set-ID bits; finalize them through the owned fd.
       await handle.chmod(params.mode);
       if (params.sync !== false) await syncFileBestEffort(handle);
-      const stat = await handle.stat();
+      const stat = fsSync.fstatSync(handle.fd);
       if (params.sync !== false) await syncDirectoryBestEffort(parentPath);
       // Publication is complete. A failed outer check must not remove its target.
       created = false;
@@ -248,7 +248,7 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
   let renamed = false;
   try {
     handle = await fs.open(tempPath, tempFlags, params.mode);
-    let verificationIdentity = await handle.stat({ bigint: true });
+    let verificationIdentity = fsSync.fstatSync(handle.fd, { bigint: true });
     tempIdentity = verificationIdentity;
     if (params.input.kind === "buffer") {
       assertWithinMaxBytes(
@@ -263,8 +263,8 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
     } else {
       await writeStreamToHandle(params.input.stream, handle, params.maxBytes);
     }
-    tempStat = await handle.stat();
-    const tempPathStat = await fs.lstat(tempPath);
+    tempStat = fsSync.fstatSync(handle.fd);
+    const tempPathStat = fsSync.lstatSync(tempPath);
     if (tempPathStat.isSymbolicLink() || !sameFileIdentity(tempPathStat, tempStat)) {
       throw new FsSafeError("path-mismatch", "fallback temp path changed during write");
     }
@@ -277,7 +277,7 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
       renamed = true;
       await getFsSafeTestHooks()?.afterPinnedWriteFallbackRename?.(targetPath);
       if (params.sync !== false) await syncDirectoryBestEffort(parentPath);
-      const targetStat = await fs.lstat(targetPath);
+      const targetStat = fsSync.lstatSync(targetPath);
       if (targetStat.isSymbolicLink()) {
         throw new FsSafeError("path-mismatch", "fallback target changed during write");
       }
@@ -294,7 +294,7 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
         }
         const expectedHash = sha256Hex(params.input.data, params.input.encoding);
         readHandle = await fs.open(targetPath, resolveReadOpenFlags());
-        const readHandleStat = await readHandle.stat({ bigint: true });
+        const readHandleStat = fsSync.fstatSync(readHandle.fd, { bigint: true });
         const actualHash = sha256Hex(await readHandle.readFile());
         if (actualHash !== expectedHash) {
           throw new FsSafeError("path-mismatch", "fallback target changed during write");

--- a/src/regular-file.ts
+++ b/src/regular-file.ts
@@ -62,7 +62,7 @@ function translateBoundedReadOverflow(error: unknown, filePath: string, maxBytes
 export async function statRegularFile(filePath: string): Promise<RegularFileStatResult> {
   let stat: Stats;
   try {
-    stat = await fs.lstat(filePath);
+    stat = fsSync.lstatSync(filePath);
   } catch (err) {
     if (isNotFoundPathError(err)) {
       return { missing: true };
@@ -98,7 +98,7 @@ export async function readRegularFile(params: {
   const maxBytes = normalizeMaxBytes(params.maxBytes);
   assertNoUnsafeDeviceReadPath(params.filePath);
   const before = await inspectFileIdentity(async () => {
-    const stat = await fs.lstat(params.filePath, { bigint: true });
+    const stat = fsSync.lstatSync(params.filePath, { bigint: true });
     assertRegularReadStat(stat, params.filePath, true);
     return stat;
   }).catch((error) => throwReadPreviewError(error, params.filePath));
@@ -116,15 +116,15 @@ export async function readRegularFile(params: {
     throw err;
   }
   try {
-    const stat = await handle.stat();
+    const stat = fsSync.fstatSync(handle.fd);
     const identity = await inspectFileIdentity(async () => {
-      const exact = await handle.stat({ bigint: true });
+      const exact = fsSync.fstatSync(handle.fd, { bigint: true });
       assertRegularReadStat(exact, params.filePath);
       return exact;
     }, before);
     try {
       await inspectFileIdentity(async () => {
-        const current = await fs.lstat(params.filePath, { bigint: true });
+        const current = fsSync.lstatSync(params.filePath, { bigint: true });
         assertRegularReadStat(current, params.filePath);
         return current;
       }, identity);
@@ -288,7 +288,7 @@ export async function appendRegularFile(options: AppendRegularFileOptions): Prom
   let preOpenStat: BigIntStats | undefined;
   try {
     preOpenStat = await inspectFileIdentity(async () => {
-      const stat = await fs.lstat(options.filePath, { bigint: true });
+      const stat = fsSync.lstatSync(options.filePath, { bigint: true });
       if (stat.isSymbolicLink()) {
         throw new Error(`Refusing to append through symlink: ${options.filePath}`);
       }
@@ -326,12 +326,12 @@ export async function appendRegularFile(options: AppendRegularFileOptions): Prom
     let identity: BigIntStats;
     try {
       identity = await inspectFileIdentity(async () => {
-        const stat = await handle.stat({ bigint: true });
+        const stat = fsSync.fstatSync(handle.fd, { bigint: true });
         assertRegularAppendStat(stat, options.filePath);
         return stat;
       }, preOpenStat);
       await inspectFileIdentity(async () => {
-        const current = await fs.lstat(options.filePath, { bigint: true });
+        const current = fsSync.lstatSync(options.filePath, { bigint: true });
         assertRegularAppendStat(current, options.filePath);
         return current;
       }, identity);

--- a/src/replace-file-descriptor.ts
+++ b/src/replace-file-descriptor.ts
@@ -88,13 +88,14 @@ export async function pinDirectoryForMode(params: {
     return;
   }
 
-  const expected = await params.fsModule.lstat(params.dirPath);
+  const expected = params.fsModule === fs
+    ? syncFs.lstatSync(params.dirPath) : await params.fsModule.lstat(params.dirPath);
   assertDirectory(expected, params.dirPath);
   const handle = await params.fsModule.open(params.dirPath, directoryOpenFlags());
   try {
     const owner = ownDirectoryMode({
       async inspect() {
-        const opened = await handle.stat();
+        const opened = params.fsModule === fs ? syncFs.fstatSync(handle.fd) : await handle.stat();
         assertOwnedDirectory(expected, opened);
         return opened.mode & 0o7777;
       },
@@ -156,14 +157,17 @@ export async function writeTempFile(params: {
 }): Promise<{ handle: FileHandle; identity: BigIntStats }> {
   const handle = await params.fsModule.open(params.tempPath, "wx", params.mode);
   try {
-    const identity = await inspectFileIdentity(() => handle.stat({ bigint: true }));
+    // Custom adapters retain their async-only metadata contract.
+    const inspect = () => params.fsModule === fs
+      ? syncFs.fstatSync(handle.fd, { bigint: true }) : handle.stat({ bigint: true });
+    const identity = await inspectFileIdentity(inspect);
     params.onIdentity?.(identity);
     await params.fsModule.writeFile(handle, params.content);
     await handle.chmod(params.mode);
     if (params.sync) {
       await syncFileBestEffort(handle);
     }
-    await inspectFileIdentity(() => handle.stat({ bigint: true }), identity);
+    await inspectFileIdentity(inspect, identity);
     return { handle, identity };
   } catch (error) {
     try {

--- a/src/replace-file-temp-owner.ts
+++ b/src/replace-file-temp-owner.ts
@@ -52,7 +52,9 @@ async function cleanupOwnedPath(params: {
 }): Promise<boolean> {
   if (!params.identity) return true;
   try {
-    const current = await params.fsModule.lstat(params.pathname, { bigint: true });
+    const current = params.fsModule === fs
+      ? syncFs.lstatSync(params.pathname, { bigint: true })
+      : await params.fsModule.lstat(params.pathname, { bigint: true });
     if (
       current.isSymbolicLink() ||
       !current.isFile() ||
@@ -86,10 +88,10 @@ export async function cleanupPinnedFilePath(params: {
       (value) => typeof value === "number" && !Number.isSafeInteger(value),
     )) return;
     await assertAsyncDirectoryGuard(guard);
-    const parent = await fs.lstat(guard.dir, { bigint: true });
+    const parent = syncFs.lstatSync(guard.dir, { bigint: true });
     if (parent.isSymbolicLink() || !parent.isDirectory() ||
       !sameFileIdentityForCleanup(parent, guard.stat)) return;
-    const opened = await params.handle.stat({ bigint: true });
+    const opened = syncFs.fstatSync(params.handle.fd, { bigint: true });
     if (!opened.isFile() || opened.nlink !== 1n ||
       !sameFileIdentityForCleanup(opened, params.identity)) return;
     await cleanupOwnedPath({
@@ -165,13 +167,15 @@ export class AsyncAtomicTempOwner {
 
   async assertCurrent(fsModule: AsyncOwnerFileSystem, pathname = this.pathname): Promise<void> {
     const opened = await inspectFileIdentity(async () => {
-      const stat = await this.#handle!.stat({ bigint: true });
+      const stat = fsModule === fs ? syncFs.fstatSync(this.#handle!.fd, { bigint: true })
+        : await this.#handle!.stat({ bigint: true });
       assertOwnedFile(stat, pathname, false);
       return stat;
     }, this.identity);
     try {
       await inspectFileIdentity(async () => {
-        const stat = await fsModule.lstat(pathname, { bigint: true });
+        const stat = fsModule === fs ? syncFs.lstatSync(pathname, { bigint: true })
+          : await fsModule.lstat(pathname, { bigint: true });
         assertOwnedFile(stat, pathname, true);
         return stat;
       }, opened);
@@ -210,12 +214,14 @@ export class AsyncAtomicTempOwner {
         throw error;
       }
       const identity = await inspectFileIdentity(async () => {
-        const stat = await published!.stat({ bigint: true });
+        const stat = fsModule === fs ? syncFs.fstatSync(published!.fd, { bigint: true })
+          : await published!.stat({ bigint: true });
         assertOwnedFile(stat, pathname, false);
         return stat;
       });
       await inspectFileIdentity(async () => {
-        const stat = await fsModule.lstat(pathname, { bigint: true });
+        const stat = fsModule === fs ? syncFs.lstatSync(pathname, { bigint: true })
+          : await fsModule.lstat(pathname, { bigint: true });
         assertOwnedFile(stat, pathname, true);
         return stat;
       }, identity);

--- a/src/root-context.ts
+++ b/src/root-context.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { inspectDirectoryIdentity } from "./directory-guard.js";
@@ -44,7 +44,7 @@ export async function expandRelativePathWithHome(relativePath: string): Promise<
   if (cachedHomePath?.raw !== rawHome) {
     let realHome = rawHome;
     try {
-      realHome = await fs.realpath(rawHome);
+      realHome = fs.realpathSync(rawHome);
     } catch {
       // If the home dir cannot be canonicalized, keep lexical expansion behavior.
     }
@@ -58,8 +58,8 @@ export async function resolveRootContext(rootDir: string): Promise<RootContext> 
   let rootReal: string;
   let rootIdentity: { dev: number; ino: number };
   try {
-    rootReal = await fs.realpath(rootDir);
-    const rootStat = await fs.stat(rootReal);
+    rootReal = fs.realpathSync(rootDir);
+    const rootStat = fs.statSync(rootReal);
     if (!rootStat.isDirectory()) {
       throw new FsSafeError("invalid-path", "root dir is not a directory");
     }
@@ -99,13 +99,13 @@ export function rootRelativeReadPath(root: RootContext, filePath: string): strin
 }
 
 export async function assertRootIdentityCurrent(root: RootContext): Promise<void> {
-  let current: Awaited<ReturnType<typeof fs.lstat>>;
+  let current: fs.Stats;
   try {
     if (typeof root.rootIdentity.dev === "bigint" && typeof root.rootIdentity.ino === "bigint") {
       await inspectDirectoryIdentity(root.rootReal, { dev: root.rootIdentity.dev, ino: root.rootIdentity.ino });
       return;
     }
-    current = await fs.lstat(root.rootReal);
+    current = fs.lstatSync(root.rootReal);
   } catch (error) {
     throw new FsSafeError("path-mismatch", "root path changed during operation", {
       cause: error instanceof Error ? error : undefined,

--- a/src/root-context.ts
+++ b/src/root-context.ts
@@ -44,7 +44,7 @@ export async function expandRelativePathWithHome(relativePath: string): Promise<
   if (cachedHomePath?.raw !== rawHome) {
     let realHome = rawHome;
     try {
-      realHome = fs.realpathSync(rawHome);
+      realHome = fs.realpathSync.native(rawHome);
     } catch {
       // If the home dir cannot be canonicalized, keep lexical expansion behavior.
     }
@@ -58,7 +58,7 @@ export async function resolveRootContext(rootDir: string): Promise<RootContext> 
   let rootReal: string;
   let rootIdentity: { dev: number; ino: number };
   try {
-    rootReal = fs.realpathSync(rootDir);
+    rootReal = fs.realpathSync.native(rootDir);
     const rootStat = fs.statSync(rootReal);
     if (!rootStat.isDirectory()) {
       throw new FsSafeError("invalid-path", "root dir is not a directory");

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -889,7 +889,7 @@ async function openWritableFileInRoot(
     ? resolved
     : await prepareRootWriteTarget(rootReal, resolved);
   try {
-    const resolvedRealPath = fsSync.realpathSync(ioPath);
+    const resolvedRealPath = fsSync.realpathSync.native(ioPath);
     if (!isPathInside(rootWithSep, resolvedRealPath)) {
       throw outsideWorkspaceError();
     }

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { BigIntStats, Stats } from "node:fs";
-import { constants as fsConstants } from "node:fs";
+import fsSync, { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -223,7 +223,7 @@ async function openVerifiedLocalFile(
   // results that get sent to messaging channels). See openclaw/openclaw#31186.
   try {
     preOpenStat = await inspectFileIdentity(async () => {
-      const stat = await fs.lstat(filePath, { bigint: true });
+      const stat = fsSync.lstatSync(filePath, { bigint: true });
       observedBeforeOpen = true;
       if (stat.isSymbolicLink() && options?.symlinks !== "follow-within-root") {
         throw new FsSafeError("symlink", "symlink not allowed");
@@ -264,14 +264,14 @@ async function openVerifiedLocalFile(
 
   try {
     await fsSafeTestHooks?.afterOpen?.(filePath, handle);
-    const stat = await handle.stat();
+    const stat = fsSync.fstatSync(handle.fd);
     if (!stat.isFile()) {
       throw new FsSafeError("not-file", "not a file");
     }
     // Keep numeric Stats for the public receipt, never for identity verification.
     let openedIdentity: BigIntStats | undefined;
     const identity = await inspectFileIdentity(
-      async () => (openedIdentity = await handle.stat({ bigint: true })),
+      async () => (openedIdentity = fsSync.fstatSync(handle.fd, { bigint: true })),
       preOpenStat && !preOpenStat.isSymbolicLink() ? preOpenStat : undefined,
     ).catch(async (error: unknown) => {
       if ([0, 1].includes(stat.nlink)) {
@@ -296,8 +296,8 @@ async function openVerifiedLocalFile(
     };
     await inspectPathIdentity(async () => {
       const pathStat = options?.symlinks === "follow-within-root"
-        ? await fs.stat(filePath, { bigint: true })
-        : await fs.lstat(filePath, { bigint: true });
+        ? fsSync.statSync(filePath, { bigint: true })
+        : fsSync.lstatSync(filePath, { bigint: true });
       if (pathStat.isSymbolicLink() && options?.symlinks !== "follow-within-root") {
         throw new FsSafeError("symlink", "symlink not allowed");
       }
@@ -317,7 +317,7 @@ async function openVerifiedLocalFile(
     await inspectPathIdentity(async () => {
       // Reuse the post-realpath observation; unknown Windows identities still
       // get a fresh observation on inspectFileIdentity's retry.
-      const realStat = resolvedStat ?? await fs.stat(realPath, { bigint: true });
+      const realStat = resolvedStat ?? fsSync.statSync(realPath, { bigint: true });
       resolvedStat = undefined;
       if (options?.hardlinks === "reject" && realStat.nlink > 1n) {
         throw hardlinkedPathNotAllowedError();
@@ -825,7 +825,7 @@ async function writeTempFileForAtomicReplace(params: {
     }
     return {
       handle: tempHandle,
-      identity: await tempHandle.stat({ bigint: true }),
+      identity: fsSync.fstatSync(tempHandle.fd, { bigint: true }),
     };
   } catch (error) {
     await tempHandle.close().catch(() => {});
@@ -889,7 +889,7 @@ async function openWritableFileInRoot(
     ? resolved
     : await prepareRootWriteTarget(rootReal, resolved);
   try {
-    const resolvedRealPath = await fs.realpath(ioPath);
+    const resolvedRealPath = fsSync.realpathSync(ioPath);
     if (!isPathInside(rootWithSep, resolvedRealPath)) {
       throw outsideWorkspaceError();
     }
@@ -938,7 +938,7 @@ async function openWritableFileInRoot(
   let realPathForCleanup: string | null = null;
   let createdIdentity: Stats | null = null;
   try {
-    const stat = await handle.stat();
+    const stat = fsSync.fstatSync(handle.fd);
     if (createdForWrite) {
       createdIdentity = stat;
     }
@@ -950,7 +950,7 @@ async function openWritableFileInRoot(
     }
 
     try {
-      const lstat = await fs.lstat(ioPath);
+      const lstat = fsSync.lstatSync(ioPath);
       if (lstat.isSymbolicLink() || !lstat.isFile()) {
         throw new FsSafeError(
           lstat.isSymbolicLink() ? "symlink" : "not-file",
@@ -968,7 +968,7 @@ async function openWritableFileInRoot(
 
     const realPath = await resolveOpenedFileRealPathForHandle(handle, ioPath);
     realPathForCleanup = realPath;
-    const realStat = await fs.stat(realPath);
+    const realStat = fsSync.statSync(realPath);
     if (!sameFileIdentity(stat, realStat)) {
       throw new FsSafeError("path-mismatch", "path mismatch");
     }
@@ -1232,13 +1232,13 @@ async function copyFileInRoot(
 }
 
 async function assertCopySourceCurrent(source: OpenResult, identity: BigIntStats): Promise<void> {
-  await inspectFileIdentity(() => source.handle.stat({ bigint: true }), identity);
+  await inspectFileIdentity(() => fsSync.fstatSync(source.handle.fd, { bigint: true }), identity);
   await assertCopySourcePathCurrent(source, identity);
 }
 
 async function assertCopySourcePathCurrent(source: OpenResult, identity: BigIntStats): Promise<void> {
   await inspectFileIdentity(async () => {
-    const current = await fs.lstat(source.realPath, { bigint: true });
+    const current = fsSync.lstatSync(source.realPath, { bigint: true });
     if (current.isSymbolicLink() || !current.isFile()) {
       throw new FsSafeError("path-mismatch", "copy source path changed");
     }
@@ -1251,7 +1251,7 @@ async function removePathIfIdentityUnchanged(
   identity: FileIdentityStat,
 ): Promise<void> {
   const parentGuard = await createAsyncDirectoryGuard(path.dirname(targetPath));
-  const current = await fs.lstat(targetPath);
+  const current = fsSync.lstatSync(targetPath);
   if (current.isSymbolicLink() || !sameFileIdentityForCleanup(current, identity)) {
     return;
   }
@@ -1289,7 +1289,7 @@ async function resolvePinnedWriteTargetInRoot(
   // and alias checks, but never open a competing owner's record just to reject it.
   if (!overwrite) {
     try {
-      const existing = await fs.stat(resolved);
+      const existing = fsSync.statSync(resolved);
       if (!existing.isFile()) throw new FsSafeError("not-file", "not a file");
       if (existing.nlink > 1) throw hardlinkedPathNotAllowedError();
       throw new FsSafeError("already-exists", "file already exists");
@@ -1414,7 +1414,7 @@ async function prepareRemoveGuard(targetPath: string) {
 async function removePathFallback(resolved: { resolved: string }): Promise<void> {
   const guard = await prepareRemoveGuard(resolved.resolved);
   try {
-    await ((await fs.lstat(resolved.resolved)).isDirectory() ? fs.rmdir(resolved.resolved) : fs.rm(resolved.resolved));
+    await (fsSync.lstatSync(resolved.resolved).isDirectory() ? fs.rmdir(resolved.resolved) : fs.rm(resolved.resolved));
   } catch (error) {
     throw normalizeRemovePathError(error);
   }
@@ -1431,7 +1431,7 @@ async function mkdirPathFallback(resolved: { rootReal: string; resolved: string 
 async function statPathFallback(root: RootContext, relativePath: string): Promise<PathStat> {
   const resolved = await resolvePinnedPathInRoot(root, { relativePath, allowRoot: true });
   try {
-    const stat = pathStatFromStats(await fs.lstat(resolved.resolved));
+    const stat = pathStatFromStats(fsSync.lstatSync(resolved.resolved));
     await assertRootIdentityCurrent(root);
     return stat;
   } catch (error) {
@@ -1459,7 +1459,7 @@ async function listPathFallback(
     for (const name of sortedNames) {
       entries.push({
         name,
-        ...pathStatFromStats(await fs.lstat(path.join(resolved.resolved, name))),
+        ...pathStatFromStats(fsSync.lstatSync(path.join(resolved.resolved, name))),
       });
     }
     await assertRootIdentityCurrent(root);
@@ -1524,7 +1524,8 @@ async function movePathFallback(
         relativePath: params.toRelative,
         policy: PATH_ALIAS_POLICIES.unlinkTarget,
       });
-      const targetStat = await fs.lstat(resolvedTarget.resolved).catch(() => undefined);
+      let targetStat: Stats | undefined;
+      try { targetStat = fsSync.lstatSync(resolvedTarget.resolved); } catch { /* Advisory lookup. */ }
       return !(
         process.platform !== "win32" &&
         params.overwrite &&
@@ -1535,7 +1536,7 @@ async function movePathFallback(
 
   let sourceStat: Stats;
   try {
-    sourceStat = await fs.lstat(source.resolved);
+    sourceStat = fsSync.lstatSync(source.resolved);
   } catch (error) {
     if (isNotFoundPathError(error)) {
       throw fileNotFoundError(error instanceof Error ? error : undefined);
@@ -1553,7 +1554,7 @@ async function movePathFallback(
   }
   if (!params.overwrite) {
     try {
-      await fs.lstat(target.resolved);
+      fsSync.lstatSync(target.resolved);
       throw new FsSafeError("already-exists", "destination exists");
     } catch (error) {
       if (error instanceof FsSafeError) {
@@ -1686,8 +1687,8 @@ async function writeMissingFileFallback(
         const handle = await fs.open(targetPath, OPEN_WRITE_CREATE_FLAGS, params.mode ?? 0o600).catch((error) => recordExclusiveCreateFailure(error, targetPath));
         created = true;
         try {
-          createdIdentity = await handle.stat();
-          const writtenStat = await handle.stat({ bigint: true });
+          createdIdentity = fsSync.fstatSync(handle.fd);
+          const writtenStat = fsSync.fstatSync(handle.fd, { bigint: true });
           if (typeof params.data === "string") {
             await handle.writeFile(params.data, params.encoding ?? "utf8");
           } else {

--- a/src/root-path-existing.ts
+++ b/src/root-path-existing.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import fsp from "node:fs/promises";
 import path from "node:path";
 import { isNotFoundPathError } from "./path.js";
 
@@ -9,7 +8,7 @@ function isFilesystemRoot(candidate: string): boolean {
 
 async function pathExists(targetPath: string): Promise<boolean> {
   try {
-    await fsp.lstat(targetPath);
+    fs.lstatSync(targetPath);
     return true;
   } catch (error) {
     if (isNotFoundPathError(error)) {
@@ -38,7 +37,7 @@ export async function resolvePathViaExistingAncestor(targetPath: string): Promis
   }
 
   try {
-    const resolvedAncestor = path.resolve(await fsp.realpath(cursor));
+    const resolvedAncestor = path.resolve(fs.realpathSync(cursor));
     return missingSuffix.length === 0
       ? resolvedAncestor
       : path.resolve(resolvedAncestor, ...missingSuffix);

--- a/src/root-path-existing.ts
+++ b/src/root-path-existing.ts
@@ -37,7 +37,7 @@ export async function resolvePathViaExistingAncestor(targetPath: string): Promis
   }
 
   try {
-    const resolvedAncestor = path.resolve(fs.realpathSync(cursor));
+    const resolvedAncestor = path.resolve(fs.realpathSync.native(cursor));
     return missingSuffix.length === 0
       ? resolvedAncestor
       : path.resolve(resolvedAncestor, ...missingSuffix);

--- a/src/root-path-symlink.ts
+++ b/src/root-path-symlink.ts
@@ -31,7 +31,7 @@ export async function resolveSymlinkHopPath(
   options: ResolveSymlinkHopOptions = {},
 ): Promise<string> {
   try {
-    return path.resolve(fs.realpathSync(symlinkPath));
+    return path.resolve(fs.realpathSync.native(symlinkPath));
   } catch (error) {
     normalizeSymlinkResolutionError(error, options);
     const linkTarget = fs.readlinkSync(symlinkPath);

--- a/src/root-path-symlink.ts
+++ b/src/root-path-symlink.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import fsp from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { isNotFoundPathError, isSymlinkOpenError } from "./path.js";
@@ -32,10 +31,10 @@ export async function resolveSymlinkHopPath(
   options: ResolveSymlinkHopOptions = {},
 ): Promise<string> {
   try {
-    return path.resolve(await fsp.realpath(symlinkPath));
+    return path.resolve(fs.realpathSync(symlinkPath));
   } catch (error) {
     normalizeSymlinkResolutionError(error, options);
-    const linkTarget = await fsp.readlink(symlinkPath);
+    const linkTarget = fs.readlinkSync(symlinkPath);
     return resolvePathViaExistingAncestor(path.resolve(path.dirname(symlinkPath), linkTarget));
   }
 }

--- a/src/root-path.ts
+++ b/src/root-path.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import fsp from "node:fs/promises";
 import path from "node:path";
 import { formatErrorDetail, shortPath } from "./error-detail.js";
 import { FsSafeError } from "./errors.js";
@@ -371,7 +370,7 @@ async function resolveRootPathLexicalAsync(
     state.lexicalCursor = path.join(state.lexicalCursor, segment);
     let stat: fs.Stats;
     try {
-      stat = await fsp.lstat(state.lexicalCursor);
+      stat = fs.lstatSync(state.lexicalCursor);
     } catch (error) {
       if (handleLexicalLstatFailure(context, error, idx)) break;
       throw error;
@@ -621,8 +620,8 @@ async function getPathKind(
 ): Promise<{ exists: boolean; kind: ResolvedRootPathKind }> {
   try {
     const stat = preserveFinalSymlink
-      ? await fsp.lstat(absolutePath)
-      : await fsp.stat(absolutePath);
+      ? fs.lstatSync(absolutePath)
+      : fs.statSync(absolutePath);
     return { exists: true, kind: toResolvedKind(stat) };
   } catch (error) {
     if (isNotFoundPathError(error)) {

--- a/src/root-paths.ts
+++ b/src/root-paths.ts
@@ -63,7 +63,7 @@ function pathStaysWithinRoot(rootDir: string, candidatePath: string): boolean {
 
 async function resolveRealPathIfExists(targetPath: string): Promise<string | undefined> {
   try {
-    return fsSync.realpathSync(targetPath);
+    return fsSync.realpathSync.native(targetPath);
   } catch {
     return undefined;
   }
@@ -75,7 +75,7 @@ async function resolveTrustedRootRealPath(rootDir: string): Promise<string | und
     if (!rootLstat.isDirectory() || rootLstat.isSymbolicLink()) {
       return undefined;
     }
-    return fsSync.realpathSync(rootDir);
+    return fsSync.realpathSync.native(rootDir);
   } catch {
     return undefined;
   }
@@ -100,7 +100,7 @@ async function validateCanonicalPathWithinRoot(params: {
     if (params.expect === "file" && candidateLstat.nlink > 1) {
       return "invalid";
     }
-    const candidateRealPath = fsSync.realpathSync(params.candidatePath);
+    const candidateRealPath = fsSync.realpathSync.native(params.candidatePath);
     return isPathInside(params.rootRealPath, candidateRealPath) ? "ok" : "invalid";
   } catch (err) {
     return isNotFoundPathError(err) ? "not-found" : "invalid";
@@ -248,9 +248,9 @@ export async function ensureDirectoryWithinRoot(params: {
       return invalidPath(scopeLabel);
     }
     await assertNoSymlinkSegments({ rootDir, targetPath, scopeLabel });
-    const rootReal = fsSync.realpathSync(rootDir);
+    const rootReal = fsSync.realpathSync.native(rootDir);
     const nearestExistingPath = await resolveNearestExistingPath(targetPath);
-    const nearestExistingReal = fsSync.realpathSync(nearestExistingPath);
+    const nearestExistingReal = fsSync.realpathSync.native(nearestExistingPath);
     if (!isPathInside(rootReal, nearestExistingReal)) {
       return invalidPath(scopeLabel);
     }
@@ -279,12 +279,12 @@ export async function ensureDirectoryWithinRoot(params: {
           }
         }
       }
-      const currentReal = fsSync.realpathSync(current);
+      const currentReal = fsSync.realpathSync.native(current);
       if (!isPathInside(rootReal, currentReal)) {
         return invalidPath(scopeLabel);
       }
     }
-    const targetReal = fsSync.realpathSync(targetPath);
+    const targetReal = fsSync.realpathSync.native(targetPath);
     if (!isPathInside(rootReal, targetReal)) {
       return invalidPath(scopeLabel);
     }
@@ -416,7 +416,7 @@ async function resolveCheckedPathsWithinRoot(
       return lexicalPathResult;
     }
     try {
-      const resolvedExistingPath = fsSync.realpathSync(raw);
+      const resolvedExistingPath = fsSync.realpathSync.native(raw);
       const relativePath = path.relative(rootRealPath, resolvedExistingPath);
       if (!isInRoot(relativePath)) {
         return lexicalPathResult;
@@ -458,7 +458,7 @@ async function resolveCheckedPathsWithinRoot(
             scopeLabel: params.scopeLabel,
           });
           const existingPath = await resolveNearestExistingPath(pathResult.fallbackPath);
-          const existingRealPath = fsSync.realpathSync(existingPath);
+          const existingRealPath = fsSync.realpathSync.native(existingPath);
           if (!isPathInside(rootRealPath, existingRealPath)) {
             return invalidPath(params.scopeLabel);
           }

--- a/src/root-paths.ts
+++ b/src/root-paths.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { formatErrorDetail } from "./error-detail.js";
@@ -62,7 +63,7 @@ function pathStaysWithinRoot(rootDir: string, candidatePath: string): boolean {
 
 async function resolveRealPathIfExists(targetPath: string): Promise<string | undefined> {
   try {
-    return await fs.realpath(targetPath);
+    return fsSync.realpathSync(targetPath);
   } catch {
     return undefined;
   }
@@ -70,11 +71,11 @@ async function resolveRealPathIfExists(targetPath: string): Promise<string | und
 
 async function resolveTrustedRootRealPath(rootDir: string): Promise<string | undefined> {
   try {
-    const rootLstat = await fs.lstat(rootDir);
+    const rootLstat = fsSync.lstatSync(rootDir);
     if (!rootLstat.isDirectory() || rootLstat.isSymbolicLink()) {
       return undefined;
     }
-    return await fs.realpath(rootDir);
+    return fsSync.realpathSync(rootDir);
   } catch {
     return undefined;
   }
@@ -86,7 +87,7 @@ async function validateCanonicalPathWithinRoot(params: {
   expect: "directory" | "file";
 }): Promise<"ok" | "not-found" | "invalid"> {
   try {
-    const candidateLstat = await fs.lstat(params.candidatePath);
+    const candidateLstat = fsSync.lstatSync(params.candidatePath);
     if (candidateLstat.isSymbolicLink()) {
       return "invalid";
     }
@@ -99,7 +100,7 @@ async function validateCanonicalPathWithinRoot(params: {
     if (params.expect === "file" && candidateLstat.nlink > 1) {
       return "invalid";
     }
-    const candidateRealPath = await fs.realpath(params.candidatePath);
+    const candidateRealPath = fsSync.realpathSync(params.candidatePath);
     return isPathInside(params.rootRealPath, candidateRealPath) ? "ok" : "invalid";
   } catch (err) {
     return isNotFoundPathError(err) ? "not-found" : "invalid";
@@ -175,7 +176,7 @@ async function resolveNearestExistingPath(targetPath: string): Promise<string> {
   let current = path.resolve(targetPath);
   while (true) {
     try {
-      await fs.lstat(current);
+      fsSync.lstatSync(current);
       return current;
     } catch (err) {
       if (!isNotFoundPathError(err)) {
@@ -203,7 +204,7 @@ async function assertNoSymlinkSegments(params: {
   for (const segment of relative.split(path.sep).filter(Boolean)) {
     current = path.join(current, segment);
     try {
-      const stat = await fs.lstat(current);
+      const stat = fsSync.lstatSync(current);
       if (stat.isSymbolicLink()) {
         throw new FsSafeError(
           "symlink", `Invalid path: must not traverse symlinks within ${params.scopeLabel}`,
@@ -242,14 +243,14 @@ export async function ensureDirectoryWithinRoot(params: {
     if (!lexical.ok) return lexical;
     const rootDir = path.resolve(params.rootDir);
     const targetPath = lexical.path;
-    const rootStat = await fs.lstat(rootDir);
+    const rootStat = fsSync.lstatSync(rootDir);
     if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
       return invalidPath(scopeLabel);
     }
     await assertNoSymlinkSegments({ rootDir, targetPath, scopeLabel });
-    const rootReal = await fs.realpath(rootDir);
+    const rootReal = fsSync.realpathSync(rootDir);
     const nearestExistingPath = await resolveNearestExistingPath(targetPath);
-    const nearestExistingReal = await fs.realpath(nearestExistingPath);
+    const nearestExistingReal = fsSync.realpathSync(nearestExistingPath);
     if (!isPathInside(rootReal, nearestExistingReal)) {
       return invalidPath(scopeLabel);
     }
@@ -259,7 +260,7 @@ export async function ensureDirectoryWithinRoot(params: {
       current = path.join(current, segment);
       while (true) {
         try {
-          const stat = await fs.lstat(current);
+          const stat = fsSync.lstatSync(current);
           if (stat.isSymbolicLink() || !stat.isDirectory()) {
             return invalidPath(scopeLabel);
           }
@@ -278,12 +279,12 @@ export async function ensureDirectoryWithinRoot(params: {
           }
         }
       }
-      const currentReal = await fs.realpath(current);
+      const currentReal = fsSync.realpathSync(current);
       if (!isPathInside(rootReal, currentReal)) {
         return invalidPath(scopeLabel);
       }
     }
-    const targetReal = await fs.realpath(targetPath);
+    const targetReal = fsSync.realpathSync(targetPath);
     if (!isPathInside(rootReal, targetReal)) {
       return invalidPath(scopeLabel);
     }
@@ -415,7 +416,7 @@ async function resolveCheckedPathsWithinRoot(
       return lexicalPathResult;
     }
     try {
-      const resolvedExistingPath = await fs.realpath(raw);
+      const resolvedExistingPath = fsSync.realpathSync(raw);
       const relativePath = path.relative(rootRealPath, resolvedExistingPath);
       if (!isInRoot(relativePath)) {
         return lexicalPathResult;
@@ -457,7 +458,7 @@ async function resolveCheckedPathsWithinRoot(
             scopeLabel: params.scopeLabel,
           });
           const existingPath = await resolveNearestExistingPath(pathResult.fallbackPath);
-          const existingRealPath = await fs.realpath(existingPath);
+          const existingRealPath = fsSync.realpathSync(existingPath);
           if (!isPathInside(rootRealPath, existingRealPath)) {
             return invalidPath(params.scopeLabel);
           }

--- a/src/root-write-mode.ts
+++ b/src/root-write-mode.ts
@@ -33,7 +33,7 @@ export async function inheritWriteTargetMode(params: {
     try {
       // A parent can change after guarded resolution. Do not inherit metadata
       // from an outside inode, even if the parent is restored before publication.
-      const realPath = fsSync.realpathSync(params.targetPath);
+      const realPath = fsSync.realpathSync.native(params.targetPath);
       if (!isPathInside(params.rootWithSep, realPath)) throw outsideWorkspaceError();
       await inspectFileIdentity(async () => {
         const current = fsSync.statSync(realPath, { bigint: true });

--- a/src/root-write-mode.ts
+++ b/src/root-write-mode.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
@@ -13,7 +14,7 @@ export async function inheritWriteTargetMode(params: {
   requestedMode?: number;
 }): Promise<number> {
   try {
-    const existing = await inspectFileIdentity(() => fs.lstat(params.targetPath, { bigint: true }));
+    const existing = await inspectFileIdentity(() => fsSync.lstatSync(params.targetPath, { bigint: true }));
     if (existing.isSymbolicLink()) throw new FsSafeError("path-alias", "path alias escape blocked");
     if (!existing.isFile()) throw new FsSafeError("not-file", "not a file");
     if (existing.nlink > 1n) throw hardlinkedPathNotAllowedError();
@@ -23,7 +24,7 @@ export async function inheritWriteTargetMode(params: {
     const handle = await fs.open(params.targetPath, resolveReadOpenFlags());
     try {
       // Bind admission to the inode whose metadata is inherited.
-      if (!sameFileIdentity(await handle.stat({ bigint: true }), existing)) {
+      if (!sameFileIdentity(fsSync.fstatSync(handle.fd, { bigint: true }), existing)) {
         throw new FsSafeError("path-mismatch", "write target changed during mode inheritance");
       }
     } finally {
@@ -32,10 +33,10 @@ export async function inheritWriteTargetMode(params: {
     try {
       // A parent can change after guarded resolution. Do not inherit metadata
       // from an outside inode, even if the parent is restored before publication.
-      const realPath = await fs.realpath(params.targetPath);
+      const realPath = fsSync.realpathSync(params.targetPath);
       if (!isPathInside(params.rootWithSep, realPath)) throw outsideWorkspaceError();
       await inspectFileIdentity(async () => {
-        const current = await fs.stat(realPath, { bigint: true });
+        const current = fsSync.statSync(realPath, { bigint: true });
         if (!current.isFile()) throw new FsSafeError("not-file", "not a file");
         if (current.nlink > 1n) throw hardlinkedPathNotAllowedError();
         return current;

--- a/src/root-write-verification.ts
+++ b/src/root-write-verification.ts
@@ -57,16 +57,16 @@ export async function verifyAtomicWriteResult(params: {
   try {
     // This descriptor remains owned by the writer, even when final mode forbids opens.
     const stat = assertDescriptor();
-    assertPath(await fs.lstat(params.targetPath, { bigint: true }));
+    assertPath(fsSync.lstatSync(params.targetPath, { bigint: true }));
     const { realPath } = await resolveOpenedFileRealPathForFd(params.fd, stat, params.targetPath);
-    assertPath(await fs.stat(realPath, { bigint: true }));
+    assertPath(fsSync.statSync(realPath, { bigint: true }));
     if (!isPathInside(params.root.rootWithSep, realPath)) {
       throw outsideWorkspaceError();
     }
     await assertAsyncDirectoryGuard(params.parentGuard);
     await assertRootIdentityCurrent(params.root);
     // Recheck after canonical resolution and directory checks, including late links.
-    assertPath(await fs.lstat(params.targetPath, { bigint: true }));
+    assertPath(fsSync.lstatSync(params.targetPath, { bigint: true }));
     assertDescriptor();
     if (needsPathOpen) {
       // A retained fd cannot prove that an opaque Windows pathname still names it.
@@ -84,15 +84,15 @@ export async function verifyAtomicWriteResult(params: {
       });
       try {
         const reopenedStat = assertDescriptor(opened.fd);
-        assertPath(await fs.lstat(params.targetPath, { bigint: true }));
+        assertPath(fsSync.lstatSync(params.targetPath, { bigint: true }));
         const { realPath: reopenedPath } = await resolveOpenedFileRealPathForFd(opened.fd, reopenedStat, params.targetPath);
-        assertPath(await fs.stat(reopenedPath, { bigint: true }));
+        assertPath(fsSync.statSync(reopenedPath, { bigint: true }));
         if (!isPathInside(params.root.rootWithSep, reopenedPath)) {
           throw outsideWorkspaceError();
         }
         await assertAsyncDirectoryGuard(params.parentGuard);
         await assertRootIdentityCurrent(params.root);
-        assertPath(await fs.lstat(params.targetPath, { bigint: true }));
+        assertPath(fsSync.lstatSync(params.targetPath, { bigint: true }));
         assertDescriptor(opened.fd);
       } finally {
         await opened.close().catch(() => undefined);

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -179,7 +179,7 @@ async function enforcePrivateDirectoryMode(params: {
 
 async function inspectPrivateDirectory(directory: string, kind: "root" | "directory component"): Promise<BigIntStats> {
   return await inspectFileIdentity(async () => {
-    const stat = await fsp.lstat(directory, { bigint: true });
+    const stat = fs.lstatSync(directory, { bigint: true });
     if (stat.isSymbolicLink()) {
       throw new Error(`Private secret ${kind} ${directory} must not be a symlink.`);
     }
@@ -328,7 +328,7 @@ async function materializeSecretFileAtomic(
 ): Promise<void> {
   const { mode, rootGuard, parentGuard, fileName, finalFilePath } = await prepareSecretFileWrite(params);
   try {
-    const stat = await fsp.lstat(finalFilePath);
+    const stat = fs.lstatSync(finalFilePath);
     if (createOnly) {
       throw new FsSafeError("secret-exists", `Private secret file ${finalFilePath} already exists.`);
     }

--- a/src/strict-file-identity.ts
+++ b/src/strict-file-identity.ts
@@ -34,7 +34,7 @@ function identityCheck(expected: ExactFileIdentity | undefined, platform: NodeJS
 // Retry only unknown Windows identities, retaining every known component so a
 // later observation cannot erase a definite mismatch. Never reopen the file.
 export async function inspectFileIdentity<T extends ExactFileIdentity>(
-  inspect: () => Promise<T>,
+  inspect: () => T | Promise<T>,
   expected?: ExactFileIdentity,
   platform: NodeJS.Platform = process.platform,
 ): Promise<T> {

--- a/src/symlink-parents.ts
+++ b/src/symlink-parents.ts
@@ -1,5 +1,4 @@
 import fsSync from "node:fs";
-import fs from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { hasNodeErrorCode, isPathRelativeEscape } from "./path.js";
@@ -48,7 +47,7 @@ export async function assertNoSymlinkParents(
   for (const [index, segment] of walk.segments.entries()) {
     current = path.join(current, segment);
     try {
-      const stat = await fs.lstat(current);
+      const stat = fsSync.lstatSync(current);
       if (stat.isSymbolicLink()) {
         if (params.allowRootChildSymlink && path.dirname(current) === walk.root) {
           continue;

--- a/test/absolute-directory.test.ts
+++ b/test/absolute-directory.test.ts
@@ -123,9 +123,9 @@ describe("ensureAbsoluteDirectory", () => {
     const targetDir = path.join(root, "target");
     await fs.mkdir(targetDir);
 
-    const realRealpath = fsSync.realpathSync.bind(fsSync);
+    const realRealpath = fsSync.realpathSync.native;
     let swapped = false;
-    const realpathSpy = vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
+    const realpathSpy = vi.spyOn(fsSync.realpathSync, "native").mockImplementation((...args) => {
       const candidate = String(args[0]);
       if (!swapped && candidate === targetDir) {
         swapped = true;

--- a/test/absolute-directory.test.ts
+++ b/test/absolute-directory.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -91,16 +92,16 @@ describe("ensureAbsoluteDirectory", () => {
     const targetDir = path.join(parentDir, "child");
     await fs.mkdir(parentDir);
 
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     let swapped = false;
-    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    const lstatSpy = vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
       const candidate = String(args[0]);
       if (!swapped && candidate === targetDir) {
         swapped = true;
-        await fs.rename(parentDir, `${parentDir}-real`);
-        await fs.symlink(outside, parentDir, "dir");
+        fsSync.renameSync(parentDir, `${parentDir}-real`);
+        fsSync.symlinkSync(outside, parentDir, "dir");
       }
-      return await realLstat(...args);
+      return realLstat(...args);
     });
 
     try {
@@ -122,18 +123,18 @@ describe("ensureAbsoluteDirectory", () => {
     const targetDir = path.join(root, "target");
     await fs.mkdir(targetDir);
 
-    const realRealpath = fs.realpath.bind(fs);
+    const realRealpath = fsSync.realpathSync.bind(fsSync);
     let swapped = false;
-    const realpathSpy = vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+    const realpathSpy = vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
       const candidate = String(args[0]);
       if (!swapped && candidate === targetDir) {
         swapped = true;
-        const resolved = await realRealpath(...args);
-        await fs.rename(targetDir, `${targetDir}-real`);
-        await fs.symlink(outside, targetDir, "dir");
+        const resolved = realRealpath(...args);
+        fsSync.renameSync(targetDir, `${targetDir}-real`);
+        fsSync.symlinkSync(outside, targetDir, "dir");
         return resolved;
       }
-      return await realRealpath(...args);
+      return realRealpath(...args);
     });
 
     try {

--- a/test/archive.test.ts
+++ b/test/archive.test.ts
@@ -1,4 +1,4 @@
-import { constants as fsConstants } from "node:fs";
+import fsSync, { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -353,14 +353,14 @@ describe("archive extraction", () => {
     zip.file("package/payload.bin", "owned");
     await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
 
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     let linked = false;
-    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    const lstatSpy = vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
       if (!linked && String(args[0]) === extractedRealPath) {
-        await fs.link(extractedRealPath, outsideAlias);
+        fsSync.linkSync(extractedRealPath, outsideAlias);
         linked = true;
       }
-      return await realLstat(...args);
+      return realLstat(...args);
     });
 
     try {

--- a/test/bounded-read.test.ts
+++ b/test/bounded-read.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { expectFsSafeErrorSync } from "./helpers/security.js";
 import * as advanced from "../src/advanced.js";
 import {
@@ -30,6 +30,7 @@ async function tempFile(content: string): Promise<string> {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   __setFsSafeTestHooksForTest(undefined);
   await Promise.all(
     [...tempDirs].map((dir) => fs.rm(dir, { recursive: true, force: true })),
@@ -38,6 +39,81 @@ afterEach(async () => {
 });
 
 describe("bounded descriptor reads", () => {
+  it.each([0, 4, 128 * 1024])("reads a known regular file of %s bytes in one call", async (size) => {
+    const filePath = await tempFile("x".repeat(size));
+    const handle = await fs.open(filePath, "r");
+    const read = vi.spyOn(handle, "read");
+    try {
+      const result = await readFileHandleBounded(handle, size);
+      expect(result).toEqual(Buffer.alloc(size, "x"));
+      expect(read).toHaveBeenCalledTimes(1);
+      expect(read.mock.calls[0]?.[2]).toBe(size + 1);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it.each([false, true])("continues after growth fills the first buffer (over limit: %s)", async (overLimit) => {
+    const filePath = await tempFile("ab");
+    const handle = await fs.open(filePath, "r");
+    const originalRead = handle.read.bind(handle);
+    const read = vi.spyOn(handle, "read").mockImplementationOnce(async (...args) => {
+      fsSync.appendFileSync(filePath, overLimit ? "cdefgh" : "cd");
+      return await originalRead(...args);
+    });
+    try {
+      const pending = readFileHandleBounded(handle, 4);
+      if (overLimit) await expect(pending).rejects.toMatchObject({ code: "too-large" });
+      else await expect(pending).resolves.toEqual(Buffer.from("abcd"));
+      expect(read.mock.calls[0]?.[2]).toBe(3);
+      expect(read.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it("keeps reading after short chunks from an unknown-size handle", async () => {
+    const chunks = [Buffer.from("ab"), Buffer.from("cd"), Buffer.alloc(0)];
+    const read = vi.fn(async (buffer: Buffer) => {
+      const chunk = chunks.shift()!;
+      chunk.copy(buffer);
+      return { buffer, bytesRead: chunk.length };
+    });
+    await expect(readFileHandleBounded({ read } as never, 4)).resolves.toEqual(Buffer.from("abcd"));
+    expect(read).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([false, true])("continues a short regular-file read before EOF (over limit: %s)", async (overLimit) => {
+    const filePath = await tempFile("abcd");
+    const handle = await fs.open(filePath, "r");
+    const originalRead = handle.read.bind(handle);
+    const read = vi.spyOn(handle, "read").mockImplementationOnce(async (buffer, offset, _length, position) => {
+      if (overLimit) fsSync.appendFileSync(filePath, "efgh");
+      return await originalRead(buffer, offset, overLimit ? 4 : 1, position);
+    });
+    try {
+      const pending = readFileHandleBounded(handle, 4);
+      if (overLimit) await expect(pending).rejects.toMatchObject({ code: "too-large" });
+      else await expect(pending).resolves.toEqual(Buffer.from("abcd"));
+      expect(read.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it("retains a custom reader when its extra fd property cannot supply a size hint", async () => {
+    const chunks = [Buffer.from("a"), Buffer.alloc(0)];
+    const reader = {
+      fd: -1,
+      async read(buffer: Buffer) {
+        const chunk = chunks.shift()!;
+        chunk.copy(buffer);
+        return { buffer, bytesRead: chunk.length };
+      },
+    };
+    await expect(readFileHandleBounded(reader as never, 1)).resolves.toEqual(Buffer.from("a"));
+  });
+
   it("rejects a non-finite stream byte cap instead of disabling the bound", () => {
     expect(() => createMaxBytesTransform(Number.NaN)).toThrow(RangeError);
     expect(() => createMaxBytesTransform(Number.NEGATIVE_INFINITY)).toThrow(RangeError);

--- a/test/deepsec-regression.test.ts
+++ b/test/deepsec-regression.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -143,14 +144,14 @@ describe("deepsec regressions", () => {
     const outsideFile = path.join(outside, "secret.txt");
     await fsp.writeFile(sourcePath, "upload");
     await fsp.writeFile(outsideFile, "secret");
-    const originalLstat = fsp.lstat;
+    const originalLstat = fsSync.lstatSync;
     let swapped = false;
-    vi.spyOn(fsp, "lstat").mockImplementation(async (candidate, options) => {
-      const stat = await originalLstat(candidate, options as never);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((candidate, options) => {
+      const stat = originalLstat(candidate, options as never);
       if (!swapped && candidate === sourcePath) {
         swapped = true;
-        await fsp.rm(sourcePath);
-        await fsp.symlink(outsideFile, sourcePath, "file");
+        fsSync.rmSync(sourcePath);
+        fsSync.symlinkSync(outsideFile, sourcePath, "file");
       }
       return stat;
     });
@@ -229,15 +230,15 @@ describe("deepsec regressions", () => {
     await fsp.mkdir(rootDir, { mode: 0o700 });
     await fsp.mkdir(outside);
     const secretPath = path.join(rootDir, "nested", "secret.txt");
-    const realRealpath = fsp.realpath;
+    const realRealpath = fsSync.realpathSync;
     let swapped = false;
-    vi.spyOn(fsp, "realpath").mockImplementation(async (target, options) => {
+    vi.spyOn(fsSync, "realpathSync").mockImplementation((target, options) => {
       if (!swapped && target === path.join(rootDir, "nested")) {
         swapped = true;
-        await fsp.rename(rootDir, originalRoot);
-        await fsp.symlink(outside, rootDir, "dir");
+        fsSync.renameSync(rootDir, originalRoot);
+        fsSync.symlinkSync(outside, rootDir, "dir");
       }
-      return await realRealpath(target, options as never);
+      return realRealpath(target, options as never);
     });
 
     await expect(
@@ -269,15 +270,15 @@ describe("deepsec regressions", () => {
     await fsp.mkdir(path.join(rootDir, "nested"), { recursive: true, mode: 0o700 });
     await fsp.mkdir(outside);
     const secretPath = path.join(rootDir, "nested", "secret.txt");
-    const realLstat = fsp.lstat;
+    const realLstat = fsSync.lstatSync;
     let swapped = false;
-    vi.spyOn(fsp, "lstat").mockImplementation(async (target, options) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((target, options) => {
       if (!swapped && String(target).endsWith(path.join("nested", "secret.txt"))) {
         swapped = true;
-        await fsp.rename(path.join(rootDir, "nested"), movedParent);
-        await fsp.symlink(outside, path.join(rootDir, "nested"), "dir");
+        fsSync.renameSync(path.join(rootDir, "nested"), movedParent);
+        fsSync.symlinkSync(outside, path.join(rootDir, "nested"), "dir");
       }
-      return await realLstat(target, options as never);
+      return realLstat(target, options as never);
     });
 
     await expect(
@@ -296,20 +297,20 @@ describe("deepsec regressions", () => {
     await fsp.mkdir(parentDir, { recursive: true, mode: 0o700 });
     await fsp.mkdir(outside);
     const secretPath = path.join(parentDir, "secret.txt");
-    const realLstat = fsp.lstat;
+    const realLstat = fsSync.lstatSync;
     let swapped = false;
-    vi.spyOn(fsp, "lstat").mockImplementation(async (target, options) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((target, options) => {
       if (!swapped && target === rootDir) {
         try {
-          await realLstat(secretPath);
+          realLstat(secretPath);
           swapped = true;
-          await fsp.rename(parentDir, movedParent);
-          await fsp.symlink(outside, parentDir, "dir");
+          fsSync.renameSync(parentDir, movedParent);
+          fsSync.symlinkSync(outside, parentDir, "dir");
         } catch {
           // Wait until the helper has committed the file in the pinned parent.
         }
       }
-      return await realLstat(target, options as never);
+      return realLstat(target, options as never);
     });
 
     await expect(
@@ -330,16 +331,16 @@ describe("deepsec regressions", () => {
     await fsp.chmod(outsideFile, 0o600);
     const secretPath = path.join(rootDir, "secret.txt");
     const finalSecretPath = path.join(await fsp.realpath(rootDir), "secret.txt");
-    const realLstat = fsp.lstat;
+    const realLstat = fsSync.lstatSync;
     let swapped = false;
-    vi.spyOn(fsp, "lstat").mockImplementation(async (target, options) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((target, options) => {
       // Exact pathname verification occurs after the writer publishes its file.
       if (!swapped && target === finalSecretPath && (options as { bigint?: boolean })?.bigint) {
         swapped = true;
-        await fsp.rm(finalSecretPath, { force: true });
-        await fsp.symlink(outsideFile, finalSecretPath, "file");
+        fsSync.rmSync(finalSecretPath, { force: true });
+        fsSync.symlinkSync(outsideFile, finalSecretPath, "file");
       }
-      return await realLstat(target, options as never);
+      return realLstat(target, options as never);
     });
 
     await expect(

--- a/test/deepsec-regression.test.ts
+++ b/test/deepsec-regression.test.ts
@@ -230,9 +230,9 @@ describe("deepsec regressions", () => {
     await fsp.mkdir(rootDir, { mode: 0o700 });
     await fsp.mkdir(outside);
     const secretPath = path.join(rootDir, "nested", "secret.txt");
-    const realRealpath = fsSync.realpathSync;
+    const realRealpath = fsSync.realpathSync.native;
     let swapped = false;
-    vi.spyOn(fsSync, "realpathSync").mockImplementation((target, options) => {
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementation((target, options) => {
       if (!swapped && target === path.join(rootDir, "nested")) {
         swapped = true;
         fsSync.renameSync(rootDir, originalRoot);

--- a/test/deny-mutations.test.ts
+++ b/test/deny-mutations.test.ts
@@ -1,4 +1,5 @@
-import fs, { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import fsSync from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveMutationComparablePaths } from "../src/deny-mutations.js";
@@ -20,7 +21,9 @@ describe("root denyMutations policies", () => {
   it.runIf(process.platform === "win32")(
     "uses the root ancestor canonicalizer for drive-relative and UNC roots",
     async () => {
-      vi.spyOn(fs, "lstat").mockRejectedValue(Object.assign(new Error("missing"), { code: "ENOENT" }));
+      vi.spyOn(fsSync, "lstatSync").mockImplementation(() => {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      });
 
       for (const input of ["C:foo", "\\\\?\\C:\\", "\\\\server\\share"]) {
         const normalized = path.resolve(input);

--- a/test/directory-guard-exact-identity.test.ts
+++ b/test/directory-guard-exact-identity.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -19,10 +20,10 @@ describe.each(["capture", "verify", "secret preparation"] as const)("Windows exa
       const directory = await tempRoot("fs-safe-directory-exact-");
       const guard = await createAsyncDirectoryGuard(directory, { bigint: true });
       Object.defineProperty(process, "platform", { value: "win32" });
-      const lstat = fs.lstat.bind(fs);
+      const lstat = fsSync.lstatSync.bind(fsSync);
       let inspections = 0;
-      vi.spyOn(fs, "lstat").mockImplementation((async (...args: Parameters<typeof fs.lstat>) => {
-        const stat = await lstat(...args);
+      vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) => {
+        const stat = lstat(...args);
         if (String(args[0]) !== directory) return stat;
         expect(typeof stat.ino).toBe("bigint");
         const attempt = ++inspections;
@@ -36,7 +37,7 @@ describe.each(["capture", "verify", "secret preparation"] as const)("Windows exa
           return Object.assign(Object.create(stat), scenario === "transient inode" ? { ino: 0n } : { dev: 0n });
         }
         return stat;
-      }) as typeof fs.lstat);
+      }) as typeof fsSync.lstatSync);
       const pending = stage === "capture" ? createAsyncDirectoryGuard(directory, { bigint: true })
         : stage === "verify" ? assertAsyncDirectoryGuard(guard)
           : prepareSecretFileWrite({ rootDir: directory, filePath: path.join(directory, "secret") });
@@ -60,7 +61,7 @@ it("does not retry an exact guard filesystem failure", async () => {
   const guard = await createAsyncDirectoryGuard(directory, { bigint: true });
   Object.defineProperty(process, "platform", { value: "win32" });
   const failure = Object.assign(new Error("inspection denied"), { code: "EACCES" });
-  const lstat = vi.spyOn(fs, "lstat").mockRejectedValue(failure);
+  const lstat = vi.spyOn(fsSync, "lstatSync").mockImplementation(() => { throw failure; });
   await expect(assertAsyncDirectoryGuard(guard)).rejects.toBe(failure);
   expect(lstat).toHaveBeenCalledTimes(1);
 });

--- a/test/fs-call-budget.test.ts
+++ b/test/fs-call-budget.test.ts
@@ -11,13 +11,22 @@ import { useRealTempDirs } from "./helpers/vitest.js";
 
 // Measured fallback calls on macOS; allow two calls for platform variation.
 const budgets = {
-  "root.readBytes": 14, // measured 12
-  readRegularFile: 8, // measured 6
-  tryReadJson: 9, // measured 7
-  replaceFileAtomic: 18, // measured 16
-  "writeJson durable:false": 18, // measured 16
-  "root.write": 56, // measured 54, including canonical mode-inheritance identity
+  "root.readBytes": 16, // measured 14, including the post-read EOF size observation
+  readRegularFile: 9, // measured 7
+  tryReadJson: 10, // measured 8
+  replaceFileAtomic: 20, // measured 18
+  "writeJson durable:false": 20, // measured 18
+  "root.write": 60, // measured 58, including canonical mode-inheritance identity
   "root.exists": 7, // measured 5
+};
+const asyncBudgets = {
+  "root.readBytes": 4, // measured 3: open, read, close
+  readRegularFile: 4, // measured 3: open, readFile, close
+  tryReadJson: 4, // measured 3: open, readFile, close
+  replaceFileAtomic: 9, // measured 8
+  "writeJson durable:false": 9, // measured 8
+  "root.write": 12, // measured 11, including two durability syncs
+  "root.exists": 1, // measured 0
 };
 const { tempRoot } = useRealTempDirs();
 
@@ -43,7 +52,15 @@ describe.skipIf(process.platform === "win32")("fallback filesystem call budgets"
           ...descriptor,
           value: function (this: unknown, ...args: unknown[]) {
             if (counting) counts.set(prefix + key, (counts.get(prefix + key) ?? 0) + 1);
-            return Reflect.apply(original, this, args);
+            const result = Reflect.apply(original, this, args);
+            if (prefix === "p." && key === "open") {
+              return result.then((opened: object) => {
+                // FileHandle.close is an own property, not a prototype method.
+                wrap(opened, ["close"], "h.");
+                return opened;
+              });
+            }
+            return result;
           },
         });
         restore.push(() => Object.defineProperty(object, key, descriptor));
@@ -69,7 +86,11 @@ describe.skipIf(process.platform === "win32")("fallback filesystem call budgets"
         try { await operations[name](); } finally { counting = false; }
         const total = [...counts.values()].reduce((sum, count) => sum + count, 0);
         const breakdown = [...counts].map(([key, count]) => `${key}=${count}`).join(" ");
+        const asyncTotal = [...counts].reduce((sum, [key, count]) =>
+          sum + (key.startsWith("s.") ? 0 : count), 0);
         expect.soft(total, `${name}: ${total} calls; ${breakdown}`).toBeLessThanOrEqual(budgets[name]);
+        expect.soft(asyncTotal, `${name}: ${asyncTotal} async calls; ${breakdown}`)
+          .toBeLessThanOrEqual(asyncBudgets[name]);
       }
     } finally {
       counting = false;

--- a/test/fs-call-budget.test.ts
+++ b/test/fs-call-budget.test.ts
@@ -50,7 +50,7 @@ describe.skipIf(process.platform === "win32")("fallback filesystem call budgets"
         const original = descriptor.value;
         Object.defineProperty(object, key, {
           ...descriptor,
-          value: function (this: unknown, ...args: unknown[]) {
+          value: Object.assign(function (this: unknown, ...args: unknown[]) {
             if (counting) counts.set(prefix + key, (counts.get(prefix + key) ?? 0) + 1);
             const result = Reflect.apply(original, this, args);
             if (prefix === "p." && key === "open") {
@@ -61,13 +61,14 @@ describe.skipIf(process.platform === "win32")("fallback filesystem call budgets"
               });
             }
             return result;
-          },
+          }, original),
         });
         restore.push(() => Object.defineProperty(object, key, descriptor));
       }
     };
     try {
       wrap(fs, Object.keys(fs), "p.");
+      wrap(fsSync.realpathSync, ["native"], "s.realpathSync.");
       wrap(fsSync, Object.keys(fsSync).filter((key) => key.endsWith("Sync") && key !== "writeSync"), "s.");
       wrap(prototype, Object.getOwnPropertyNames(prototype).filter((key) => key !== "constructor" && key !== "fd"), "h.");
       const operations: Record<keyof typeof budgets, () => Promise<unknown>> = {

--- a/test/helpers/read-admission-identity.ts
+++ b/test/helpers/read-admission-identity.ts
@@ -69,6 +69,7 @@ export function observeReadAdmission(filePath: string, options: {
     opened = true;
     open();
     handles.push(handle);
+    descriptors.add(handle.fd);
     if (options.swap === "after-open") swap();
     const stat = handle.stat.bind(handle);
     vi.spyOn(handle, "stat").mockImplementation(async (options) =>
@@ -83,6 +84,7 @@ export function observeReadAdmission(filePath: string, options: {
     const actualClose = handle.close.bind(handle);
     vi.spyOn(handle, "close").mockImplementation(async () => {
       close();
+      descriptors.delete(handle.fd);
       await actualClose();
     });
     return handle;

--- a/test/json-durable-queue-batch-durability.test.ts
+++ b/test/json-durable-queue-batch-durability.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -198,7 +199,7 @@ describe("queue migration durability", () => {
     const failure = ioFailure();
     const realWrite = fs.writeFile.bind(fs);
     const realRename = fs.rename.bind(fs);
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     let published = false;
     vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
       if (stage === "write" && typeof args[0] === "object" && "fd" in args[0]) throw failure;
@@ -209,9 +210,9 @@ describe("queue migration durability", () => {
       await realRename(source, target);
       if (target === paths.processingPath) published = true;
     });
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
       if (stage === "verify" && published && args[0] === paths.processingPath) throw failure;
-      return await realLstat(...args);
+      return realLstat(...args);
     });
     const load = () => loadPendingJsonDurableQueueEntries({ ...options, read: migrate });
 

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -145,7 +145,7 @@ describe("json file helpers", () => {
   it("does not retry initially missing nullable JSON reads", async () => {
     const root = await tempRoot("fs-safe-json-missing-");
     const missing = path.join(root, "missing.json");
-    const lstatSpy = vi.spyOn(fs, "lstat");
+    const lstatSpy = vi.spyOn(fsSync, "lstatSync");
 
     try {
       await expect(readJsonIfExists(missing)).resolves.toBeNull();
@@ -163,14 +163,14 @@ describe("json file helpers", () => {
     await fs.writeFile(filePath, "{\"ok\":true}", "utf8");
     await fs.writeFile(secretPath, "{\"secret\":true}", "utf8");
 
-    const originalLstat = fs.lstat.bind(fs);
+    const originalLstat = fsSync.lstatSync.bind(fsSync);
     let swapped = false;
-    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const stat = await originalLstat(...args);
+    const lstatSpy = vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const stat = originalLstat(...args);
       if (!swapped && args[0] === filePath) {
         swapped = true;
-        await fs.rm(filePath, { force: true });
-        await fs.symlink(secretPath, filePath);
+        fsSync.rmSync(filePath, { force: true });
+        fsSync.symlinkSync(secretPath, filePath);
       }
       return stat;
     });

--- a/test/move-path-authority.test.ts
+++ b/test/move-path-authority.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -54,20 +55,17 @@ describe("movePathWithCopyFallback publication authority", () => {
     const expired = new Error("move owner expired");
     let active = true;
     const rename = observeRename(fixture, route.fallback);
-    const paused = Promise.withResolvers<void>();
-    const release = Promise.withResolvers<void>();
-    const lstat = fs.lstat;
-    let pausedOnce = false;
-    vi.spyOn(fs, "lstat").mockImplementation(async (candidate, options) => {
-      const stat = await lstat(candidate, options as never);
+    const lstat = fsSync.lstatSync;
+    let expiredDuringPreparation = false;
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((candidate, options) => {
+      const stat = lstat(candidate, options as never);
       if (
-        !pausedOnce && candidate === fixture.targetParent &&
+        !expiredDuringPreparation && candidate === fixture.targetParent &&
         (!route.fallback || rename.mock.calls.length > 0)
       ) {
-        pausedOnce = true;
-        paused.resolve();
+        expiredDuringPreparation = true;
         // Deliver unchanged filesystem evidence after the caller loses authority.
-        await release.promise;
+        active = false;
       }
       return stat;
     });
@@ -80,20 +78,10 @@ describe("movePathWithCopyFallback publication authority", () => {
       },
     }).catch((error: unknown) => error);
 
-    try {
-      await Promise.race([
-        paused.promise,
-        move.then(() => { throw new Error("move settled before the preparation barrier"); }),
-      ]);
-      active = false;
-      release.resolve();
-      expect(await move).toBe(expired);
-      expect(rename).toHaveBeenCalledTimes(route.fallback ? 1 : 0);
-      await expectUnpublished(fixture);
-    } finally {
-      release.resolve();
-      await move;
-    }
+    expect(await move).toBe(expired);
+    expect(expiredDuringPreparation).toBe(true);
+    expect(rename).toHaveBeenCalledTimes(route.fallback ? 1 : 0);
+    await expectUnpublished(fixture);
   });
 
   it.each(routes)("does not yield between approval and $name dispatch", async (route) => {

--- a/test/move-path-mutation-receipt.test.ts
+++ b/test/move-path-mutation-receipt.test.ts
@@ -181,10 +181,10 @@ describe("move publication receipts and mutation authority", () => {
         expectReceipt(receipt, move.target);
         committed = true;
       });
-      const lstat = fs.lstat;
-      vi.spyOn(fs, "lstat").mockImplementation(async (candidate, options) => {
+      const lstat = fsSync.lstatSync;
+      vi.spyOn(fsSync, "lstatSync").mockImplementation((candidate, options) => {
         if (committed && candidate === move.parent) throw failed;
-        return await lstat(candidate, options as never);
+        return lstat(candidate, options as never);
       });
       await expect(movePathWithCopyFallback({
         from: move.source,

--- a/test/native-write-mode-ownership.test.ts
+++ b/test/native-write-mode-ownership.test.ts
@@ -62,6 +62,9 @@ describe.skipIf(!nativeAvailable)("native Windows final-mode ownership", () => {
           return project(stat, await original(args[0], { bigint: true }));
         }) as typeof fs.stat);
       }
+      const statSync = fsSync.statSync.bind(fsSync);
+      vi.spyOn(fsSync, "statSync").mockImplementation(((...args: Parameters<typeof fsSync.statSync>) =>
+        project(statSync(...args), statSync(args[0], { bigint: true }))) as typeof fsSync.statSync);
       const lstatSync = fsSync.lstatSync.bind(fsSync);
       vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) =>
         project(lstatSync(...args), lstatSync(args[0], { bigint: true }))) as typeof fsSync.lstatSync);

--- a/test/new-primitives.test.ts
+++ b/test/new-primitives.test.ts
@@ -1105,14 +1105,14 @@ describe("regular file append", () => {
     await fs.writeFile(filePath, "safe", "utf8");
     await fs.writeFile(secretPath, "secret", "utf8");
 
-    const originalLstat = fs.lstat.bind(fs);
+    const originalLstat = syncFs.lstatSync.bind(syncFs);
     let swapped = false;
-    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const stat = await originalLstat(...args);
+    const lstatSpy = vi.spyOn(syncFs, "lstatSync").mockImplementation((...args) => {
+      const stat = originalLstat(...args);
       if (!swapped && args[0] === filePath) {
         swapped = true;
-        await fs.rm(filePath, { force: true });
-        await fs.symlink(secretPath, filePath);
+        syncFs.rmSync(filePath, { force: true });
+        syncFs.symlinkSync(secretPath, filePath);
       }
       return stat;
     });

--- a/test/opened-realpath-observation.test.ts
+++ b/test/opened-realpath-observation.test.ts
@@ -23,9 +23,9 @@ describe("opened realpath observations", () => {
     const handle = await fs.open(target, "r");
     try {
       const identity = await handle.stat({ bigint: true });
-      const realpath = fsSync.realpathSync.bind(fsSync);
+      const realpath = fsSync.realpathSync.native;
       const calls: string[] = [];
-      vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
+      vi.spyOn(fsSync.realpathSync, "native").mockImplementation((...args) => {
         const candidate = String(args[0]);
         calls.push(candidate);
         if (candidate.startsWith("/proc/self/fd/")) throw Object.assign(new Error("no procfs"), { code: "ENOENT" });
@@ -50,9 +50,9 @@ describe("opened realpath observations", () => {
     const handle = await fs.open(target, "r");
     try {
       const identity = await handle.stat({ bigint: true });
-      const realpath = fsSync.realpathSync.bind(fsSync);
+      const realpath = fsSync.realpathSync.native;
       let attempts = 0;
-      vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
+      vi.spyOn(fsSync.realpathSync, "native").mockImplementation((...args) => {
         if (String(args[0]) === target) {
           if (++attempts === 1) throw Object.assign(new Error("raced lookup"), { code: "ENOENT" });
           fsSync.renameSync(target, path.join(directory, "saved"));

--- a/test/opened-realpath-observation.test.ts
+++ b/test/opened-realpath-observation.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -22,16 +23,16 @@ describe("opened realpath observations", () => {
     const handle = await fs.open(target, "r");
     try {
       const identity = await handle.stat({ bigint: true });
-      const realpath = fs.realpath.bind(fs);
+      const realpath = fsSync.realpathSync.bind(fsSync);
       const calls: string[] = [];
-      vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+      vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
         const candidate = String(args[0]);
         calls.push(candidate);
         if (candidate.startsWith("/proc/self/fd/")) throw Object.assign(new Error("no procfs"), { code: "ENOENT" });
         if (candidate.startsWith("/dev/fd/")) return target;
-        return await realpath(...args);
+        return realpath(...args);
       });
-      const stat = vi.spyOn(fs, "stat");
+      const stat = vi.spyOn(fsSync, "statSync");
       Object.defineProperty(process, "platform", { value: host });
       const resolved = await resolveOpenedFileRealPathForFd(handle.fd, identity, target);
       expect(resolved).toMatchObject({ realPath: target, stat: { dev: identity.dev, ino: identity.ino } });
@@ -49,15 +50,15 @@ describe("opened realpath observations", () => {
     const handle = await fs.open(target, "r");
     try {
       const identity = await handle.stat({ bigint: true });
-      const realpath = fs.realpath.bind(fs);
+      const realpath = fsSync.realpathSync.bind(fsSync);
       let attempts = 0;
-      vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+      vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
         if (String(args[0]) === target) {
           if (++attempts === 1) throw Object.assign(new Error("raced lookup"), { code: "ENOENT" });
-          await fs.rename(target, path.join(directory, "saved"));
-          await fs.writeFile(target, "replacement");
+          fsSync.renameSync(target, path.join(directory, "saved"));
+          fsSync.writeFileSync(target, "replacement");
         }
-        return await realpath(...args);
+        return realpath(...args);
       });
       Object.defineProperty(process, "platform", { value: "darwin" });
       await expect(resolveOpenedFileRealPathForFd(handle.fd, identity, target)).rejects.toMatchObject({ code: "path-mismatch" });
@@ -81,9 +82,9 @@ describe("opened realpath observations", () => {
         if (scenario === "hardlink") await fs.link(target, path.join(directory, "alias"));
       },
     });
-    const stat = fs.stat.bind(fs);
-    vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
-      const observed = await stat(...args);
+    const stat = fsSync.statSync.bind(fsSync);
+    vi.spyOn(fsSync, "statSync").mockImplementation((...args) => {
+      const observed = stat(...args);
       if (resolving && String(args[0]) === target && args[1]?.bigint) {
         observations++;
         if (scenario === "windows retry" && observations === 1) observed.ino = 0n;

--- a/test/opened-realpath.test.ts
+++ b/test/opened-realpath.test.ts
@@ -36,10 +36,10 @@ describe("opened file realpath resolution", () => {
     fd: number,
     pathError?: { path: string; code: string },
   ): void {
-    const realpath = fsSync.realpathSync.bind(fsSync);
+    const realpath = fsSync.realpathSync.native;
     const descriptorPaths = new Set([`/proc/self/fd/${fd}`, `/dev/fd/${fd}`]);
 
-    vi.spyOn(fsSync, "realpathSync").mockImplementation((target) => {
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementation((target) => {
       if (descriptorPaths.has(String(target))) {
         throw Object.assign(new Error("descriptor path unavailable"), { code: "ENOENT" });
       }

--- a/test/opened-realpath.test.ts
+++ b/test/opened-realpath.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -35,17 +36,17 @@ describe("opened file realpath resolution", () => {
     fd: number,
     pathError?: { path: string; code: string },
   ): void {
-    const realpath = fs.realpath.bind(fs);
+    const realpath = fsSync.realpathSync.bind(fsSync);
     const descriptorPaths = new Set([`/proc/self/fd/${fd}`, `/dev/fd/${fd}`]);
 
-    vi.spyOn(fs, "realpath").mockImplementation(async (target) => {
+    vi.spyOn(fsSync, "realpathSync").mockImplementation((target) => {
       if (descriptorPaths.has(String(target))) {
         throw Object.assign(new Error("descriptor path unavailable"), { code: "ENOENT" });
       }
       if (String(target) === pathError?.path) {
         throw Object.assign(new Error("path lookup failed"), { code: pathError.code });
       }
-      return await realpath(target);
+      return realpath(target);
     });
   }
 

--- a/test/regular-file-failure.test.ts
+++ b/test/regular-file-failure.test.ts
@@ -41,7 +41,7 @@ describe("regular file refusal and race handling", () => {
     expect(() => statRegularFileSync(root)).toThrow("path must be a regular file");
 
     const denied = Object.assign(new Error("inspection denied"), { code: "EACCES" });
-    vi.spyOn(fs, "lstat").mockRejectedValueOnce(denied);
+    vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => { throw denied; });
     await expect(statRegularFile(missing)).rejects.toBe(denied);
     vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => {
       throw denied;
@@ -108,11 +108,11 @@ describe("regular file refusal and race handling", () => {
     vi.spyOn(fs, "open").mockRejectedValueOnce(missing);
     await expect(readRegularFile({ filePath })).rejects.toMatchObject({ code: "path-mismatch" });
 
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     let calls = 0;
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
       if (String(args[0]) === filePath && ++calls === 2) throw missing;
-      return await realLstat(...args);
+      return realLstat(...args);
     });
     await expect(readRegularFile({ filePath })).rejects.toMatchObject({ code: "path-mismatch" });
   });
@@ -208,19 +208,17 @@ describe("regular file refusal and race handling", () => {
     const oldPath = path.join(root, "old");
     await fs.writeFile(filePath, "original");
     const preview = setIdentity(await fs.lstat(filePath, { bigint: true }), roundedIdentityA);
-    vi.spyOn(fs, "lstat").mockResolvedValueOnce(preview);
+    vi.spyOn(fsSync, "lstatSync").mockReturnValueOnce(preview);
     const realOpen = fs.open.bind(fs);
     vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
       await fs.rename(filePath, oldPath);
       await fs.writeFile(filePath, "replacement");
       const handle = await realOpen(...args);
       const opened = setIdentity(await handle.stat({ bigint: true }), roundedIdentityB);
-      return {
-        stat: async () => opened,
-        chmod: handle.chmod.bind(handle),
-        appendFile: handle.appendFile.bind(handle),
-        close: handle.close.bind(handle),
-      } as Awaited<ReturnType<typeof fs.open>>;
+      const fstat = fsSync.fstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) =>
+        fd === handle.fd ? opened : fstat(fd, options));
+      return handle;
     });
 
     expect(Number(roundedIdentityA)).toBe(Number(roundedIdentityB));
@@ -270,7 +268,7 @@ describe("regular file refusal and race handling", () => {
       await fs.writeFile(filePath, "original");
       if (variant === "async") {
         const unknown = setIdentity(await fs.lstat(filePath, { bigint: true }), 0n);
-        vi.spyOn(fs, "lstat").mockResolvedValue(unknown);
+        vi.spyOn(fsSync, "lstatSync").mockReturnValue(unknown);
         const open = vi.spyOn(fs, "open");
         await expect(appendRegularFile({ filePath, content: "x" })).rejects.toThrow(
           "file identity changed or could not be verified",
@@ -377,11 +375,11 @@ describe("regular file refusal and race handling", () => {
     const filePath = path.join(root, "value");
     await fs.writeFile(filePath, "abc");
     const denied = Object.assign(new Error("inspection denied"), { code: "EACCES" });
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     let calls = 0;
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
       if (String(args[0]) === filePath && ++calls === 2) throw denied;
-      return await realLstat(...args);
+      return realLstat(...args);
     });
     await expect(readRegularFile({ filePath })).rejects.toBe(denied);
   });
@@ -438,7 +436,7 @@ describe("regular file refusal and race handling", () => {
     const realOpen = fs.open.bind(fs);
     vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
       const handle = await realOpen(...args);
-      vi.spyOn(handle, "stat").mockResolvedValueOnce(directoryStat);
+      vi.spyOn(fsSync, "fstatSync").mockReturnValueOnce(directoryStat);
       return handle;
     });
     await expect(appendRegularFile({ filePath, content: "d" })).rejects.toThrow(

--- a/test/root-copy-read-identity.test.ts
+++ b/test/root-copy-read-identity.test.ts
@@ -36,10 +36,10 @@ describe("Root copy source lifetime", () => {
       fsSync.renameSync(replacement, source);
       swapped = true;
     };
-    for (const method of ["lstat", "stat"] as const) {
-      const actual = fs[method].bind(fs);
-      vi.spyOn(fs, method).mockImplementation(async (...args) => {
-        const stat = await actual(...args);
+    for (const method of ["lstatSync", "statSync"] as const) {
+      const actual = fsSync[method].bind(fsSync);
+      vi.spyOn(fsSync, method).mockImplementation((...args) => {
+        const stat = actual(...args);
         if (String(args[0]) === source) {
           const value = swapped ? (timing === "unknown-after-copy" ? 0n : ino + 1n) : ino;
           stat.ino = args[1]?.bigint ? value : Number(value);
@@ -51,11 +51,12 @@ describe("Root copy source lifetime", () => {
       afterOpen(candidate, handle) {
         if (candidate !== source) return;
         close = vi.spyOn(handle, "close");
-        const actualStat = handle.stat.bind(handle);
+        const actualStat = fsSync.fstatSync.bind(fsSync);
         let inspections = 0;
-        vi.spyOn(handle, "stat").mockImplementation(async (options) => {
+        vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+          if (fd !== handle.fd) return actualStat(fd, options);
           if (++inspections === 3 && timing === "before-copy") swap();
-          const stat = await actualStat(options);
+          const stat = actualStat(fd, options);
           stat.ino = options?.bigint ? ino : Number(ino);
           return stat;
         });

--- a/test/root-directory-errors.test.ts
+++ b/test/root-directory-errors.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -32,7 +33,10 @@ describe("root directory operational diagnostics", () => {
       code, errno: -1, syscall, path: path.join(rootDir, "child"),
     });
     for (const entry of ["helper", "scope"] as const) {
-      const spy = vi.spyOn(fs, syscall).mockRejectedValueOnce(cause);
+      const spy = syscall === "mkdir"
+        ? vi.spyOn(fs, "mkdir").mockRejectedValueOnce(cause)
+        : vi.spyOn(fsSync, syscall === "lstat" ? "lstatSync" : "realpathSync")
+          .mockImplementationOnce(() => { throw cause; });
       const result = entry === "helper"
         ? await ensureDirectoryWithinRoot({ rootDir, requestedPath: "child", scopeLabel: "uploads" })
         : await pathScope(rootDir, { label: "uploads" }).ensureDir("child");
@@ -57,11 +61,12 @@ describe("root directory operational diagnostics", () => {
     const rootDir = await tempRoot("fs-safe-dir-stage-");
     const target = location === "root" ? rootDir : path.join(rootDir, "child");
     const cause = Object.assign(new Error("I/O failure"), { code: "EIO", errno: -5, syscall });
-    const original = fs[syscall].bind(fs);
+    const method = syscall === "lstat" ? "lstatSync" : "realpathSync";
+    const original = fsSync[method].bind(fsSync);
     let calls = 0;
-    const spy = vi.spyOn(fs, syscall).mockImplementation(async (...args) => {
+    const spy = vi.spyOn(fsSync, method).mockImplementation((...args) => {
       if (String(args[0]) === target && ++calls === occurrence) throw cause;
-      return await original(...args);
+      return original(...args);
     });
     const result = await pathScope(rootDir, { label: "uploads" }).ensureDir("child");
     expectOperational(result, cause, "EIO", syscall);
@@ -80,7 +85,7 @@ describe("root directory operational diagnostics", () => {
       syscall: `lstat\r${"y".repeat(1000)}`,
       path: path.join(rootDir, "secret"),
     });
-    vi.spyOn(fs, "lstat").mockRejectedValueOnce(cause);
+    vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => { throw cause; });
     const result = await pathScope(rootDir, { label: `uploads\n${"z".repeat(1000)}` })
       .ensureDir("requested-secret");
     expect(result.ok).toBe(false);
@@ -98,7 +103,7 @@ describe("root directory operational diagnostics", () => {
     "retains unexpected non-errno failures without rejecting",
     async (cause) => {
       const rootDir = await tempRoot("fs-safe-dir-unexpected-");
-      vi.spyOn(fs, "lstat").mockRejectedValueOnce(cause);
+      vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => { throw cause; });
       const result = await pathScope(rootDir, { label: "uploads" }).ensureDir("child");
       expect(result).toMatchObject({ ok: false, diagnostic: { category: "operational" } });
       if (result.ok) throw new Error("expected directory failure");
@@ -116,11 +121,11 @@ describe("root directory operational diagnostics", () => {
     const requestedPath = path.join("missing", "date", "a".repeat(256));
     const target = path.join(rootDir, requestedPath);
     await expect(fs.lstat(target)).rejects.toMatchObject({ code: "ENOENT" });
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     const causes: unknown[] = [];
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
       try {
-        return await realLstat(...args);
+        return realLstat(...args);
       } catch (cause) {
         if ((cause as NodeJS.ErrnoException).code === "ENAMETOOLONG") causes.push(cause);
         throw cause;
@@ -173,7 +178,7 @@ describe("root directory policy results", () => {
 
   it("rejects traversal, root aliases, escaping defaults and NUL before I/O", async () => {
     const rootDir = await tempRoot("fs-safe-dir-input-");
-    const lstat = vi.spyOn(fs, "lstat");
+    const lstat = vi.spyOn(fsSync, "lstatSync");
     const mkdir = vi.spyOn(fs, "mkdir");
     for (const params of [
       { requestedPath: "../outside" },
@@ -274,11 +279,11 @@ describe("root directory policy results", () => {
     const rootDir = await tempRoot("fs-safe-dir-canonical-");
     const outside = await tempRoot("fs-safe-dir-canonical-outside-");
     const candidatePath = location === "root" ? rootDir : path.join(rootDir, "child");
-    const realRealpath = fs.realpath.bind(fs);
+    const realRealpath = fsSync.realpathSync.bind(fsSync);
     let calls = 0;
-    vi.spyOn(fs, "realpath").mockImplementation(async (candidate, options) => {
+    vi.spyOn(fsSync, "realpathSync").mockImplementation((candidate, options) => {
       if (String(candidate) === candidatePath && ++calls === occurrence) return outside;
-      return await realRealpath(candidate, options);
+      return realRealpath(candidate, options);
     });
     await expect(pathScope(rootDir, { label: "uploads" }).ensureDir("child"))
       .resolves.toEqual(policyFailure);

--- a/test/root-directory-errors.test.ts
+++ b/test/root-directory-errors.test.ts
@@ -35,8 +35,9 @@ describe("root directory operational diagnostics", () => {
     for (const entry of ["helper", "scope"] as const) {
       const spy = syscall === "mkdir"
         ? vi.spyOn(fs, "mkdir").mockRejectedValueOnce(cause)
-        : vi.spyOn(fsSync, syscall === "lstat" ? "lstatSync" : "realpathSync")
-          .mockImplementationOnce(() => { throw cause; });
+        : syscall === "lstat"
+          ? vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => { throw cause; })
+          : vi.spyOn(fsSync.realpathSync, "native").mockImplementationOnce(() => { throw cause; });
       const result = entry === "helper"
         ? await ensureDirectoryWithinRoot({ rootDir, requestedPath: "child", scopeLabel: "uploads" })
         : await pathScope(rootDir, { label: "uploads" }).ensureDir("child");
@@ -61,10 +62,10 @@ describe("root directory operational diagnostics", () => {
     const rootDir = await tempRoot("fs-safe-dir-stage-");
     const target = location === "root" ? rootDir : path.join(rootDir, "child");
     const cause = Object.assign(new Error("I/O failure"), { code: "EIO", errno: -5, syscall });
-    const method = syscall === "lstat" ? "lstatSync" : "realpathSync";
-    const original = fsSync[method].bind(fsSync);
+    const original = syscall === "lstat" ? fsSync.lstatSync : fsSync.realpathSync.native;
     let calls = 0;
-    const spy = vi.spyOn(fsSync, method).mockImplementation((...args) => {
+    const spy = syscall === "lstat" ? vi.spyOn(fsSync, "lstatSync") : vi.spyOn(fsSync.realpathSync, "native");
+    spy.mockImplementation((...args) => {
       if (String(args[0]) === target && ++calls === occurrence) throw cause;
       return original(...args);
     });
@@ -279,9 +280,9 @@ describe("root directory policy results", () => {
     const rootDir = await tempRoot("fs-safe-dir-canonical-");
     const outside = await tempRoot("fs-safe-dir-canonical-outside-");
     const candidatePath = location === "root" ? rootDir : path.join(rootDir, "child");
-    const realRealpath = fsSync.realpathSync.bind(fsSync);
+    const realRealpath = fsSync.realpathSync.native;
     let calls = 0;
-    vi.spyOn(fsSync, "realpathSync").mockImplementation((candidate, options) => {
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementation((candidate, options) => {
       if (String(candidate) === candidatePath && ++calls === occurrence) return outside;
       return realRealpath(candidate, options);
     });

--- a/test/root-error-coverage.test.ts
+++ b/test/root-error-coverage.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -203,7 +204,7 @@ describe("root context error paths", () => {
       .resolves.toMatchObject({ resolved: path.join(rootDir, "value.txt") });
 
     const denied = Object.assign(new Error("permission denied"), { code: "EACCES" });
-    vi.spyOn(fs, "realpath").mockRejectedValueOnce(denied);
+    vi.spyOn(fsSync, "realpathSync").mockImplementationOnce(() => { throw denied; });
     await expect(resolveRootContext(rootDir)).rejects.toBe(denied);
   });
 });

--- a/test/root-error-coverage.test.ts
+++ b/test/root-error-coverage.test.ts
@@ -204,7 +204,7 @@ describe("root context error paths", () => {
       .resolves.toMatchObject({ resolved: path.join(rootDir, "value.txt") });
 
     const denied = Object.assign(new Error("permission denied"), { code: "EACCES" });
-    vi.spyOn(fsSync, "realpathSync").mockImplementationOnce(() => { throw denied; });
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementationOnce(() => { throw denied; });
     await expect(resolveRootContext(rootDir)).rejects.toBe(denied);
   });
 });

--- a/test/root-path-store-coverage.test.ts
+++ b/test/root-path-store-coverage.test.ts
@@ -29,18 +29,18 @@ afterEach(() => {
 describe("absolute path failure coverage", () => {
   it("classifies root lookup errno and preserves unexpected failures", async () => {
     const target = path.join(path.parse(process.cwd()).root, "missing");
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
 
     for (const [errno, code] of [["ENOENT", "not-found"], ["ENOTDIR", "not-file"]] as const) {
-      vi.spyOn(fs, "lstat").mockRejectedValueOnce(
-        Object.assign(new Error(errno), { code: errno }),
-      );
+      vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => {
+        throw Object.assign(new Error(errno), { code: errno });
+      });
       await expect(ensureAbsoluteDirectory(target, { scopeLabel: "test root" }))
         .resolves.toMatchObject({ ok: false, code });
       vi.restoreAllMocks();
     }
 
-    vi.spyOn(fs, "lstat").mockImplementationOnce(async () => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => {
       throw Object.assign(new Error("permission denied"), { code: "EACCES" });
     }).mockImplementation(realLstat);
     await expect(ensureAbsoluteDirectory(target, { scopeLabel: "test root" }))
@@ -75,7 +75,7 @@ describe("absolute path failure coverage", () => {
       });
 
     const denied = Object.assign(new Error("permission denied"), { code: "EACCES" });
-    vi.spyOn(fs, "realpath").mockRejectedValueOnce(denied);
+    vi.spyOn(fsSync, "realpathSync").mockImplementationOnce(() => { throw denied; });
     await expect(resolveAbsolutePathForRead(path.join(root, "value.txt"))).rejects.toBe(denied);
   });
 
@@ -85,14 +85,14 @@ describe("absolute path failure coverage", () => {
     const original = `${root}-original`;
     tempDirs.push(original);
     const target = path.join(root, "missing");
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     let rootLookups = 0;
-    vi.spyOn(fs, "lstat").mockImplementation(async (candidate, options) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((candidate, options) => {
       if (String(candidate) === root && ++rootLookups === 2) {
-        await fs.rename(root, original);
-        await fs.symlink(outside, root, "dir");
+        fsSync.renameSync(root, original);
+        fsSync.symlinkSync(outside, root, "dir");
       }
-      return await realLstat(candidate, options);
+      return realLstat(candidate, options);
     });
 
     await expect(ensureAbsoluteDirectory(target, { scopeLabel: "test root" }))
@@ -106,9 +106,9 @@ describe("absolute path failure coverage", () => {
     const target = path.join(root, "missing");
     await fs.writeFile(file, "not a directory");
     const fileStat = await fs.lstat(file);
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     let rootLookups = 0;
-    vi.spyOn(fs, "lstat").mockImplementation(async (candidate, options) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((candidate, options) => {
       if (String(candidate) === root) {
         rootLookups += 1;
         if (rootLookups === 2) return fileStat;
@@ -116,20 +116,20 @@ describe("absolute path failure coverage", () => {
           throw Object.assign(new Error("vanished"), { code: "ENOENT" });
         }
       }
-      return await realLstat(candidate, options);
+      return realLstat(candidate, options);
     });
     await expect(ensureAbsoluteDirectory(target, { scopeLabel: "test root" }))
       .resolves.toMatchObject({ ok: false, code: "not-found" });
 
     vi.restoreAllMocks();
     const denied = Object.assign(new Error("permission denied"), { code: "EACCES" });
-    vi.spyOn(fs, "lstat").mockImplementation(async (candidate, options) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((candidate, options) => {
       if (String(candidate) === target) throw denied;
-      return await realLstat(candidate, options);
+      return realLstat(candidate, options);
     });
     await expect(ensureAbsoluteDirectory(target, { scopeLabel: "test root" })).rejects.toBe(denied);
     vi.restoreAllMocks();
-    vi.spyOn(fs, "lstat").mockRejectedValueOnce(denied);
+    vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => { throw denied; });
     await expect(canonicalPathFromExistingAncestor(target)).rejects.toBe(denied);
   });
 
@@ -138,20 +138,20 @@ describe("absolute path failure coverage", () => {
     const file = path.join(root, "file.txt");
     await fs.writeFile(file, "file");
     const fileStat = await fs.lstat(file);
-    vi.spyOn(fs, "lstat").mockResolvedValueOnce(fileStat);
+    vi.spyOn(fsSync, "lstatSync").mockReturnValueOnce(fileStat);
     await expect(ensureAbsoluteDirectory(path.join(root, "missing"), { scopeLabel: "test root" }))
       .resolves.toMatchObject({ ok: false, code: "not-file" });
 
     vi.restoreAllMocks();
     const target = path.join(root, "new.txt");
-    const realRealpath = fs.realpath.bind(fs);
+    const realRealpath = fsSync.realpathSync.bind(fsSync);
     let rejected = false;
-    vi.spyOn(fs, "realpath").mockImplementation(async (candidate, options) => {
+    vi.spyOn(fsSync, "realpathSync").mockImplementation((candidate, options) => {
       if (!rejected && String(candidate) === root) {
         rejected = true;
         throw Object.assign(new Error("canonicalization unavailable"), { code: "EACCES" });
       }
-      return await realRealpath(candidate, options);
+      return realRealpath(candidate, options);
     });
     await expect(resolveAbsolutePathForWrite(target)).resolves.toMatchObject({ path: target });
   });

--- a/test/root-path-store-coverage.test.ts
+++ b/test/root-path-store-coverage.test.ts
@@ -75,7 +75,7 @@ describe("absolute path failure coverage", () => {
       });
 
     const denied = Object.assign(new Error("permission denied"), { code: "EACCES" });
-    vi.spyOn(fsSync, "realpathSync").mockImplementationOnce(() => { throw denied; });
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementationOnce(() => { throw denied; });
     await expect(resolveAbsolutePathForRead(path.join(root, "value.txt"))).rejects.toBe(denied);
   });
 
@@ -144,9 +144,9 @@ describe("absolute path failure coverage", () => {
 
     vi.restoreAllMocks();
     const target = path.join(root, "new.txt");
-    const realRealpath = fsSync.realpathSync.bind(fsSync);
+    const realRealpath = fsSync.realpathSync.native;
     let rejected = false;
-    vi.spyOn(fsSync, "realpathSync").mockImplementation((candidate, options) => {
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementation((candidate, options) => {
       if (!rejected && String(candidate) === root) {
         rejected = true;
         throw Object.assign(new Error("canonicalization unavailable"), { code: "EACCES" });

--- a/test/root-read-identity.test.ts
+++ b/test/root-read-identity.test.ts
@@ -1,4 +1,4 @@
-import { Stats } from "node:fs";
+import fsSync, { Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -33,10 +33,10 @@ describe("root read exact identity", () => {
       let swapped = false;
       let close: ReturnType<typeof vi.spyOn> | undefined;
       let read: ReturnType<typeof vi.spyOn> | undefined;
-      for (const operation of ["lstat", "stat"] as const) {
-        const actual = fs[operation].bind(fs);
-        vi.spyOn(fs, operation).mockImplementation(async (...args) => {
-          const stat = await actual(...args);
+      for (const operation of ["lstatSync", "statSync"] as const) {
+        const actual = fsSync[operation].bind(fsSync);
+        vi.spyOn(fsSync, operation).mockImplementation((...args) => {
+          const stat = actual(...args);
           if (String(args[0]) === filePath) {
             const ino = originalIno + (swapped ? 1n : 0n);
             stat.ino = args[1]?.bigint ? ino : Number(ino);
@@ -55,9 +55,10 @@ describe("root read exact identity", () => {
           if (candidate !== filePath) return;
           close = vi.spyOn(handle, "close");
           read = vi.spyOn(handle, "read");
-          const actual = handle.stat.bind(handle);
-          vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-            const stat = await actual(options);
+          const actual = fsSync.fstatSync.bind(fsSync);
+          vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+            if (fd !== handle.fd) return actual(fd, options);
+            const stat = actual(fd, options);
             stat.ino = options?.bigint ? originalIno + 1n : Number(originalIno + 1n);
             return stat;
           });
@@ -84,18 +85,18 @@ describe("root read exact identity", () => {
       let opened = false;
       let close: ReturnType<typeof vi.spyOn> | undefined;
       let read: ReturnType<typeof vi.spyOn> | undefined;
-      const lstat = fs.lstat.bind(fs);
-      vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-        const stat = await lstat(...args);
+      const lstat = fsSync.lstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+        const stat = lstat(...args);
         if (String(args[0]) === filePath && args[1]?.bigint &&
           ((boundary === "preview" && !opened) || (boundary === "pathname" && opened))) {
           stat.ino = 0n;
         }
         return stat;
       });
-      const stat = fs.stat.bind(fs);
-      vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
-        const result = await stat(...args);
+      const stat = fsSync.statSync.bind(fsSync);
+      vi.spyOn(fsSync, "statSync").mockImplementation((...args) => {
+        const result = stat(...args);
         if (String(args[0]) === filePath && args[1]?.bigint && boundary === "realpath") {
           result.ino = 0n;
         }
@@ -107,9 +108,10 @@ describe("root read exact identity", () => {
           opened = true;
           close = vi.spyOn(handle, "close");
           read = vi.spyOn(handle, "read");
-          const actual = handle.stat.bind(handle);
-          vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-            const result = await actual(options);
+          const actual = fsSync.fstatSync.bind(fsSync);
+          vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+            if (fd !== handle.fd) return actual(fd, options);
+            const result = actual(fd, options);
             if (options?.bigint && boundary === "descriptor") result.ino = 0n;
             return result;
           });
@@ -146,9 +148,9 @@ describe("root read exact identity", () => {
     const beforeOpen = vi.fn();
     __setFsSafeTestHooksForTest({ beforeOpen });
     const failure = Object.assign(new Error("re-inspection denied"), { code: "EACCES" });
-    const lstat = fs.lstat.bind(fs);
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const stat = await lstat(...args);
+    const lstat = fsSync.lstatSync.bind(fsSync);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const stat = lstat(...args);
       if (String(args[0]) === filePath && args[1]?.bigint && beforeOpen.mock.calls.length === 0) {
         inspections++;
         if (inspections === 1) stat.ino = 0n;

--- a/test/root-write-exact-identity.test.ts
+++ b/test/root-write-exact-identity.test.ts
@@ -57,24 +57,24 @@ describe("Root exact publication identity", () => {
       expect(Number(inode)).toBe(Number(inode - 1n));
       if (scenario === "unknown Windows path") Object.defineProperty(process, "platform", { value: "win32" });
       const fstat = fsSync.fstatSync.bind(fsSync);
-      const lstat = fs.lstat.bind(fs);
-      const stat = fs.stat.bind(fs);
+      const lstat = fsSync.lstatSync.bind(fsSync);
+      const stat = fsSync.statSync.bind(fsSync);
       vi.spyOn(fsSync, "fstatSync").mockImplementation(((...args: Parameters<typeof fsSync.fstatSync>) => {
         const actual = fstat(...args);
         return actual.isFile() ? project(actual, scenario === "fd mismatch" ? inode : expectedInode, expectedDevice) : actual;
       }) as typeof fsSync.fstatSync);
-      vi.spyOn(fs, "lstat").mockImplementation((async (...args: Parameters<typeof fs.lstat>) => {
-        const actual = await lstat(...args);
+      vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) => {
+        const actual = lstat(...args);
         if (String(args[0]) !== target) return actual;
         return scenario === "unknown Windows path" ? project(actual, 0n, 0n)
           : project(actual, scenario === "path mismatch" ? inode : expectedInode, expectedDevice);
-      }) as typeof fs.lstat);
-      vi.spyOn(fs, "stat").mockImplementation((async (...args: Parameters<typeof fs.stat>) => {
-        const actual = await stat(...args);
+      }) as typeof fsSync.lstatSync);
+      vi.spyOn(fsSync, "statSync").mockImplementation(((...args: Parameters<typeof fsSync.statSync>) => {
+        const actual = stat(...args);
         if (String(args[0]) !== target) return actual;
         return scenario === "unknown Windows path" ? project(actual, 0n, 0n)
           : project(actual, scenario === "canonical mismatch" ? inode : expectedInode, expectedDevice);
-      }) as typeof fs.stat);
+      }) as typeof fsSync.statSync);
       try {
         const pending = verify({ root: context, targetPath: target, fd: handle.fd,
           expectedIdentity: { dev: expectedDevice, ino: expectedInode }, parentGuard });
@@ -93,14 +93,14 @@ describe("Root exact publication identity", () => {
       if (route === "descriptor") Object.defineProperty(process, "platform", { value: "linux" });
       const target = path.join(directory, "target");
       const handle = await fs.open(target, "wx", 0o600);
-      const realpath = fs.realpath.bind(fs);
-      const stat = fs.stat.bind(fs);
-      const lstat = fs.lstat.bind(fs);
-      const handleStat = handle.stat.bind(handle);
+      const realpath = fsSync.realpathSync.bind(fsSync);
+      const stat = fsSync.statSync.bind(fsSync);
+      const lstat = fsSync.lstatSync.bind(fsSync);
+      const handleStat = fsSync.fstatSync.bind(fsSync);
       let pathnameAttempts = 0;
-      vi.spyOn(handle, "stat").mockImplementation((async (...args: Parameters<typeof handle.stat>) =>
-        project(await handleStat(...args))) as typeof handle.stat);
-      vi.spyOn(fs, "realpath").mockImplementation((async (...args: Parameters<typeof fs.realpath>) => {
+      vi.spyOn(fsSync, "fstatSync").mockImplementation(((...args: Parameters<typeof fsSync.fstatSync>) =>
+        args[0] === handle.fd ? project(handleStat(...args)) : handleStat(...args)) as typeof fsSync.fstatSync);
+      vi.spyOn(fsSync, "realpathSync").mockImplementation(((...args: Parameters<typeof fsSync.realpathSync>) => {
         const candidate = String(args[0]);
         if (candidate.startsWith("/dev/fd/") || candidate.startsWith("/proc/self/fd/")) {
           if (route === "descriptor") return target;
@@ -109,23 +109,23 @@ describe("Root exact publication identity", () => {
         if (candidate === target && route === "parent scan" && pathnameAttempts++ === 0) {
           throw Object.assign(new Error("pathname raced"), { code: "ENOENT" });
         }
-        return await realpath(...args);
-      }) as typeof fs.realpath);
+        return realpath(...args);
+      }) as typeof fsSync.realpathSync);
       const sampled: Array<number | bigint> = [];
-      vi.spyOn(fs, "stat").mockImplementation((async (...args: Parameters<typeof fs.stat>) => {
-        const actual = await stat(...args);
+      vi.spyOn(fsSync, "statSync").mockImplementation(((...args: Parameters<typeof fsSync.statSync>) => {
+        const actual = stat(...args);
         if (String(args[0]) !== target) return actual;
         const projected = project(actual);
         sampled.push(projected.ino);
         return projected;
-      }) as typeof fs.stat);
-      vi.spyOn(fs, "lstat").mockImplementation((async (...args: Parameters<typeof fs.lstat>) => {
-        const actual = await lstat(...args);
+      }) as typeof fsSync.statSync);
+      vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) => {
+        const actual = lstat(...args);
         if (String(args[0]) !== target) return actual;
         const projected = project(actual);
         sampled.push(projected.ino);
         return projected;
-      }) as typeof fs.lstat);
+      }) as typeof fsSync.lstatSync);
       try {
         const pending = route === "numeric handle wrapper"
           ? resolveOpenedFileRealPathForHandle(handle, target)
@@ -163,10 +163,10 @@ for (const route of routes) {
         const fstat = fsSync.fstatSync.bind(fsSync);
         vi.spyOn(fsSync, "fstatSync").mockImplementation(((...args: Parameters<typeof fsSync.fstatSync>) =>
           project(fstat(...args), currentInode())) as typeof fsSync.fstatSync);
-        for (const method of ["stat", "lstat"] as const) {
-          const original = fs[method].bind(fs);
-          vi.spyOn(fs, method).mockImplementation((async (...args: Parameters<typeof fs.stat>) =>
-            project(await original(...args), currentInode())) as typeof fs.stat);
+        for (const method of ["statSync", "lstatSync"] as const) {
+          const original = fsSync[method].bind(fsSync);
+          vi.spyOn(fsSync, method).mockImplementation(((...args: Parameters<typeof fsSync.statSync>) =>
+            project(original(...args), currentInode())) as typeof fsSync.statSync);
         }
         const open = fs.open.bind(fs);
         vi.spyOn(fs, "open").mockImplementation(async (...args) => {
@@ -288,16 +288,16 @@ for (const backend of ["fallback", "native"] as const) {
           reopened.push(handle);
           return handle;
         });
-        for (const method of ["stat", "lstat"] as const) {
-          const original = fs[method].bind(fs);
-          vi.spyOn(fs, method).mockImplementation((async (...args: Parameters<typeof fs.stat>) => {
-            const stat = await original(...args);
+        for (const method of ["statSync", "lstatSync"] as const) {
+          const original = fsSync[method].bind(fsSync);
+          vi.spyOn(fsSync, method).mockImplementation(((...args: Parameters<typeof fsSync.statSync>) => {
+            const stat = original(...args);
             if (!opaque || String(args[0]) !== target) return stat;
             return Object.assign(Object.create(stat), {
               dev: typeof stat.dev === "bigint" ? 0n : 0,
               ino: typeof stat.ino === "bigint" ? 0n : 0,
             });
-          }) as typeof fs.stat);
+          }) as typeof fsSync.statSync);
         }
         const verifier = vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(
           async (params) => {

--- a/test/root-write-exact-identity.test.ts
+++ b/test/root-write-exact-identity.test.ts
@@ -93,14 +93,14 @@ describe("Root exact publication identity", () => {
       if (route === "descriptor") Object.defineProperty(process, "platform", { value: "linux" });
       const target = path.join(directory, "target");
       const handle = await fs.open(target, "wx", 0o600);
-      const realpath = fsSync.realpathSync.bind(fsSync);
+      const realpath = fsSync.realpathSync.native;
       const stat = fsSync.statSync.bind(fsSync);
       const lstat = fsSync.lstatSync.bind(fsSync);
       const handleStat = fsSync.fstatSync.bind(fsSync);
       let pathnameAttempts = 0;
       vi.spyOn(fsSync, "fstatSync").mockImplementation(((...args: Parameters<typeof fsSync.fstatSync>) =>
         args[0] === handle.fd ? project(handleStat(...args)) : handleStat(...args)) as typeof fsSync.fstatSync);
-      vi.spyOn(fsSync, "realpathSync").mockImplementation(((...args: Parameters<typeof fsSync.realpathSync>) => {
+      vi.spyOn(fsSync.realpathSync, "native").mockImplementation(((...args: Parameters<typeof fsSync.realpathSync.native>) => {
         const candidate = String(args[0]);
         if (candidate.startsWith("/dev/fd/") || candidate.startsWith("/proc/self/fd/")) {
           if (route === "descriptor") return target;
@@ -110,7 +110,7 @@ describe("Root exact publication identity", () => {
           throw Object.assign(new Error("pathname raced"), { code: "ENOENT" });
         }
         return realpath(...args);
-      }) as typeof fsSync.realpathSync);
+      }) as typeof fsSync.realpathSync.native);
       const sampled: Array<number | bigint> = [];
       vi.spyOn(fsSync, "statSync").mockImplementation(((...args: Parameters<typeof fsSync.statSync>) => {
         const actual = stat(...args);

--- a/test/root-write-inheritance.test.ts
+++ b/test/root-write-inheritance.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -59,21 +60,21 @@ for (const nativeMode of ["auto", "off"] as const) {
       await fs.writeFile(target, "original", { mode: 0o600 });
       await fs.writeFile(path.join(outside, "target"), "outside");
       await fs.chmod(path.join(outside, "target"), 0o666);
-      const lstat = fs.lstat.bind(fs);
+      const lstat = fsSync.lstatSync.bind(fsSync);
       let attacked = false;
-      vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+      vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
         if (String(args[0]) === target && args[1]?.bigint && !attacked) {
           attacked = true;
-          await fs.rename(parent, saved);
-          await fs.symlink(outside, parent);
-          const observed = await lstat(...args);
+          fsSync.renameSync(parent, saved);
+          fsSync.symlinkSync(outside, parent);
+          const observed = lstat(...args);
           if (restoreParent) {
-            await fs.unlink(parent);
-            await fs.rename(saved, parent);
+            fsSync.unlinkSync(parent);
+            fsSync.renameSync(saved, parent);
           }
           return observed;
         }
-        return await lstat(...args);
+        return lstat(...args);
       });
       await expect(safe.write("parent/target", "sensitive")).rejects.toMatchObject({
         code: restoreParent ? "path-mismatch" : "outside-workspace",

--- a/test/root-write-lifetime.test.ts
+++ b/test/root-write-lifetime.test.ts
@@ -64,11 +64,11 @@ describe.skipIf(process.platform === "win32")("FUSE accepted descriptor lifetime
           await fs.rename(target, path.join(directory, "accepted"));
           await fs.writeFile(target, "payload", { mode });
         } else if (scenario === "outer I/O") {
-          const realLstat = fs.lstat.bind(fs);
-          vi.spyOn(fs, "lstat").mockImplementation((async (...args: Parameters<typeof fs.lstat>) => {
+          const realLstat = fsSync.lstatSync.bind(fsSync);
+          vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) => {
             if (String(args[0]) === target) throw sentinel;
-            return await realLstat(...args);
-          }) as typeof fs.lstat);
+            return realLstat(...args);
+          }) as typeof fsSync.lstatSync);
         }
         await verifyPublished(params);
       });
@@ -183,13 +183,13 @@ for (const backend of ["javascript", "native", "windows fallback branch"] as con
                 : { isFile: () => false });
           }) as typeof fsSync.fstatSync);
           if (backend === "windows fallback branch") {
-            const realLstat = fs.lstat.bind(fs);
-            vi.spyOn(fs, "lstat").mockImplementation((async (...args: Parameters<typeof fs.lstat>) => {
-              const stat = await realLstat(...args);
+            const realLstat = fsSync.lstatSync.bind(fsSync);
+            vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) => {
+              const stat = realLstat(...args);
               if (String(args[0]) !== target) return stat;
               unknownPathChecked = true;
               return Object.assign(Object.create(stat), { dev: 0, ino: 0 });
-            }) as typeof fs.lstat);
+            }) as typeof fsSync.lstatSync);
           }
           await verifyPublished(params);
         });

--- a/test/root-write-reopen.test.ts
+++ b/test/root-write-reopen.test.ts
@@ -31,13 +31,13 @@ describe("Windows publication reopen guards", () => {
     let readFile: ReturnType<typeof vi.spyOn> | undefined;
     let retainedFd: number | undefined;
     let linked = false;
-    for (const operation of ["stat", "lstat"] as const) {
-      const actual = fs[operation].bind(fs);
-      vi.spyOn(fs, operation).mockImplementation(async (...args) => {
-        const stat = await actual(...args);
+    for (const operation of ["statSync", "lstatSync"] as const) {
+      const actual = fsSync[operation].bind(fsSync);
+      vi.spyOn(fsSync, operation).mockImplementation((...args) => {
+        const stat = actual(...args);
         if (!opaque || String(args[0]) !== target) return stat;
-        if (operation === "stat" && reopened && attack === "late hardlink" && !linked) {
-          await fs.link(target, alias);
+        if (operation === "statSync" && reopened && attack === "late hardlink" && !linked) {
+          fsSync.linkSync(target, alias);
           linked = true;
         }
         stat.dev = args[1]?.bigint ? 0n : 0;

--- a/test/root-write-verification.test.ts
+++ b/test/root-write-verification.test.ts
@@ -63,39 +63,39 @@ for (const backend of ["javascript", "native", "windows fallback branch"] as con
         let retainedFd: number | undefined;
         let publishedPath = target;
         let injected = false;
-        const realLstat = fs.lstat.bind(fs);
-        const inject = async (kind: Attack) => {
+        const realLstat = fsSync.lstatSync.bind(fsSync);
+        const inject = (kind: Attack) => {
           injected = true;
           if (kind === "same bytes" || kind === "different bytes" || kind === "symlink") {
             publishedPath = path.join(parent, "original");
-            await fs.rename(target, publishedPath);
+            fsSync.renameSync(target, publishedPath);
             if (kind === "symlink") {
-              await fs.symlink(outsideFile, target);
+              fsSync.symlinkSync(outsideFile, target);
             } else {
-              await fs.writeFile(target, kind === "same bytes" ? payload : "raced bytes", { mode });
+              fsSync.writeFileSync(target, kind === "same bytes" ? payload : "raced bytes", { mode });
             }
           } else if (kind === "hardlink" || kind === "late hardlink") {
-            await fs.link(target, path.join(parent, "alias"));
+            fsSync.linkSync(target, path.join(parent, "alias"));
           } else if (kind === "parent escape" || kind === "parent rebind") {
             const moved = path.join(outside, "moved-parent");
-            await fs.rename(parent, moved);
+            fsSync.renameSync(parent, moved);
             publishedPath = path.join(moved, "target");
             if (kind === "parent escape") {
-              await fs.symlink(moved, parent);
+              fsSync.symlinkSync(moved, parent);
             } else {
-              await fs.mkdir(parent);
-              await fs.rename(publishedPath, target);
+              fsSync.mkdirSync(parent);
+              fsSync.renameSync(publishedPath, target);
               publishedPath = target;
             }
           } else if (kind === "root escape" || kind === "root rebind") {
             const moved = path.join(outside, "moved-root");
-            await fs.rename(workspace, moved);
+            fsSync.renameSync(workspace, moved);
             publishedPath = path.join(moved, "parent", "target");
             if (kind === "root escape") {
-              await fs.symlink(moved, workspace);
+              fsSync.symlinkSync(moved, workspace);
             } else {
-              await fs.mkdir(workspace);
-              await fs.rename(path.join(moved, "parent"), parent);
+              fsSync.mkdirSync(workspace);
+              fsSync.renameSync(path.join(moved, "parent"), parent);
               publishedPath = target;
             }
           }
@@ -106,18 +106,18 @@ for (const backend of ["javascript", "native", "windows fallback branch"] as con
           expect(fsSync.fstatSync(params.fd).isFile()).toBe(true);
           if (attack === "late hardlink") {
             // Add a link after canonical resolution, while checking the parent.
-            vi.spyOn(fs, "lstat").mockImplementation((async (...args: Parameters<typeof fs.lstat>) => {
-              if (!injected && String(args[0]) === parent) await inject(attack);
-              return await realLstat(...args);
-            }) as typeof fs.lstat);
+            vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) => {
+              if (!injected && String(args[0]) === parent) inject(attack);
+              return realLstat(...args);
+            }) as typeof fsSync.lstatSync);
           } else if (["EIO", "EACCES", "EPERM", "EEXIST"].includes(attack)) {
-            vi.spyOn(fs, "lstat").mockImplementation((async (...args: Parameters<typeof fs.lstat>) => {
+            vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) => {
               if (String(args[0]) === target) {
                 injected = true;
                 throw sentinel;
               }
-              return await realLstat(...args);
-            }) as typeof fs.lstat);
+              return realLstat(...args);
+            }) as typeof fsSync.lstatSync);
           } else {
             await inject(attack);
           }

--- a/test/secret-directory-receipt.test.ts
+++ b/test/secret-directory-receipt.test.ts
@@ -21,7 +21,7 @@ describe("secret directory admission receipts", () => {
       await fs.mkdir(parent, { mode: 0o700 });
       const filePath = path.join(parent, phase === "ancestor" ? "inner/token" : "token");
       const lstat = fsSync.lstatSync.bind(fsSync);
-      const realpath = fsSync.realpathSync.bind(fsSync);
+      const realpath = fsSync.realpathSync.native;
       let inspections = 0;
       let admitted = false;
       let swapped = false;
@@ -39,7 +39,7 @@ describe("secret directory admission receipts", () => {
         if (isParent && options?.bigint && ++inspections >= 3) admitted = true;
         return value;
       });
-      vi.spyOn(fsSync, "realpathSync").mockImplementation((target, options) => {
+      vi.spyOn(fsSync.realpathSync, "native").mockImplementation((target, options) => {
         if (phase === "final parent" && admitted && String(target) === parent && !swapped) swap();
         return realpath(target, options);
       });

--- a/test/secret-directory-receipt.test.ts
+++ b/test/secret-directory-receipt.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, vi } from "vitest";
@@ -19,28 +20,28 @@ describe("secret directory admission receipts", () => {
       const moved = path.join(rootDir, "admitted");
       await fs.mkdir(parent, { mode: 0o700 });
       const filePath = path.join(parent, phase === "ancestor" ? "inner/token" : "token");
-      const lstat = fs.lstat.bind(fs);
-      const realpath = fs.realpath.bind(fs);
+      const lstat = fsSync.lstatSync.bind(fsSync);
+      const realpath = fsSync.realpathSync.bind(fsSync);
       let inspections = 0;
       let admitted = false;
       let swapped = false;
-      const swap = async () => {
+      const swap = () => {
         swapped = true;
-        await fs.rename(parent, moved);
-        await fs.mkdir(parent, { mode: 0o750 });
-        await fs.chmod(parent, 0o750);
+        fsSync.renameSync(parent, moved);
+        fsSync.mkdirSync(parent, { mode: 0o750 });
+        fsSync.chmodSync(parent, 0o750);
       };
-      vi.spyOn(fs, "lstat").mockImplementation(async (target, options) => {
+      vi.spyOn(fsSync, "lstatSync").mockImplementation((target, options) => {
         const isParent = String(target) === parent;
-        if (phase === "ancestor" && admitted && isParent && !swapped) await swap();
-        const value = await lstat(target, options);
+        if (phase === "ancestor" && admitted && isParent && !swapped) swap();
+        const value = lstat(target, options);
         // Initial inspection, guard capture, then the permission-admission inspection.
         if (isParent && options?.bigint && ++inspections >= 3) admitted = true;
         return value;
       });
-      vi.spyOn(fs, "realpath").mockImplementation(async (target, options) => {
-        if (phase === "final parent" && admitted && String(target) === parent && !swapped) await swap();
-        return await realpath(target, options);
+      vi.spyOn(fsSync, "realpathSync").mockImplementation((target, options) => {
+        if (phase === "final parent" && admitted && String(target) === parent && !swapped) swap();
+        return realpath(target, options);
       });
 
       const failure = await write({ rootDir, filePath, content: "synthetic" }).catch((error: unknown) => error);

--- a/test/secret-write-publication.test.ts
+++ b/test/secret-write-publication.test.ts
@@ -181,8 +181,8 @@ for (const backend of ["off", "require"] as const) {
               injected = true;
               throw sentinel;
             } else if (attack === "I/O failure" || attack === "late hardlink" || attack === "late mode") {
-              const lstat = fs.lstat.bind(fs);
-              vi.spyOn(fs, "lstat").mockImplementation((async (...args: Parameters<typeof fs.lstat>) => {
+              const lstat = fsSync.lstatSync.bind(fsSync);
+              vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) => {
                 if (attack === "I/O failure" && String(args[0]) === filePath) {
                   injected = true;
                   throw sentinel;
@@ -190,11 +190,11 @@ for (const backend of ["off", "require"] as const) {
                 // Run after the first file check, during ancestry validation.
                 if (!injected && String(args[0]) === parent) {
                   injected = true;
-                  if (attack === "late hardlink") await fs.link(filePath, path.join(parent, "alias"));
+                  if (attack === "late hardlink") fsSync.linkSync(filePath, path.join(parent, "alias"));
                   else fsSync.fchmodSync(params.fd, 0o644);
                 }
-                return await lstat(...args);
-              }) as typeof fs.lstat);
+                return lstat(...args);
+              }) as typeof fsSync.lstatSync);
             }
             try {
               await verify(params);

--- a/test/sibling-temp-directory-mode.test.ts
+++ b/test/sibling-temp-directory-mode.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, expect, vi } from "vitest";
@@ -51,8 +52,8 @@ itPosix.each(["lstat", "open", "pathname-type", "stat", "descriptor-type", "iden
     const failure = Object.assign(new Error(`directory ${phase} failed`), { code: "EIO" });
     const chmod = vi.fn();
     let directory: FileHandle | undefined;
-    if (phase === "lstat") vi.spyOn(fs, "lstat").mockRejectedValueOnce(failure);
-    if (phase === "pathname-type") vi.spyOn(fs, "lstat").mockResolvedValueOnce(await fs.stat(f.final));
+    if (phase === "lstat") vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => { throw failure; });
+    if (phase === "pathname-type") vi.spyOn(fsSync, "lstatSync").mockReturnValueOnce(await fs.stat(f.final));
     vi.spyOn(fs, "open").mockImplementation(async (...args) => {
       if (args[0] !== f.dir) return await open(...args);
       if (phase === "open") throw failure;
@@ -66,7 +67,13 @@ itPosix.each(["lstat", "open", "pathname-type", "stat", "descriptor-type", "iden
         chmod();
         throw new Error("directory chmod denied");
       });
-      if (phase === "stat") vi.spyOn(directory, "stat").mockRejectedValue(failure);
+      if (phase === "stat") {
+        const fstat = fsSync.fstatSync.bind(fsSync);
+        vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+          if (fd === directory!.fd) throw failure;
+          return fstat(fd, options);
+        });
+      }
       if (phase === "close") {
         const close = directory.close.bind(directory);
         vi.spyOn(directory, "close").mockImplementation(async () => {

--- a/test/sidecar-lock-root-ancestry.test.ts
+++ b/test/sidecar-lock-root-ancestry.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
@@ -61,9 +62,9 @@ it.each(["numeric", "unknown", "changed", "EACCES", "EIO"])("rejects %s canonica
     __setFsSafeTestHooksForTest();
     await fs.unlink(lockPath);
     Object.defineProperty(process, "platform", { value: "win32" });
-    const lstat = fs.lstat.bind(fs);
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const value = await lstat(...args);
+    const lstat = fsSync.lstatSync.bind(fsSync);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const value = lstat(...args);
       if (String(args[0]) === parent && typeof args[1] === "object" && args[1]?.bigint) {
         if (kind === "EACCES" || kind === "EIO") throw Object.assign(new Error("directory failure"), { code: kind });
         Object.assign(value, { ino: kind === "numeric" ? Number(value.ino) : kind === "unknown" ? 0n : BigInt(value.ino) + 1n });
@@ -80,10 +81,10 @@ it.each(["EACCES", "EIO"])("does not treat initial directory %s as missing-paren
   const lockPath = path.join(capability.rootReal, "state.lock");
   await capability.create("state.lock", "{}");
   const failure = Object.assign(new Error("directory failure"), { code });
-  const lstat = fs.lstat.bind(fs), open = vi.spyOn(capability, "open");
-  vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+  const lstat = fsSync.lstatSync.bind(fsSync), open = vi.spyOn(capability, "open");
+  vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
     if (String(args[0]) === capability.rootReal && typeof args[1] === "object" && args[1]?.bigint) throw failure;
-    return await lstat(...args);
+    return lstat(...args);
   });
   await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" })).rejects.toBe(failure);
   expect(open).not.toHaveBeenCalled();

--- a/test/sidecar-lock-root-create-denial.test.ts
+++ b/test/sidecar-lock-root-create-denial.test.ts
@@ -247,10 +247,10 @@ describe("Root exclusive-create denial (synthetic Windows/errno; real files)", (
         attempts += 1;
         if (operation === "write") vi.spyOn(handle, "writeFile").mockRejectedValue(error);
         else {
-          const realStat = handle.stat.bind(handle);
-          vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-            if (options?.bigint) throw error;
-            return await realStat(options);
+          const realStat = fs.fstatSync.bind(fs);
+          vi.spyOn(fs, "fstatSync").mockImplementation((fd, options) => {
+            if (fd === handle.fd && options?.bigint) throw error;
+            return realStat(fd, options);
           });
         }
       }

--- a/test/sidecar-lock-root-preopen-boundary.test.ts
+++ b/test/sidecar-lock-root-preopen-boundary.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
@@ -74,9 +75,10 @@ itPosix.each(["root", "ancestor", "symlink-leaf", "directory-leaf", "before-mult
       if (candidate !== lockPath) return;
       descriptor = handle;
       if (mutation === "numeric-multilink") {
-        const stat = handle.stat.bind(handle);
-        vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-          const value = await stat(options);
+        const stat = fsSync.fstatSync.bind(fsSync);
+        vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+          const value = stat(fd, options);
+          if (fd !== handle.fd) return value;
           return options?.bigint ? value : Object.assign(value, { nlink: 2 });
         });
       }

--- a/test/sidecar-lock-root-resolver.test.ts
+++ b/test/sidecar-lock-root-resolver.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
@@ -36,23 +37,23 @@ it.each(["EPERM", "EBADF"])("retries the recorded Windows resolver %s only with 
       await owner.release();
       expect((await handle.stat({ bigint: true })).nlink).toBe(0n);
       Object.defineProperty(process, "platform", { value: "win32" });
-      const realpath = fs.realpath.bind(fs), stat = fs.stat.bind(fs);
-      vi.spyOn(fs, "realpath").mockImplementation(async (...values) => {
+      const realpath = fsSync.realpathSync.bind(fsSync), stat = fsSync.statSync.bind(fsSync);
+      vi.spyOn(fsSync, "realpathSync").mockImplementation((...values) => {
         if (String(values[0]) === lockPath) {
           if (code === "EBADF") throw failure;
           return failure.path;
         }
-        return await realpath(...values);
+        return realpath(...values);
       });
-      vi.spyOn(fs, "stat").mockImplementation(async (...values) => {
+      vi.spyOn(fsSync, "statSync").mockImplementation((...values) => {
         if (String(values[0]) === failure.path) throw failure;
-        return await stat(...values);
+        return stat(...values);
       });
     } });
     try { return await open(...args); } finally {
       Object.defineProperty(process, "platform", platform);
-      vi.mocked(fs.realpath).mockRestore();
-      vi.mocked(fs.stat).mockRestore();
+      vi.mocked(fsSync.realpathSync).mockRestore();
+      vi.mocked(fsSync.statSync).mockRestore();
     }
   });
   const waiter = await waiterManager.acquire(target, {
@@ -96,10 +97,10 @@ it.each(["numeric", "unknown", "closed", "changed", "linked", "multiple-links"])
           });
         }
         Object.defineProperty(process, "platform", { value: "win32" });
-        const realpath = fs.realpath.bind(fs);
-        vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+        const realpath = fsSync.realpathSync.bind(fsSync);
+        vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
           if (String(args[0]) === lockPath) throw failure;
-          return await realpath(...args);
+          return realpath(...args);
         });
       },
     });
@@ -139,7 +140,14 @@ it.each(["parser", "read", "stat"])("does not retry a Windows %s exception shape
   const create = vi.spyOn(capability, "create").mockRejectedValue(new FsSafeError("already-exists", "exists"));
   const parsePayload = vi.fn(() => { throw failure; });
   if (stage !== "parser") __setFsSafeTestHooksForTest({ afterOpen(candidate, handle) {
-    if (candidate === lockPath) vi.spyOn(handle, stage).mockRejectedValue(failure);
+    if (candidate !== lockPath) return;
+    if (stage === "stat") {
+      const fstat = fsSync.fstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+        if (fd === handle.fd) throw failure;
+        return fstat(fd, options);
+      });
+    } else vi.spyOn(handle, "read").mockRejectedValue(failure);
   } });
   Object.defineProperty(process, "platform", { value: "win32" });
   const manager = createFileLockManager(`read-error:${lockPath}`);
@@ -174,10 +182,10 @@ it.each(["EPERM", "EBADF"])("generic Root.open preserves the Windows resolver %s
     __setFsSafeTestHooksForTest();
     await fs.unlink(lockPath);
     Object.defineProperty(process, "platform", { value: "win32" });
-    const realpath = fs.realpath.bind(fs);
-    vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+    const realpath = fsSync.realpathSync.bind(fsSync);
+    vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
       if (String(args[0]) === lockPath) throw failure;
-      return await realpath(...args);
+      return realpath(...args);
     });
   } });
   await expect(capability.open("state.lock")).rejects.toBe(failure);
@@ -222,11 +230,11 @@ it.each(["sequential", "nested", "interleaved"])(
     // Synthetic Windows resolver EPERM; unlink and descriptor checks are real.
     Object.defineProperty(process, "platform", { value: "win32" });
     const failure = Object.assign(new Error("synthetic resolver failure"), { code: "EPERM" });
-    const realpath = fs.realpath.bind(fs);
+    const realpath = fsSync.realpathSync.bind(fsSync);
     let deny = false, observingFirst = false;
-    vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
+    vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
       if (args[0] === firstPath && deny && observingFirst) throw failure;
-      return await realpath(...args);
+      return realpath(...args);
     });
     let unblock!: () => void, entered!: () => void;
     const paused = new Promise<void>((resolve) => { entered = resolve; });

--- a/test/sidecar-lock-root-resolver.test.ts
+++ b/test/sidecar-lock-root-resolver.test.ts
@@ -37,8 +37,8 @@ it.each(["EPERM", "EBADF"])("retries the recorded Windows resolver %s only with 
       await owner.release();
       expect((await handle.stat({ bigint: true })).nlink).toBe(0n);
       Object.defineProperty(process, "platform", { value: "win32" });
-      const realpath = fsSync.realpathSync.bind(fsSync), stat = fsSync.statSync.bind(fsSync);
-      vi.spyOn(fsSync, "realpathSync").mockImplementation((...values) => {
+      const realpath = fsSync.realpathSync.native, stat = fsSync.statSync.bind(fsSync);
+      vi.spyOn(fsSync.realpathSync, "native").mockImplementation((...values) => {
         if (String(values[0]) === lockPath) {
           if (code === "EBADF") throw failure;
           return failure.path;
@@ -52,7 +52,7 @@ it.each(["EPERM", "EBADF"])("retries the recorded Windows resolver %s only with 
     } });
     try { return await open(...args); } finally {
       Object.defineProperty(process, "platform", platform);
-      vi.mocked(fsSync.realpathSync).mockRestore();
+      vi.mocked(fsSync.realpathSync.native).mockRestore();
       vi.mocked(fsSync.statSync).mockRestore();
     }
   });
@@ -97,8 +97,8 @@ it.each(["numeric", "unknown", "closed", "changed", "linked", "multiple-links"])
           });
         }
         Object.defineProperty(process, "platform", { value: "win32" });
-        const realpath = fsSync.realpathSync.bind(fsSync);
-        vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
+        const realpath = fsSync.realpathSync.native;
+        vi.spyOn(fsSync.realpathSync, "native").mockImplementation((...args) => {
           if (String(args[0]) === lockPath) throw failure;
           return realpath(...args);
         });
@@ -182,8 +182,8 @@ it.each(["EPERM", "EBADF"])("generic Root.open preserves the Windows resolver %s
     __setFsSafeTestHooksForTest();
     await fs.unlink(lockPath);
     Object.defineProperty(process, "platform", { value: "win32" });
-    const realpath = fsSync.realpathSync.bind(fsSync);
-    vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
+    const realpath = fsSync.realpathSync.native;
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementation((...args) => {
       if (String(args[0]) === lockPath) throw failure;
       return realpath(...args);
     });
@@ -230,9 +230,9 @@ it.each(["sequential", "nested", "interleaved"])(
     // Synthetic Windows resolver EPERM; unlink and descriptor checks are real.
     Object.defineProperty(process, "platform", { value: "win32" });
     const failure = Object.assign(new Error("synthetic resolver failure"), { code: "EPERM" });
-    const realpath = fsSync.realpathSync.bind(fsSync);
+    const realpath = fsSync.realpathSync.native;
     let deny = false, observingFirst = false;
-    vi.spyOn(fsSync, "realpathSync").mockImplementation((...args) => {
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementation((...args) => {
       if (args[0] === firstPath && deny && observingFirst) throw failure;
       return realpath(...args);
     });

--- a/test/sidecar-lock-root-unlink.test.ts
+++ b/test/sidecar-lock-root-unlink.test.ts
@@ -1,8 +1,10 @@
+import fsSync from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import { createFileLockManager } from "../src/file-lock.js";
 import { root } from "../src/root.js";
+import * as rootPath from "../src/root-path.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
 import { useTempDirs } from "./helpers/vitest.js";
 
@@ -17,28 +19,22 @@ function atFdResolution(lockPath: string, mutate: (handle: FileHandle) => Promis
   let opened: FileHandle | undefined;
   let fired = false;
   let mutation: Promise<void> | undefined;
-  const realpath = fs.realpath.bind(fs);
-  const wrapper = vi.spyOn(fs, "realpath").mockImplementation(async (...args) => {
-    const candidate = String(args[0]);
-    // After afterOpen, the resolver probes procfs on Linux and the lock path elsewhere.
-    if (!fired && opened && candidate === (process.platform === "linux" ? `/proc/self/fd/${opened.fd}` : lockPath)) {
+  __setFsSafeTestHooksForTest({
+    async afterOpenedPathIdentityCheck(candidate, handle) {
+      if (fired || candidate !== lockPath) return;
+      opened = handle;
       fired = true;
       __setFsSafeTestHooksForTest();
-      mutation = mutate(opened);
+      // This awaited hook immediately precedes descriptor realpath resolution.
+      mutation = mutate(handle);
       await mutation;
-    }
-    return await realpath(...args);
-  });
-  __setFsSafeTestHooksForTest({
-    afterOpen(candidate, handle) {
-      if (candidate === lockPath && !opened) opened = handle;
     },
   });
   return {
     get opened() { return opened; },
     get fired() { return fired; },
     async join() { await mutation; },
-    restore() { wrapper.mockRestore(); __setFsSafeTestHooksForTest(); },
+    restore() { __setFsSafeTestHooksForTest(); },
   };
 }
 
@@ -126,15 +122,26 @@ it("owner release during create-only preflight needs no existing-file descriptor
   let fired = false;
   const open = vi.fn();
   __setFsSafeTestHooksForTest({ afterOpen: open });
-  const stat = fs.stat.bind(fs);
-  vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
-    const result = await stat(...args);
+  let release: Promise<void> | undefined;
+  const stat = fsSync.statSync.bind(fsSync);
+  vi.spyOn(fsSync, "statSync").mockImplementation((...args) => {
+    const result = stat(...args);
     if (String(args[0]) === lockPath && !fired) {
       fired = true;
       expect(open).not.toHaveBeenCalled();
       __setFsSafeTestHooksForTest();
-      await owner.release();
+      release = owner.release();
     }
+    return result;
+  });
+  let firstResolution = true;
+  const resolve = rootPath.resolveRootPath;
+  vi.spyOn(rootPath, "resolveRootPath").mockImplementation(async (params) => {
+    const joinRelease = firstResolution && params.absolutePath === lockPath;
+    if (joinRelease) firstResolution = false;
+    const result = await resolve(params);
+    // Join release at the existing async preflight boundary, before admission.
+    if (joinRelease && release) await release;
     return result;
   });
   const waiter = await waiterManager.acquire(target, {


### PR DESCRIPTION
Async filesystem hot paths spent 50–70% of profiled wall time waiting for libuv metadata round-trips. On the profiling machine, lstat cost about 14 µs asynchronously versus 1.4 µs synchronously. This change performs metadata observations synchronously inside async operations, while open, data reads/writes, fsync, rename, directory creation, unlink, and close remain asynchronous.

Every existing containment, identity, symlink, hardlink, mode, retry, and publication check stays in its original order. Awaited production test hooks stay in place. The path resolution result does not carry a final stat, so the independent pre-open observation remains. Existing-ancestor resolution retains its lstat-based missing/error behavior rather than adopting the sync API's existsSync semantics.

### Changes by file

- `root-path.ts`, `root-path-existing.ts`, `root-path-symlink.ts`, `symlink-parents.ts`: synchronous lexical traversal and symlink/ancestor observations, with existing async signatures and error mapping.
- `root-context.ts`, `path-policy.ts`, `root-paths.ts`, `absolute-path.ts`: synchronous root, canonical alias, and directory observations.
- `root-impl.ts`, `root-write-mode.ts`, `root-write-verification.ts`: synchronous pre-open/path/canonical observations and fstat via retained descriptors, including mode inheritance and post-publication checks.
- `opened-realpath.ts`, `strict-file-identity.ts`: synchronous observers in the existing async-shaped identity retry and descriptor/path resolution flows; parent enumeration remains async.
- `directory-guard.ts`, `guarded-mkdir.ts`, `directory-durability.ts`: synchronous guard and directory receipt observations, used by the existing guarded mutation helpers; mkdir/open/fsync/close remain async.
- `pinned-write.ts`, `native-pinned-write.ts`, `replace-file-descriptor.ts`, `replace-file-temp-owner.ts`, `secret-file.ts`: synchronous staging, parent admission, retained-fd, temp/path, and published-file observations.
- `regular-file.ts`, `file-store.ts`, `file-store-boundary.ts`, `file-store-prune.ts`: synchronous read/exists and related store observations; JSON readers inherit the change through the guarded regular-file reader.
- `bounded-read.ts`: read min(maxBytes, observed regular-file size) + 1 bytes in one initial async call. A short read is accepted only after a fresh same-fd size observation confirms that the bytes consumed cover the current file size; otherwise reading continues through the existing bounded streaming loop. This refines the proposed short-read shortcut because short regular-file reads are not necessarily EOF. Read-only adapters and non-regular/unknown-size inputs retain streaming behavior.
- `test/fs-call-budget.test.ts`: separate async-hop budgets, updated total-call budgets, and counting of FileHandle.close own properties as well as prototype methods.
- `test/bounded-read.test.ts`: one-read coverage for empty, small and multi-chunk-sized files, growth below/above the cap, partial reads before EOF, and custom/unknown-size adapters.
- `docs/reading.md`, `CHANGELOG.md`: document brief synchronous metadata observations and asynchronous data I/O.

The explicit compatibility exception is custom `replaceFileAtomic` filesystem adapters: their public interface exposes only async metadata functions and FileHandles, so those observations remain async. The default Node backend uses synchronous observations. No mutation-metadata call was converted.

### Async-hop and total-call budgets

Measured on macOS with native mode off, including FileHandle.close. Async counts include only fs/promises functions and FileHandle methods; synchronous observations are excluded. Total-call limits retain two calls of platform headroom; async limits are measured + 1.

| Operation | Async before | Async after | Async limit | Total before/after | Total limit |
|---|---:|---:|---:|---:|---:|
| root.readBytes | 13 | 3 | 4 | 13 / 14 | 16 |
| readRegularFile | 7 | 3 | 4 | 7 / 7 | 9 |
| tryReadJson | 8 | 3 | 4 | 8 / 8 | 10 |
| replaceFileAtomic | 17 | 8 | 9 | 18 / 18 | 20 |
| writeJson durable:false | 17 | 8 | 9 | 18 / 18 | 20 |
| root.write | 56 | 11 | 12 | 58 / 58 | 60 |
| root.exists | 5 | 0 | 1 | 5 / 5 | 7 |

Remaining read hops are open/read/close. Atomic replacement retains mkdir, two opens, two closes, writeFile, chmod, and rename. Root.write retains three opens/closes, writeFile, chmod, rename, and two durability syncs.

### Interleaved A/B

Baseline: origin/main at 9ad2d5c, separately compiled with the same dependencies and prepared WASM artifact. Node 24.20.0 on macOS. The supplied harness alternates baseline/PR for five rounds and reports the best ms/op; 150 iterations per small case and 20 per 1 MiB case. The repository benchmark script is unchanged.

Native auto

```text
mode=auto  (best of 5 rounds, ms/op)
root.write                 base   11.298  pr   11.320     -0% faster
root.write 1MiB            base   12.362  pr   12.288      1% faster
root.readBytes             base    0.232  pr    0.121     48% faster
root.readBytes 1MiB        base    0.757  pr    0.247     67% faster
replaceFileAtomic          base    0.647  pr    0.560     13% faster
writeJson durable:false    base    0.605  pr    0.511     16% faster
writeJson                  base   10.114  pr   10.454     -3% faster
tryReadJson                base    0.132  pr    0.076     42% faster
readRegularFile            base    0.102  pr    0.070     32% faster
```

Native off

```text
mode=off  (best of 5 rounds, ms/op)
root.write                 base   13.936  pr   12.424     11% faster
root.write 1MiB            base   13.865  pr   13.851      0% faster
root.readBytes             base    0.236  pr    0.123     48% faster
root.readBytes 1MiB        base    0.726  pr    0.325     55% faster
replaceFileAtomic          base    0.604  pr    0.517     14% faster
writeJson durable:false    base    0.601  pr    0.533     11% faster
writeJson                  base   12.164  pr   12.995     -7% faster
tryReadJson                base    0.147  pr    0.090     39% faster
readRegularFile            base    0.121  pr    0.088     27% faster
```

The 40% readBytes target is met in both modes. tryReadJson reaches 42% in auto and 39% in off, just below the 40% off-mode target. replaceFileAtomic improves 13–14%, below the 30% target; its eight remaining async calls are listed above. Durability costs remain unchanged. The tables report the fixed five-round run after the earlier full-suite run finished.

### Validation

- `pnpm exec tsc --pretty false`: passed.
- `pnpm lint:file-size`, `pnpm lint:fs-boundary`, `pnpm docs:check`, `node scripts/check-pack.mjs`, `git diff --check`: passed.
- `pnpm test:security`: **226 passed**, 5 files.
- Final `pnpm test --maxWorkers=4`: **7,809 passed, 80 skipped, 2 known local failures**; 231 files passed, 2 skipped, 1 failed. Both failures are in `consumer-pnpm-lifecycle.test.ts`, where this local launcher does not expose the expected pnpm lifecycle JavaScript CLI.
- The local Node 24 stdin fixture needed explicit CommonJS mode to avoid a hang during the unrelated ClawSweeper dispatch test. A temporary PATH wrapper adds `--input-type=commonjs` only to no-argument Node invocations; file-based scripts and the library tests use the same Node runtime unchanged. The dispatch fixture then passed, including in the final full run.
- The archive suite passed with `--maxWorkers=1` and in the final full run. An earlier store-overlap run reported the existing fail-closed `path-mismatch` during concurrent replacement; isolated reruns and the final full run passed without changing that test or relaxing identity checks.
- `pnpm check` reached the known local WASM build failure (missing `wasm32-unknown-unknown` Rust target). The prepared WASM artifact was restored; TypeScript and all remaining component checks were run explicitly as requested.
- Independent Codex autoreview: **scoped-clean through P2**. The short-read finding was addressed with the fresh descriptor-size check and focused partial-read/overflow regressions.

### Re-pointed race/fault tests

The following test files and shared fixture were updated to intercept the new synchronous observation. All scenarios and parameterized cases remain. Synthetic filesystem swaps inside synchronous spies now use synchronous fixture mutations. Async owner-release scenarios retain their barriers at the existing pre-resolution hook or async resolver wrapper; directory-preparation authority expiration is injected before the synchronous observation returns.

- `test/absolute-directory.test.ts`
- `test/archive.test.ts`
- `test/deepsec-regression.test.ts`
- `test/deny-mutations.test.ts`
- `test/directory-guard-exact-identity.test.ts`
- `test/helpers/read-admission-identity.ts`
- `test/json-durable-queue-batch-durability.test.ts`
- `test/json.test.ts`
- `test/move-path-authority.test.ts`
- `test/native-write-mode-ownership.test.ts`
- `test/new-primitives.test.ts`
- `test/opened-realpath-observation.test.ts`
- `test/opened-realpath.test.ts`
- `test/regular-file-failure.test.ts`
- `test/root-copy-read-identity.test.ts`
- `test/root-directory-errors.test.ts`
- `test/root-error-coverage.test.ts`
- `test/root-path-store-coverage.test.ts`
- `test/root-read-identity.test.ts`
- `test/root-write-exact-identity.test.ts`
- `test/root-write-inheritance.test.ts`
- `test/root-write-lifetime.test.ts`
- `test/root-write-reopen.test.ts`
- `test/root-write-verification.test.ts`
- `test/secret-directory-receipt.test.ts`
- `test/secret-write-publication.test.ts`
- `test/sibling-temp-directory-mode.test.ts`
- `test/sidecar-lock-root-ancestry.test.ts`
- `test/sidecar-lock-root-create-denial.test.ts`
- `test/sidecar-lock-root-preopen-boundary.test.ts`
- `test/sidecar-lock-root-resolver.test.ts`
- `test/sidecar-lock-root-unlink.test.ts`
