### PR TITLE
fix(move): retain admitted hardlink policy for 0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,58 @@
 
 ## Unreleased
 
+## 0.8.5 - 2026-09-07
+
+### Highlights
+
+- **Strict moves stay strict:** a move started with hardlink rejection keeps that policy throughout asynchronous preparation and copying, even when the caller reuses or changes its options object.
+
+### Safe moves
+
+- Preserve the admitted `sourceHardlinks` policy through staged-copy fallback. A late hardlink is still rejected before destination publication, with the source and its alias preserved, instead of being accepted after an in-flight options change.
+- Document when move policy is captured and how it relates to the existing per-mutation authority checks and destination-publication receipts.
+
 ## 0.8.4 - 2026-09-07
+
+### Highlights
+
+- **Faster reads and writes:** metadata checks avoid unnecessary event-loop round-trips while data I/O stays asynchronous; reconstructible data can explicitly opt out of fsync with `durable: false`.
+- **Inspect TARs without extracting:** the new bounded archive inspection API uses the same native/WASM admission and canonical planner as extraction.
+
+### Filesystem performance and durability
+
+- Run metadata checks inside async operations synchronously (microseconds each), cutting event-loop round-trips per read/write while data I/O remains asynchronous and native canonical path spelling is preserved, including Windows short paths.
+- Add `durable` to Root write/create/writeJson/createJson/append options and Root defaults; `durable: false` skips file and parent fsync for reconstructible data (default unchanged: durable).
+
+### Archive inspection and compatibility
 
 - Add bounded `inspectTarArchive` with complete native/WASM admission and the same canonical extraction planner, preserving effective member identities without materializing an output tree.
 - Preserve inherited and getter-backed extraction options on the WASM TAR path, matching native and ZIP handling for destinations, filters, stripping, and modes.
+
+### Validation
+
 - Apply the existing filesystem-test worker cap locally as well as in CI, and drain archive publication fixtures before resetting hooks or cleaning restricted directories after timeouts.
-- Add `durable` to Root write/create/writeJson/createJson/append options and Root defaults; `durable: false` skips file and parent fsync for reconstructible data (default unchanged: durable).
-- Run metadata checks inside async operations synchronously (microseconds each), cutting event-loop round-trips per read/write while data I/O remains asynchronous and native canonical path spelling is preserved, including Windows short paths.
 
 ## 0.8.3 - 2026-09-06
 
+### Highlights
+
+- **Safer cancellable moves:** callers can guard every source removal and retain an exact destination-publication receipt for recovery after later failures, including Windows and cross-device fallbacks.
+- **Less filesystem overhead:** reads and writes make fewer calls while preserving their existing boundary and identity checks.
+
+### Move authority and recovery
+
 - Add optional synchronous move authority checks before renames and each copied-source removal, plus an exact bigint destination-publication receipt for caller-owned recovery after later failure; retain cross-device and Windows `EPERM` copy fallbacks and the existing `Promise<void>` contract.
 
-- Simplify internals without changing public behavior: remove unused string/home helpers, `resolveUserPath`, `createBoundedReadStream`, `sidecarLockPayloadIsStale`, and `tarManifestEntryCost`; share filesystem utilities and merge private modules.
+### Filesystem performance and durability
+
 - Reduce filesystem calls per read and write while retaining boundary, hardlink, hook, retry, and post-mutation identity checks.
 - Skip native publication's extra mode-only file fsync for modes that retain owner read/write when staging permissions have not widened; after a crash, a file may retain staged `0o600` instead of the wider requested mode, while restrictive modes retain the extra fsync.
+
+### Tooling and maintenance
+
 - Add 1 MiB read/write and existing-mode inheritance benchmarks, with native-mode metadata and per-case iteration counts.
