### PR TITLE
fix(move): preserve Windows junction identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve Windows file identity across open-induced `ctime` changes during guarded move fallback, and recreate directory junctions without requiring symlink privileges.
+
 ## 0.8.6 - 2026-09-07
 
 **Highlights:** Clearer guidance for atomic writes on Windows exFAT, with a repeatable filesystem compatibility probe.

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -163,8 +163,9 @@ async function copyRegularFilePinned(params: {
   mode: number;
   rejectHardlinks: boolean;
   to: string;
-}): Promise<void> {
+}): Promise<EntryIdentity> {
   let destinationCreated = false;
+  let openedIdentity: EntryIdentity;
   let sourceHandle: FileHandle;
   try {
     sourceHandle = await fs.open(params.from, resolveReadOpenFlags());
@@ -177,12 +178,26 @@ async function copyRegularFilePinned(params: {
   }
   try {
     const openedStat = await sourceHandle.stat();
+    openedIdentity = entryIdentity(openedStat);
     if (params.rejectHardlinks && openedStat.nlink > 1) {
       throw hardlinkedSourceError(params.from);
     }
-    if (!openedStat.isFile() || !sameIdentity(params.identity, entryIdentity(openedStat))) {
+    const openAdvancedWindowsCtime =
+      process.platform === "win32" &&
+      params.identity.dev === openedIdentity.dev &&
+      params.identity.ino === openedIdentity.ino &&
+      params.identity.mode === openedIdentity.mode &&
+      params.identity.nlink === openedIdentity.nlink &&
+      params.identity.size === openedIdentity.size &&
+      params.identity.mtimeMs === openedIdentity.mtimeMs &&
+      openedIdentity.ctimeMs >= params.identity.ctimeMs;
+    if (
+      !openedStat.isFile() ||
+      (!sameIdentity(params.identity, openedIdentity) && !openAdvancedWindowsCtime)
+    ) {
       throw sourceChangedError(params.from);
     }
+    await assertSourceStillMatches(params.from, openedIdentity);
 
     const destinationHandle = await fs.open(
       params.to,
@@ -205,7 +220,7 @@ async function copyRegularFilePinned(params: {
       if (params.rejectHardlinks && finalSourceStat.nlink > 1) {
         throw hardlinkedSourceError(params.from);
       }
-      if (!sameIdentity(params.identity, entryIdentity(finalSourceStat))) {
+      if (!sameIdentity(openedIdentity, entryIdentity(finalSourceStat))) {
         throw sourceChangedError(params.from);
       }
       await destinationHandle.chmod(modeBits(params.mode));
@@ -220,6 +235,7 @@ async function copyRegularFilePinned(params: {
   } finally {
     await sourceHandle.close();
   }
+  return openedIdentity;
 }
 
 async function copyEntryWithManifest(
@@ -238,7 +254,10 @@ async function copyEntryWithManifest(
   }
 
   if (sourceStat.isSymbolicLink()) {
-    await fs.symlink(await fs.readlink(from), to);
+    const target = await fs.readlink(from);
+    const targetType =
+      process.platform === "win32" && (await fs.stat(from)).isDirectory() ? "junction" : undefined;
+    await fs.symlink(target, to, targetType);
     // readlink() is path-based; verify the symlink we copied is still the one
     // we inspected before letting the staged destination become visible.
     await assertSourceStillMatches(from, identity);
@@ -278,14 +297,14 @@ async function copyEntryWithManifest(
     throw hardlinkedSourceError(from);
   }
 
-  await copyRegularFilePinned({
+  const copiedIdentity = await copyRegularFilePinned({
     from,
     identity,
     mode: sourceStat.mode,
     rejectHardlinks: options.sourceHardlinks === "reject",
     to,
   });
-  return { ...identity, kind: "leaf" };
+  return { ...copiedIdentity, kind: "leaf" };
 }
 
 function assertSynchronousResult(returned: unknown, name: string): void {

--- a/test/move-path-windows.test.ts
+++ b/test/move-path-windows.test.ts
@@ -1,0 +1,57 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { movePathWithCopyFallback } from "../src/move-path.js";
+
+const tempDirs: string[] = [];
+
+async function tempRoot(prefix: string): Promise<string> {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
+});
+
+describe.runIf(process.platform === "win32")("movePathWithCopyFallback on Windows", () => {
+  it("moves a newly created directory when hardlink rejection requires copy fallback", async () => {
+    const base = await tempRoot("fs-safe-move-windows-ctime-");
+    const source = path.join(base, "source-dir");
+    const dest = path.join(base, "dest-dir");
+    await fsp.mkdir(source);
+    await fsp.writeFile(path.join(source, "copied.txt"), "copied");
+
+    await movePathWithCopyFallback({
+      from: source,
+      sourceHardlinks: "reject",
+      to: dest,
+    });
+
+    await expect(fsp.readFile(path.join(dest, "copied.txt"), "utf8")).resolves.toBe("copied");
+    await expect(fsp.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves directory junctions during copy fallback", async () => {
+    const base = await tempRoot("fs-safe-move-windows-junction-");
+    const source = path.join(base, "source-dir");
+    const dest = path.join(base, "dest-dir");
+    const junctionTarget = path.join(base, "junction-target");
+    await fsp.mkdir(source);
+    await fsp.mkdir(junctionTarget);
+    await fsp.symlink(junctionTarget, path.join(source, "host"), "junction");
+
+    await movePathWithCopyFallback({
+      from: source,
+      sourceHardlinks: "reject",
+      to: dest,
+    });
+
+    await expect(fsp.realpath(path.join(dest, "host"))).resolves.toBe(
+      await fsp.realpath(junctionTarget),
+    );
+    await expect(fsp.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
## Summary

- rebind guarded copy manifests to the identity observed through the pinned source handle
- tolerate only Windows open-induced `ctime` advancement when every other identity field remains unchanged and the pathname still matches the handle
- preserve Windows directory junction type during copy fallback so publication does not require symlink privilege

## Why

OpenClaw plugin installs use `movePathWithCopyFallback(..., { sourceHardlinks: "reject" })`. On native Windows, opening a newly-created source file can advance `ctimeMs` without changing inode, mode, links, size, or `mtimeMs`, causing a false `ESTALE`. After that is addressed, copying a plugin-local OpenClaw directory junction as a generic symlink fails with `EPERM` for non-elevated users.

This was reproduced through the public OpenClaw Claw lifecycle with `research-monitor` and `video-concept-producer`; both previously failed during plugin publication and both proceeded through add, deterministic application execution, status, and update with this patch.

## Validation

- `pnpm lint:file-size`
- `pnpm lint:fs-boundary`
- `pnpm exec tsc -p tsconfig.json`
- `pnpm exec vitest run test/move-path-regression.test.ts test/move-path-windows.test.ts --maxWorkers=1 --reporter=dot` (12 passed, 9 platform-skipped)
- independent security review: no findings

The full local suite is not representative on this non-elevated Windows host: unrelated symlink tests fail with `EPERM`, and archive tests require the Rust-built `dist/archive-parser.wasm` artifact.