### PR TITLE
feat(store): add durable option to FileStore and jsonStore writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `Root.copyIn({ durable: false })`, with per-call, root-default, then `true` precedence, to skip file and parent-directory fsync for reconstructible data.
 - Add `extractArchive({ durable: false })` to skip durability syncs for temporary or reconstructible extraction destinations.
 - Speed up archive extraction by omitting private staging syncs, deferring publication durability to one bounded file/directory pass, and sharing duplicate destination guards without weakening containment checks.
+- Add store-level and per-write `durable` options to FileStore and synchronous writes, plus JSON-store durability defaults, so reconstructible data can skip file and parent fsync while preserving guarded atomic publication.
 - Preserve Windows file identity across open-induced `ctime` changes during guarded move fallback, and recreate directory junctions without requiring symlink privileges.
 
 ## 0.8.6 - 2026-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add `Root.copyIn({ durable: false })`, with per-call, root-default, then `true` precedence, to skip file and parent-directory fsync for reconstructible data.
 - Add `extractArchive({ durable: false })` to skip durability syncs for temporary or reconstructible extraction destinations.
 - Speed up archive extraction by omitting private staging syncs, deferring publication durability to one bounded file/directory pass, and sharing duplicate destination guards without weakening containment checks.
-- Add store-level and per-write `durable` options to FileStore and synchronous writes, plus JSON-store durability defaults, so reconstructible data can skip file and parent fsync while preserving guarded atomic publication.
+- Add store-level and per-call `durable` options to FileStore writes, streams, copies, and synchronous writes, plus JSON-store durability defaults, so reconstructible data can skip file and parent fsync while preserving guarded atomic publication.
 - Preserve Windows file identity across open-induced `ctime` changes during guarded move fallback, and recreate directory junctions without requiring symlink privileges.
 
 ## 0.8.6 - 2026-09-07

--- a/docs/file-store.md
+++ b/docs/file-store.md
@@ -124,9 +124,7 @@ and publication identity checks are unchanged.
 | Method | Durability support |
 |---|---|
 | `write`, `writeText`, `writeJson` (async and sync) | Per-call option overrides store default. |
-| `writeStream`, `private: true` | Per-call option overrides store default. |
-| `writeStream`, `private: false` | Always durable until Root.copyIn gains the option; `durable` is ignored. |
-| `copyIn` (either private mode) | Always durable until Root.copyIn gains the option; `durable` is ignored. |
+| `writeStream`, `copyIn` (either private mode) | Per-call option overrides store default. |
 | JSON `write`, `update`, `updateOr` | JSON handle option overrides file-store default. |
 
 ### `write(rel, data, options?)`
