### PR TITLE
fix(root): publish read-only modes through the Windows write fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Publish read-only modes (for example `0o400`) through the Windows JavaScript write fallback by keeping the placeholder and temporary file private at `0o600`, then applying the final mode through the retained handle after rename and before post-write verification.
 - Add `Root.copyIn({ durable: false })`, with per-call, root-default, then `true` precedence, to skip file and parent-directory fsync for reconstructible data.
 - Add `extractArchive({ durable: false })` to skip durability syncs for temporary or reconstructible extraction destinations.
 - Speed up archive extraction by omitting private staging syncs, deferring publication durability to one bounded file/directory pass, and sharing duplicate destination guards without weakening containment checks.

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1614,7 +1614,11 @@ async function writeFileFallback(
   const target = await openWritableFileInRoot(root, {
     relativePath: params.relativePath,
     mkdir: params.mkdir,
-    mode: params.mode,
+    // The placeholder only reserves and verifies the name. Keep it private and
+    // writable: a read-only placeholder (mode 0o400 maps to the Windows read-only
+    // attribute) cannot be renamed over, and broader modes must not be exposed
+    // before the published file is identity-fenced.
+    mode: 0o600,
     denyMutations: params.denyMutations,
     truncateExisting: false,
   });
@@ -1632,7 +1636,7 @@ async function writeFileFallback(
       tempPath,
       data: params.data,
       encoding: params.encoding,
-      mode,
+      mode: 0o600,
     });
     writtenHandle = written.handle;
     unregisterTempPath.setIdentity(written.identity);
@@ -1643,6 +1647,15 @@ async function writeFileFallback(
     });
     unregisterTempPath();
     unregisterTempPath = null;