+- Simplify internals without changing public behavior: remove unused string/home helpers, `resolveUserPath`, `createBoundedReadStream`, `sidecarLockPayloadIsStale`, and `tarManifestEntryCost`; share filesystem utilities and merge private modules.
 
 ## 0.8.2 - 2026-09-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "fs-safe-native"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "bzip2",
  "flate2",

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -200,6 +200,8 @@ await movePathWithCopyFallback({
 ```
 
 Use it when source and destination might live on different filesystems (containers, tmpfs, separate volumes).
+The hardlink policy is captured when the move starts. Changing or reusing the
+options object later does not change the policy of an in-flight move.
 `sourceHardlinks: "reject"` performs a recursive preflight capped at 50,000
 entries before any mutation. Because link count and rename cannot be one atomic
 portable operation, this mode always commits a fresh inode/tree through the

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fs-safe-native"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/openclaw/fs-safe"

--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-native-build",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Private build workspace for the native bindings bundled by @openclaw/fs-safe.",
   "private": true,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Capability-style filesystem roots for Node.js apps that handle untrusted relative paths.",
   "keywords": [
     "filesystem",
@@ -156,13 +156,13 @@
     "archive:producer-smoke": "node scripts/archive-producer-smoke.mjs"
   },
   "optionalDependencies": {
-    "@openclaw/fs-safe-darwin-arm64": "0.8.4",
-    "@openclaw/fs-safe-darwin-x64": "0.8.4",
-    "@openclaw/fs-safe-linux-arm64-gnu": "0.8.4",
-    "@openclaw/fs-safe-linux-arm64-musl": "0.8.4",
-    "@openclaw/fs-safe-linux-x64-gnu": "0.8.4",
-    "@openclaw/fs-safe-linux-x64-musl": "0.8.4",
-    "@openclaw/fs-safe-win32-x64-msvc": "0.8.4",
+    "@openclaw/fs-safe-darwin-arm64": "0.8.5",
+    "@openclaw/fs-safe-darwin-x64": "0.8.5",
+    "@openclaw/fs-safe-linux-arm64-gnu": "0.8.5",
+    "@openclaw/fs-safe-linux-arm64-musl": "0.8.5",
+    "@openclaw/fs-safe-linux-x64-gnu": "0.8.5",
+    "@openclaw/fs-safe-linux-x64-musl": "0.8.5",
+    "@openclaw/fs-safe-win32-x64-msvc": "0.8.5",
     "jszip": "^3.10.1"
   },
   "devDependencies": {

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-darwin-arm64",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "macOS arm64 native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-darwin-x64",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "macOS x64 native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-gnu/package.json
+++ b/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-arm64-gnu",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Linux arm64 glibc native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-arm64-musl/package.json
+++ b/packages/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-arm64-musl",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Linux arm64 musl native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-x64-gnu/package.json
+++ b/packages/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-x64-gnu",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Linux x64 glibc native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/linux-x64-musl/package.json
+++ b/packages/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-linux-x64-musl",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Linux x64 musl native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/packages/win32-x64-msvc/package.json
+++ b/packages/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fs-safe-win32-x64-msvc",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Windows x64 MSVC native binding for @openclaw/fs-safe.",
   "license": "MIT",
   "author": "OpenClaw Team <dev@openclaw.ai>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,25 +49,25 @@ importers:
         version: 5.0.0(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.1))
     optionalDependencies:
       '@openclaw/fs-safe-darwin-arm64':
-        specifier: 0.8.4
+        specifier: 0.8.5
         version: link:packages/darwin-arm64
       '@openclaw/fs-safe-darwin-x64':
-        specifier: 0.8.4
+        specifier: 0.8.5
         version: link:packages/darwin-x64
       '@openclaw/fs-safe-linux-arm64-gnu':
-        specifier: 0.8.4
+        specifier: 0.8.5
         version: link:packages/linux-arm64-gnu
       '@openclaw/fs-safe-linux-arm64-musl':
-        specifier: 0.8.4
+        specifier: 0.8.5
         version: link:packages/linux-arm64-musl
       '@openclaw/fs-safe-linux-x64-gnu':
-        specifier: 0.8.4
+        specifier: 0.8.5
         version: link:packages/linux-x64-gnu
       '@openclaw/fs-safe-linux-x64-musl':
-        specifier: 0.8.4
+        specifier: 0.8.5
         version: link:packages/linux-x64-musl
       '@openclaw/fs-safe-win32-x64-msvc':
-        specifier: 0.8.4
+        specifier: 0.8.5
         version: link:packages/win32-x64-msvc
       jszip:
         specifier: ^3.10.1

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -370,7 +370,7 @@ export async function movePathWithCopyFallback(
       sourcePath,
       staged,
       {
-        sourceHardlinks: options.sourceHardlinks ?? "allow",
+        sourceHardlinks: rejectHardlinks ? "reject" : "allow",
         ...(rejectHardlinks ? { budget: { discovered: 1 } } : {}),
       },
       sourceIdentity,

--- a/test/move-path-regression.test.ts
+++ b/test/move-path-regression.test.ts
@@ -6,6 +6,7 @@ import { itPosix, itWin32, useTempDirs } from "./helpers/vitest.js";
 import {
   moveCopyFallbackReasonForRenameError,
   movePathWithCopyFallback,
+  type MovePathWithCopyFallbackOptions,
 } from "../src/move-path.js";
 
 const { tempRoot } = useTempDirs();
@@ -24,7 +25,6 @@ function spyOnRename(
     await implementation(from, to, rename);
   });
 }
-
 
 async function withProcessPlatform(platform: NodeJS.Platform, body: () => Promise<void>): Promise<void> {
   const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
@@ -99,11 +99,12 @@ describe("movePathWithCopyFallback regressions", () => {
     await expect(fsp.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("rejects a hardlink added after preflight without publishing a target", async () => {
+  it.each([false, true])("rejects a late hardlink when caller options change=%s", async (changeOptions) => {
     const base = await tempRoot("fs-safe-move-hardlink-race-");
     const source = path.join(base, "source.txt");
     const hardlink = path.join(base, "late-link.txt");
     const dest = path.join(base, "dest.txt");
+    const moveOptions: MovePathWithCopyFallbackOptions = { from: source, sourceHardlinks: "reject", to: dest };
     await fsp.writeFile(source, "source");
     const realLstat = fsp.lstat;
     let sourceInspections = 0;
@@ -111,11 +112,12 @@ describe("movePathWithCopyFallback regressions", () => {
       const stat = await realLstat(candidate, options as never);
       if (candidate === source && ++sourceInspections === 1) {
         await fsp.link(source, hardlink);
+        if (changeOptions) moveOptions.sourceHardlinks = "allow";
       }
       return stat;
     });
 
-    await expectFsSafeError(movePathWithCopyFallback({ from: source, sourceHardlinks: "reject", to: dest }), "hardlink");
+    await expectFsSafeError(movePathWithCopyFallback(moveOptions), "hardlink");
 
     await expect(fsp.readFile(source, "utf8")).resolves.toBe("source");
     await expect(fsp.readFile(hardlink, "utf8")).resolves.toBe("source");


### PR DESCRIPTION
A move started with `sourceHardlinks: "reject"` captures that policy for preflight but previously reread the caller's mutable options object during staged copy. Changing the options while preflight was pending could therefore admit a late hardlink and publish the destination. Keep the captured policy through copy so the move rejects the hardlink, preserves the source and alias, and leaves the destination unpublished.

Extend the existing real-hardlink regression with an in-flight options change; it fails against the original source and passes with this fix. Document per-call policy capture. Prepare patch version 0.8.5 consistently across the root, native workspace, seven native packages, and generated lockfiles. Organize 0.8.3–0.8.5 changelog sections around highlights and user interest, preserving every existing historical change bullet and the mode-fsync crash caveat.

Validation: full `pnpm check` passed locally (5,358 tests passed; 2,598 conditional/platform/native skips), including build, docs examples, filesystem-boundary and file-size guards, and package checks. Focused move suites passed 81 tests with five platform-specific skips. Independent Codex review of the complete candidate was clean through P2. Cross-platform/native CI remains required before release. A Crabbox Linux attempt failed during Actions hydration before running its command, so it supplies no remote test evidence; its lease is released.

Publishing remains the repository's protected annotated-tag workflow after this PR lands on main. No local npm publication or downstream dependency patch is involved.
