### PR TITLE
perf(archive): defer extraction durability to one pass and add durable options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add `Root.copyIn({ durable: false })`, with per-call, root-default, then `true` precedence, to skip file and parent-directory fsync for reconstructible data.
+- Add `extractArchive({ durable: false })` to skip durability syncs for temporary or reconstructible extraction destinations.
+- Speed up archive extraction by omitting private staging syncs, deferring publication durability to one bounded file/directory pass, and sharing duplicate destination guards without weakening containment checks.
 - Preserve Windows file identity across open-induced `ctime` changes during guarded move fallback, and recreate directory junctions without requiring symlink privileges.
 
 ## 0.8.6 - 2026-09-07

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -43,6 +43,7 @@ type ExtractArchiveOptions = {
   archivePath: string;          // absolute path to the archive
   destDir: string;              // absolute destination directory; must already exist
   timeoutMs: number;            // positive wall-clock budget; <= 0/non-finite disables it
+  durable?: boolean;            // true; sync published files and directories before completion
   kind?: ArchiveKind;           // "zip" | "tar" | "tar-zstd" | "tar-bzip2"
   stripComponents?: number;     // strip N leading dirs from entry paths
   tarGzip?: boolean;            // when archive is .tar.gz/.tgz
@@ -54,6 +55,27 @@ type ExtractArchiveOptions = {
   onFiltered?: "reject-archive" | "skip-entry";
 };
 ```
+
+`durable` defaults to `true`. Private staging never fsyncs, and publication copies
+defer durability until the complete merge succeeds. The final pass syncs each
+published file once (at most eight concurrently), then each published directory
+once, deepest first, and finally the destination directory. All work stays inside
+the extraction deadline; active syncs are joined before rejection. File sync
+failures use the same error surface as `Root.copyIn()`; directory I/O failures
+also reject, with the existing platform limitations on directory flushing.
+Files whose final mode prevents reading, including `0o000` and write-only files,
+sync once through the copy's retained descriptor during publication. Permissions
+are never widened to reopen them. Directory modes are finalized after the file
+pass, with a descriptor pinned before chmod for syncing restrictive directories.
+Existing inaccessible directories are never widened; an existing search-only
+directory must become readable in its final mode if no readable sync descriptor
+can be acquired before chmod.
+
+Use `durable: false` for extractions into temporary or reconstructible locations.
+It skips all file and directory syncs while preserving atomic file publication,
+mode enforcement, identity checks, and containment checks. Successful default
+extraction syncs file contents and directory entries before returning; failures
+can leave a partially published tree as described below.
 
 `entryModes` defaults to `"clamp"`: directories become `0o755`; files become
 `0o644`, or `0o755` when the archived owner-execute bit is set. `"preserve"`
@@ -201,11 +223,13 @@ before publication preserves a pre-existing file, and rejection does not grant
 authority to delete a substituted file or alias. Failed extraction does not
 restore overwritten contents. Active destination mutations and their guarded
 cleanup still finish before rejection; no later destination mutation begins.
-New directories whose postorder finalization was never reached can retain their
+New directories whose finalization was never reached can retain their
 private working mode after failure. Failure cleanup closes retained descriptors;
-it does not run a final chmod sweep or roll back the archive. The public merge
+it does not run a cleanup chmod sweep or roll back the archive. The public merge
 helper still derives modes from its external source tree and must be able to
 read that source; it never chmods an unreadable external source to admit it.
+That helper retains per-copy durability and immediate postorder directory-mode
+finalization; the deferred pass described above belongs to `extractArchive()`.
 
 ### Limits
 

--- a/docs/root.md
+++ b/docs/root.md
@@ -18,7 +18,7 @@ const fs = await root("/srv/workspace", {
 function root(rootDir: string, defaults?: RootDefaults): Promise<Root>;
 
 type RootDefaults = {
-  durable?: boolean;               // fsync write/create/writeJson/createJson/append; default true
+  durable?: boolean;               // fsync write/create/writeJson/createJson/append/copyIn; default true
   hardlinks?: "reject" | "allow";  // refuse files with nlink > 1 on read; defaults to "reject"
   denyMutations?: DenyMutationPolicy; // absolute paths/prefixes mutation methods may not change
   maxBytes?: number;               // refuse reads larger than this many bytes; defaults to 16 MiB
@@ -111,7 +111,7 @@ fs.ensureRoot(options?)                  // accepts "" / "." as the root itself
 
 `write`, `create`, `append`, `writeJson`, and `createJson` accept `mode?: number`; use `0o600` for credentials and other private state. `writeJson` also accepts the same options as `JSON.stringify` plus `trailingNewline?: boolean` (defaults `true` so the file ends in `\n`).
 
-These five methods also accept `durable?: boolean`: the per-call value overrides
+These five methods and `copyIn` also accept `durable?: boolean`: the per-call value overrides
 `Root.defaults.durable`, which defaults to `true` when omitted. An explicitly
 `undefined` per-call value preserves the root default. `durable: false` keeps
 the existing publication behavior, modes, and identity checks but skips file

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -91,14 +91,14 @@ await fs.write("notes/today.txt", "hello\n", { encoding: "utf8" });
 | `overwrite` | `boolean` | `true`; `false` is create-only. |
 | `renameIdentity` | `RenameIdentityPolicy` | `"strict"`. |
 
-`write`, `create`, `writeJson`, `createJson`, and `append` accept `durable`.
+`write`, `create`, `writeJson`, `createJson`, `append`, and `copyIn` accept `durable`.
 Precedence is per-call option, then `Root.defaults.durable`, then `true`;
 an explicitly `undefined` call option preserves the root default.
 `durable: false` keeps the sibling-temp replace/rename behavior of replacement
 writes but skips file and parent-directory fsync calls. Create-only and append
 publication behavior, permissions, identity checks, and error codes are unchanged.
 Use it only for reconstructible data: a crash may lose the write or leave the
-previous file. `copyIn`, `move`, and streaming `openWritable` do not use this option.
+previous file. `move` and streaming `openWritable` do not use this option.
 The existing pure-JavaScript Windows writer performs no fsync calls in either
 setting; native Windows writes honor the option. Directory sync remains best-effort.
 
@@ -185,7 +185,9 @@ await fs.copyIn("inbox/upload.bin", "/tmp/incoming.bin", {
 });
 ```
 
-Options are `{ denyMutations?, maxBytes?, mkdir?, mode?, sourceHardlinks? }`.
+Options are `{ denyMutations?, durable?, maxBytes?, mkdir?, mode?, sourceHardlinks? }`.
+`durable` follows the root default and is `true` when omitted at both levels;
+set it to `false` to skip file and parent-directory syncs for reconstructible data.
 Use `sourceHardlinks: "reject"` to refuse if the source itself is a hardlinked
 alias. There is no encoding option: copying preserves source bytes.
 

--- a/src/archive-durability.ts
+++ b/src/archive-durability.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ownExtractionDestinationMutation, type ExtractionDeadline } from "./archive-deadline.js";
+import { assertDirectoryIdentityGuard, assertResolvedInsideDestination, createArchiveSymlinkTraversalError } from "./archive-staging.js";
+import type { AsyncDirectoryGuard } from "./directory-guard.js";
+import { pinNodeDirectoryForMode } from "./directory-mode-node.js";
+import { pinDirectory, syncDirectory, type PinnedDirectory } from "./directory-durability.js";
+import { syncFileBestEffort } from "./file-sync.js";
+import type { PublishedWriteIdentity } from "./pinned-write.js";
+import type { Root } from "./root.js";
+import { normalizePinnedWriteError } from "./root-errors.js";
+import { inspectFileIdentity } from "./strict-file-identity.js";
+import { getFsSafeTestHooks } from "./test-hooks.js";
+import { FsSafeError } from "./errors.js";
+
+export type ArchivePublishedFile = {
+  relativePath: string;
+  identity: PublishedWriteIdentity;
+  guards: readonly AsyncDirectoryGuard[];
+};
+export type ArchivePublishedDirectory = {
+  guard: AsyncDirectoryGuard;
+  parents: readonly AsyncDirectoryGuard[];
+  mode: number;
+};
+
+export async function finalizeArchivePublication(params: {
+  targetRoot: Root;
+  destinationGuard: AsyncDirectoryGuard;
+  sourceGuard: AsyncDirectoryGuard;
+  files: readonly ArchivePublishedFile[];
+  directories: readonly ArchivePublishedDirectory[];
+  durable: boolean;
+  deadline?: ExtractionDeadline;
+}): Promise<void> {
+  const check = () => params.deadline?.check();
+  const assertGuards = async (guards: readonly AsyncDirectoryGuard[]) => {
+    for (const guard of [params.destinationGuard, ...guards, params.sourceGuard]) {
+      await assertDirectoryIdentityGuard(guard);
+      check();
+    }
+  };
+  await ownExtractionDestinationMutation(params.deadline, async () => {
+    if (params.durable) {
+      // Join every active sync before propagating failure or starting another batch.
+      for (let offset = 0; offset < params.files.length; offset += 8) {
+        check();
+        const results = await Promise.allSettled(params.files.slice(offset, offset + 8).map(async (file) => {
+          await assertGuards(file.guards);
+          await using opened = await params.targetRoot.open(file.relativePath, { hardlinks: "reject", symlinks: "reject" })
+            .catch((error: unknown) => {
+              if (error instanceof FsSafeError && (error.code === "hardlink" || error.code === "path-alias")) {
+                throw createArchiveSymlinkTraversalError(file.relativePath);
+              }
+              throw error;
+            });
+          check();
+          await inspectFileIdentity(() => opened.handle.stat({ bigint: true }), file.identity);
+          check();
+          await syncFileBestEffort(opened.handle).catch((error: unknown) => { throw normalizePinnedWriteError(error); });
+          check();
+          await assertGuards(file.guards);
+          await inspectFileIdentity(async () => {
+            const stat = await fs.lstat(opened.realPath, { bigint: true });
+            if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink > 1n) {
+              throw new FsSafeError("path-mismatch", "archive file changed during durability pass");
+            }
+            return stat;
+          }, file.identity);
+          check();
+        }));
+        const failure = results.find((result) => result.status === "rejected");
+        if (failure?.status === "rejected") throw failure.reason;
+      }
+    }
+    // Leave working modes intact until file syncing finishes. Re-pin one directory
+    // at a time against its original guard, so wide archives do not exhaust fds.
+    const directories = [...params.directories].sort((a, b) =>
+      b.guard.dir.split(path.sep).length - a.guard.dir.split(path.sep).length);
+    for (const directory of directories) {
+      const guards = [...directory.parents, directory.guard];
+      await assertGuards(guards);
+      const owner = await pinNodeDirectoryForMode(directory.guard.dir);
+      let pinned: PinnedDirectory | undefined;
+      try {
+        check();
+        await assertGuards(guards);
+        if (params.durable && process.platform !== "win32") {
+          // An existing search-only directory may become readable in its final mode.
+          try { pinned = await pinDirectory(directory.guard.dir); }
+          catch (error) { if ((error as NodeJS.ErrnoException).code !== "EACCES") throw error; }
+          check();
+        }
+        await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("chmod", directory.guard.dir);
+        check();
+        await assertGuards(guards);
+        await owner.apply(directory.mode, { check, beforeChmod: async () => {
+          await assertGuards(guards);
+          await assertResolvedInsideDestination({ destinationRealDir: params.destinationGuard.realPath,
+            targetPath: directory.guard.dir, originalPath: path.relative(params.targetRoot.rootDir, directory.guard.dir) });
+          check();
+        } });
+        check();
+        await assertGuards(guards);
+        if (params.durable) {
+          if (process.platform === "win32") {
+            await syncDirectory(directory.guard.dir).catch((error: unknown) => { throw normalizePinnedWriteError(error); });
+          } else {
+            pinned ??= await pinDirectory(directory.guard.dir);
+            check();
+            await pinned.sync().catch((error: unknown) => { throw normalizePinnedWriteError(error); });
+          }
+          check();
+          await assertGuards(guards);
+        }
+      } finally {
+        try { await pinned?.close(); } finally { await owner.close(); }
+      }
+    }
+    if (params.durable) {
+      await assertGuards([]);
+      await syncDirectory(params.destinationGuard.realPath).catch((error: unknown) => { throw normalizePinnedWriteError(error); });
+      check();
+      await assertGuards([]);
+    }
+  });
+}

