### PR TITLE
feat(archive): inspect admitted TAR members without extracting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.8.4 - 2026-09-07
+
+- Add bounded `inspectTarArchive` with complete native/WASM admission and the same canonical extraction planner, preserving effective member identities without materializing an output tree.
+- Apply the existing filesystem-test worker cap locally as well as in CI, and drain archive publication fixtures before resetting hooks or cleaning restricted directories after timeouts.
 - Add `durable` to Root write/create/writeJson/createJson/append options and Root defaults; `durable: false` skips file and parent fsync for reconstructible data (default unchanged: durable).
 - Run metadata checks inside async operations synchronously (microseconds each), cutting event-loop round-trips per read/write while data I/O remains asynchronous and native canonical path spelling is preserved, including Windows short paths.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 0.8.4 - 2026-09-07
 
 - Add bounded `inspectTarArchive` with complete native/WASM admission and the same canonical extraction planner, preserving effective member identities without materializing an output tree.
+- Preserve inherited and getter-backed extraction options on the WASM TAR path, matching native and ZIP handling for destinations, filters, stripping, and modes.
 - Apply the existing filesystem-test worker cap locally as well as in CI, and drain archive publication fixtures before resetting hooks or cleaning restricted directories after timeouts.
 - Add `durable` to Root write/create/writeJson/createJson/append options and Root defaults; `durable: false` skips file and parent fsync for reconstructible data (default unchanged: durable).
 - Run metadata checks inside async operations synchronously (microseconds each), cutting event-loop round-trips per read/write while data I/O remains asynchronous and native canonical path spelling is preserved, including Windows short paths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "fs-safe-native"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "bzip2",
  "flate2",

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -422,6 +422,63 @@ Normal link/filter policy still governs the described member. Canonical
 pre-strip filter paths, decoded-stream ceilings, and physical EOF checks apply
 to plain/gzip TAR and native zstd/bzip2 alike.
 