@@ -167,8 +165,8 @@ const path = await cache.writeStream("downloads/blob.bin", Readable.from(remoteF
 
 Streams into a sibling temp with a running byte budget. Aborts the source stream with `too-large` if `maxBytes` is exceeded mid-stream — partial writes are cleaned up.
 
-Private streams honor `durable`. Non-private streams stage their input and
-publish through Root `copyIn`, so they remain always durable for now.
+Streams honor `durable` in both private modes. Non-private streams stage their
+input and forward the resolved durability option to Root `copyIn` for publication.
 
 ### `copyIn(rel, sourcePath, options?)`
 
@@ -178,8 +176,8 @@ const path = await cache.copyIn("ingest/upload.bin", "/tmp/upload.bin");
 
 One-shot ingest from an absolute source path. Source is checked for symlink/non-regular before copy. Same mode rules as `write`.
 
-`copyIn` remains always durable in both private modes until Root `copyIn`
-gains the option. It ignores both store-level and per-call `durable` values.
+`copyIn` honors per-call and store-level `durable` values in both private modes,
+with the same precedence as `write`.
 
 ### `FileStoreWriteOptions`
 
@@ -197,7 +195,7 @@ type FileStoreWriteOptions = {
 
 | `FileStoreWriteOptions` option | Default |
 |---|---|
-| `durable` | Store option, otherwise `true`; ignored by `copyIn` and non-private `writeStream`. |
+| `durable` | Store option, otherwise `true`. |
 | `dirMode` / `mode` | Store directory/file modes. |
 | `maxBytes` | Store byte limit. |
 | `tempPrefix` | Writer-specific temporary prefix. |

--- a/docs/file-store.md
+++ b/docs/file-store.md
@@ -28,8 +28,17 @@ const cache = fileStore({
   dirMode: 0o700,     // mode for parent directories created on demand (default 0o700)
   maxBytes: 64 * 1024 * 1024, // optional: refuse writes/reads larger than this
   private: true,      // use secret-file atomic writes for private state
+  durable: true,      // sync file and parent directory (default true)
 });
 ```
+
+| `FileStoreOptions` option | Default | Purpose |
+|---|---|---|
+| `rootDir` | Required | Store directory. |
+| `private` | `false` | Use the secret-file atomic path. |
+| `mode` / `dirMode` | `0o600` / `0o700` | File and parent-directory modes. |
+| `maxBytes` | Unset | Store read/write byte limit. |
+| `durable` | `true` | Sync the written file and its parent directory; see method support below. |
 
 Store and per-call `maxBytes` values must be non-negative safe integers or positive `Infinity`. Zero is an active zero-byte cap; `Infinity` disables the cap. An omitted or explicitly `undefined` per-call value preserves the store-level limit. The same rule applies to buffer writes, streams, copies, async reads, and synchronous reads/writes.
 
@@ -101,7 +110,24 @@ therefore does not imply that no filesystem access or serialization occurred.
 
 ## Writes
 
-Every write goes through `writeSiblingTempFile` — temp + rename, mode applied to file and parent dir, both `fsync`'d.
+Writes use guarded sibling-temp publication: apply file and directory modes,
+then rename into place. By default, the file and parent directory are synced
+where supported by the platform and writer.
+
+`durable: false` keeps the sibling-temp replace/rename behavior but skips the
+temp-file and parent-directory `fsync` calls. Use it only for reconstructible
+metadata where lower latency matters more than crash-durability. Per-call
+`durable` overrides the store option, which defaults to `true`; an omitted or
+`undefined` override preserves the store default. Modes, path confinement,
+and publication identity checks are unchanged.
+
+| Method | Durability support |
+|---|---|
+| `write`, `writeText`, `writeJson` (async and sync) | Per-call option overrides store default. |
+| `writeStream`, `private: true` | Per-call option overrides store default. |
+| `writeStream`, `private: false` | Always durable until Root.copyIn gains the option; `durable` is ignored. |
+| `copyIn` (either private mode) | Always durable until Root.copyIn gains the option; `durable` is ignored. |
+| JSON `write`, `update`, `updateOr` | JSON handle option overrides file-store default. |
 
 ### `write(rel, data, options?)`
 
@@ -118,7 +144,7 @@ Convenience wrappers over `write`. `writeJson` pretty-prints with a trailing new
 ### `json<T>(rel, options?)`
 
 Returns a typed single-file JSON state helper for a file under this store. It
-inherits the store's root, mode, max-size, and private-write policy, then adds
+inherits the store's root, mode, max-size, durability, and private-write policy, then adds
 `readOr`, `readRequired`, `update`, `updateOr`, and optional sidecar locking:
 
 ```ts
@@ -129,6 +155,9 @@ await state.updateOr(defaultState, (current) => ({ ...current, enabled: true }))
 Use this when one JSON file owns one piece of state. `jsonStore({ filePath })`
 is the absolute-path convenience wrapper for the same primitive.
 
+Pass `{ durable: false }` or `{ durable: true }` to `json()` to override the
+parent store's durability for all mutations of that JSON handle.
+
 ### `writeStream(rel, stream, options?)`
 
 ```ts
@@ -138,6 +167,9 @@ const path = await cache.writeStream("downloads/blob.bin", Readable.from(remoteF
 
 Streams into a sibling temp with a running byte budget. Aborts the source stream with `too-large` if `maxBytes` is exceeded mid-stream — partial writes are cleaned up.
 
+Private streams honor `durable`. Non-private streams stage their input and
+publish through Root `copyIn`, so they remain always durable for now.
+
 ### `copyIn(rel, sourcePath, options?)`
 
 ```ts
@@ -146,18 +178,33 @@ const path = await cache.copyIn("ingest/upload.bin", "/tmp/upload.bin");
 
 One-shot ingest from an absolute source path. Source is checked for symlink/non-regular before copy. Same mode rules as `write`.
 
+`copyIn` remains always durable in both private modes until Root `copyIn`
+gains the option. It ignores both store-level and per-call `durable` values.
+
 ### `FileStoreWriteOptions`
 
 Per-call overrides for the store-level defaults:
 
 ```ts
 type FileStoreWriteOptions = {
+  durable?: boolean;   // store default, otherwise true
   dirMode?: number;
   mode?: number;
   maxBytes?: number;
   tempPrefix?: string;  // override the default "." + basename
 };
 ```
+
+| `FileStoreWriteOptions` option | Default |
+|---|---|
+| `durable` | Store option, otherwise `true`; ignored by `copyIn` and non-private `writeStream`. |
+| `dirMode` / `mode` | Store directory/file modes. |
+| `maxBytes` | Store byte limit. |
+| `tempPrefix` | Writer-specific temporary prefix. |
+
+The same durability precedence applies to `fileStoreSync().write`,
+`writeText`, and `writeJson`. The synchronous store has no `writeStream` or
+`copyIn` methods.
 
 ## Reads
 
@@ -254,5 +301,5 @@ await root.move(`pending/${id}`, `done/${id}`);
 
 - [`root()`](root.md) — the boundary `FileStore` is built on; reach for it when you need move/list/append.
 - [JSON store](json-store.md) — the JSON-state-file equivalent of this surface.
-- [Atomic writes](atomic.md) — `writeSiblingTempFile` is what every write goes through.
+- [Atomic writes](atomic.md) — lower-level sibling-temp publication helpers.
 - [Temp workspaces](temp.md) — private scratch directories backed by `FileStore`.

--- a/docs/json-store.md
+++ b/docs/json-store.md
@@ -45,6 +45,7 @@ type JsonStoreOptions<T> = {
   filePath: string;
   dirMode?: number;                                // default 0o700
   mode?: number;                                   // default 0o600
+  durable?: boolean;                              // default true
   trailingNewline?: boolean;                       // default true
   lock?: boolean | JsonStoreLockOptions;           // false / undefined = no lock
 };
@@ -70,6 +71,15 @@ type JsonStore<T> = {
 
 `jsonStore({ filePath })` resolves `rootDir = dirname(filePath)` and calls
 `fileStore({ rootDir, private: true }).json(basename(filePath), options)`.
+
+`durable: false` keeps sibling-temp replace/rename behavior but skips the
+temp-file and parent-directory `fsync` calls. Use it only for reconstructible
+metadata where lower latency matters more than crash-durability. The default
+is `true`, subject to platform sync support. This store-level policy applies
+to `write`, `update`, and `updateOr`; these methods have no per-call options.
+For `fileStore(...).json(rel, options)`, `options.durable` overrides the parent
+file store's durability, while omission or `undefined` inherits it. Modes,
+identity checks, mutation serialization, and sidecar locking are unchanged.
 
 The store does **not** validate the parsed value against `T` at runtime — the cast is unchecked. Wrap with a schema (zod/valibot) if the file might be hand-edited or written by another process you don't control.
 

--- a/docs/secret-file.md
+++ b/docs/secret-file.md
@@ -172,8 +172,14 @@ type WriteSecretFileParams = {
   content: string | Uint8Array;
   mode?: number;                // file mode for the new file (default PRIVATE_SECRET_FILE_MODE = 0o600)
   dirMode?: number;             // mode for the root and intermediate dirs (default PRIVATE_SECRET_DIR_MODE = 0o700)
+  durable?: boolean;            // default true; false skips file and parent fsync
 };
 ```
+
+`durable: false` preserves atomic publication, modes, and identity checks while
+skipping file and parent-directory `fsync` calls. Use it only for reconstructible
+data where lower latency matters more than crash-durability; private and JSON
+stores forward their durability policy here.
 
 The full POSIX directory mode is asserted on each component along the path: `rootDir`, then any intermediate dirs, then the parent. Existing directories, including another creator's `EEXIST` winner, must already match `dirMode` exactly or the write fails with `insecure-permissions`; they are never chmod-repaired. An explicitly requested directory mode such as `0o2750` preserves its setgid bit. Audit and adjust existing secret directories yourself. The admitted directory guards are retained through traversal and the final writer/lock handoff; a fresh pathname lookup cannot silently authorize a replacement. The caller must still trust the selected root and its owners; matching permission bits alone do not establish that trust.
 

--- a/scripts/benchmark.mjs
+++ b/scripts/benchmark.mjs
@@ -67,7 +67,7 @@ function formatRatio(value) {
 }
 
 async function ensureDistIsBuilt() {
-  const required = ["dist/root.js", "dist/regular-file.js", "dist/atomic.js", "dist/json.js"];
+  const required = ["dist/root.js", "dist/regular-file.js", "dist/atomic.js", "dist/json.js", "dist/store.js"];
   const missing = required.filter((filePath) => !fsSync.existsSync(filePath));
   if (missing.length > 0) {
     throw new Error(`Benchmark needs built dist files. Run pnpm build first. Missing: ${missing.join(", ")}`);
@@ -144,11 +144,13 @@ async function main() {
     { readRegularFile },
     { root },
     { tryReadJson, writeJson },
+    { fileStore },
   ] = await Promise.all([
     import("../dist/atomic.js"),
     import("../dist/regular-file.js"),
     import("../dist/root.js"),
     import("../dist/json.js"),
+    import("../dist/store.js"),
   ]);
   const args = parseArgs(process.argv.slice(2));
   const iterations = args.iterations;
@@ -162,6 +164,7 @@ async function main() {
 
   try {
     const safe = await root(workspace, { mkdir: true, hardlinks: "allow" });
+    const store = fileStore({ rootDir: workspace });
     const readPath = path.join(workspace, "read.txt");
     const readRelPath = "read.txt";
     const jsonPath = path.join(workspace, "state.json");
@@ -228,6 +231,22 @@ async function main() {
         run: async (i) => {
           await safe.write("root-write-nondurable.txt", `${i}:${payload.toString("utf8")}`, { durable: false });
         },
+      },
+      {
+        group: "file store",
+        name: "raw fs.writeFile",
+        baseline: true,
+        run: () => fs.writeFile(path.join(workspace, "store-raw.txt"), payload, { mode: 0o600 }),
+      },
+      {
+        group: "file store",
+        name: "fileStore.write",
+        run: () => store.write("store-write.txt", payload),
+      },
+      {
+        group: "file store",
+        name: "fileStore.write durable:false",
+        run: () => store.write("store-write-nondurable.txt", payload, { durable: false }),
       },
       {
         group: "read json",

--- a/src/file-store-sync-write.ts
+++ b/src/file-store-sync-write.ts
@@ -27,6 +27,7 @@ export function writeFileSyncAtomic(params: {
   filePath: string;
   content: string | Uint8Array;
   privateMode: boolean;
+  durable: boolean;
   dirMode: number;
   mode: number;
 }): string {
@@ -78,7 +79,7 @@ export function writeFileSyncAtomic(params: {
         if (!opened.isFile() || opened.nlink > 1) {
           throw new FsSafeError("path-mismatch", "store temp is not an owned regular file");
         }
-        fs.fsyncSync(descriptor);
+        if (params.durable) fs.fsyncSync(descriptor);
         return opened;
       } finally {
         fs.closeSync(descriptor);
@@ -121,11 +122,13 @@ export function writeFileSyncAtomic(params: {
     }
     if (parentGuard) {
       assertSyncDirectoryGuard(parentGuard);
-      syncDirectorySync({
-        path: parentGuard.dir,
-        realPath: parentGuard.realPath,
-        identity: parentGuard.stat,
-      }, { label: "store parent" });
+      if (params.durable) {
+        syncDirectorySync({
+          path: parentGuard.dir,
+          realPath: parentGuard.realPath,
+          identity: parentGuard.stat,
+        }, { label: "store parent" });
+      }
       assertSyncDirectoryGuard(parentGuard);
     }
     return filePath;

--- a/src/file-store.ts
+++ b/src/file-store.ts
@@ -28,7 +28,7 @@ import { writeSecretFileAtomic } from "./secret-file.js";
 export type FileStoreOptions = {
   rootDir: string;
   private?: boolean;
-  /** Default for write and private writeStream; true syncs file and parent where supported. */
+  /** Default for writes, streams, and copies; true syncs file and parent where supported. */
   durable?: boolean;
   dirMode?: number;
   mode?: number;
@@ -36,7 +36,7 @@ export type FileStoreOptions = {
 };
 
 export type FileStoreWriteOptions = {
-  /** Write durability; ignored by copyIn and non-private writeStream until Root.copyIn supports it. */
+  /** Override store durability; defaults to the store option, then true. */
   durable?: boolean;
   dirMode?: number;
   mode?: number;
@@ -60,10 +60,7 @@ export type FileStore = {
   open(relativePath: string, options?: RootReadOptions): Promise<OpenResult>;
   read(relativePath: string, options?: RootReadOptions): Promise<ReadResult>;
   readBytes(relativePath: string, options?: RootReadOptions): Promise<Buffer>;
-  readText(
-    relativePath: string,
-    options?: FileStoreReadOptions,
-  ): Promise<string>;
+  readText(relativePath: string, options?: FileStoreReadOptions): Promise<string>;
   readTextIfExists(relativePath: string, options?: FileStoreReadOptions): Promise<string | null>;
   readJson<T = unknown>(relativePath: string, options?: FileStoreReadOptions): Promise<T>;
   readJsonIfExists<T = unknown>(
@@ -186,6 +183,7 @@ async function copyIntoRoot(params: {
   rootDir: string;
   relativePath: string;
   sourcePath: string;
+  durable: boolean;
   dirMode?: number;
   maxBytes?: number;
   mode?: number;
@@ -206,6 +204,7 @@ async function copyIntoRoot(params: {
   });
   await ensureParentInRoot(scopedRoot, relativePath, dirMode);
   await scopedRoot.copyIn(relativePath, params.sourcePath, {
+    durable: params.durable,
     maxBytes: params.maxBytes,
     mkdir: false,
     mode: params.mode ?? 0o600,
@@ -301,6 +300,7 @@ export function fileStore(options: FileStoreOptions): FileStore {
           rootDir,
           relativePath: safeRelativePath,
           sourcePath: staged.path,
+          durable: writeOptions?.durable ?? durable,
           maxBytes: limit,
           mode: writeOptions?.mode ?? mode,
           tempPrefix: writeOptions?.tempPrefix,
@@ -318,12 +318,13 @@ export function fileStore(options: FileStoreOptions): FileStore {
           sourcePath,
           maxBytes: configuredLimit ?? DEFAULT_ROOT_MAX_BYTES,
         });
-        return await write(relativePath, buffer, { ...writeOptions, durable: true });
+        return await write(relativePath, buffer, writeOptions);
       }
       return await copyIntoRoot({
         rootDir,
         relativePath,
         sourcePath,
+        durable: writeOptions?.durable ?? durable,
         dirMode: writeOptions?.dirMode ?? dirMode,
         maxBytes: configuredLimit,
         mode: writeOptions?.mode ?? mode,

--- a/src/file-store.ts
+++ b/src/file-store.ts
@@ -28,12 +28,16 @@ import { writeSecretFileAtomic } from "./secret-file.js";
 export type FileStoreOptions = {
   rootDir: string;
   private?: boolean;
+  /** Default for write and private writeStream; true syncs file and parent where supported. */
+  durable?: boolean;
   dirMode?: number;
   mode?: number;
   maxBytes?: number;
 };
 
 export type FileStoreWriteOptions = {
+  /** Write durability; ignored by copyIn and non-private writeStream until Root.copyIn supports it. */
+  durable?: boolean;
   dirMode?: number;
   mode?: number;
   maxBytes?: number;
@@ -51,16 +55,8 @@ export type FileStore = {
     data: string | Uint8Array,
     options?: FileStoreWriteOptions,
   ): Promise<string>;
-  writeStream(
-    relativePath: string,
-    stream: Readable,
-    options?: FileStoreWriteOptions,
-  ): Promise<string>;
-  copyIn(
-    relativePath: string,
-    sourcePath: string,
-    options?: FileStoreWriteOptions,
-  ): Promise<string>;
+  writeStream(relativePath: string, stream: Readable, options?: FileStoreWriteOptions): Promise<string>;
+  copyIn(relativePath: string, sourcePath: string, options?: FileStoreWriteOptions): Promise<string>;
   open(relativePath: string, options?: RootReadOptions): Promise<OpenResult>;
   read(relativePath: string, options?: RootReadOptions): Promise<ReadResult>;
   readBytes(relativePath: string, options?: RootReadOptions): Promise<Buffer>;
@@ -222,6 +218,7 @@ export function fileStore(options: FileStoreOptions): FileStore {
   const privateMode = options.private ?? false;
   const dirMode = options.dirMode ?? 0o700;
   const mode = options.mode ?? 0o600;
+  const durable = options.durable ?? true;
   const maxBytes = normalizeMaxBytes(options.maxBytes);
 
   async function openRoot(): Promise<Root> {
@@ -243,6 +240,7 @@ export function fileStore(options: FileStoreOptions): FileStore {
         rootDir,
         filePath: destination,
         content,
+        durable: writeOptions?.durable ?? durable,
         dirMode: writeOptions?.dirMode ?? dirMode,
         mode: writeOptions?.mode ?? mode,
       });
@@ -258,6 +256,7 @@ export function fileStore(options: FileStoreOptions): FileStore {
     await scopedRoot.write(safeRelativePath, content, {
       mkdir: false,
       mode: writeOptions?.mode ?? mode,
+      durable: writeOptions?.durable ?? durable,
     });
     return destination;
   }
@@ -286,6 +285,7 @@ export function fileStore(options: FileStoreOptions): FileStore {
           rootDir,
           filePath: destination,
           content: Buffer.concat(chunks),
+          durable: writeOptions?.durable ?? durable,
           dirMode: writeOptions?.dirMode ?? dirMode,
           mode: writeOptions?.mode ?? mode,
         });
@@ -318,7 +318,7 @@ export function fileStore(options: FileStoreOptions): FileStore {
           sourcePath,
           maxBytes: configuredLimit ?? DEFAULT_ROOT_MAX_BYTES,
         });
-        return await write(relativePath, buffer, writeOptions);
+        return await write(relativePath, buffer, { ...writeOptions, durable: true });
       }
       return await copyIntoRoot({
         rootDir,
@@ -409,6 +409,7 @@ export function fileStore(options: FileStoreOptions): FileStore {
             await write(
               relativePath,
               options?.trailingNewline === false ? json : `${json}\n`,
+              { durable: options?.durable },
             );
           },
         },
@@ -426,6 +427,7 @@ export function fileStoreSync(options: FileStoreOptions): FileStoreSync {
   const privateMode = options.private ?? false;
   const dirMode = options.dirMode ?? 0o700;
   const mode = options.mode ?? 0o600;
+  const durable = options.durable ?? true;
   const maxBytes = normalizeMaxBytes(options.maxBytes);
 
   function write(
@@ -442,6 +444,7 @@ export function fileStoreSync(options: FileStoreOptions): FileStoreSync {
       filePath: destination,
       content,
       privateMode,
+      durable: writeOptions?.durable ?? durable,
       dirMode: writeOptions?.dirMode ?? dirMode,
       mode: writeOptions?.mode ?? mode,
     });

--- a/src/json-document-store.ts
+++ b/src/json-document-store.ts
@@ -23,6 +23,8 @@ export type JsonStoreLockOptions = {
 };
 
 export type JsonFileStoreOptions = {
+  /** Overrides the parent store's durability for every JSON mutation. */
+  durable?: boolean;
   trailingNewline?: boolean;
   lock?: boolean | JsonStoreLockOptions;
 };
@@ -43,7 +45,7 @@ export type JsonStoreAdapter<T> = {
   prepareLock?: () => Promise<Root>;
   readIfExists(): Promise<T | undefined>;
   readRequired(): Promise<T>;
-  write(value: T, options?: { trailingNewline?: boolean }): Promise<void>;
+  write(value: T, options?: { trailingNewline?: boolean; durable?: boolean }): Promise<void>;
 };
 
 function cloneFallback<T>(value: T): T {
@@ -90,6 +92,7 @@ export function createJsonStore<T>(
   async function write(value: T): Promise<void> {
     await adapter.write(value, {
       trailingNewline: options.trailingNewline ?? true,
+      durable: options.durable,
     });
   }
 

--- a/src/secret-file.ts
+++ b/src/secret-file.ts
@@ -277,6 +277,7 @@ type SecretFileWriteParams = {
   content: string | Uint8Array;
   mode?: number;
   dirMode?: number;
+  durable?: boolean;
 };
 
 async function secretFileWriteQueueKey(filePath: string): Promise<string> {
@@ -352,6 +353,7 @@ async function materializeSecretFileAtomic(
     basename: fileName,
     mkdir: false,
     mode,
+    sync: params.durable !== false,
     overwrite: !createOnly,
     input: { kind: "buffer", data: typeof params.content === "string" ? params.content : Buffer.from(params.content) },
     rootIdentity: { dev: parentGuard.stat.dev, ino: parentGuard.stat.ino },

--- a/test/store-durable-option.test.ts
+++ b/test/store-durable-option.test.ts
@@ -46,13 +46,13 @@ async function observeSyncs(directory: string) {
   return events;
 }
 
-function expectSyncs(events: string[], durable: boolean, syncStore: boolean, backend: string) {
+function expectSyncs(events: string[], durable: boolean, syncStore: boolean, backend: string, rootCopy = false) {
   if (!durable) {
     expect(events).toEqual([]);
   } else if (process.platform !== "win32") {
     expect(events).toEqual(["file", "parent"]);
-  } else if (syncStore || backend === "require") {
-    // Directory sync is not portable on Windows; the JS async fallback is unsynced.
+  } else if (syncStore || rootCopy || (backend !== "off" && nativeAvailable)) {
+    // Windows directory sync is not portable; JS async writes can also be unsynced.
     expect(events).toContain("file");
   }
 }
@@ -71,46 +71,34 @@ const policies: {
   { name: "per-call false overrides store true", storeDefault: true, options: { durable: false }, sync: false },
 ];
 
-for (const backend of ["require", "off"] as const) {
+for (const backend of ["auto", "require", "off"] as const) {
   describe.skipIf(backend === "require" && !nativeAvailable)(`store durable option: native ${backend}`, () => {
     for (const privateMode of [false, true]) {
       for (const method of ["writeStream", "copyIn"] as const) {
-        const deferred = method === "copyIn" || !privateMode;
-        const note = deferred ? " (always durable until Root.copyIn gains the option)" : "";
-        it.skipIf(deferred).each(policies)(`private=${privateMode} ${method}${note}: $name`, async ({ storeDefault, options, sync }) => {
+        it.each(policies)(`private=${privateMode} ${method}: $name`, async ({ storeDefault, options, sync }) => {
           configureFsSafeNative({ mode: backend });
           const directory = await tempRoot("fs-safe-store-copy-durable-");
           const source = path.join(directory, "source");
-          await fs.writeFile(source, "payload");
           const store = fileStore({ rootDir: directory, private: privateMode, durable: storeDefault });
           const target = path.join(directory, "nested/target");
           const events = await observeSyncs(directory);
-          const result = method === "copyIn"
-            ? await store.copyIn("nested/target", source, { ...options, mode: 0o640 })
-            : await store.writeStream("nested/target", Readable.from(["pay", "load"]), { ...options, mode: 0o640 });
-          expect(result).toBe(target);
-          expectSyncs(events, sync, false, backend);
-          expect(await fs.readFile(target, "utf8")).toBe("payload");
-          if (process.platform !== "win32") {
-            expect((await fs.stat(target)).mode & 0o777).toBe(0o640);
-            expect((await fs.stat(path.dirname(target))).mode & 0o777).toBe(0o700);
+          for (const value of ["first", "replacement"]) {
+            await fs.writeFile(source, value);
+            events.length = 0;
+            const mode = value === "first" ? 0o640 : 0o600;
+            const result = method === "copyIn"
+              ? await store.copyIn("nested/target", source, { ...options, mode })
+              : await store.writeStream("nested/target", Readable.from([value.slice(0, 2), value.slice(2)]), { ...options, mode });
+            expect(result).toBe(target);
+            expectSyncs(events, sync, false, backend, !privateMode);
+            expect(await fs.readFile(target, "utf8")).toBe(value);
+            if (process.platform !== "win32") {
+              expect((await fs.stat(target)).mode & 0o777).toBe(mode);
+              expect((await fs.stat(path.dirname(target))).mode & 0o777).toBe(0o700);
+            }
+            expect(await fs.readdir(path.dirname(target))).toEqual(["target"]);
           }
-          expect(await fs.readdir(path.dirname(target))).toEqual(["target"]);
         });
-        if (deferred) {
-          it(`private=${privateMode} ${method}: always durable until Root.copyIn gains the option`, async () => {
-            configureFsSafeNative({ mode: backend });
-            const directory = await tempRoot("fs-safe-store-deferred-durable-");
-            const source = path.join(directory, "source");
-            await fs.writeFile(source, "payload");
-            const store = fileStore({ rootDir: directory, private: privateMode, durable: false });
-            const events = await observeSyncs(directory);
-            if (method === "copyIn") await store.copyIn("target", source, { durable: false });
-            else await store.writeStream("target", Readable.from(["payload"]), { durable: false });
-            expectSyncs(events, true, false, backend);
-            expect(await store.readText("target")).toBe("payload");
-          });
-        }
       }
       for (const syncStore of [false, true]) {
         for (const method of ["write", "writeText", "writeJson"] as const) {

--- a/test/store-durable-option.test.ts
+++ b/test/store-durable-option.test.ts
@@ -1,0 +1,199 @@
+import fsSync from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureFsSafeNative } from "../src/config.js";
+import { fileStore, fileStoreSync, jsonStore, type FileStoreWriteOptions } from "../src/store.js";
+import * as verification from "../src/root-write-verification.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const verifyPublished = verification.verifyAtomicWriteResult;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  configureFsSafeNative({ mode: "auto" });
+});
+
+async function observeSyncs(directory: string) {
+  const probePath = path.join(directory, "probe");
+  const probe = await fs.open(probePath, "w");
+  const prototype = Object.getPrototypeOf(probe) as FileHandle;
+  await probe.close();
+  await fs.unlink(probePath);
+  const events: string[] = [];
+  const record = (fd: number) => events.push(fsSync.fstatSync(fd).isFile() ? "file" : "parent");
+  const asyncSync = prototype.sync;
+  const syncSync = fsSync.fsyncSync;
+  vi.spyOn(prototype, "sync").mockImplementation(async function (this: FileHandle) {
+    record(this.fd);
+    await asyncSync.call(this);
+  });
+  // The native pinned writer also synchronizes through this Node helper.
+  vi.spyOn(fsSync, "fsyncSync").mockImplementation((fd) => {
+    record(fd);
+    syncSync(fd);
+  });
+  return events;
+}
+
+function expectSyncs(events: string[], durable: boolean, syncStore: boolean, backend: string) {
+  if (!durable) {
+    expect(events).toEqual([]);
+  } else if (process.platform !== "win32") {
+    expect(events).toEqual(["file", "parent"]);
+  } else if (syncStore || backend === "require") {
+    // Directory sync is not portable on Windows; the JS async fallback is unsynced.
+    expect(events).toContain("file");
+  }
+}
+
+const policies: {
+  name: string;
+  storeDefault?: boolean;
+  options?: FileStoreWriteOptions;
+  sync: boolean;
+}[] = [
+  { name: "default", sync: true },
+  { name: "per-call false", options: { durable: false }, sync: false },
+  { name: "store false", storeDefault: false, sync: false },
+  { name: "undefined preserves store false", storeDefault: false, options: { durable: undefined }, sync: false },
+  { name: "per-call true overrides store false", storeDefault: false, options: { durable: true }, sync: true },
+  { name: "per-call false overrides store true", storeDefault: true, options: { durable: false }, sync: false },
+];
+
+for (const backend of ["require", "off"] as const) {
+  describe(`store durable option: native ${backend}`, () => {
+    for (const privateMode of [false, true]) {
+      for (const method of ["writeStream", "copyIn"] as const) {
+        const deferred = method === "copyIn" || !privateMode;
+        const note = deferred ? " (always durable until Root.copyIn gains the option)" : "";
+        it.skipIf(deferred).each(policies)(`private=${privateMode} ${method}${note}: $name`, async ({ storeDefault, options, sync }) => {
+          configureFsSafeNative({ mode: backend });
+          const directory = await tempRoot("fs-safe-store-copy-durable-");
+          const source = path.join(directory, "source");
+          await fs.writeFile(source, "payload");
+          const store = fileStore({ rootDir: directory, private: privateMode, durable: storeDefault });
+          const target = path.join(directory, "nested/target");
+          const events = await observeSyncs(directory);
+          const result = method === "copyIn"
+            ? await store.copyIn("nested/target", source, { ...options, mode: 0o640 })
+            : await store.writeStream("nested/target", Readable.from(["pay", "load"]), { ...options, mode: 0o640 });
+          expect(result).toBe(target);
+          expectSyncs(events, sync, false, backend);
+          expect(await fs.readFile(target, "utf8")).toBe("payload");
+          if (process.platform !== "win32") {
+            expect((await fs.stat(target)).mode & 0o777).toBe(0o640);
+            expect((await fs.stat(path.dirname(target))).mode & 0o777).toBe(0o700);
+          }
+          expect(await fs.readdir(path.dirname(target))).toEqual(["target"]);
+        });
+        if (deferred) {
+          it(`private=${privateMode} ${method}: always durable until Root.copyIn gains the option`, async () => {
+            configureFsSafeNative({ mode: backend });
+            const directory = await tempRoot("fs-safe-store-deferred-durable-");
+            const source = path.join(directory, "source");
+            await fs.writeFile(source, "payload");
+            const store = fileStore({ rootDir: directory, private: privateMode, durable: false });
+            const events = await observeSyncs(directory);
+            if (method === "copyIn") await store.copyIn("target", source, { durable: false });
+            else await store.writeStream("target", Readable.from(["payload"]), { durable: false });
+            expectSyncs(events, true, false, backend);
+            expect(await store.readText("target")).toBe("payload");
+          });
+        }
+      }
+      for (const syncStore of [false, true]) {
+        for (const method of ["write", "writeText", "writeJson"] as const) {
+          it.each(policies)(`${syncStore ? "sync" : "async"} private=${privateMode} ${method}: $name`, async ({ storeDefault, options, sync }) => {
+            configureFsSafeNative({ mode: backend });
+            const directory = await tempRoot("fs-safe-store-durable-");
+            const store = (syncStore ? fileStoreSync : fileStore)({
+              rootDir: directory, private: privateMode, durable: storeDefault, mode: 0o640,
+            });
+            const target = path.join(directory, "nested/target");
+            const events = await observeSyncs(directory);
+            for (const value of ["first", "replacement"]) {
+              events.length = 0;
+              const mode = value === "first" ? 0o640 : 0o600;
+              const writeOptions = value === "first" ? options : { ...options, mode };
+              const result = method === "writeJson"
+                ? await store.writeJson("nested/target", { value }, writeOptions)
+                : await store[method]("nested/target", value, writeOptions);
+              expect(result).toBe(target);
+              expectSyncs(events, sync, syncStore, backend);
+              expect(await fs.readFile(target, "utf8")).toBe(method === "writeJson"
+                ? `${JSON.stringify({ value }, null, 2)}\n` : value);
+              if (process.platform !== "win32") {
+                expect((await fs.stat(target)).mode & 0o777).toBe(mode);
+                expect((await fs.stat(path.dirname(target))).mode & 0o777).toBe(0o700);
+              }
+              expect(await fs.readdir(path.dirname(target))).toEqual(["target"]);
+            }
+          });
+        }
+        it(`rejects a substituted publication with durable=false, sync=${syncStore}, private=${privateMode}`, async () => {
+          configureFsSafeNative({ mode: backend });
+          const directory = await tempRoot("fs-safe-store-durable-fence-");
+          const target = path.join(directory, "target");
+          const published = path.join(directory, "published");
+          const events = await observeSyncs(directory);
+          if (syncStore) {
+            const rename = fsSync.renameSync;
+            vi.spyOn(fsSync, "renameSync").mockImplementation((from, to) => {
+              rename(from, to);
+              if (to !== target) return;
+              rename(target, published);
+              fsSync.writeFileSync(target, "substitute");
+            });
+            expect(() => fileStoreSync({ rootDir: directory, private: privateMode, durable: false })
+              .write("target", "payload")).toThrow(expect.objectContaining({ code: "path-mismatch" }));
+          } else {
+            vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+              await fs.rename(target, published);
+              await fs.writeFile(target, "substitute");
+              await verifyPublished(params);
+            });
+            await expect(fileStore({ rootDir: directory, private: privateMode, durable: false })
+              .write("target", "payload")).rejects.toMatchObject({ code: "path-mismatch" });
+          }
+          expect(events).toEqual([]);
+          expect(await fs.readFile(target, "utf8")).toBe("substitute");
+          expect(await fs.readFile(published, "utf8")).toBe("payload");
+        });
+      }
+    }
+
+    for (const method of ["write", "update", "updateOr"] as const) {
+      it.each([undefined, false, true])(`jsonStore ${method}: durable=%s`, async (durable) => {
+        configureFsSafeNative({ mode: backend });
+        const directory = await tempRoot("fs-safe-json-durable-");
+        const filePath = path.join(directory, "nested/state.json");
+        const store = jsonStore<{ count: number }>({ filePath, durable });
+        const events = await observeSyncs(directory);
+        if (method === "write") await store.write({ count: 1 });
+        else if (method === "update") await store.update((current) => ({ count: (current?.count ?? 0) + 1 }));
+        else await store.updateOr({ count: 0 }, (current) => ({ count: current.count + 1 }));
+        expectSyncs(events, durable !== false, false, backend);
+        expect(await store.readRequired()).toEqual({ count: 1 });
+        if (process.platform !== "win32") expect((await fs.stat(filePath)).mode & 0o777).toBe(0o600);
+      });
+    }
+
+    it.each([
+      { storeDefault: false, jsonDefault: undefined, sync: false },
+      { storeDefault: false, jsonDefault: true, sync: true },
+      { storeDefault: true, jsonDefault: false, sync: false },
+    ])("bound JSON durable inheritance: %j", async ({ storeDefault, jsonDefault, sync }) => {
+      configureFsSafeNative({ mode: backend });
+      const directory = await tempRoot("fs-safe-bound-json-durable-");
+      const store = fileStore({ rootDir: directory, durable: storeDefault })
+        .json<{ count: number }>("state.json", { durable: jsonDefault });
+      const events = await observeSyncs(directory);
+      await store.updateOr({ count: 0 }, (current) => ({ count: current.count + 1 }));
+      expectSyncs(events, sync, false, backend);
+      expect(await store.readRequired()).toEqual({ count: 1 });
+    });
+  });
+}

--- a/test/store-durable-option.test.ts
+++ b/test/store-durable-option.test.ts
@@ -4,12 +4,20 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { configureFsSafeNative } from "../src/config.js";
+import { __loadBundledNativeForTest } from "../src/native.js";
 import { fileStore, fileStoreSync, jsonStore, type FileStoreWriteOptions } from "../src/store.js";
 import * as verification from "../src/root-write-verification.js";
 import { useRealTempDirs } from "./helpers/vitest.js";
 
 const { tempRoot } = useRealTempDirs();
 const verifyPublished = verification.verifyAtomicWriteResult;
+let nativeAvailable = false;
+try {
+  __loadBundledNativeForTest();
+  nativeAvailable = true;
+} catch (error) {
+  if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error;
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -64,7 +72,7 @@ const policies: {
 ];
 
 for (const backend of ["require", "off"] as const) {
-  describe(`store durable option: native ${backend}`, () => {
+  describe.skipIf(backend === "require" && !nativeAvailable)(`store durable option: native ${backend}`, () => {
     for (const privateMode of [false, true]) {
       for (const method of ["writeStream", "copyIn"] as const) {
         const deferred = method === "copyIn" || !privateMode;


### PR DESCRIPTION
FileStore writes always forced file and parent fsync, making reconstructible caches and indexes pay durable-write latency. Add `durable?: boolean` to store defaults and write options, with per-call > store > `true` precedence. Async `write`, `writeText`, `writeJson`, `writeStream`, and `copyIn` honor the policy in both private modes, as do synchronous writes and JSON-store mutations.

Non-private copies and staged streams forward the resolved policy to Root.copyIn. Private copies reuse the guarded private writer without forcing durability. The change only gates synchronization: atomic publication, modes, identity checks, byte limits, mutation serialization, and locking retain their existing behavior. JSON handles accept a durability default while mutation signatures stay unchanged. The synchronous store continues to expose write/writeText/writeJson; it has no copyIn or writeStream API.

Validation:

- TypeScript compilation (`pnpm exec tsc -p tsconfig.json`), `pnpm lint:file-size`, `pnpm lint:fs-boundary`, `pnpm docs:check`, `node scripts/check-pack.mjs`, and `git diff --check` passed. The prepared archive WASM artifact was retained; the local Rust/WASM build was not used as proof.
- Focused durability suite: 336 passed across native auto/off/require, including copy/stream initial publication and replacement, option precedence, sync counts, content/modes, and publication-substitution rejection. Require-mode cases skip when a bundled binding is unavailable.
- `pnpm test`: 8,447 passed, 83 skipped, 3 failed. Two are the known consumer-pnpm-lifecycle failures. The third was a concurrent-read identity rejection in the unchanged private store-stress test, followed by cleanup ENOTEMPTY; its isolated `--maxWorkers=1` rerun passed all 8 tests. No archive timeouts occurred.
- `pnpm test:security`: 226 passed.
- Independent Codex autoreview: no actionable findings through P2.

Existing local benchmark (`node scripts/benchmark.mjs --iterations 300 --samples 3`), 128-byte payloads on macOS arm64 / Node v26.8.1. Best totals for 300 writes; report-only measurements:

| Native mode | Raw writeFile | fileStore.write | durable:false | Durable / false |
|---|---:|---:|---:|---:|
| auto | 184.00 ms | 8,936.72 ms | 882.18 ms | 10.1x |
| off | 427.84 ms | 8,697.17 ms | 2,131.99 ms | 4.1x |