+    // Apply the requested mode only after publication, through the retained
+    // handle of the inode we wrote, mirroring the native Windows writer. On
+    // failure remove the published file if it is still ours, then rethrow.
+    try {
+      await written.handle.chmod(mode);
+    } catch (error) {
+      await removePathIfIdentityUnchanged(destinationPath, written.identity).catch(() => {});
+      throw error;
+    }
     try {
       await verifyAtomicWriteResult({
         root,

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1614,10 +1614,7 @@ async function writeFileFallback(
   const target = await openWritableFileInRoot(root, {
     relativePath: params.relativePath,
     mkdir: params.mkdir,
-    // The placeholder only reserves and verifies the name. Keep it private and
-    // writable: a read-only placeholder (mode 0o400 maps to the Windows read-only
-    // attribute) cannot be renamed over, and broader modes must not be exposed
-    // before the published file is identity-fenced.
+    // Private, writable placeholder: Windows cannot rename over a read-only file.
     mode: 0o600,
     denyMutations: params.denyMutations,
     truncateExisting: false,
@@ -1647,9 +1644,7 @@ async function writeFileFallback(
     });
     unregisterTempPath();
     unregisterTempPath = null;
-    // Apply the requested mode only after publication, through the retained
-    // handle of the inode we wrote, mirroring the native Windows writer. On
-    // failure remove the published file if it is still ours, then rethrow.
+    // Final mode via the retained handle after publication, as the native writer does.
     try {
       await written.handle.chmod(mode);
     } catch (error) {

--- a/test/root-durable-option.test.ts
+++ b/test/root-durable-option.test.ts
@@ -60,8 +60,7 @@ const policies: { name: string; rootDefault?: boolean; options?: RootWriteOption
 for (const backend of ["auto", "off"] as const) {
   describe.skipIf(backend === "auto" && !nativeAvailable)(`Root durable option: native ${backend}`, () => {
     for (const method of ["write", "create", "writeJson", "createJson", "append", "copyIn"] as const) {
-      // The Windows JavaScript fallback cannot rename over a read-only destination.
-      const modes = process.platform === "win32" && backend === "off" && method !== "append" ? [0o640] : [0o640, 0o400];
+      const modes = [0o640, 0o400];
       it.each(policies.flatMap((policy) => modes.map((mode) => ({ ...policy, mode }))))(
         `${method}: $name, mode $mode`,
         async ({ rootDefault, options, sync, mode }) => {
@@ -164,6 +163,77 @@ for (const backend of ["auto", "off"] as const) {
 }
 
 describe.skipIf(process.platform === "win32")("Windows writer branch simulation", () => {
+  it("keeps JS write creation private and applies the final mode after rename", async () => {
+    configureFsSafeNative({ mode: "off" });
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const directory = await tempRoot("fs-safe-win-js-read-only-");
+    const target = path.join(directory, "target");
+    const safe = await root(directory);
+    const open = fs.open.bind(fs);
+    const creationModes: (number | string | undefined)[] = [];
+    const events: string[] = [];
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      const filePath = String(args[0]);
+      const creates = typeof args[1] === "number"
+        ? (args[1] & fsSync.constants.O_CREAT) !== 0 : /^[wa]/.test(args[1]);
+      if (filePath.startsWith(directory + path.sep) && creates) {
+        creationModes.push(args[2]);
+        if (filePath !== target) {
+          const chmod = handle.chmod.bind(handle);
+          vi.spyOn(handle, "chmod").mockImplementation(async (mode) => {
+            expect((await fs.stat(target)).ino).toBe((await handle.stat()).ino);
+            expect((await fs.stat(target)).mode & 0o777).toBe(0o600);
+            await expect(fs.lstat(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+            events.push("chmod");
+            await chmod(mode);
+          });
+        }
+      }
+      return handle;
+    });
+    vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+      events.push("verify");
+      expect((await fs.stat(target)).mode & 0o777).toBe(0o400);
+      await verifyPublished(params);
+    });
+
+    await safe.write("target", "payload", { mode: 0o400 });
+
+    expect(creationModes).toEqual([0o600, 0o600]);
+    expect(events).toEqual(["chmod", "verify"]);
+    expect((await fs.stat(target)).mode & 0o777).toBe(0o400);
+    expect(await fs.readFile(target, "utf8")).toBe("payload");
+    expect(await fs.readdir(directory)).toEqual(["target"]);
+  });
+
+  it("removes the published JS write when final handle chmod fails", async () => {
+    configureFsSafeNative({ mode: "off" });
+    Object.defineProperty(process, "platform", { value: "win32" });
+    const directory = await tempRoot("fs-safe-win-js-mode-cleanup-");
+    const target = path.join(directory, "target");
+    const safe = await root(directory);
+    const failure = Object.assign(new Error("synthetic mode failure"), { code: "EIO" });
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      const filePath = String(args[0]);
+      if (path.dirname(filePath) === directory && path.basename(filePath).startsWith(".fs-safe-")) {
+        vi.spyOn(handle, "chmod").mockImplementationOnce(async () => {
+          expect((await fs.stat(target)).ino).toBe((await handle.stat()).ino);
+          expect(await fs.readFile(target, "utf8")).toBe("payload");
+          throw failure;
+        });
+      }
+      return handle;
+    });
+
+    await expect(safe.write("target", "payload", { mode: 0o400 })).rejects.toBe(failure);
+
+    await expect(fs.lstat(target)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await fs.readdir(directory)).toEqual([]);
+  });
+
   it.each([true, false])("preserves the unsynced JS writer with durable %s", async (durable) => {
     configureFsSafeNative({ mode: "off" });
     Object.defineProperty(process, "platform", { value: "win32" });

--- a/test/root-fallback-read-only-mode-windows.test.ts
+++ b/test/root-fallback-read-only-mode-windows.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { configureFsSafeNative, root } from "../src/index.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  configureFsSafeNative({ mode: "auto" });
+});
+
+describe.skipIf(process.platform !== "win32")("Windows JS fallback read-only modes", () => {
+  it.each([
+    { method: "write", mode: 0o400 },
+    { method: "writeJson", mode: 0o400 },
+    { method: "create", mode: 0o400 },
+    { method: "write", mode: 0o440 },
+  ] as const)("$method publishes mode $mode", async ({ method, mode }) => {
+    configureFsSafeNative({ mode: "off" });
+    const directory = await tempRoot("fs-safe-win-fallback-read-only-");
+    const target = path.join(directory, "target");
+    const safe = await root(directory);
+    const content = method === "writeJson" ? '{"value":"payload"}\n' : "payload";
+
+    if (method === "writeJson") {
+      await expect(safe.writeJson("target", { value: "payload" }, { mode })).resolves.toBeUndefined();
+    } else {
+      await expect(safe[method]("target", "payload", { mode })).resolves.toBeUndefined();
+    }
+
+    expect(await fs.readFile(target, "utf8")).toBe(content);
+    expect((await fs.stat(target)).mode & 0o200).toBe(0);
+    expect(await fs.readdir(directory)).toEqual(["target"]);
+    await fs.chmod(target, 0o600);
+    expect(await fs.readFile(target, "utf8")).toBe(content);
+
+    await expect(safe.write("writable", "payload", { mode: 0o640 })).resolves.toBeUndefined();
+    expect(await fs.readFile(path.join(directory, "writable"), "utf8")).toBe("payload");
+    expect((await fs.stat(path.join(directory, "writable"))).mode & 0o200).toBe(0o200);
+    expect((await fs.readdir(directory)).sort()).toEqual(["target", "writable"]);
+  });
+});


### PR DESCRIPTION
## Problem

`writeFileFallback` in `src/root-impl.ts` is the path `root.write` / `root.writeJson` take on Windows when the native binding is unavailable. It pre-created the destination with the requested mode, wrote the sibling temporary file with the final mode, and then renamed. A mode without the owner-write bit (`0o400`, `0o440`, `0o444`) maps to the Windows read-only attribute, and renaming over a read-only destination fails with `EPERM` (errno -4048). So `root.write("x", data, { mode: 0o400 })` failed on the JavaScript fallback, as seen in the first CI run of #237 (`test/root-durable-option.test.ts`, "native off > write: default, mode 256" on `windows-latest`). That test has been skipping read-only modes on this path since.

## Fix

Mirror the native Windows writer (`src/native-pinned-write-windows.ts`): keep the placeholder and the temporary file private at `0o600`, rename, then apply the requested mode through the retained handle of the inode that was written, and only then run the unchanged post-write verification. If the final chmod fails, the published file is removed only when its identity still matches (fail-closed on unknown Windows identities), and the error is rethrown. Every boundary and identity check, the temp cleanup registration, and the `finally` cleanup are unchanged. No other write path is touched.

## Tests

- New `test/root-fallback-read-only-mode-windows.test.ts` (Windows only): `write`, `writeJson`, and `create` with `0o400`, plus `write` with `0o440`, in native `off` mode. Asserts content, the read-only attribute, no temp leftovers, and that a later writable write still works.
- `test/root-durable-option.test.ts`: the Windows skip for read-only modes is gone. Two POSIX simulations (platform mocked to `win32`, native off) assert that no file under the root is created with `0o400`, that the final mode lands after rename and before verification, and that a failing final chmod removes the published file and leaves no temp file. Both fail on `main`.

## Proof

- `pnpm test:security`: 226 passed.
- `pnpm test`: 5358 passed; only the two known local `consumer-pnpm-lifecycle` environment failures remain.
- `pnpm check` steps: lint, docs check, tests, and pack check pass; the local wasm build step is a toolchain limitation of this machine and is covered by CI.
- Real Windows: both test files pass on a fresh Windows Server instance with Node 22.23.2 and the native binding off (4 new Windows tests, 67 durable-option tests, 73 skipped native-auto cases).
- Codex autoreview: scoped-clean at P0–P2.