--- a/src/archive-merge.ts
+++ b/src/archive-merge.ts
@@ -14,6 +14,9 @@ import { formatErrorDetail } from "./error-detail.js";
 import { isPathInside } from "./path.js";
 import { root } from "./root.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
+import { onCopyPublication, type CopyPublicationOptions } from "./copy-publication.js";
+import { syncFileBestEffortSync } from "./file-sync.js";
+import { finalizeArchivePublication, type ArchivePublishedDirectory, type ArchivePublishedFile } from "./archive-durability.js";
 
 export type ArchivePublicationEntry = { path: string; kind: "file" | "directory"; mode: number };
 type MergeParams = {
@@ -24,16 +27,18 @@ type MergeParams = {
 };
 
 export async function mergePlannedArchiveIntoDestination(
-  params: MergeParams & { entries: readonly ArchivePublicationEntry[] },
+  params: MergeParams & { entries: readonly ArchivePublicationEntry[]; durable?: boolean },
 ): Promise<void> {
-  await mergeTree(params, params.entries);
+  await mergeTree(params, params.entries, params.durable !== false);
 }
 
 export async function mergeExtractedTreeIntoDestination(params: MergeParams): Promise<void> {
   await mergeTree(params);
 }
 
-async function mergeTree(params: MergeParams, publication?: readonly ArchivePublicationEntry[]): Promise<void> {
+async function mergeTree(params: MergeParams, publication?: readonly ArchivePublicationEntry[], durable = true): Promise<void> {
+  const publishedFiles: ArchivePublishedFile[] = [];
+  const publishedDirectories: ArchivePublishedDirectory[] = [];
   const check = () => params.deadline?.check();
   check();
   const destinationGuard = await createDirectoryIdentityGuard(params.destinationRealDir);
@@ -93,7 +98,7 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
       const mode = plan ? planned?.mode ?? 0o755 : sourceStat.mode & 0o777;
       await preparePrivateArchiveOutputPath({
         ...params, relPath, outPath: destinationPath, originalPath, isDirectory: kind === "directory",
-      }, assertGuards);
+      }, assertGuards, destinationGuard);
       check();
       if (kind === "directory") {
         // Ownership spans open, descendants, finalization and close, including timeout.
@@ -113,6 +118,11 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
             ancestors.push({ guard, owner });
             try {
               await walk(sourcePath);
+              if (publication) {
+                await assertGuards();
+                publishedDirectories.push({ guard, mode, parents: ancestors.slice(0, -1).map((ancestor) => ancestor.guard) });
+                return;
+              }
               await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("chmod", destinationPath);
               check();
               await assertGuards();
@@ -140,7 +150,24 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
         await ownExtractionDestinationMutation(params.deadline, async () => {
           await assertGuards();
           try {
-            await targetRoot.copyIn(relPath, sourcePath, { mkdir: true, mode });
+            const options: CopyPublicationOptions & { mkdir: boolean; mode: number; durable: boolean } = {
+              mkdir: true, mode, durable: publication ? false : true,
+            };
+            if (publication && durable) {
+              options[onCopyPublication] = async (fd, identity) => {
+                check();
+                if ((mode & 0o400) === 0) {
+                  // Final mode may prohibit reopening. Sync the writer's still-owned
+                  // descriptor without widening permissions or syncing its parent.
+                  syncFileBestEffortSync(fd);
+                  check();
+                } else {
+                  publishedFiles.push({ relativePath: relPath, identity,
+                    guards: ancestors.map((ancestor) => ancestor.guard) });
+                }
+              };
+            }
+            await targetRoot.copyIn(relPath, sourcePath, options);
             check();
             await assertGuards();
             await assertResolvedInsideDestination({
@@ -164,4 +191,8 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
     }
   };
   await walk(params.sourceDir);
+  if (publication) {
+    await finalizeArchivePublication({ targetRoot, destinationGuard, sourceGuard,
+      files: publishedFiles, directories: publishedDirectories, durable, deadline: params.deadline });
+  }
 }

--- a/src/archive-native.ts
+++ b/src/archive-native.ts
@@ -41,6 +41,7 @@ export function throwMappedNativeArchiveError(error: unknown): never {
 }
 
 export async function extractNativeArchive(params: {
+  durable?: boolean;
   binding: NativeBinding;
   archivePath: string;
   destDir: string;
@@ -134,6 +135,7 @@ export async function extractNativeArchive(params: {
         params.deadline.check();
         await mergePlannedArchiveIntoDestination({
           entries: plan,
+          durable: params.durable,
           sourceDir: stagingDir,
           destinationDir: params.destDir,
           destinationRealDir,

--- a/src/archive-options.ts
+++ b/src/archive-options.ts
@@ -15,6 +15,7 @@ export type ExtractArchiveOptions = {
   archivePath: string;
   destDir: string;
   timeoutMs: number;
+  durable?: boolean;
   kind?: ArchiveKind;
   stripComponents?: number;
   tarGzip?: boolean;

--- a/src/archive-staging.ts
+++ b/src/archive-staging.ts
@@ -168,12 +168,14 @@ export async function prepareArchiveOutputPath(params: ArchiveOutputPathParams):
 
 export async function preparePrivateArchiveOutputPath(
   params: ArchiveOutputPathParams, assertGuards?: () => Promise<void>,
+  destinationGuard?: AsyncDirectoryGuard,
 ): Promise<void> {
-  await prepareOutputPath(params, assertGuards, true);
+  await prepareOutputPath(params, assertGuards, true, destinationGuard);
 }
 
 async function prepareOutputPath(
   params: ArchiveOutputPathParams, assertGuards?: () => Promise<void>, privateWorkingMode = false,
+  existingDestinationGuard?: AsyncDirectoryGuard,
 ): Promise<void> {
   checkExtractionDeadline(params.deadline);
   const targetRoot = privateWorkingMode ? {
@@ -194,16 +196,23 @@ async function prepareOutputPath(
         mode: 0o700,
         rejectSymlinks: true,
         beforeComponent: async () => {
-          await assertDirectoryIdentityGuard(destinationGuard);
-          checkExtractionDeadline(params.deadline);
-          await assertGuards?.();
+          await assertOutputGuards();
           checkExtractionDeadline(params.deadline);
         },
       });
     },
   } : await root(params.destinationRealDir);
   checkExtractionDeadline(params.deadline);
-  const destinationGuard = await createDirectoryIdentityGuard(params.destinationRealDir);
+  const destinationGuard = existingDestinationGuard ?? await createDirectoryIdentityGuard(params.destinationRealDir);
+  const assertOutputGuards = async () => {
+    // The merge's callback verifies this same original destination guard.
+    if (existingDestinationGuard && assertGuards) await assertGuards();
+    else {
+      await assertDirectoryIdentityGuard(destinationGuard);
+      checkExtractionDeadline(params.deadline);
+      await assertGuards?.();
+    }
+  };
   checkExtractionDeadline(params.deadline);
   const relPath = params.relPath.split(path.sep).join(path.posix.sep);
   await assertNoSymlinkTraversal({
@@ -217,9 +226,7 @@ async function prepareOutputPath(
     await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("mkdir", params.outPath);
     checkExtractionDeadline(params.deadline);
     await ownExtractionDestinationMutation(params.deadline, async () => {
-      await assertDirectoryIdentityGuard(destinationGuard);
-      checkExtractionDeadline(params.deadline);
-      await assertGuards?.();
+      await assertOutputGuards();
       checkExtractionDeadline(params.deadline);
       await mkdirArchiveOutput({
         targetRoot,
@@ -244,9 +251,7 @@ async function prepareOutputPath(
     await getFsSafeTestHooks()?.beforeArchiveOutputMutation?.("mkdir", path.dirname(params.outPath));
     checkExtractionDeadline(params.deadline);
     await ownExtractionDestinationMutation(params.deadline, async () => {
-      await assertDirectoryIdentityGuard(destinationGuard);
-      checkExtractionDeadline(params.deadline);
-      await assertGuards?.();
+      await assertOutputGuards();
       checkExtractionDeadline(params.deadline);
       await mkdirArchiveOutput({
         targetRoot,

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -164,6 +164,8 @@ async function writeZipFileEntry(params: {
       dir: path.dirname(destinationPath),
       chmodDir: false,
       mode: 0o600,
+      syncTempFile: false,
+      syncParentDir: false,
       writeTemp: async (tempPath) => {
         tempHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, 0o600);
         const writable = tempHandle.createWriteStream();
@@ -205,6 +207,7 @@ async function writeZipFileEntry(params: {
 }
 
 async function extractZip(params: {
+  durable?: boolean;
   archivePath: string;
   destDir: string;
   stripComponents?: number;
@@ -295,6 +298,7 @@ async function extractZip(params: {
         params.deadline.check();
         await mergePlannedArchiveIntoDestination({
           entries: acceptedEntries,
+          durable: params.durable,
           sourceDir: stagingRealDir,
           destinationDir: params.destDir,
           destinationRealDir,
@@ -323,6 +327,7 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
   // getters and inherited policy must survive identically on every backend.
   const options = {
     archivePath: params.archivePath, destDir: params.destDir,
+    durable: params.durable,
     stripComponents: params.stripComponents, limits,
     entryModes: params.entryModes, entryFilter: params.entryFilter, onFiltered,
   };
@@ -355,7 +360,7 @@ export async function extractArchive(params: ExtractArchiveOptions): Promise<voi
 }
 
 async function extractWasmTar(params: {
-  archivePath: string; options: Pick<ExtractArchiveOptions, "destDir" | "stripComponents" | "entryModes" | "entryFilter" | "onFiltered">;
+  archivePath: string; options: Pick<ExtractArchiveOptions, "destDir" | "durable" | "stripComponents" | "entryModes" | "entryFilter" | "onFiltered">;
   limits: ResolvedArchiveExtractLimits;
   tarLimits: TarMeterLimits; deadline: ExtractionDeadline;
 }): Promise<void> {
@@ -382,6 +387,7 @@ async function extractWasmTar(params: {
         if (member.kind === "file") {
           await runPinnedWriteHelper({ rootPath: stagingDir, relativeParentPath: path.posix.dirname(member.path),
             basename: path.posix.basename(member.path), mkdir: false, mode: 0o600, overwrite: false,
+            sync: false,
             maxBytes: member.size, input: { kind: "stream", stream: Readable.from(payload) } });
         }
         deadline.check();
@@ -389,7 +395,7 @@ async function extractWasmTar(params: {
     });
     deadline.check();
     await mergePlannedArchiveIntoDestination({ entries: accepted, sourceDir: stagingDir,
-      destinationDir: options.destDir, destinationRealDir, deadline });
+      destinationDir: options.destDir, destinationRealDir, deadline, durable: options.durable });
     deadline.check();
   } });
 }

--- a/src/copy-publication.ts
+++ b/src/copy-publication.ts
@@ -1,0 +1,8 @@
+import type { PinnedWriteParams } from "./pinned-write.js";
+
+// Internal composition hook; the descriptor is borrowed until the callback returns.
+// Kept off RootCopyOptions and all public package exports.
+export const onCopyPublication = Symbol("onCopyPublication");
+export type CopyPublicationOptions = {
+  [onCopyPublication]?: PinnedWriteParams["verifyPublished"];
+};

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -73,6 +73,7 @@ import { serializePathWrite } from "./write-queue.js";
 import { verifyAtomicWriteResult } from "./root-write-verification.js";
 import { inheritWriteTargetMode } from "./root-write-mode.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
+import { onCopyPublication, type CopyPublicationOptions } from "./copy-publication.js";
 
 export type { DenyMutationPolicy } from "./deny-mutations.js";
 export type { RenameIdentityPolicy } from "./pinned-write.js";
@@ -123,7 +124,7 @@ export type RootOpenWritableOptions = Pick<RootDefaults, "denyMutations" | "mkdi
   writeMode?: WritableOpenMode;
 };
 
-export type RootCopyOptions = Pick<RootDefaults, "denyMutations" | "maxBytes" | "mkdir" | "mode"> & {
+export type RootCopyOptions = Pick<RootDefaults, "denyMutations" | "durable" | "maxBytes" | "mkdir" | "mode"> & {
   sourceHardlinks?: HardlinkPolicy;
 };
 
@@ -611,6 +612,8 @@ export class RootHandle implements Root {
       mkdir: this.defaults.mkdir,
       mode: this.defaults.mode,
       ...copyOptions,
+      durable: options.durable ?? this.defaults.durable ?? true,
+      verifyPublished: (options as CopyPublicationOptions)[onCopyPublication],
     });
   }
 
@@ -1177,6 +1180,8 @@ async function copyFileInRoot(
     mode?: number;
     denyMutations?: DenyMutationPolicy;
     sourceHardlinks?: HardlinkPolicy;
+    durable?: boolean;
+    verifyPublished?: CopyPublicationOptions[typeof onCopyPublication];
   },
 ): Promise<void> {
   assertValidRootRelativePath(params.relativePath);
@@ -1212,6 +1217,8 @@ async function copyFileInRoot(
             mode: pinned.mode,
             overwrite: true,
             maxBytes: params.maxBytes,
+            sync: params.durable !== false,
+            verifyPublished: params.verifyPublished,
             input: { kind: "stream", stream: source.handle.createReadStream() },
             rootIdentity: root.rootIdentity,
           });

--- a/test/archive-durability-pass.test.ts
+++ b/test/archive-durability-pass.test.ts
@@ -1,0 +1,94 @@
+import fsSync from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { extractArchive } from "../src/archive.js";
+import { configureFsSafeNative } from "../src/native-config.js";
+import { modeArchive, removeModeFixture } from "./helpers/archive-modes.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => { vi.restoreAllMocks(); configureFsSafeNative({ mode: "auto" }); });
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+};
+async function fixture() {
+  configureFsSafeNative({ mode: "off" });
+  const base = await tempRoot("fs-safe-durability-pass-");
+  const destDir = path.join(base, "output");
+  await fs.mkdir(destDir);
+  const archivePath = path.join(base, "input.tar");
+  await fs.writeFile(archivePath, await modeArchive("tar", Array.from({ length: 9 }, (_, i) => ({ path: `f${i}`, mode: 0o644 }))));
+  const probe = await fs.open(path.join(base, "probe"), "w");
+  const prototype = Object.getPrototypeOf(probe) as FileHandle;
+  await probe.close();
+  return { options: { archivePath, destDir, kind: "tar" as const, timeoutMs: 10000 }, prototype };
+}
+
+it.each(["file", "directory"])("propagates %s sync failure", async (kind) => {
+  const { options, prototype } = await fixture();
+  const sync = prototype.sync;
+  let failed = false;
+  vi.spyOn(prototype, "sync").mockImplementation(async function (this: FileHandle) {
+    if (fsSync.fstatSync(this.fd).isFile() === (kind === "file")) {
+      failed = true;
+      throw Object.assign(new Error("injected sync failure"), { code: "EIO" });
+    }
+    await sync.call(this);
+  });
+  await expect(extractArchive(options)).rejects.toMatchObject({ code: "invalid-path", cause: { code: "EIO" } });
+  expect(failed).toBe(true);
+});
+
+it("bounds file syncs at eight and joins them on timeout before rejecting", async () => {
+  const { options, prototype } = await fixture();
+  const entered = deferred();
+  const release = deferred();
+  const sync = prototype.sync;
+  let active = 0;
+  let started = 0;
+  let peak = 0;
+  let settled = false;
+  vi.spyOn(prototype, "sync").mockImplementation(async function (this: FileHandle) {
+    if (!fsSync.fstatSync(this.fd).isFile()) return await sync.call(this);
+    started++;
+    peak = Math.max(peak, ++active);
+    if (active === 8) entered.resolve();
+    await release.promise;
+    try { await sync.call(this); } finally { active--; }
+  });
+  const extraction = extractArchive({ ...options, timeoutMs: 1000 });
+  void extraction.then(() => { settled = true; }, () => { settled = true; });
+  try {
+    await entered.promise;
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    expect(settled).toBe(false);
+    expect(peak).toBe(8);
+  } finally { release.resolve(); }
+  await expect(extraction).rejects.toThrow("timed out");
+  expect(active).toBe(0);
+  expect(started).toBe(8);
+}, 10000);
+
+it.each([true, false])("keeps restrictive file and directory modes with durable %s", async (durable) => {
+  const { options } = await fixture();
+  await fs.writeFile(options.archivePath, await modeArchive("tar", [
+    { path: "closed/", directory: true, mode: 0 },
+    { path: "closed/write-only", mode: 0o200 },
+    { path: "closed/unreadable", mode: 0 },
+    { path: "closed/read-only", mode: 0o400 },
+  ]));
+  try {
+    await extractArchive({ ...options, entryModes: "preserve", durable });
+    if (process.platform !== "win32") expect((await fs.stat(path.join(options.destDir, "closed"))).mode & 0o777).toBe(0);
+    await fs.chmod(path.join(options.destDir, "closed"), 0o700);
+    for (const [name, mode] of [["write-only", 0o200], ["unreadable", 0], ["read-only", 0o400]] as const) {
+      const target = path.join(options.destDir, "closed", name);
+      if (process.platform !== "win32") expect((await fs.stat(target)).mode & 0o777).toBe(mode);
+      await fs.chmod(target, 0o600);
+      expect(await fs.readFile(target, "utf8")).toBe("NEW");
+    }
+  } finally { await removeModeFixture(options.destDir); }
+});

--- a/test/archive-fsync-budget.test.ts
+++ b/test/archive-fsync-budget.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { extractArchive } from "../src/archive.js";
+import { configureFsSafeNative } from "../src/native-config.js";
+import { __resetNativeLoaderForTest, __setNativeLoaderForTest } from "../src/native.js";
+import { modeArchive } from "./helpers/archive-modes.js";
+import { paxNative } from "./helpers/archive-pax-native.js";
+import { observeArchiveFs } from "./helpers/archive-fs-counts.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  configureFsSafeNative({ mode: "auto" });
+  __resetNativeLoaderForTest();
+});
+
+for (const backend of ["auto", "off"] as const) {
+  describe.skipIf(backend === "auto" && !paxNative)(`archive sync budget: native ${backend}`, () => {
+    for (const kind of ["tar", "zip"] as const) {
+      it.each([undefined, false])(`${kind}: durable %s`, async (durable) => {
+        if (paxNative) __setNativeLoaderForTest(() => paxNative);
+        configureFsSafeNative({ mode: backend });
+        const base = await tempRoot("fs-safe-fsync-budget-");
+        const destDir = path.join(base, "output");
+        await fs.mkdir(destDir);
+        const archivePath = path.join(base, `input.${kind}`);
+        await fs.writeFile(archivePath, await modeArchive(kind, [
+          ...Array.from({ length: 3 }, (_, d) => ({ path: `d${d}/`, directory: true, mode: 0o755 })),
+          ...Array.from({ length: 20 }, (_, f) => ({ path: `d${f % 3}/f${f}`, mode: 0o644 })),
+        ]));
+        const observed = await observeArchiveFs(base);
+        await extractArchive({ archivePath, destDir, kind, timeoutMs: 30000, durable });
+        // Native archive extraction has no Rust fsync; native pinned writers use
+        // fs.fsyncSync, so all active sync routes are included in these counters.
+        const diagnostic = JSON.stringify({ backend, kind, durable, calls: observed.total(), counts: observed.counts });
+        expect(observed.syncs.filter((type) => type === "file").length, diagnostic).toBe(durable === false ? 0 : 20);
+        const directorySyncs = observed.syncs.filter((type) => type === "directory").length;
+        if (process.platform === "win32" && durable !== false) expect(directorySyncs, diagnostic).toBeLessThanOrEqual(4);
+        else expect(directorySyncs, diagnostic).toBe(durable === false ? 0 : 4);
+        // Baseline JS-visible fs calls for this 20-file/3-directory fixture, plus 20%.
+        const baseline = backend === "auto" ? (kind === "tar" ? 2535 : 2544) : kind === "tar" ? 4132 : 4348;
+        expect(observed.total() / 20, diagnostic).toBeLessThanOrEqual(Math.ceil(baseline * 1.2) / 20);
+        vi.restoreAllMocks();
+        for (let f = 0; f < 20; f++) expect(await fs.readFile(path.join(destDir, `d${f % 3}/f${f}`), "utf8")).toBe("NEW");
+      });
+    }
+  });
+}

--- a/test/helpers/archive-fs-counts.ts
+++ b/test/helpers/archive-fs-counts.ts
@@ -1,0 +1,41 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import path from "node:path";
+import { vi } from "vitest";
+
+export async function observeArchiveFs(directory: string) {
+  const probe = await fs.open(path.join(directory, "probe"), "w");
+  const prototype = Object.getPrototypeOf(probe) as FileHandle;
+  await probe.close();
+  await fs.unlink(path.join(directory, "probe"));
+  const counts: Record<string, number> = {};
+  const syncs: string[] = [];
+  const fstat = fsSync.fstatSync;
+  const bump = (name: string) => { counts[name] = (counts[name] ?? 0) + 1; };
+  const record = (fd: number) => syncs.push(fstat(fd).isFile() ? "file" : "directory");
+  const groups = [
+    [fsSync, "s", ["fsyncSync", "fdatasyncSync", "copyFileSync", "openSync", "renameSync", "lstatSync", "statSync", "fstatSync"]],
+    [fs, "p", ["open", "rename", "copyFile", "mkdir", "readFile", "writeFile", "lstat", "stat", "realpath", "unlink", "rm", "readdir", "link"]],
+    [prototype, "h", ["sync", "datasync", "stat", "read", "write", "writeFile", "readFile", "chmod", "close"]],
+  ] as const;
+  for (const [object, prefix, names] of groups) {
+    for (const name of names) {
+      const target = object as unknown as Record<string, (...args: unknown[]) => unknown>;
+      const original = target[name]!;
+      if (typeof original !== "function") continue;
+      vi.spyOn(target, name).mockImplementation(function (this: FileHandle, ...args: unknown[]) {
+        bump(`${prefix}.${name}`);
+        if (["sync", "datasync"].includes(name)) record(this.fd);
+        if (["fsyncSync", "fdatasyncSync"].includes(name)) record(args[0] as number);
+        return original.apply(this, args);
+      });
+    }
+  }
+  const realpath = fsSync.realpathSync.native;
+  vi.spyOn(fsSync.realpathSync, "native").mockImplementation((...args: Parameters<typeof realpath>) => {
+    bump("s.realpathSync.native");
+    return realpath(...args);
+  });
+  return { counts, syncs, total: () => Object.values(counts).reduce((sum, count) => sum + count, 0) };
+}

--- a/test/root-durable-option.test.ts
+++ b/test/root-durable-option.test.ts
@@ -59,7 +59,7 @@ const policies: { name: string; rootDefault?: boolean; options?: RootWriteOption
 
 for (const backend of ["auto", "off"] as const) {
   describe.skipIf(backend === "auto" && !nativeAvailable)(`Root durable option: native ${backend}`, () => {
-    for (const method of ["write", "create", "writeJson", "createJson", "append"] as const) {
+    for (const method of ["write", "create", "writeJson", "createJson", "append", "copyIn"] as const) {
       // The Windows JavaScript fallback cannot rename over a read-only destination.
       const modes = process.platform === "win32" && backend === "off" && method !== "append" ? [0o640] : [0o640, 0o400];
       it.each(policies.flatMap((policy) => modes.map((mode) => ({ ...policy, mode }))))(
@@ -69,14 +69,18 @@ for (const backend of ["auto", "off"] as const) {
           const directory = await tempRoot("fs-safe-durable-");
           const safe = await root(directory, { durable: rootDefault });
           expect(safe.defaults.durable).toBe(rootDefault);
+          const source = path.join(await tempRoot("fs-safe-copy-source-"), "source");
+          if (method === "copyIn") await fs.writeFile(source, "payload");
           const { events, asyncSpy, syncSpy } = await observeSyncs(directory);
           const isJson = method === "writeJson" || method === "createJson";
           if (isJson) {
             await safe[method]("target", { value: "payload" }, { ...options, mode });
+          } else if (method === "copyIn") {
+            await safe.copyIn("target", source, { ...options, mode });
           } else {
             await safe[method]("target", "payload", { ...options, mode });
           }
-          if (!sync || (process.platform === "win32" && backend === "off" && method !== "append")) {
+          if (!sync || (process.platform === "win32" && backend === "off" && method !== "append" && method !== "copyIn")) {
             expect(asyncSpy).not.toHaveBeenCalled();
             expect(syncSpy).not.toHaveBeenCalled();
           } else if (process.platform === "win32") {
@@ -143,7 +147,7 @@ for (const backend of ["auto", "off"] as const) {
       expect(await fs.readFile(path.join(directory, "published"), "utf8")).toBe("payload");
     });
 
-    it("retains create-only errors and copyIn durability with a false root default", async () => {
+    it("retains create-only errors and skips copyIn syncing with a false root default", async () => {
       configureFsSafeNative({ mode: backend });
       const directory = await tempRoot("fs-safe-durable-copy-");
       const source = path.join(directory, "source");
@@ -153,7 +157,7 @@ for (const backend of ["auto", "off"] as const) {
       await expect(safe.write("../escape", "payload")).rejects.toMatchObject({ code: "outside-workspace" });
       const { events } = await observeSyncs(directory);
       await safe.copyIn("target", source);
-      expect(events).toContain("file");
+      expect(events).toEqual([]);
       expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("payload");
     });
   });


### PR DESCRIPTION
## Problem and behavior

Archive extraction inherited per-write fsync from durable root primitives. On the measured macOS host the supplied nominal 20-file harness made 4,664 JS-visible filesystem calls and 82 syncs for TAR in native auto mode, and 7,776 calls / 164 syncs with native off. ZIP made 2,373 / 4,128 calls and 40 syncs. Publication also repeatedly checked the same destination guard while preparing parents.

Private staging now never syncs. Extraction publishes sequentially through `Root.copyIn(..., { durable: false })`, then syncs published files in batches of at most eight, followed by directories deepest first and the destination. `extractArchive({ durable: false })` omits the pass. `Root.copyIn` now resolves durability as per-call > root default > true. Neither option changes containment, source validation, atomic publication, or hardlink rejection.

Readable files reopen through `Root.open`, then compare their exact bigint identity to the copy's publication receipt before syncing. Unreadable final modes sync once through the copy's borrowed writer descriptor. Directory modes finalize after the file pass: each directory is re-pinned against its original guards, synced through a descriptor pinned before chmod, and closed before proceeding. The pass joins all in-flight work on errors and deadlines. Existing inaccessible directories are never widened; an existing search-only directory must become readable in its final mode when a readable sync descriptor cannot be acquired before chmod. The public external-tree merge helper retains its existing per-copy durability and immediate postorder mode-finalization contract.

`copyIn` already streams through the shared native/JS pinned writer; it does not invoke Rust `cloneFileExclusive`. The existing `sync` flag therefore handles both backends without a native ABI change or a forced JS fallback.

## Files

- `root-impl.ts`, `copy-publication.ts`: optional copy durability and an internal borrowed-descriptor publication callback (not a public API).
- `archive.ts`, `archive-native.ts`, `archive-options.ts`: non-durable private staging and propagation of extraction durability; ZIP staging already skipped syncs and now says so explicitly.
- `archive-merge.ts`, `archive-durability.ts`: sequential unsynced publication, publication identity receipts, bounded file syncing, and postorder directory finalization/syncing.
- `archive-staging.ts`: reuse the original destination guard and eliminate duplicate assertions of that same guard.
- Root durability, archive sync-budget, and durability-pass tests: precedence, exact sync counts, fs-call budgets, error propagation, concurrency, deadline joining, and restrictive modes.
- `docs/archive.md`, `docs/root.md`, `docs/writing.md`, `CHANGELOG.md`: options, completion/failure semantics, restrictive modes, and release notes. Public API delta: two optional `durable?: boolean` fields; no new public exports.

## Collapsed guard calls

1. `preparePrivateArchiveOutputPath` reuses the merge's original destination guard instead of taking a redundant fresh snapshot for every output; the original identity remains authoritative.
2. The `mkdirPathComponentsWithGuards.beforeComponent` callback no longer asserts that destination guard immediately before `assertGuards`, which asserts the identical guard again. The callback still runs for every component.
3. Directory preparation's owned mutation removes the same duplicate destination assertion immediately before `assertGuards`.
4. File-parent preparation's owned mutation removes the same duplicate destination assertion immediately before `assertGuards`.

No top-of-loop `mergeTree` assertion was removed: in this base revision, `lstat`, `realpath`, traversal checks, or hooks separate it from subsequent guards. Post-mutation, post-hook, ancestor-owner, source, containment, and identity checks remain.

## Measurements

Supplied nominal 20-file harness: **JS-visible fs calls / sync calls**.

| Native mode | Format | Before | After, default | After, durable false |
|---|---|---:|---:|---:|
| auto | TAR | 4,664 / 82 | 5,463 / 43 | 4,358 / 0 |
| auto | ZIP | 2,373 / 40 | 2,795 / 22 | 2,231 / 0 |
| off | TAR | 7,776 / 164 | 7,345 / 43 | 6,240 / 0 |
| off | ZIP | 4,128 / 40 | 4,270 / 22 | 3,706 / 0 |

On this macOS host, `inspectTarArchive` reports 41 regular files in the nominal 20-file TAR: 20 payload files plus 21 AppleDouble files hidden by system tar's listing. Thus 43 default syncs are exactly 41 files + one published directory + the destination. ZIP has 20 files, so its default total is 22. The analogous nominal 500-file TAR workload also includes AppleDouble records; no archive entries were silently discarded to improve these numbers.

The exact regression fixture contains **20 files and three directories**: default extraction makes exactly **20 file + 4 directory syncs**, and `durable: false` makes **zero**, for TAR/ZIP in native auto/off. Its call budgets are the measured baseline plus 20%:

| Native mode | Format | Baseline calls | Default after | Budget |
|---|---|---:|---:|---:|
| auto | TAR | 2,535 | 3,035 | 3,042 |
| auto | ZIP | 2,544 | 3,044 | 3,053 |
| off | TAR | 4,132 | 4,032 | 4,959 |
| off | ZIP | 4,348 | 4,568 | 5,218 |

Remaining `lstat` / `realpath` calls in the supplied nominal 20-file harness (sync and async combined):

| Native mode | Format | Default after | Durable false |
|---|---|---:|---:|
| auto | TAR | 2,596 / 1,525 | 2,090 / 1,223 |
| auto | ZIP | 1,326 / 788 | 1,069 / 631 |
| off | TAR | 3,330 / 2,425 | 2,824 / 2,123 |
| off | ZIP | 2,032 / 1,319 | 1,775 / 1,162 |

Deferring sync does not remove the two-tree staging/publication design, per-entry guarded parent preparation, source checks, or ancestor identity walks. Verified reopen adds work in native mode; these remaining checks limit the speedup.

### 500-file timing harness

Milliseconds per operation, two measured runs after a warm-up. The payload tree has 500 files in 10 subdirectories; TAR includes the macOS metadata records described above. Lower is better.

| Native mode | Format | Baseline, first complete run | Baseline, repeat | After, default | After, durable false |
|---|---|---:|---:|---:|---:|
| auto | TAR | 17,530 | 24,993 | 2,203 | 3,432 |
| auto | gzip TAR | 32,537 | — | 4,874 | 3,376 |
| auto | ZIP | 14,815 | 10,978 | 1,622 | 1,673 |
| off | TAR | 40,550 | 40,185 | 6,383 | 3,516 |
| off | gzip TAR | 46,745 | — | 24,288 | 10,007 |
| off | ZIP | 10,693 | 12,680 | 14,439 | 6,626 |

The original unmodified timing harness reported native TAR at **21,144 ms/op** before stopping at its unsupported `tar-gzip` kind. The complete runs above use the corrected kind. A final ZIP-only repeat, prompted by the apparent JS ZIP regression, measured **6,706 ms/op default** and **2,629 ms/op with durable false** in native-off mode; the slower first result remains in the table.

**The requested targets were not met consistently.** Native TAR default is 8.0–11.3× faster across the two complete baselines; native ZIP is 6.8–9.1×. JS TAR is about 6.3× by default and 11.4–11.5× with durability disabled. No measured durability-off case reached 30×. The JS ZIP result varied from a regression to a modest improvement, so this PR does not claim a stable speedup for that case.

This shared host had substantial timing variation: system unzip ranged from **106 to 2,055 ms/op**, and system TAR extraction ranged from **210 to 8,081 ms/op**. The first baseline overlapped local validation; repeated TAR/ZIP baselines and all after runs took place after those jobs finished. Other host activity remained uncontrolled. Counts are deterministic; these elapsed-time results should not be treated as universal performance guarantees.



## Validation

```text
pnpm exec tsc                         PASS
pnpm lint:file-size                   PASS
pnpm lint:fs-boundary                 PASS
pnpm docs:check                       PASS: documentation examples match the built package
node scripts/check-pack.mjs           PASS; public export snapshot unchanged
pnpm test                            1 failed | 237 passed | 4 skipped (242 files)
                                     2 failed | 8112 passed | 83 skipped (8197 tests)
pnpm test:security                   5 passed (5 files); 226 passed (226 tests)
git diff --check                     PASS
```

Both full-suite failures are the known local `test/consumer-pnpm-lifecycle.test.ts` failures: this pnpm executable does not expose the lifecycle JavaScript CLI the test requires. All archive tests passed. Focused runs with `--maxWorkers=1`: root durability 162 passed; archive sync budget 8 passed; durability-pass failure/deadline/mode tests 5 passed; existing archive mode/ownership suites 63 passed.

`pnpm check` reached the build and failed at Rust E0463 because this host lacks `wasm32-unknown-unknown`. TypeScript succeeded; the prepared parser WASM was restored, then TypeScript, both lint checks, docs, packaging, and diff checking passed. No generated `dist/` output is committed. There is no Rust/native ABI delta requiring a rebuild.

Independent Codex autoreview against the starting `origin/main` revision: scoped-clean at P0–P2, no actionable findings.

The supplied `fsyncs2.mjs` was run with Node in native auto and off before and after. A copy enabling `durable: false` supplied the unsynced measurements. The supplied `arch.mjs` was run against a detached scratch build of `origin/main` (`6ae2e2e`), with shared `node_modules`, TypeScript output, and the prepared WASM. Its `tar-gzip` kind fails in the baseline, so the complete timing runs use a copy correcting that kind to `tar` (gzip is detected from input) and exposing the durable option. Each timing is the original harness's mean of two measured runs after one warm-up. TAR/ZIP baseline repeats ran after verification jobs finished. Filesystem counters cover the harness's JS-visible calls; they are not kernel syscall traces.