+## `inspectTarArchive`
+
+Inspect accepted TAR members without creating an extracted tree. This operation
+uses the same complete Rust/WASM admission and TypeScript extraction planner as
+`extractArchive`, with zero stripping. It detects plain TAR or gzip from the
+input bytes; ZIP, zstd, and bzip2 are not part of this inspection API.
+
+```ts
+import { inspectTarArchive } from "@openclaw/fs-safe/archive";
+
+const entries = await inspectTarArchive({
+  archivePath: "/srv/uploads/tree.tar.gz",
+  timeoutMs: 30_000,
+  limits: {
+    maxArchiveBytes: 16 * 1024 * 1024,
+    maxEntries: 5_000,
+    maxEntryBytes: 16 * 1024 * 1024,
+    maxExtractedBytes: 64 * 1024 * 1024,
+  },
+  entryFilter: ({ kind }) => kind === "file" || kind === "directory" ? "extract" : "skip",
+  onFiltered: "reject-archive",
+});
+```
+
+`InspectTarArchiveOptions` accepts `archivePath`, `timeoutMs`, `limits`,
+`entryFilter`, and `onFiltered`, with the same defaults and error classes as
+extraction. The result is a frozen array of frozen `InspectedTarEntry` records:
+`{ path: string; kind: "file" | "directory"; size: number }`, in archive order.
+`size` is the effective declared payload length. `path` is extraction's
+canonical pre-strip identity: case, Unicode spelling, BOM, and embedded LF are
+preserved, while separators and dot components follow the existing archive path
+contract. No human-readable tar listing or escape decoding is involved.
+
+Full framing, gzip integrity, EOF, metadata, decoded-byte, and manifest-budget
+validation finishes before the caller's filter runs. The shared planner then
+applies traversal, collision, depth, blocked-type, and accepted-payload limits.
+A failure returns no partial result. Filter callbacks are decisions, not admission
+receipts: later policy, collision, or budget checks can still reject the archive.
+Only the resolved Promise/result is authorization-worthy; do not perform
+irreversible actions from a filter callback.
+
+Root-only records count toward entry limits but produce no result; PAX/GNU metadata headers are not members. Only accepted
+file/directory members appear, not implicit parent directories. Unsupported
+records follow extraction's omission policy unless the filter rejects them, as
+in the example. AppleDouble records encoded as ordinary files are ordinary
+members, not hidden metadata.
+
+Inspection pins and privately stages its input, then cleans up that copy. It
+neither creates destination paths nor tests destination permissions or platform
+filename restrictions. Its result is evidence about those inspected bytes, not
+an extraction capability or a promise that a later file at `archivePath` is
+unchanged. Callers making authorization decisions must retain the same private
+immutable archive or verify byte identity before extracting with matching
+filter/limit settings. Extraction always performs its own admission and guarded
+publication. Native `off`, `auto`, and `require` retain their existing selection
+and availability semantics; inspection does not fall back after native failure.
+
 ## `resolveArchiveKind`
 
 ```ts

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fs-safe-native"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/openclaw/fs-safe"

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-native-build",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Private build workspace for the native bindings bundled by @openclaw/fs-safe.",
   "private": true,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Capability-style filesystem roots for Node.js apps that handle untrusted relative paths.",
   "keywords": [
     "filesystem",
@@ -156,13 +156,13 @@
     "archive:producer-smoke": "node scripts/archive-producer-smoke.mjs"
   },
   "optionalDependencies": {
-    "@openclaw/fs-safe-darwin-arm64": "0.8.3",
-    "@openclaw/fs-safe-darwin-x64": "0.8.3",
-    "@openclaw/fs-safe-linux-arm64-gnu": "0.8.3",
-    "@openclaw/fs-safe-linux-arm64-musl": "0.8.3",
-    "@openclaw/fs-safe-linux-x64-gnu": "0.8.3",
-    "@openclaw/fs-safe-linux-x64-musl": "0.8.3",
-    "@openclaw/fs-safe-win32-x64-msvc": "0.8.3",
+    "@openclaw/fs-safe-darwin-arm64": "0.8.4",
+    "@openclaw/fs-safe-darwin-x64": "0.8.4",
+    "@openclaw/fs-safe-linux-arm64-gnu": "0.8.4",
+    "@openclaw/fs-safe-linux-arm64-musl": "0.8.4",
+    "@openclaw/fs-safe-linux-x64-gnu": "0.8.4",
+    "@openclaw/fs-safe-linux-x64-musl": "0.8.4",
+    "@openclaw/fs-safe-win32-x64-msvc": "0.8.4",
     "jszip": "^3.10.1"
   },
   "devDependencies": {

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-darwin-arm64",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "macOS arm64 native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-darwin-x64",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "macOS x64 native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-arm64-gnu",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Linux arm64 glibc native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-musl/package.json
+++ b/packages/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-arm64-musl",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Linux arm64 musl native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-x64-gnu",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Linux x64 glibc native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-x64-musl/package.json
+++ b/packages/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-x64-musl",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Linux x64 musl native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/win32-x64-msvc/package.json
+++ b/packages/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-win32-x64-msvc",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Windows x64 MSVC native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,25 +49,25 @@ importers:
         version: 5.0.0(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1))
     optionalDependencies:
       '@openclaw/fs-safe-darwin-arm64':
-        specifier: 0.8.3
+        specifier: 0.8.4
         version: link:packages/darwin-arm64
       '@openclaw/fs-safe-darwin-x64':
-        specifier: 0.8.3
+        specifier: 0.8.4
         version: link:packages/darwin-x64
       '@openclaw/fs-safe-linux-arm64-gnu':
-        specifier: 0.8.3
+        specifier: 0.8.4
         version: link:packages/linux-arm64-gnu
       '@openclaw/fs-safe-linux-arm64-musl':
-        specifier: 0.8.3
+        specifier: 0.8.4
         version: link:packages/linux-arm64-musl
       '@openclaw/fs-safe-linux-x64-gnu':
-        specifier: 0.8.3
+        specifier: 0.8.4
         version: link:packages/linux-x64-gnu
       '@openclaw/fs-safe-linux-x64-musl':
-        specifier: 0.8.3
+        specifier: 0.8.4
         version: link:packages/linux-x64-musl
       '@openclaw/fs-safe-win32-x64-msvc':
-        specifier: 0.8.3
+        specifier: 0.8.4
         version: link:packages/win32-x64-msvc
       jszip:
         specifier: ^3.10.1

--- a/src/archive-native.ts
+++ b/src/archive-native.ts
@@ -6,27 +6,17 @@ import {
   ArchiveSecurityError,
   isArchiveFormatErrorMessage,
 } from "./archive-errors.js";
-import { formatErrorDetail } from "./error-detail.js";
-import {
-  createArchiveOutputPathTracker,
-  resolveArchiveOutputPath,
-  stripArchivePath,
-  validateArchiveEntryPath,
-} from "./archive-entry.js";
+import { stripArchivePath, validateArchiveEntryPath } from "./archive-entry.js";
+import { createArchiveEntryPlanner, type ArchivePlanEntry } from "./archive-plan.js";
 import type { ExtractionDeadline } from "./archive-deadline.js";
 import { stageArchiveFileForExtraction } from "./archive-input.js";
 import type { ArchiveKind } from "./archive-kind.js";
 import {
-  ARCHIVE_LIMIT_ERROR_CODE,
-  ArchiveLimitError,
   assertArchiveEntryCountWithinLimit,
-  assertArchiveEntryPathComponentsWithinLimit,
-  createByteBudgetTracker,
   type ResolvedArchiveExtractLimits,
   type TarMeterLimits,
 } from "./archive-limits.js";
 import type { ExtractArchiveOptions } from "./archive-options.js";
-import { resolveArchiveEntryMode, shouldExtractArchiveEntry } from "./archive-policy.js";
 import {
   prepareArchiveDestinationDir,
   withStagedArchiveDestination,
@@ -36,13 +26,7 @@ import type { ZipDirectoryEntry } from "./archive-zip-directory.js";
 import type { NativeBinding } from "./native.js";
 import { admitZipFile } from "./archive-zip-admission.js";
 
-function policyKind(kind: string): "file" | "directory" | "symlink" | "other" {
-  if (kind === "file" || kind === "directory") return kind;
-  if (kind === "symlink" || kind === "hardlink") return "symlink";
-  return "other";
-}
-
-function throwMappedNativeError(error: unknown): never {
+export function throwMappedNativeArchiveError(error: unknown): never {
   if (error instanceof Error) {
     const mapped = classifyArchiveParserError(error.message, { cause: error });
     if (mapped) throw mapped;
@@ -92,7 +76,7 @@ export async function extractNativeArchive(params: {
             tarLimits,
             params.deadline.signal,
           )
-          .catch(throwMappedNativeError);
+          .catch(throwMappedNativeArchiveError);
         params.deadline.check();
         assertArchiveEntryCountWithinLimit(manifest.length, limits);
         if (physicalCount !== undefined && manifest.length !== physicalCount) {
@@ -116,77 +100,17 @@ export async function extractNativeArchive(params: {
         if (params.kind !== "zip") {
           for (const entry of manifest) validateArchiveEntryPath(entry.path);
         }
-        const strip = Math.max(0, Math.floor(params.stripComponents ?? 0));
-        const budget = createByteBudgetTracker(limits);
-        const trackOutputPath = createArchiveOutputPathTracker();
-        const plan: Array<{
-          index: number;
-          path: string;
-          kind: "file" | "directory";
-          size: number;
-          mode: number;
-        }> = [];
-
+        const planEntry = createArchiveEntryPlanner({ ...params, rootDir: stagingDir });
+        const plan: Array<ArchivePlanEntry & { index: number }> = [];
         for (const entry of manifest) {
           params.deadline.check();
-          validateArchiveEntryPath(entry.path);
-          const canonicalPath = stripArchivePath(entry.path, 0);
-          if (!canonicalPath) continue;
-          const relPath = stripArchivePath(canonicalPath, strip);
-          if (!relPath) continue;
-          validateArchiveEntryPath(relPath);
-          assertArchiveEntryPathComponentsWithinLimit(relPath, limits);
-          trackOutputPath(relPath, entry.path);
-          resolveArchiveOutputPath({ rootDir: stagingDir, relPath, originalPath: entry.path });
-          const kind = policyKind(entry.kind);
-          if (
-            !shouldExtractArchiveEntry({
-              filter: params.entryFilter,
-              onFiltered: params.onFiltered,
-              entry: { path: canonicalPath, kind, size: entry.size },
-            })
-          ) {
-            continue;
-          }
-          if (entry.kind === "sparse") {
-            throw new ArchiveFormatError(
-              `GNU sparse archive entry is not supported: ${formatErrorDetail(entry.path)}`,
-            );
-          }
-          if (kind === "symlink" || entry.kind === "blocked") {
-            const label = params.kind === "zip" ? "zip" : "tar";
-            throw new ArchiveSecurityError(
-              "entry-link",
-              `${label} entry is a link: ${formatErrorDetail(entry.path)}`,
-            );
-          }
-          if (!Number.isSafeInteger(entry.size) || entry.size < 0) {
-            throw new ArchiveLimitError(
-              ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT,
-            );
-          }
-          // GNUDumpDir can carry a body; charge accepted TAR sizes as JS does.
-          if (kind === "file" || (kind === "directory" && params.kind !== "zip")) {
-            budget.startEntry();
-            budget.addEntrySize(entry.size);
-          }
-          if (kind === "file" || kind === "directory") {
-            plan.push({
-              index: entry.index,
-              path: relPath,
-              kind,
-              size: entry.size,
-              mode: resolveArchiveEntryMode({
-                kind,
-                archivedMode: params.kind === "zip"
-                  ? zipEntries[entry.index]!.creatorSystem === 3
-                    ? zipEntries[entry.index]!.externalAttributes >>> 16
-                    : undefined
-                  : entry.mode,
-                policy: params.entryModes,
-              }),
-            });
-          }
+          const mode = params.kind === "zip"
+            ? zipEntries[entry.index]!.creatorSystem === 3
+              ? zipEntries[entry.index]!.externalAttributes >>> 16
+              : undefined
+            : entry.mode;
+          const accepted = planEntry({ ...entry, mode });
+          if (accepted) plan.push({ ...accepted, index: entry.index });
         }
 
         const directory = await fs.open(
@@ -203,7 +127,7 @@ export async function extractNativeArchive(params: {
             plan.map((entry) => ({ ...entry, mode: entry.kind === "directory" ? 0o700 : 0o600 })),
             tarLimits,
             params.deadline.signal,
-          ).catch(throwMappedNativeError);
+          ).catch(throwMappedNativeArchiveError);
         } finally {
           await directory.close().catch(() => undefined);
         }

--- a/src/archive-native.ts
+++ b/src/archive-native.ts
@@ -100,7 +100,7 @@ export async function extractNativeArchive(params: {
         if (params.kind !== "zip") {
           for (const entry of manifest) validateArchiveEntryPath(entry.path);
         }
-        const planEntry = createArchiveEntryPlanner({ ...params, rootDir: stagingDir });
+        const planEntry = createArchiveEntryPlanner({ ...params, rootDir: stagingDir }, params.kind);
         const plan: Array<ArchivePlanEntry & { index: number }> = [];
         for (const entry of manifest) {
           params.deadline.check();

--- a/src/archive-plan.ts
+++ b/src/archive-plan.ts
@@ -1,0 +1,77 @@
+import { ArchiveFormatError, ArchiveSecurityError } from "./archive-errors.js";
+import {
+  createArchiveOutputPathTracker,
+  resolveArchiveOutputPath,
+  stripArchivePath,
+  validateArchiveEntryPath,
+} from "./archive-entry.js";
+import type { ArchiveKind } from "./archive-kind.js";
+import {
+  ARCHIVE_LIMIT_ERROR_CODE,
+  ArchiveLimitError,
+  assertArchiveEntryCountWithinLimit,
+  assertArchiveEntryPathComponentsWithinLimit,
+  createByteBudgetTracker,
+  resolveExtractLimits,
+} from "./archive-limits.js";
+import type { ExtractArchiveOptions } from "./archive-options.js";
+import { resolveArchiveEntryMode, shouldExtractArchiveEntry } from "./archive-policy.js";
+import { formatErrorDetail } from "./error-detail.js";
+
+export type ArchiveMemberKind = "file" | "directory" | "symlink" | "hardlink" | "blocked" | "sparse" | "other";
+export type ArchivePlanEntry = { path: string; kind: "file" | "directory"; size: number; mode: number };
+export type ArchivePlanOptions = Pick<ExtractArchiveOptions,
+  "stripComponents" | "limits" | "entryModes" | "entryFilter" | "onFiltered"> & {
+  kind: ArchiveKind;
+  rootDir?: string;
+  escapeLabel?: string;
+};
+
+// Inspection and both executors decide over the same admitted identities.
+// A destination is optional only for inspection; writers still prove containment.
+export function createArchiveEntryPlanner(params: ArchivePlanOptions): (entry: {
+  path: string; kind: ArchiveMemberKind; size: number; mode?: number;
+}) => ArchivePlanEntry | null {
+  const strip = Math.max(0, Math.floor(params.stripComponents ?? 0));
+  const limits = resolveExtractLimits(params.limits);
+  const budget = createByteBudgetTracker(limits);
+  const trackOutputPath = createArchiveOutputPathTracker();
+  let entryCount = 0;
+  return (entry) => {
+    assertArchiveEntryCountWithinLimit(++entryCount, limits);
+    validateArchiveEntryPath(entry.path, { escapeLabel: params.escapeLabel });
+    const canonicalPath = stripArchivePath(entry.path, 0);
+    if (!canonicalPath) return null;
+    const relPath = stripArchivePath(canonicalPath, strip);
+    if (!relPath) return null;
+    validateArchiveEntryPath(relPath, { escapeLabel: params.escapeLabel });
+    assertArchiveEntryPathComponentsWithinLimit(relPath, limits);
+    trackOutputPath(relPath, entry.path);
+    if (params.rootDir !== undefined) {
+      resolveArchiveOutputPath({ rootDir: params.rootDir, relPath, originalPath: entry.path,
+        escapeLabel: params.escapeLabel });
+    }
+    const kind = entry.kind === "file" || entry.kind === "directory" ? entry.kind
+      : entry.kind === "symlink" || entry.kind === "hardlink" ? "symlink" : "other";
+    if (!shouldExtractArchiveEntry({ filter: params.entryFilter, onFiltered: params.onFiltered,
+      entry: { path: canonicalPath, kind, size: entry.size } })) return null;
+    if (entry.kind === "sparse") {
+      throw new ArchiveFormatError(`GNU sparse archive entry is not supported: ${formatErrorDetail(entry.path)}`);
+    }
+    if (kind === "symlink" || entry.kind === "blocked") {
+      const label = params.kind === "zip" ? "zip" : "tar";
+      throw new ArchiveSecurityError("entry-link", `${label} entry is a link: ${formatErrorDetail(entry.path)}`);
+    }
+    if (!Number.isSafeInteger(entry.size) || entry.size < 0) {
+      throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT);
+    }
+    // Unsupported records remain visible to policy but cannot create outputs.
+    if (kind === "other") return null;
+    if (kind === "file" || params.kind !== "zip") {
+      budget.startEntry();
+      budget.addEntrySize(entry.size);
+    }
+    return { path: relPath, kind, size: entry.size,
+      mode: resolveArchiveEntryMode({ kind, archivedMode: entry.mode, policy: params.entryModes }) };
+  };
+}

--- a/src/archive-plan.ts
+++ b/src/archive-plan.ts
@@ -22,14 +22,13 @@ export type ArchiveMemberKind = "file" | "directory" | "symlink" | "hardlink" | 
 export type ArchivePlanEntry = { path: string; kind: "file" | "directory"; size: number; mode: number };
 export type ArchivePlanOptions = Pick<ExtractArchiveOptions,
   "stripComponents" | "limits" | "entryModes" | "entryFilter" | "onFiltered"> & {
-  kind: ArchiveKind;
   rootDir?: string;
   escapeLabel?: string;
 };
 
 // Inspection and both executors decide over the same admitted identities.
 // A destination is optional only for inspection; writers still prove containment.
-export function createArchiveEntryPlanner(params: ArchivePlanOptions): (entry: {
+export function createArchiveEntryPlanner(params: ArchivePlanOptions, archiveKind: ArchiveKind): (entry: {
   path: string; kind: ArchiveMemberKind; size: number; mode?: number;
 }) => ArchivePlanEntry | null {
   const strip = Math.max(0, Math.floor(params.stripComponents ?? 0));
@@ -59,7 +58,7 @@ export function createArchiveEntryPlanner(params: ArchivePlanOptions): (entry: {
       throw new ArchiveFormatError(`GNU sparse archive entry is not supported: ${formatErrorDetail(entry.path)}`);
     }
     if (kind === "symlink" || entry.kind === "blocked") {
-      const label = params.kind === "zip" ? "zip" : "tar";
+      const label = archiveKind === "zip" ? "zip" : "tar";
       throw new ArchiveSecurityError("entry-link", `${label} entry is a link: ${formatErrorDetail(entry.path)}`);
     }
     if (!Number.isSafeInteger(entry.size) || entry.size < 0) {
@@ -67,7 +66,7 @@ export function createArchiveEntryPlanner(params: ArchivePlanOptions): (entry: {
     }
     // Unsupported records remain visible to policy but cannot create outputs.
     if (kind === "other") return null;
-    if (kind === "file" || params.kind !== "zip") {
+    if (kind === "file" || archiveKind !== "zip") {
       budget.startEntry();
       budget.addEntrySize(entry.size);
     }

--- a/src/archive-tar-inspect.ts
+++ b/src/archive-tar-inspect.ts
@@ -1,0 +1,62 @@
+import { withExtractionDeadline } from "./archive-deadline.js";
+import { validateArchiveEntryPath } from "./archive-entry.js";
+import { stageArchiveFileForExtraction } from "./archive-input.js";
+import { resolveExtractLimits, resolveTarMeterLimits } from "./archive-limits.js";
+import { throwMappedNativeArchiveError } from "./archive-native.js";
+import type { ExtractArchiveOptions } from "./archive-options.js";
+import { createArchiveEntryPlanner, type ArchivePlanEntry } from "./archive-plan.js";
+import { resolveArchiveFilteredEntryPolicy } from "./archive-policy.js";
+import { createTarEntryPlanner } from "./archive-tar.js";
+import { inspectTar } from "./archive-tar-stream.js";
+import type { AdmittedTarMember } from "./archive-tar-wasm.js";
+import { getNativeBinding } from "./native.js";
+
+export type InspectTarArchiveOptions = Pick<ExtractArchiveOptions,
+  "archivePath" | "timeoutMs" | "limits" | "entryFilter" | "onFiltered">;
+export type InspectedTarEntry = Readonly<Pick<ArchivePlanEntry, "path" | "kind" | "size">>;
+
+/** Complete TAR/gzip admission and zero-strip extraction policy, without output writes. */
+export async function inspectTarArchive(params: InspectTarArchiveOptions): Promise<readonly InspectedTarEntry[]> {
+  const onFiltered = resolveArchiveFilteredEntryPolicy(params.onFiltered);
+  const limits = resolveExtractLimits(params.limits);
+  const tarLimits = resolveTarMeterLimits(limits);
+  const native = getNativeBinding();
+  return await withExtractionDeadline(params.timeoutMs, "inspect tar", async (deadline) => {
+    const staged = await stageArchiveFileForExtraction({ archivePath: params.archivePath, limits, deadline });
+    try {
+      // Staging closes descriptors asynchronously; expiry there must not start a decoder.
+      deadline.check();
+      const entries: InspectedTarEntry[] = [];
+      const append = (entry: ArchivePlanEntry | null) => {
+        if (entry) entries.push(Object.freeze({ path: entry.path, kind: entry.kind, size: entry.size }));
+      };
+      const policy = { limits, entryFilter: params.entryFilter, onFiltered };
+      if (native) {
+        const manifest = await native.inspectArchiveNative(staged.path, "tar", tarLimits, deadline.signal)
+          .catch(throwMappedNativeArchiveError);
+        deadline.check();
+        // Match extraction's whole-manifest validation before caller policy runs.
+        for (const entry of manifest) validateArchiveEntryPath(entry.path);
+        const planEntry = createArchiveEntryPlanner({ ...policy, kind: "tar" });
+        for (const entry of manifest) {
+          deadline.check();
+          append(planEntry(entry));
+        }
+      } else {
+        const manifest: AdmittedTarMember[] = [];
+        await inspectTar({ archivePath: staged.path, limits: tarLimits, signal: deadline.signal,
+          onMember: (entry) => { manifest.push(entry); } });
+        const planEntry = createTarEntryPlanner(policy);
+        for (const entry of manifest) {
+          deadline.check();
+          append(planEntry(entry));
+        }
+      }
+      deadline.check();
+      // This is bounded evidence about the staged bytes, not a reusable write plan.
+      return Object.freeze(entries);
+    } finally {
+      await staged.cleanup();
+    }
+  });
+}

--- a/src/archive-tar-inspect.ts
+++ b/src/archive-tar-inspect.ts
@@ -37,7 +37,7 @@ export async function inspectTarArchive(params: InspectTarArchiveOptions): Promi
         deadline.check();
         // Match extraction's whole-manifest validation before caller policy runs.
         for (const entry of manifest) validateArchiveEntryPath(entry.path);
-        const planEntry = createArchiveEntryPlanner({ ...policy, kind: "tar" });
+        const planEntry = createArchiveEntryPlanner(policy, "tar");
         for (const entry of manifest) {
           deadline.check();
           append(planEntry(entry));

--- a/src/archive-tar.ts
+++ b/src/archive-tar.ts
@@ -1,35 +1,33 @@
+import type { ArchiveExtractLimits } from "./archive-limits.js";
 import {
-  createArchiveOutputPathTracker,
-  resolveArchiveOutputPath,
-  stripArchivePath,
-  validateArchiveEntryPath,
-} from "./archive-entry.js";
-import {
-  assertArchiveEntryCountWithinLimit,
-  assertArchiveEntryPathComponentsWithinLimit,
-  createByteBudgetTracker,
-  resolveExtractLimits,
-  type ArchiveExtractLimits,
-} from "./archive-limits.js";
+  createArchiveEntryPlanner,
+  type ArchivePlanEntry,
+  type ArchivePlanOptions,
+} from "./archive-plan.js";
 import {
   archiveEntryKindFromTarType,
-  shouldExtractArchiveEntry,
   type ArchiveEntryFilter,
   type ArchiveFilteredEntryPolicy,
 } from "./archive-policy.js";
-import { ArchiveSecurityError } from "./archive-errors.js";
-import { formatErrorDetail } from "./error-detail.js";
 
 export type TarEntryInfo = { path: string; type: string; size: number; mode?: number };
 
 const BLOCKED_TAR_ENTRY_TYPES = new Set([
-  "SymbolicLink",
-  "Link",
   "BlockDevice",
   "CharacterDevice",
   "FIFO",
   "Socket",
 ]);
+
+export function createTarEntryPlanner(params: Omit<ArchivePlanOptions, "kind">):
+  (entry: TarEntryInfo) => ArchivePlanEntry | null {
+  const plan = createArchiveEntryPlanner({ ...params, kind: "tar" });
+  return (entry) => {
+    const kind = BLOCKED_TAR_ENTRY_TYPES.has(entry.type) ? "blocked" : archiveEntryKindFromTarType(entry.type);
+    // The public checker accepts structural entry objects, including class getters.
+    return plan({ path: entry.path, kind, size: entry.size, mode: entry.mode });
+  };
+}
 
 export function createTarEntryPreflightChecker(params: {
   rootDir: string;
@@ -39,56 +37,6 @@ export function createTarEntryPreflightChecker(params: {
   entryFilter?: ArchiveEntryFilter;
   onFiltered?: ArchiveFilteredEntryPolicy;
 }): (entry: TarEntryInfo) => boolean {
-  const strip = Math.max(0, Math.floor(params.stripComponents ?? 0));
-  const limits = resolveExtractLimits(params.limits);
-  let entryCount = 0;
-  const budget = createByteBudgetTracker(limits);
-  const trackOutputPath = createArchiveOutputPathTracker();
-
-  return (entry: TarEntryInfo) => {
-    entryCount += 1;
-    assertArchiveEntryCountWithinLimit(entryCount, limits);
-    validateArchiveEntryPath(entry.path, { escapeLabel: params.escapeLabel });
-
-    const canonicalPath = stripArchivePath(entry.path, 0);
-    if (!canonicalPath) return false;
-    const relPath = stripArchivePath(canonicalPath, strip);
-    if (!relPath) {
-      return false;
-    }
-    validateArchiveEntryPath(relPath, { escapeLabel: params.escapeLabel });
-    assertArchiveEntryPathComponentsWithinLimit(relPath, limits);
-    trackOutputPath(relPath, entry.path);
-    resolveArchiveOutputPath({
-      rootDir: params.rootDir,
-      relPath,
-      originalPath: entry.path,
-      escapeLabel: params.escapeLabel,
-    });
-
-    const kind = archiveEntryKindFromTarType(entry.type);
-    if (
-      !shouldExtractArchiveEntry({
-        filter: params.entryFilter,
-        onFiltered: params.onFiltered,
-        entry: { path: canonicalPath, kind, size: entry.size },
-      })
-    ) {
-      return false;
-    }
-
-    if (BLOCKED_TAR_ENTRY_TYPES.has(entry.type)) {
-      throw new ArchiveSecurityError(
-        "entry-link",
-        `tar entry is a link: ${formatErrorDetail(entry.path)}`,
-      );
-    }
-
-    // Accepted unsupported records remain omitted, as in the native plan.
-    if (kind === "other") return false;
-
-    budget.startEntry();
-    budget.addEntrySize(entry.size);
-    return true;
-  };
+  const plan = createTarEntryPlanner(params);
+  return (entry) => plan(entry) !== null;
 }

--- a/src/archive-tar.ts
+++ b/src/archive-tar.ts
@@ -19,9 +19,10 @@ const BLOCKED_TAR_ENTRY_TYPES = new Set([
   "Socket",
 ]);
 
-export function createTarEntryPlanner(params: Omit<ArchivePlanOptions, "kind">):
+export function createTarEntryPlanner(params: ArchivePlanOptions):
   (entry: TarEntryInfo) => ArchivePlanEntry | null {
-  const plan = createArchiveEntryPlanner({ ...params, kind: "tar" });
+  // Preserve inherited/getter-backed public options and per-entry policy reads.
+  const plan = createArchiveEntryPlanner(params, "tar");
   return (entry) => {
     const kind = BLOCKED_TAR_ENTRY_TYPES.has(entry.type) ? "blocked" : archiveEntryKindFromTarType(entry.type);
     // The public checker accepts structural entry objects, including class getters.

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -1,8 +1,8 @@
-import { createTarEntryPreflightChecker } from "./archive-tar.js";
+import { createTarEntryPlanner } from "./archive-tar.js";
 import { inspectTar, replayTar } from "./archive-tar-stream.js";
 import type { AdmittedTarMember } from "./archive-tar-wasm.js";
 import { runPinnedWriteHelper } from "./pinned-write.js";
-import fsSync, { constants as fsConstants } from "node:fs";
+import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -55,7 +55,6 @@ import { extractNativeArchive } from "./archive-native.js";
 import { stageArchiveFileForExtraction } from "./archive-input.js";
 import { getNativeBinding } from "./native.js";
 import {
-  resolveArchiveEntryMode,
   resolveArchiveFilteredEntryPolicy,
   shouldExtractArchiveEntry,
 } from "./archive-policy.js";
@@ -77,6 +76,7 @@ export {
 } from "./archive-entry.js";
 export { resolveArchiveKind, resolvePackedRootDir, type ArchiveKind } from "./archive-kind.js";
 export { readArchiveEntry } from "./archive-read.js";
+export { inspectTarArchive, type InspectTarArchiveOptions, type InspectedTarEntry } from "./archive-tar-inspect.js";
 export {
   ARCHIVE_LIMIT_ERROR_CODE,
   ArchiveLimitError,
@@ -380,14 +380,11 @@ async function extractWasmTar(params: {
   const destinationRealDir = await prepareArchiveDestinationDir(options.destDir);
   await withStagedArchiveDestination({ destinationRealDir, run: async (stagingPath) => {
     const stagingDir = await fs.realpath(stagingPath);
-    const check = createTarEntryPreflightChecker({ rootDir: destinationRealDir,
-      stripComponents: options.stripComponents, limits: params.limits,
-      entryFilter: options.entryFilter, onFiltered: options.onFiltered });
-    const strip = Math.max(0, Math.floor(options.stripComponents ?? 0));
-    const accepted = manifest.filter((entry) => { deadline.check(); return check(entry); }).map((entry) => {
-      const kind = entry.type === "Directory" || entry.type === "GNUDumpDir" ? "directory" as const : "file" as const;
-      return { ...entry, path: stripArchivePath(entry.path, strip)!, kind,
-        mode: resolveArchiveEntryMode({ kind, archivedMode: entry.mode, policy: options.entryModes }) };
+    const planEntry = createTarEntryPlanner({ ...options, rootDir: destinationRealDir, limits: params.limits });
+    const accepted = manifest.flatMap((entry) => {
+      deadline.check();
+      const planned = planEntry(entry);
+      return planned ? [{ ...entry, ...planned }] : [];
     });
     await replayTar({ archivePath: params.archivePath, limits: tarLimits, signal: deadline.signal, members: accepted,
       async consume(member, payload) {

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -319,21 +319,16 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
   const limits = resolveExtractLimits(params.limits);
   const tarLimits = resolveTarMeterLimits(limits);
   const native = getNativeBinding();
+  // Read the declared public fields before private adapters copy options: class
+  // getters and inherited policy must survive identically on every backend.
+  const options = {
+    archivePath: params.archivePath, destDir: params.destDir,
+    stripComponents: params.stripComponents, limits,
+    entryModes: params.entryModes, entryFilter: params.entryFilter, onFiltered,
+  };
   if (native) {
     await withExtractionDeadline(params.timeoutMs, label, async (deadline) =>
-      extractNativeArchive({
-        binding: native,
-        archivePath: params.archivePath,
-        destDir: params.destDir,
-        kind,
-        stripComponents: params.stripComponents,
-        limits,
-        tarLimits,
-        deadline,
-        entryModes: params.entryModes,
-        entryFilter: params.entryFilter,
-        onFiltered,
-      }),
+      extractNativeArchive({ ...options, binding: native, kind, tarLimits, deadline }),
     );
     return;
   }
@@ -341,12 +336,12 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
   if (kind === "tar") {
     await withExtractionDeadline(params.timeoutMs, label, async (deadline) => {
       const stagedArchive = await stageArchiveFileForExtraction({
-        archivePath: params.archivePath,
+        archivePath: options.archivePath,
         limits,
         deadline,
       });
       try {
-        await extractWasmTar({ archivePath: stagedArchive.path, options: { ...params, onFiltered }, limits, tarLimits, deadline });
+        await extractWasmTar({ archivePath: stagedArchive.path, options, limits, tarLimits, deadline });
       } finally {
         await stagedArchive.cleanup();
       }
@@ -355,21 +350,13 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
   }
 
   await withExtractionDeadline(params.timeoutMs, label, async (deadline) =>
-    extractZip({
-      archivePath: params.archivePath,
-      destDir: params.destDir,
-      stripComponents: params.stripComponents,
-      limits,
-      deadline,
-      entryModes: params.entryModes,
-      entryFilter: params.entryFilter,
-      onFiltered,
-    }),
+    extractZip({ ...options, deadline }),
   );
 }
 
 async function extractWasmTar(params: {
-  archivePath: string; options: ExtractArchiveOptions; limits: ResolvedArchiveExtractLimits;
+  archivePath: string; options: Pick<ExtractArchiveOptions, "destDir" | "stripComponents" | "entryModes" | "entryFilter" | "onFiltered">;
+  limits: ResolvedArchiveExtractLimits;
   tarLimits: TarMeterLimits; deadline: ExtractionDeadline;
 }): Promise<void> {
   const { options, deadline, tarLimits } = params;

--- a/src/native-binding.ts
+++ b/src/native-binding.ts
@@ -1,4 +1,5 @@
 import type { TarMeterLimits } from "./archive-limits.js";
+import type { ArchiveMemberKind } from "./archive-plan.js";
 
 export interface NativeFileHash {
   bytes: number;
@@ -19,7 +20,7 @@ export interface NativeFileIdentity {
 export interface NativeArchiveEntry {
   index: number;
   path: string;
-  kind: string;
+  kind: ArchiveMemberKind;
   size: number;
   mode: number;
 }

--- a/test/archive-directory-publication.test.ts
+++ b/test/archive-directory-publication.test.ts
@@ -1,21 +1,34 @@
 import type { BigIntStats } from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mergeExtractedTreeIntoDestination } from "../src/archive.js";
 import { withExtractionDeadline } from "../src/archive-deadline.js";
 import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
-import { useRealTempDirs } from "./helpers/vitest.js";
+import { removeModeFixture } from "./helpers/archive-modes.js";
+import { useSuiteFixture } from "./helpers/suite-fixture.js";
 
-const { tempRoot } = useRealTempDirs();
-const restoreModes: string[] = [];
-afterEach(async () => {
-  __setFsSafeTestHooksForTest(undefined);
-  __resetFsSafeNativeConfigForTest();
-  vi.restoreAllMocks();
-  for (const directory of restoreModes.splice(0)) await fs.chmod(directory, 0o700).catch(() => undefined);
+let suiteDir: string | undefined;
+const runFixture = useSuiteFixture(async () => {
+  suiteDir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-dir-publication-"));
+  return await fs.realpath(suiteDir);
+}, async () => {
+  if (suiteDir) await removeModeFixture(suiteDir);
 });
+
+function run(operation: (directory: string) => Promise<void>) {
+  return runFixture(async (directory) => {
+    try { await operation(directory); }
+    finally {
+      // A Vitest timeout must not reset hooks while publication is still running.
+      __setFsSafeTestHooksForTest(undefined);
+      __resetFsSafeNativeConfigForTest();
+      vi.restoreAllMocks();
+    }
+  });
+}
 
 function deferred() {
   let resolve!: () => void;
@@ -23,9 +36,9 @@ function deferred() {
   return { promise, resolve };
 }
 
-async function fixture(children = true) {
+async function fixture(directory: string, children = true) {
   configureFsSafeNative({ mode: "off" });
-  const base = await tempRoot("fs-safe-dir-publication-");
+  const base = await fs.mkdtemp(path.join(directory, "case-"));
   const sourceDir = path.join(base, "source");
   const destinationDir = path.join(base, "destination");
   const sourceNested = path.join(sourceDir, "nested");
@@ -38,13 +51,12 @@ async function fixture(children = true) {
     await fs.chmod(sourceNested, 0o555);
   }
   await fs.mkdir(destinationDir);
-  restoreModes.push(sourceNested, target);
   return { base, sourceNested, target, params: { sourceDir, destinationDir, destinationRealDir: destinationDir } };
 }
 
 describe.skipIf(process.platform === "win32" || process.getuid?.() === 0)("real non-root directory publication", () => {
-  it("retains only depth-proportional directory descriptors across many siblings", async () => {
-    const { params } = await fixture(false);
+  it("retains only depth-proportional directory descriptors across many siblings", () => run(async (directory) => {
+    const { params } = await fixture(directory, false);
     await fs.rmdir(path.join(params.sourceDir, "nested"));
     for (let sibling = 0; sibling < 20; sibling++) {
       await fs.mkdir(path.join(params.sourceDir, `sibling-${sibling}`, "middle", "leaf"), { recursive: true });
@@ -65,27 +77,27 @@ describe.skipIf(process.platform === "win32" || process.getuid?.() === 0)("real 
     });
     await mergeExtractedTreeIntoDestination(params);
     expect({ active, peak, closes }).toEqual({ active: 0, peak: 3, closes: 60 });
-  });
+  }));
 
-  it.each([0o300, 0o700])("updates an existing %s directory after publishing children", async (mode) => {
-    const { target, params } = await fixture();
+  it.each([0o300, 0o700])("updates an existing %s directory after publishing children", (mode) => run(async (directory) => {
+    const { target, params } = await fixture(directory);
     await fs.mkdir(target, { mode: 0o700 });
     await fs.writeFile(path.join(target, "value"), "OLD");
     await fs.chmod(target, mode);
     await mergeExtractedTreeIntoDestination(params);
     expect((await fs.stat(target)).mode & 0o777).toBe(0o555);
     expect(await fs.readFile(path.join(target, "value"), "utf8")).toBe("NEW");
-  });
+  }));
 
-  it("finalizes an existing empty search-only directory", async () => {
-    const { target, params } = await fixture(false);
+  it("finalizes an existing empty search-only directory", () => run(async (directory) => {
+    const { target, params } = await fixture(directory, false);
     await fs.mkdir(target, { mode: 0o100 });
     await mergeExtractedTreeIntoDestination(params);
     expect((await fs.stat(target)).mode & 0o777).toBe(0o555);
-  });
+  }));
 
-  it.each([0o500, 0])("does not widen an existing inaccessible %s directory to write children", async (mode) => {
-    const { target, params } = await fixture();
+  it.each([0o500, 0])("does not widen an existing inaccessible %s directory to write children", (mode) => run(async (directory) => {
+    const { target, params } = await fixture(directory);
     await fs.mkdir(target, { mode: 0o700 });
     await fs.writeFile(path.join(target, "value"), "OLD");
     await fs.chmod(target, mode);
@@ -93,10 +105,10 @@ describe.skipIf(process.platform === "win32" || process.getuid?.() === 0)("real 
     expect((await fs.stat(target)).mode & 0o777).toBe(mode);
     await fs.chmod(target, 0o700);
     expect(await fs.readFile(path.join(target, "value"), "utf8")).toBe("OLD");
-  });
+  }));
 
-  it.each(["directory", "root", "ancestor"] as const)("rejects a %s substitution before finalization without chmodding it", async (swap) => {
-    const { base, sourceNested, target, params } = await fixture();
+  it.each(["directory", "root", "ancestor"] as const)("rejects a %s substitution before finalization without chmodding it", (swap) => run(async (directory) => {
+    const { base, sourceNested, target, params } = await fixture(directory);
     if (swap === "ancestor") {
       await fs.chmod(sourceNested, 0o700);
       await fs.mkdir(path.join(sourceNested, "child"), { mode: 0o555 });
@@ -120,10 +132,10 @@ describe.skipIf(process.platform === "win32" || process.getuid?.() === 0)("real 
     expect({ dev: retained.dev, ino: retained.ino, mode: retained.mode }).toEqual({
       dev: original!.dev, ino: original!.ino, mode: original!.mode,
     });
-  });
+  }));
 
-  it("propagates directory chmod failures and performs no final mode sweep", async () => {
-    const { target, params } = await fixture();
+  it("propagates directory chmod failures and performs no final mode sweep", () => run(async (directory) => {
+    const { target, params } = await fixture(directory);
     const realOpen = fs.open.bind(fs);
     let closes = 0;
     let pinned = false;
@@ -141,10 +153,10 @@ describe.skipIf(process.platform === "win32" || process.getuid?.() === 0)("real 
     expect(closes).toBe(1);
     expect((await fs.stat(target)).mode & 0o777).toBe(0o700);
     expect(await fs.readFile(path.join(target, "value"), "utf8")).toBe("NEW");
-  });
+  }));
 
-  it.each(["before-dispatch", "active-chmod", "opening"] as const)("joins %s timeout and closes the pinned directory exactly once", async (stage) => {
-    const { target, params } = await fixture();
+  it.each(["before-dispatch", "active-chmod", "opening"] as const)("joins %s timeout and closes the pinned directory exactly once", (stage) => run(async (directory) => {
+    const { target, params } = await fixture(directory);
     await fs.mkdir(path.join(params.sourceDir, "zz-later"), { mode: 0o555 });
     const entered = deferred();
     const expired = deferred();
@@ -193,5 +205,5 @@ describe.skipIf(process.platform === "win32" || process.getuid?.() === 0)("real 
     const after = chmods;
     await new Promise<void>((done) => setImmediate(done));
     expect(chmods).toBe(after);
-  });
+  }));
 });

--- a/test/archive-inspection.test.ts
+++ b/test/archive-inspection.test.ts
@@ -1,0 +1,225 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createTarEntryPreflightChecker,
+  extractArchive,
+  inspectTarArchive,
+  type ArchiveEntryFilter,
+  type ArchiveExtractLimits,
+} from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __setNativeLoaderForTest, __resetNativeLoaderForTest } from "../src/native.js";
+import { tarFixture } from "./helpers/archive-fuzz.js";
+import { paxNative } from "./helpers/archive-pax-native.js";
+import { unifiedFixture, unicodeNames } from "./helpers/archive-unified.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const filesOnly: ArchiveEntryFilter = ({ kind }) => kind === "file" || kind === "directory" ? "extract" : "skip";
+
+it("preserves structural entry objects in the public preflight checker", async () => {
+  class Entry {
+    get path() { return "value.txt"; }
+    get type() { return "File"; }
+    get size() { return 5; }
+  }
+  const rootDir = await tempRoot("fs-safe-preflight-entry-");
+  expect(createTarEntryPreflightChecker({ rootDir })(new Entry())).toBe(true);
+});
+
+it.skipIf(!paxNative)("does not start native inspection after timing out during staging's final close", async () => {
+  const root = await tempRoot("fs-safe-inspection-close-deadline-");
+  const archivePath = path.join(root, "archive.tar");
+  await fs.writeFile(archivePath, tarFixture([{ path: "value", body: "original" }]));
+  const native = paxNative!;
+  const inspectNative = vi.fn(native.inspectArchiveNative.bind(native));
+  configureFsSafeNative({ mode: "require" });
+  __setNativeLoaderForTest(() => ({ ...native, inspectArchiveNative: inspectNative }));
+
+  const closing = Promise.withResolvers<void>();
+  const releaseClose = Promise.withResolvers<void>();
+  const cleaned = Promise.withResolvers<void>();
+  const realOpen = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+    const handle = await realOpen(...args);
+    if (args[0] === archivePath) {
+      const realClose = handle.close.bind(handle);
+      vi.spyOn(handle, "close").mockImplementation(async () => {
+        await realClose();
+        closing.resolve();
+        await releaseClose.promise;
+      });
+    }
+    return handle;
+  });
+  const realRm = fs.rm.bind(fs);
+  vi.spyOn(fs, "rm").mockImplementation(async (...args: Parameters<typeof fs.rm>) => {
+    await realRm(...args);
+    if (String(args[0]).includes("fs-safe-archive-input-")) cleaned.resolve();
+  });
+
+  // Intercept only deadline registration; staging I/O and Vitest's timers stay real.
+  const deadlineTimer = vi.spyOn(globalThis, "setTimeout").mockImplementation((callback, _ms, ...args) => {
+    void closing.promise.then(() => callback(...args));
+    return {} as ReturnType<typeof setTimeout>;
+  });
+  const inspection = inspectTarArchive({ archivePath, timeoutMs: 1_000 });
+  deadlineTimer.mockRestore();
+  const rejection = expect(inspection).rejects.toThrow("inspect tar timed out after 1000ms");
+  try {
+    await closing.promise;
+    await rejection;
+    expect(inspectNative).not.toHaveBeenCalled();
+  } finally {
+    // Join private staging cleanup so the late continuation cannot leak into another test.
+    releaseClose.resolve();
+    await cleaned.promise;
+  }
+  expect(inspectNative).not.toHaveBeenCalled();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetNativeLoaderForTest();
+  __resetFsSafeNativeConfigForTest();
+});
+
+for (const mode of ["off", "require"] as const) {
+  describe.runIf(mode === "off" || Boolean(paxNative))(`TAR inspection (${mode})`, () => {
+    beforeEach(() => {
+      configureFsSafeNative({ mode });
+      if (mode === "require") __setNativeLoaderForTest(() => paxNative!);
+    });
+
+    it.each(unicodeNames.flatMap((name) => [false, true].map((gzip) => [name, gzip] as const)))(
+      "preserves admitted identity %j and effective payloads (gzip=%s)", async (name, gzip) => {
+        const root = await tempRoot("fs-safe-inspection-");
+        const fixture = unifiedFixture(name);
+        const archivePath = path.join(root, "archive");
+        await fs.writeFile(archivePath, gzip ? gzipSync(fixture.bytes) : fixture.bytes);
+        const inspected = await inspectTarArchive({ archivePath, timeoutMs: 10_000, entryFilter: filesOnly });
+        expect(inspected).toEqual([
+          { path: name, kind: "file", size: fixture.payload.length },
+          { path: "sentinel", kind: "file", size: 3 },
+        ]);
+        expect(Object.isFrozen(inspected)).toBe(true);
+        expect(inspected.every(Object.isFrozen)).toBe(true);
+        // Windows cannot create LF names, but inspection must not rewrite them.
+        if (process.platform === "win32" && name.includes("\n")) return;
+        const destDir = path.join(root, "destination");
+        await fs.mkdir(destDir);
+        const observed: Parameters<ArchiveEntryFilter>[0][] = [];
+        await extractArchive({ archivePath, destDir, kind: "tar", timeoutMs: 10_000,
+          entryFilter: (entry) => { observed.push(entry); return filesOnly(entry); } });
+        expect(observed).toEqual(inspected);
+        expect(await fs.readFile(path.join(destDir, name))).toEqual(fixture.payload);
+        expect(await fs.readFile(path.join(destDir, "sentinel"), "utf8")).toBe("end");
+      },
+    );
+
+    it("shares canonical directory, strip-zero, and explicit skip policy with extraction", async () => {
+      const root = await tempRoot("fs-safe-inspection-policy-");
+      const archivePath = path.join(root, "archive.tar");
+      await fs.writeFile(archivePath, tarFixture([
+        { path: "./", type: "5" },
+        { path: "./pkg//", type: "5" },
+        { path: "./pkg//value", body: "value" },
+        { path: "pkg\\link", type: "2", linkPath: "value" },
+      ]));
+      await expect(inspectTarArchive({ archivePath, timeoutMs: 10_000, entryFilter: filesOnly }))
+        .rejects.toMatchObject({ code: "entry-filtered" });
+      const options = { archivePath, timeoutMs: 10_000, entryFilter: filesOnly, onFiltered: "skip-entry" as const };
+      const inspected = await inspectTarArchive(options);
+      expect(inspected).toEqual([
+        { path: "pkg", kind: "directory", size: 0 },
+        { path: "pkg/value", kind: "file", size: 5 },
+      ]);
+      const destDir = path.join(root, "destination");
+      await fs.mkdir(destDir);
+      await extractArchive({ ...options, destDir });
+      expect(await fs.readdir(path.join(destDir, "pkg"))).toEqual(["value"]);
+      expect(await fs.readFile(path.join(destDir, "pkg/value"), "utf8")).toBe("value");
+    });
+
+    it("returns archive members, not implicit parent directories created during extraction", async () => {
+      const root = await tempRoot("fs-safe-inspection-parents-");
+      const archivePath = path.join(root, "archive.tar.gz");
+      await fs.writeFile(archivePath, gzipSync(tarFixture([{ path: ".hidden/nested/value", body: "value" }])));
+      const options = { archivePath, timeoutMs: 10_000, entryFilter: filesOnly };
+      expect(await inspectTarArchive(options)).toEqual([{ path: ".hidden/nested/value", kind: "file", size: 5 }]);
+      const destDir = path.join(root, "destination");
+      await fs.mkdir(destDir);
+      await extractArchive({ ...options, destDir });
+      expect((await fs.stat(path.join(destDir, ".hidden"))).isDirectory()).toBe(true);
+      expect((await fs.stat(path.join(destDir, ".hidden/nested"))).isDirectory()).toBe(true);
+      expect(await fs.readFile(path.join(destDir, ".hidden/nested/value"), "utf8")).toBe("value");
+    });
+
+    it.each([
+      { name: "hidden traversal", entries: [{ path: ".hidden/../escape", body: "x" }], filterCalls: 0 },
+      { name: "hidden collision", entries: [{ path: ".hidden/value" }, { path: ".hidden\\value" }], filterCalls: 1 },
+    ])("rejects $name even when the filter skips every member", async ({ entries, filterCalls }) => {
+      const root = await tempRoot("fs-safe-inspection-filtered-");
+      const archivePath = path.join(root, "archive.tar");
+      await fs.writeFile(archivePath, tarFixture(entries));
+      const entryFilter = vi.fn<ArchiveEntryFilter>(() => "skip");
+      const options = { archivePath, timeoutMs: 10_000, entryFilter, onFiltered: "skip-entry" as const };
+      await expect(inspectTarArchive(options)).rejects.toMatchObject({ code: "entry-path" });
+      expect(entryFilter).toHaveBeenCalledTimes(filterCalls);
+      entryFilter.mockClear();
+      const destDir = path.join(root, "destination");
+      await fs.mkdir(destDir);
+      await expect(extractArchive({ ...options, destDir })).rejects.toMatchObject({ code: "entry-path" });
+      expect(entryFilter).toHaveBeenCalledTimes(filterCalls);
+      expect(await fs.readdir(destDir)).toEqual([]);
+    });
+
+    it.each([
+      { name: "traversal", entries: [{ path: "../escape", body: "x" }], code: "entry-path" },
+      { name: "collision", entries: [{ path: "dir/value" }, { path: "dir\\value" }], code: "entry-path" },
+      { name: "case collision", entries: [{ path: "value" }, { path: "VALUE" }], code: "entry-path" },
+      { name: "link", entries: [{ path: "link", type: "2", linkPath: "target" }], code: "entry-filtered" },
+      { name: "device", entries: [{ path: "device", type: "3" }], code: "entry-filtered" },
+    ])("rejects $name before producing an inspection result or extracted files", async ({ entries, code }) => {
+      const root = await tempRoot("fs-safe-inspection-reject-");
+      const archivePath = path.join(root, "archive.tar.gz");
+      await fs.writeFile(archivePath, gzipSync(tarFixture(entries)));
+      const options = { archivePath, timeoutMs: 10_000, entryFilter: filesOnly };
+      await expect(inspectTarArchive(options)).rejects.toMatchObject({ code });
+      const destDir = path.join(root, "destination");
+      await fs.mkdir(destDir);
+      await expect(extractArchive({ ...options, destDir })).rejects.toMatchObject({ code });
+      expect(await fs.readdir(destDir)).toEqual([]);
+    });
+
+    it.each([
+      { limits: { maxArchiveBytes: 1 }, code: "archive-size-exceeds-limit" },
+      { limits: { maxEntries: 1 }, code: "archive-entry-count-exceeds-limit" },
+      { limits: { maxEntryBytes: 2 }, code: "archive-entry-extracted-size-exceeds-limit" },
+      { limits: { maxExtractedBytes: 5 }, code: "archive-extracted-size-exceeds-limit" },
+      { limits: { maxEntryPathComponents: 1 }, code: "archive-entry-path-components-exceeds-limit" },
+    ] satisfies { limits: ArchiveExtractLimits; code: string }[])("enforces $code during inspection", async ({ limits, code }) => {
+      const root = await tempRoot("fs-safe-inspection-limit-");
+      const archivePath = path.join(root, "archive.tar");
+      await fs.writeFile(archivePath, tarFixture([{ path: "nested/a", body: "abc" }, { path: "b", body: "def" }]));
+      await expect(inspectTarArchive({ archivePath, timeoutMs: 10_000, limits }))
+        .rejects.toMatchObject({ code });
+    });
+
+    it.each(["tar tail", "gzip checksum"])("finishes whole-stream admission before policy (%s)", async (fault) => {
+      const root = await tempRoot("fs-safe-inspection-framing-");
+      const bytes = gzipSync(Buffer.concat([
+        tarFixture([{ path: "value", body: "original" }]),
+        fault === "tar tail" ? Buffer.from([1]) : Buffer.alloc(0),
+      ]));
+      if (fault === "gzip checksum") bytes[bytes.length - 8] ^= 1;
+      const archivePath = path.join(root, "archive.tar.gz");
+      await fs.writeFile(archivePath, bytes);
+      const entryFilter = vi.fn<ArchiveEntryFilter>(() => "extract");
+      await expect(inspectTarArchive({ archivePath, timeoutMs: 10_000, entryFilter })).rejects.toThrow();
+      expect(entryFilter).not.toHaveBeenCalled();
+    });
+  });
+}

--- a/test/archive-preflight-options.test.ts
+++ b/test/archive-preflight-options.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as tar from "tar";
+import { createTarEntryPreflightChecker, extractArchive, type ArchiveEntryFilter } from "../src/archive.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __setNativeLoaderForTest, __resetNativeLoaderForTest } from "../src/native.js";
+import { paxNative } from "./helpers/archive-pax-native.js";
+import { tarFixture } from "./helpers/archive-fuzz.js";
+import { modeArchive } from "./helpers/archive-modes.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const entry = { path: "value", type: "File", size: 5 };
+
+afterEach(() => {
+  __resetNativeLoaderForTest();
+  __resetFsSafeNativeConfigForTest();
+});
+
+for (const mode of ["off", "require"] as const) {
+  describe.runIf(mode === "off" || Boolean(paxNative))(`structural extraction options (${mode})`, () => {
+    it.each((["tar", "zip"] as const).flatMap((kind) => [true, false].map((allowed) => ({ kind, allowed }))))(
+      "extractArchive retains getter-backed $kind options (allowed=$allowed)", async ({ kind, allowed }) => {
+      configureFsSafeNative({ mode });
+      if (mode === "require") __setNativeLoaderForTest(() => paxNative!);
+      const base = await tempRoot("fs-safe-extraction-options-");
+      const archivePath = path.join(base, `archive.${kind}`);
+      const destDir = path.join(base, "output");
+      await fs.mkdir(destDir);
+      await fs.writeFile(archivePath, await modeArchive(kind, [{ path: "pkg/value", mode: 0o700 }]));
+      const entryFilter = vi.fn<ArchiveEntryFilter>(() => allowed ? "extract" : "skip");
+      class Options {
+        get archivePath() { return archivePath; }
+        get destDir() { return destDir; }
+        get timeoutMs() { return 10_000; }
+        get stripComponents() { return 1; }
+        get limits() { return { maxEntries: 1, maxEntryBytes: 3 }; }
+        get entryModes() { return "preserve" as const; }
+        get entryFilter() { return entryFilter; }
+        get onFiltered() { return "reject-archive" as const; }
+      }
+      if (allowed) {
+        await extractArchive(new Options());
+        expect(await fs.readFile(path.join(destDir, "value"), "utf8")).toBe("NEW");
+        if (process.platform !== "win32") expect((await fs.stat(path.join(destDir, "value"))).mode & 0o777).toBe(0o700);
+      } else {
+        await expect(extractArchive(new Options())).rejects.toMatchObject({ code: "entry-filtered" });
+        expect(await fs.readdir(destDir)).toEqual([]);
+      }
+      expect(entryFilter).toHaveBeenCalledExactlyOnceWith({ path: "pkg/value", kind: "file", size: 3 });
+    });
+  });
+}
+
+describe("structural public preflight options", () => {
+  it("reads inherited filters at each check rather than copying options", async () => {
+    const rootDir = await tempRoot("fs-safe-preflight-filter-");
+    let filter = vi.fn<ArchiveEntryFilter>(() => "extract");
+    class Options {
+      get rootDir() { return rootDir; }
+      get entryFilter() { return filter; }
+    }
+    const check = createTarEntryPreflightChecker(new Options());
+    expect(check(entry)).toBe(true);
+    expect(filter).toHaveBeenCalledOnce();
+    filter = vi.fn<ArchiveEntryFilter>(() => "skip");
+    expect(() => check({ ...entry, path: "next" })).toThrow(expect.objectContaining({ code: "entry-filtered" }));
+    expect(filter).toHaveBeenCalledOnce();
+  });
+
+  it("retains getter-backed limits, stripping and skip policy", async () => {
+    const rootDir = await tempRoot("fs-safe-preflight-options-");
+    class Limited {
+      get rootDir() { return rootDir; }
+      get limits() { return { maxEntries: 0 }; }
+    }
+    class Stripped {
+      get rootDir() { return rootDir; }
+      get stripComponents() { return 1; }
+    }
+    class Skipped {
+      get rootDir() { return rootDir; }
+      get entryFilter(): ArchiveEntryFilter { return () => "skip"; }
+      get onFiltered() { return "skip-entry" as const; }
+    }
+    expect(() => createTarEntryPreflightChecker(new Limited())(entry))
+      .toThrow(expect.objectContaining({ code: "archive-entry-count-exceeds-limit" }));
+    expect(createTarEntryPreflightChecker(new Stripped())(entry)).toBe(false);
+    expect(createTarEntryPreflightChecker(new Skipped())(entry)).toBe(false);
+  });
+
+  it.each([true, false])("custom extractor preserves getter policy (allowed=%s)", async (allowed) => {
+    const rootDir = await tempRoot("fs-safe-preflight-extractor-");
+    class Policy {
+      get rootDir() { return rootDir; }
+      get entryFilter(): ArchiveEntryFilter { return () => allowed ? "extract" : "skip"; }
+    }
+    class Options extends Policy {}
+    const check = createTarEntryPreflightChecker(new Options());
+    // The documented custom-extractor hook runs before node-tar starts member output.
+    const extract = () => tar.x({ sync: true, cwd: rootDir, onReadEntry: check })
+      .end(tarFixture([{ path: "value", body: "synthetic" }]));
+    if (allowed) {
+      extract();
+      expect(await fs.readFile(path.join(rootDir, "value"), "utf8")).toBe("synthetic");
+    } else {
+      expect(extract).toThrow(expect.objectContaining({ code: "entry-filtered" }));
+      expect(await fs.readdir(rootDir)).toEqual([]);
+    }
+  });
+});

--- a/test/archive-publication-modes.test.ts
+++ b/test/archive-publication-modes.test.ts
@@ -1,26 +1,39 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { extractArchive } from "../src/archive.js";
 import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
 import { __loadBundledNativeForTest, __resetNativeLoaderForTest, __setNativeLoaderForTest, type NativeBinding } from "../src/native.js";
-import { modeArchive, type ModeEntry } from "./helpers/archive-modes.js";
-import { useRealTempDirs } from "./helpers/vitest.js";
+import { modeArchive, removeModeFixture, type ModeEntry } from "./helpers/archive-modes.js";
+import { useSuiteFixture } from "./helpers/suite-fixture.js";
 
-const { tempRoot } = useRealTempDirs();
+let suiteDir: string | undefined;
+const runFixture = useSuiteFixture(async () => {
+  suiteDir = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-publication-modes-"));
+  return await fs.realpath(suiteDir);
+}, async () => {
+  if (suiteDir) await removeModeFixture(suiteDir);
+});
 let native: NativeBinding | undefined;
 try { native = __loadBundledNativeForTest(); }
 catch (error) { if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error; }
 const backends = native ? ["off", "require"] as const : ["off"] as const;
 const nonRootPosix = process.platform !== "win32" && process.getuid?.() !== 0;
 
-afterEach(() => {
-  __resetFsSafeNativeConfigForTest();
-  __resetNativeLoaderForTest();
-});
+function run(operation: (directory: string) => Promise<void>) {
+  return runFixture(async (directory) => {
+    try { await operation(directory); }
+    finally {
+      // Reset backend selection only after timed-out test work has settled.
+      __resetFsSafeNativeConfigForTest();
+      __resetNativeLoaderForTest();
+    }
+  });
+}
 
-async function fixture(kind: "tar" | "zip", entries: ModeEntry[]) {
-  const base = await tempRoot("fs-safe-publication-modes-");
+async function fixture(directory: string, kind: "tar" | "zip", entries: ModeEntry[]) {
+  const base = await fs.mkdtemp(path.join(directory, "case-"));
   const archivePath = path.join(base, `fixture.${kind}`);
   const destDir = path.join(base, "output");
   await fs.mkdir(destDir);
@@ -48,25 +61,25 @@ describe.skipIf(!nonRootPosix).each(backends)("%s real non-root publication mode
   }
   it.each([
     ["tar", 0o022], ["tar", 0o077], ["zip", 0o022], ["zip", 0o077],
-  ] as const)("preserves %s file rwx under umask %s, including zero and special bits", async (kind, umask) => {
+  ] as const)("preserves %s file rwx under umask %s, including zero and special bits", (kind, umask) => run(async (directory) => {
     configure();
     const previousUmask = process.umask(umask);
     try {
       const entries = [0, 0o200, 0o400, 0o710, 0o7777, 0o7000].map((mode) => ({ path: `mode-${mode}`, mode }));
-      const params = await fixture(kind, entries);
+      const params = await fixture(directory, kind, entries);
       for (const entry of entries) await fs.writeFile(path.join(params.destDir, entry.path), "OLD");
       await extractArchive({ ...params, entryModes: "preserve" });
       const actual = await inspectTree(params.destDir, entries);
       for (const entry of entries) expect(actual.get(entry.path)).toBe(entry.mode & 0o777);
     } finally { process.umask(previousUmask); }
-  });
+  }));
 
   it.each([
     ["tar", 0o022, "before"], ["tar", 0o022, "after"],
     ["tar", 0o077, "before"], ["tar", 0o077, "after"],
     ["zip", 0o022, "before"], ["zip", 0o022, "after"],
     ["zip", 0o077, "before"], ["zip", 0o077, "after"],
-  ] as const)("finalizes %s directories under umask %s with explicit entries %s children", async (kind, umask, order) => {
+  ] as const)("finalizes %s directories under umask %s with explicit entries %s children", (kind, umask, order) => run(async (directory) => {
     configure();
     const previousUmask = process.umask(umask);
     try {
@@ -78,21 +91,21 @@ describe.skipIf(!nonRootPosix).each(backends)("%s real non-root publication mode
       const files: ModeEntry[] = [0, 0o100, 0o500, 0o555].map((mode) => ({ path: `dir-${mode}/nested/value`, mode: 0o200 }));
       files.push({ path: "bin/tool", mode: 0o755 });
       const entries = order === "before" ? [...dirs, ...files] : [...files, ...dirs];
-      const params = await fixture(kind, entries);
+      const params = await fixture(directory, kind, entries);
       await extractArchive({ ...params, entryModes: "preserve" });
       const expected = [...entries, { path: "bin/", directory: true, mode: 0o755 }];
       const actual = await inspectTree(params.destDir, expected);
       for (const entry of expected) expect(actual.get(entry.path)).toBe(entry.mode! & 0o777);
     } finally { process.umask(previousUmask); }
-  });
+  }));
 
-  it.each(["tar", "zip"] as const)("clamps %s files and implicit parents and calls strip/filter policy once", async (kind) => {
+  it.each(["tar", "zip"] as const)("clamps %s files and implicit parents and calls strip/filter policy once", (kind) => run(async (directory) => {
     configure();
     const entries = [
       { path: "pkg/bin/tool", mode: 0o710 }, { path: "pkg/value", mode: 0 },
       { path: "pkg/skip", mode: 0o200 },
     ];
-    const params = await fixture(kind, entries);
+    const params = await fixture(directory, kind, entries);
     const seen: string[] = [];
     await extractArchive({ ...params, stripComponents: 1, onFiltered: "skip-entry", entryFilter: ({ path }) => {
       seen.push(path); return path === "pkg/skip" ? "skip" : "extract";
@@ -103,21 +116,21 @@ describe.skipIf(!nonRootPosix).each(backends)("%s real non-root publication mode
     ]);
     expect(Object.fromEntries(actual)).toEqual({ "bin/": 0o755, value: 0o644, "bin/tool": 0o755 });
     await expect(fs.stat(path.join(params.destDir, "skip"))).rejects.toMatchObject({ code: "ENOENT" });
-  });
+  }));
 
-  it("distinguishes absent ZIP metadata from explicit UNIX zero", async () => {
+  it("distinguishes absent ZIP metadata from explicit UNIX zero", () => run(async (directory) => {
     configure();
     const entries: ModeEntry[] = [
       { path: "absent", mode: null }, { path: "zero", mode: 0 },
       { path: "absent-dir/", directory: true, mode: null }, { path: "zero-dir/", directory: true, mode: 0 },
     ];
-    const params = await fixture("zip", entries);
+    const params = await fixture(directory, "zip", entries);
     await extractArchive({ ...params, entryModes: "preserve" });
     const actual = await inspectTree(params.destDir, entries);
     expect(Object.fromEntries(actual)).toEqual({ absent: 0o644, zero: 0, "absent-dir/": 0o755, "zero-dir/": 0 });
-  });
+  }));
 
-  it.each(["tar", "zip"] as const)("keeps %s explicit directory modes after strip/filter admission", async (kind) => {
+  it.each(["tar", "zip"] as const)("keeps %s explicit directory modes after strip/filter admission", (kind) => run(async (directory) => {
     configure();
     const entries: ModeEntry[] = [
       { path: "pkg/restricted/", directory: true, mode: 0 },
@@ -125,7 +138,7 @@ describe.skipIf(!nonRootPosix).each(backends)("%s real non-root publication mode
       { path: "pkg/skipped/", directory: true, mode: 0 },
       { path: "pkg/skipped/value", mode: 0o200 },
     ];
-    const params = await fixture(kind, entries);
+    const params = await fixture(directory, kind, entries);
     const seen: string[] = [];
     await extractArchive({ ...params, stripComponents: 1, entryModes: "preserve", onFiltered: "skip-entry", entryFilter: (entry) => {
       seen.push(entry.path);
@@ -134,11 +147,11 @@ describe.skipIf(!nonRootPosix).each(backends)("%s real non-root publication mode
     expect(seen).toEqual(["pkg/restricted", "pkg/restricted/value", "pkg/skipped", "pkg/skipped/value"]);
     const actual = await inspectTree(params.destDir, entries.map((entry) => ({ ...entry, path: entry.path.slice(4) })));
     expect(Object.fromEntries(actual)).toEqual({ "restricted/": 0, "restricted/value": 0o400, "skipped/": 0o755, "skipped/value": 0o200 });
-  });
+  }));
 
-  it.each(["tar", "zip"] as const)("associates %s modes with staged Unicode and case identity", async (kind) => {
+  it.each(["tar", "zip"] as const)("associates %s modes with staged Unicode and case identity", (kind) => run(async (directory) => {
     configure();
-    const params = await fixture(kind, [
+    const params = await fixture(directory, kind, [
       { path: "Dir/é", mode: 0o200 }, { path: "dir/", directory: true, mode: 0o500 },
     ]);
     await extractArchive({ ...params, entryModes: "preserve" });
@@ -149,5 +162,5 @@ describe.skipIf(!nonRootPosix).each(backends)("%s real non-root publication mode
     await fs.chmod(path.join(params.destDir, "dir"), 0o700);
     const actual = await inspectTree(params.destDir, [{ path: "Dir/é" }]);
     expect(actual.get("Dir/é")).toBe(0o200);
-  });
+  }));
 });

--- a/test/helpers/archive-modes.ts
+++ b/test/helpers/archive-modes.ts
@@ -1,7 +1,18 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import JSZip from "jszip";
 import { tarFixture } from "./archive-fuzz.js";
 
 export type ModeEntry = { path: string; mode?: number | null; directory?: boolean };
+
+// Only owned synthetic fixtures: assertions can fail before restoring traversal.
+export async function removeModeFixture(directory: string): Promise<void> {
+  await fs.chmod(directory, 0o700);
+  for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+    if (entry.isDirectory()) await removeModeFixture(path.join(directory, entry.name));
+  }
+  await fs.rm(directory, { recursive: true, force: true });
+}
 
 export async function modeArchive(kind: "tar" | "zip", entries: ModeEntry[]): Promise<Buffer> {
   if (kind === "tar") {

--- a/test/public-api.json
+++ b/test/public-api.json
@@ -568,6 +568,7 @@
         "createArchiveSymlinkTraversalError",
         "createTarEntryPreflightChecker",
         "extractArchive",
+        "inspectTarArchive",
         "isWindowsDrivePath",
         "loadZipArchiveWithPreflight",
         "mergeExtractedTreeIntoDestination",
@@ -598,6 +599,8 @@
         "ArchiveSecurityError",
         "ArchiveSecurityErrorCode",
         "ExtractArchiveOptions",
+        "InspectTarArchiveOptions",
+        "InspectedTarEntry",
         "TarEntryInfo",
         "ZipArchiveWithFiles"
       ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,9 +5,9 @@ export default defineConfig({
     include: ["test/**/*.test.ts"],
     pool: "forks",
     // Windows hosted runners become nondeterministic when filesystem stress
-    // suites compete. Other CI hosts stay bounded so high-core machines do not
-    // make the stress and property suites time out under process contention.
-    maxWorkers: process.platform === "win32" ? 1 : process.env.CI ? 4 : undefined,
+    // suites compete. Other hosts stay bounded too: local high-core machines
+    // hit the same stress/property-suite contention as CI.
+    maxWorkers: process.platform === "win32" ? 1 : 4,
     expect: {
       requireAssertions: true,
     },


### PR DESCRIPTION
## What Problem This Solves

Consumers that authorize TAR members before extraction need the exact identities admitted by the extractor, not a human-readable listing or a second decoder. The motivating File Transfer defect is tracked in [openclaw/openclaw#140737](https://github.com/openclaw/openclaw/issues/140737): newline display escaping can cause a false denial, and macOS tar listings can omit AppleDouble records that extraction materializes. No authorization bypass is claimed.

[PR 229](https://github.com/openclaw/fs-safe/pull/229) unified native/WASM TAR interpretation but intentionally did not add inspection. This PR adds that narrow consumer seam and prepares the authorized 0.8.4 release.

## Why This Change Was Made

`inspectTarArchive({ archivePath, timeoutMs, limits, entryFilter, onFiltered })` stages its input, completes existing native/WASM TAR/gzip admission, and uses the same canonical member planner as extraction. It returns a frozen readonly array of accepted explicit `{ path, kind, size }` members without creating an output tree. Rust decoding, native protocol, guarded writers and filesystem authority are unchanged; duplicate native/TAR planning is removed rather than copied into a new permissive path.

The result is metadata about admitted bytes, not a replay capability or a guarantee that later extraction will succeed. Consumers retain byte/hash identity and re-admit at extraction. Implicit parent directories are not invented as TAR members; consumers that authorize filesystem paths must check their ancestor closure. Filter callbacks are decisions, not admission receipts: a later collision or policy failure can still reject the archive. Only the resolved result proves completed admission.

## User Impact

Archive consumers gain bounded, lossless canonical member inspection through `@openclaw/fs-safe/archive`, including effective PAX names and real metadata sidecar members. Existing extraction options, defaults, filtering, mode handling, error classification, collision checks, budgets and native/WASM behavior remain intact. There are no new codecs, native schema changes, destination options, public offsets or reusable write handles.

The current-main port preserves the folded WASM extractor and shared parser-error classifier. It also preserves structural class/getter-backed inputs to the existing public TAR preflight checker and fences deadline expiry during asynchronous staging cleanup before native inspection starts.

The release metadata aligns the root, seven platform packages, private native workspace and Cargo version at 0.8.4, with owner-generated lockfiles. Existing main changes for opt-in Root durability and synchronous metadata observations are retained in the dated release notes. Publication remains the protected annotated-tag workflow with OIDC; nothing is published locally.

## Evidence

The inspection suite exercises real native and WASM admission/extraction, strict Unicode and newline identities, plain/gzip input, effective sizes, immutable results, complete gzip/physical-tail validation, filtering, limits, collisions, blocked members, implicit-parent semantics, structural preflight compatibility and the post-staging deadline fence. The OpenClaw prototype additionally proves real system-tar producer → exact policy → guarded extraction for newline and synthetic AppleDouble cases on both backends.

Final local validation passed on the 0.8.4 candidate:

```bash
pnpm native:build
```

```bash
pnpm check
```

```bash
git diff --check
```

The final default full gate passed **8,076 tests, 81 platform skips**, plus file-size/boundary guards, TypeScript/WASM build, executable documentation and package/public-API checks. It used the checked-in worker budget, not a CLI worker or timeout override. Fresh isolated Codex autoreview is scoped-clean through P2, with no accepted/actionable findings. [Exact-head CI run 34082385281](https://github.com/openclaw/fs-safe/actions/runs/34082385281) and [coverage run 34082385287](https://github.com/openclaw/fs-safe/actions/runs/34082385287) are green for corrected head `48090a0ea54ab948226ba5236197bcd85cc36087`: Node 22/24 checks on Linux/macOS/Windows, native checks on those hosts plus Linux musl, bundled package smoke on Linux/macOS/Windows, Cargo clippy/audit, and cross-platform coverage. The refreshed ClawSweeper review finds no actionable issue and accepts the real-output proof.

The shared-planner and canonical-options refactor has **−4 net production lines** while adding the public inspection capability; regression/test-support/API-baseline growth is **+376 lines**. Release manifests and generated lockfiles contain only aligned workspace version changes.

The first full default test run exposed local runner oversubscription: local macOS selected 31 workers while CI already used four. It passed 8,063 tests but timed out the descriptor-retention case. The entire unchanged corpus at four workers passed 8,064 tests with 81 platform skips; that case took 255 ms instead of timing out at 5,091 ms. The candidate applies the existing CI resource cap locally too, retaining all 20 siblings, peak-three-descriptor and 60-close assertions and the original five-second deadline. Separate fixture-lifetime repairs drain timed-out work before backend/hook reset and restore traversal only on owned synthetic fixture directories before cleanup. No production guard or assertion is weakened.

### Review correction and real output proof

The [structural-options finding](https://github.com/openclaw/fs-safe/pull/239#issuecomment-5564777115) and its rank-up moves are addressed. The public preflight checker now retains the original options object, including inherited/getter-backed settings and per-member policy reads; archive kind is a separate private planner argument. The same investigation exposed a pre-existing WASM extraction handoff that copied public options before planning. Declared extraction fields are now read once at the public owner and passed consistently to native, WASM and ZIP executors, removing duplicate argument lists.

Before correction, the preflight contracts failed because the filter was never called and getter-backed limits were ignored. The WASM getter-backed extraction controls failed with an undefined destination while native controls passed. After correction, all **531 focused tests** pass, including twelve structural-option boundary cases. The real custom extractor uses the documented node-tar `onReadEntry` hook with synchronous in-memory TAR input: the allowed case verifies exact saved bytes, and the denied case verifies `entry-filtered` plus an empty output directory. Guarded TAR/ZIP extraction has matching allowed/denied coverage on both backends, with exact bytes, stripping, POSIX modes and one policy callback.

```bash
pnpm test test/archive-preflight-options.test.ts test/archive-inspection.test.ts test/archive-filter-paths.test.ts test/archive-tar-ignored-meter.test.ts --reporter=verbose
```

Sanitized terminal excerpt from that run:

```text
✓ structural public preflight options > reads inherited filters at each check rather than copying options
✓ structural public preflight options > retains getter-backed limits, stripping and skip policy
✓ structural public preflight options > custom extractor preserves getter policy (allowed=true)
✓ structural public preflight options > custom extractor preserves getter policy (allowed=false)
Test Files  4 passed (4)
Tests       531 passed (531)
```

The corrected whole PR also passed fresh isolated autoreview through P2 and the default full `pnpm check` (8,076 passed, 81 platform skips). The corrected head also has its own green hosted CI and coverage, linked above; the initial-head runs are not used as its merge proof. No release tag has been created.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
