### PR TITLE
perf(archive): publish sibling entries with bounded concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Publish archive sibling files and stage ZIP files in bounded batches of eight, retaining guarded publication, byte limits, and joined failure/deadline handling.
 - Add `Root.copyIn({ durable: false })`, with per-call, root-default, then `true` precedence, to skip file and parent-directory fsync for reconstructible data.
 - Add `extractArchive({ durable: false })` to skip durability syncs for temporary or reconstructible extraction destinations.
 - Speed up archive extraction by omitting private staging syncs, deferring publication durability to one bounded file/directory pass, and sharing duplicate destination guards without weakening containment checks.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -223,6 +223,7 @@ before publication preserves a pre-existing file, and rejection does not grant
 authority to delete a substituted file or alias. Failed extraction does not
 restore overwritten contents. Active destination mutations and their guarded
 cleanup still finish before rejection; no later destination mutation begins.
+Sibling files are published with bounded concurrency (8), so up to that many additional siblings may complete before a failure is reported; the ordering and atomicity of each file's publication are unchanged.
 New directories whose finalization was never reached can retain their
 private working mode after failure. Failure cleanup closes retained descriptors;
 it does not run a cleanup chmod sweep or roll back the archive. The public merge

--- a/src/archive-batch.ts
+++ b/src/archive-batch.ts
@@ -1,0 +1,35 @@
+import { ownExtractionDestinationMutation, recordExtractionBatchFailure, type ExtractionDeadline } from "./archive-deadline.js";
+
+/** Admission stays sequential; no work escapes a drained batch, even on failure. */
+export function createArchiveBatch(deadline?: ExtractionDeadline) {
+  const pending: Array<() => Promise<void>> = [];
+  const drain = async () => {
+    if (!pending.length) return;
+    const tasks = pending.splice(0);
+    await ownExtractionDestinationMutation(deadline, async () => {
+      let failed = false;
+      let firstError: unknown;
+      await Promise.allSettled(tasks.map(async (run) => {
+        if (failed) return;
+        try { await run(); }
+        catch (error) {
+          // Preserve observation order, even when an earlier entry fails later.
+          if (!failed) {
+            failed = true;
+            firstError = error;
+            recordExtractionBatchFailure(deadline, error);
+          }
+          throw error;
+        }
+      }));
+      if (failed) throw firstError;
+    });
+  };
+  return {
+    async add(run: () => Promise<void>) {
+      pending.push(run);
+      if (pending.length === 8) await drain();
+    },
+    drain,
+  };
+}

--- a/src/archive-deadline.ts
+++ b/src/archive-deadline.ts
@@ -6,6 +6,14 @@ export type ExtractionDeadline = {
   dispose: () => void;
 };
 
+const batchFailures = new WeakMap<ExtractionDeadline, { error: unknown }>();
+
+export function recordExtractionBatchFailure(deadline: ExtractionDeadline | undefined, error: unknown): void {
+  if (deadline && !deadline.signal.aborted && !batchFailures.has(deadline)) {
+    batchFailures.set(deadline, { error });
+  }
+}
+
 export async function ownExtractionDestinationMutation<T>(
   deadline: ExtractionDeadline | undefined,
   run: () => Promise<T>,
@@ -128,10 +136,15 @@ export async function withExtractionDeadline<T>(
         // Preserve prompt timeout settlement for non-mutating work, but never
         // return while live destination publication or rollback is still owned.
         await deadline.waitForDestinationMutations();
+        // A sibling failure observed before expiry wins, even if joining its
+        // already-started siblings and their cleanup outlives the timer.
+        const failure = batchFailures.get(deadline);
+        if (failure) throw failure.error;
       }
       throw error;
     }
   } finally {
+    batchFailures.delete(deadline);
     deadline.dispose();
   }
 }

--- a/src/archive-merge.ts
+++ b/src/archive-merge.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ownExtractionDestinationMutation, type ExtractionDeadline } from "./archive-deadline.js";
+import { createArchiveBatch } from "./archive-batch.js";
 import {
   assertDirectoryIdentityGuard, assertResolvedInsideDestination,
   createDirectoryIdentityGuard, createArchiveSymlinkTraversalError,
@@ -59,10 +60,10 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
     plan!.set(stagedPath, entry);
   }
   const ancestors: Array<{ guard: AsyncDirectoryGuard; owner: DirectoryModeOwner }> = [];
-  const assertGuards = async () => {
+  const assertAncestorGuards = async (guards: typeof ancestors) => {
     await assertDirectoryIdentityGuard(destinationGuard);
     check();
-    for (const ancestor of ancestors) {
+    for (const ancestor of guards) {
       await assertDirectoryIdentityGuard(ancestor.guard);
       check();
       await ancestor.owner.verify(check);
@@ -71,10 +72,12 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
     await assertDirectoryIdentityGuard(sourceGuard);
     check();
   };
+  const assertGuards = () => assertAncestorGuards(ancestors);
   const walk = async (sourceDir: string): Promise<void> => {
     await assertGuards();
     const entries = await fs.readdir(sourceDir, { withFileTypes: true });
     check();
+    const batch = createArchiveBatch(params.deadline);
     for (const entry of entries) {
       await assertGuards();
       const sourcePath = path.join(sourceDir, entry.name);
@@ -96,11 +99,17 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
         throw new FsSafeError("path-mismatch", "archive staging disagrees with the admitted publication plan");
       }
       const mode = plan ? planned?.mode ?? 0o755 : sourceStat.mode & 0o777;
-      await preparePrivateArchiveOutputPath({
-        ...params, relPath, outPath: destinationPath, originalPath, isDirectory: kind === "directory",
-      }, assertGuards, destinationGuard);
-      check();
+      const fileAncestors = ancestors.slice();
+      const assertFileGuards = () => assertAncestorGuards(fileAncestors);
+      const prepare = async (assertOutputGuards: () => Promise<void>) => {
+        await preparePrivateArchiveOutputPath({
+          ...params, relPath, outPath: destinationPath, originalPath, isDirectory: kind === "directory",
+        }, assertOutputGuards, destinationGuard);
+        check();
+      };
       if (kind === "directory") {
+        await batch.drain();
+        await prepare(assertGuards);
         // Ownership spans open, descendants, finalization and close, including timeout.
         await ownExtractionDestinationMutation(params.deadline, async () => {
           await assertGuards();
@@ -147,48 +156,55 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
           }
         });
       } else {
-        await ownExtractionDestinationMutation(params.deadline, async () => {
-          await assertGuards();
-          try {
-            const options: CopyPublicationOptions & { mkdir: boolean; mode: number; durable: boolean } = {
-              mkdir: true, mode, durable: publication ? false : true,
-            };
-            if (publication && durable) {
-              options[onCopyPublication] = async (fd, identity) => {
-                check();
-                if ((mode & 0o400) === 0) {
-                  // Final mode may prohibit reopening. Sync the writer's still-owned
-                  // descriptor without widening permissions or syncing its parent.
-                  syncFileBestEffortSync(fd);
-                  check();
-                } else {
-                  publishedFiles.push({ relativePath: relPath, identity,
-                    guards: ancestors.map((ancestor) => ancestor.guard) });
-                }
+        const publish = async () => {
+          await prepare(assertFileGuards);
+          await ownExtractionDestinationMutation(params.deadline, async () => {
+            await assertFileGuards();
+            try {
+              const options: CopyPublicationOptions & { mkdir: boolean; mode: number; durable: boolean } = {
+                mkdir: true, mode, durable: publication ? false : true,
               };
+              if (publication && durable) {
+                options[onCopyPublication] = async (fd, identity) => {
+                  check();
+                  if ((mode & 0o400) === 0) {
+                    // Final mode may prohibit reopening. Sync the writer's still-owned
+                    // descriptor without widening permissions or syncing its parent.
+                    syncFileBestEffortSync(fd);
+                    check();
+                  } else {
+                    publishedFiles.push({ relativePath: relPath, identity,
+                      guards: fileAncestors.map((ancestor) => ancestor.guard) });
+                  }
+                };
+              }
+              await targetRoot.copyIn(relPath, sourcePath, options);
+              check();
+              await assertFileGuards();
+              await assertResolvedInsideDestination({
+                destinationRealDir: params.destinationRealDir, targetPath: destinationPath, originalPath,
+              });
+              check();
+              const stat = await fs.lstat(destinationPath);
+              check();
+              if (stat.isSymbolicLink() || (stat.isFile() && stat.nlink > 1)) {
+                throw createArchiveSymlinkTraversalError(originalPath);
+              }
+            } catch (error) {
+              // copyIn alone owns cleanup; no receipt permits archive-layer unlink.
+              if (error instanceof FsSafeError && (error.code === "hardlink" || error.code === "path-alias")) {
+                throw createArchiveSymlinkTraversalError(originalPath);
+              }
+              throw error;
             }
-            await targetRoot.copyIn(relPath, sourcePath, options);
-            check();
-            await assertGuards();
-            await assertResolvedInsideDestination({
-              destinationRealDir: params.destinationRealDir, targetPath: destinationPath, originalPath,
-            });
-            check();
-            const stat = await fs.lstat(destinationPath);
-            check();
-            if (stat.isSymbolicLink() || (stat.isFile() && stat.nlink > 1)) {
-              throw createArchiveSymlinkTraversalError(originalPath);
-            }
-          } catch (error) {
-            // copyIn alone owns cleanup; no receipt permits archive-layer unlink.
-            if (error instanceof FsSafeError && (error.code === "hardlink" || error.code === "path-alias")) {
-              throw createArchiveSymlinkTraversalError(originalPath);
-            }
-            throw error;
-          }
-        });
+          });
+        };
+        // The public unplanned merge retains its sequential source-tree contract.
+        if (publication) await batch.add(publish);
+        else await publish();
       }
     }
+    await batch.drain();
   };
   await walk(params.sourceDir);
   if (publication) {

--- a/src/archive-zip-budget.ts
+++ b/src/archive-zip-budget.ts
@@ -1,0 +1,22 @@
+import { createByteBudgetTracker, type ResolvedArchiveExtractLimits } from "./archive-limits.js";
+
+export function createZipExtractionBudget(limits: ResolvedArchiveExtractLimits) {
+  const total = createByteBudgetTracker(limits);
+  return (declaredSize: number): ((bytes: number) => void) => {
+    total.startEntry();
+    total.addEntrySize(declaredSize);
+    const entry = createByteBudgetTracker(limits);
+    let remaining = declaredSize;
+    return (bytes) => {
+      // Keep actual-byte checks before integrity checking; a lying size must not
+      // bypass either limit while concurrent streams consume their reservations.
+      entry.addBytes(bytes);
+      const excess = Math.max(0, bytes - remaining);
+      remaining = Math.max(0, remaining - bytes);
+      if (excess) {
+        total.startEntry();
+        total.addBytes(excess);
+      }
+    };
+  };
+}

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -2,6 +2,8 @@ import { createTarEntryPlanner } from "./archive-tar.js";
 import { inspectTar, replayTar } from "./archive-tar-stream.js";
 import type { AdmittedTarMember } from "./archive-tar-wasm.js";
 import { runPinnedWriteHelper } from "./pinned-write.js";
+import { createArchiveBatch } from "./archive-batch.js";
+import { createZipExtractionBudget } from "./archive-zip-budget.js";
 import { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
@@ -23,7 +25,6 @@ import {
 import {
   assertArchiveEntryCountWithinLimit,
   assertArchiveEntryPathComponentsWithinLimit,
-  createByteBudgetTracker,
   createExtractBudgetTransform,
   resolveExtractLimits,
   resolveTarMeterLimits,
@@ -110,7 +111,6 @@ const OPEN_WRITE_CREATE_FLAGS =
   fsConstants.O_CREAT |
   fsConstants.O_EXCL |
   (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
-type ZipExtractBudget = ReturnType<typeof createByteBudgetTracker>;
 
 async function readZipEntryStream(entry: ZipEntry): Promise<NodeJS.ReadableStream> {
   if (typeof entry.nodeStream === "function") {
@@ -148,11 +148,10 @@ function resolveZipOutputPath(params: {
 async function writeZipFileEntry(params: {
   entry: ZipEntry;
   outPath: string;
-  budget: ZipExtractBudget;
+  addBytes: (bytes: number) => void;
   deadline: ExtractionDeadline;
 }): Promise<void> {
   params.deadline.check();
-  params.budget.startEntry();
   const readable = await readZipEntryStream(params.entry);
   const destinationPath = params.outPath;
 
@@ -176,7 +175,7 @@ async function writeZipFileEntry(params: {
         try {
           await pipeline(
             readable,
-            createExtractBudgetTransform({ onChunkBytes: params.budget.addBytes }),
+            createExtractBudgetTransform({ onChunkBytes: params.addBytes }),
             createZipIntegrityTransform(params.entry),
             writable,
             { signal: params.deadline.signal },
@@ -235,7 +234,7 @@ async function extractZip(params: {
 
     assertArchiveEntryCountWithinLimit(entries.length, limits);
 
-    const budget = createByteBudgetTracker(limits);
+    const reserveEntry = createZipExtractionBudget(limits);
     const trackOutputPath = createArchiveOutputPathTracker();
 
     await withStagedArchiveDestination({
@@ -243,6 +242,7 @@ async function extractZip(params: {
       run: async (stagingDir) => {
         const stagingRealDir = await fs.realpath(stagingDir);
         const acceptedEntries: ArchivePublicationEntry[] = [];
+        const batch = createArchiveBatch(params.deadline);
         for (const entry of entries) {
           params.deadline.check();
           const output = resolveZipOutputPath({
@@ -274,7 +274,7 @@ async function extractZip(params: {
           const mode = zipEntryMode(entry, params.entryModes);
           acceptedEntries.push({ path: output.relPath, kind: entry.dir ? "directory" : "file", mode });
 
-          await preparePrivateArchiveOutputPath({
+          const prepare = () => preparePrivateArchiveOutputPath({
             destinationDir: stagingRealDir,
             destinationRealDir: stagingRealDir,
             relPath: output.relPath,
@@ -284,16 +284,18 @@ async function extractZip(params: {
             deadline: params.deadline,
           });
           if (entry.dir) {
+            await batch.drain();
+            await prepare();
             continue;
           }
 
-          await writeZipFileEntry({
-            entry,
-            outPath: output.outPath,
-            budget,
-            deadline: params.deadline,
+          const addBytes = reserveEntry(entrySize);
+          await batch.add(async () => {
+            await prepare();
+            await writeZipFileEntry({ entry, outPath: output.outPath, addBytes, deadline: params.deadline });
           });
         }
+        await batch.drain();
 
         params.deadline.check();
         await mergePlannedArchiveIntoDestination({

--- a/test/archive-concurrency.test.ts
+++ b/test/archive-concurrency.test.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { extractArchive } from "../src/archive.js";
+import * as batches from "../src/archive-batch.js";
+import { configureFsSafeNative } from "../src/native-config.js";
+import { __resetNativeLoaderForTest, __setNativeLoaderForTest } from "../src/native.js";
+import { RootHandle } from "../src/root-impl.js";
+import { modeArchive, type ModeEntry } from "./helpers/archive-modes.js";
+import { observeArchiveFs } from "./helpers/archive-fs-counts.js";
+import { paxNative } from "./helpers/archive-pax-native.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  configureFsSafeNative({ mode: "auto" });
+  __resetNativeLoaderForTest();
+});
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+};
+function sequentialBatches() {
+  return vi.spyOn(batches, "createArchiveBatch").mockImplementation(() => ({
+    add: async (run) => { await run(); }, drain: async () => {},
+  }));
+}
+async function tree(directory: string): Promise<unknown[]> {
+  const result: unknown[] = [];
+  for (const name of (await fs.readdir(directory)).sort()) {
+    const file = path.join(directory, name);
+    const stat = await fs.lstat(file);
+    result.push({ name, mode: process.platform === "win32" ? 0 : stat.mode & 0o777,
+      content: stat.isDirectory() ? await tree(file) : await fs.readFile(file, "utf8") });
+  }
+  return result;
+}
+async function fixture(kind: "tar" | "zip", entries?: ModeEntry[]) {
+  const base = await tempRoot("fs-safe-concurrency-");
+  const archivePath = path.join(base, `input.${kind}`);
+  await fs.writeFile(archivePath, await modeArchive(kind, entries ?? [
+    { path: "d/", directory: true, mode: 0o755 },
+    ...Array.from({ length: 10 }, (_, i) => ({ path: `d/f${i.toString().padStart(2, "0")}`, mode: 0o644 })),
+    { path: "zz-later/", directory: true, mode: 0o755 },
+    { path: "zz-later/file", mode: 0o644 },
+  ]));
+  const destination = async (name: string) => {
+    const destDir = path.join(base, name);
+    await fs.mkdir(destDir);
+    return { archivePath, destDir, kind, timeoutMs: 30000 };
+  };
+  return { base, destination };
+}
+
+for (const backend of ["auto", "off"] as const) {
+  describe.skipIf(backend === "auto" && !paxNative)(`archive concurrency: native ${backend}`, () => {
+    for (const kind of ["tar", "zip"] as const) {
+      const useBackend = () => {
+        if (paxNative) __setNativeLoaderForTest(() => paxNative);
+        configureFsSafeNative({ mode: backend });
+      };
+      it.each(["clamp", "preserve"] as const)(`${kind}: matches sequential contents, modes and fs-call budget (%s)`, async (entryModes) => {
+        useBackend();
+        const entries = ["a", "a/b", "a/b/c"].flatMap((dir, level) => [
+          { path: `${dir}/`, directory: true, mode: 0o750 },
+          ...Array.from({ length: 10 }, (_, i) => ({ path: `${dir}/f${i}`, mode: i % 2 ? 0o640 : 0o751 })),
+          { path: `${dir}/empty-${level}/`, directory: true, mode: 0o700 },
+        ]);
+        const { base, destination } = await fixture(kind, entries);
+        const serial = await destination("serial");
+        const concurrent = await destination("concurrent");
+        sequentialBatches();
+        const baseline = await observeArchiveFs(base);
+        await extractArchive({ ...serial, entryModes });
+        const baselineCalls = baseline.total();
+        vi.restoreAllMocks();
+        const observed = await observeArchiveFs(base);
+        await extractArchive({ ...concurrent, entryModes });
+        const calls = observed.total();
+        vi.restoreAllMocks();
+        expect(await tree(concurrent.destDir)).toEqual(await tree(serial.destDir));
+        expect(calls, JSON.stringify({ backend, kind, baselineCalls, calls })).toBeLessThanOrEqual(baselineCalls * 1.05);
+      });
+
+      it.each([["f00", false], ["f07", false], ["f07", true]] as const)(
+        `${kind}: joins a failed batch and preserves its first error (file %s, crosses deadline %s)`, async (failingFile, crossesDeadline) => {
+        useBackend();
+        const { destination } = await fixture(kind);
+        const entered = deferred();
+        const release = deferred();
+        const failed = deferred();
+        const unhandled: unknown[] = [];
+        const onUnhandled = (error: unknown) => { unhandled.push(error); };
+        process.on("unhandledRejection", onUnhandled);
+        const copyIn = RootHandle.prototype.copyIn;
+        let active = 0;
+        let started = 0;
+        let startedAfterFailure = 0;
+        let settled = false;
+        let firstError: unknown;
+        const laterFailure = failingFile === "f07" ? "f00" : "f01";
+        vi.spyOn(RootHandle.prototype, "copyIn").mockImplementation(async function (relativePath, sourcePath, options) {
+          if (firstError) startedAfterFailure++;
+          started++;
+          if (++active === 8) entered.resolve();
+          try {
+            if (relativePath === `d/${failingFile}`) {
+              await entered.promise;
+              await fs.rename(sourcePath, `${sourcePath}.saved`);
+              await fs.mkdir(sourcePath);
+              try { await copyIn.call(this, relativePath, sourcePath, options); }
+              catch (error) { firstError = error; failed.resolve(); throw error; }
+            } else {
+              await release.promise;
+              if (relativePath === `d/${laterFailure}`) throw new Error("later sibling failure");
+              await copyIn.call(this, relativePath, sourcePath, options);
+            }
+          } finally { active--; }
+        });
+        const parallel = await destination("parallel-failure");
+        const extraction = extractArchive({ ...parallel, timeoutMs: crossesDeadline ? 1000 : parallel.timeoutMs });
+        void extraction.then(() => { settled = true; }, () => { settled = true; });
+        try {
+          await failed.promise;
+          if (crossesDeadline) await new Promise((resolve) => setTimeout(resolve, 1100));
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          expect(settled).toBe(false);
+          expect(active).toBeGreaterThan(0);
+          release.resolve();
+          await expect(extraction).rejects.toBe(firstError);
+          expect(firstError).toMatchObject({ code: "not-file" });
+          expect(active).toBe(0);
+          expect(started).toBe(8);
+          expect(startedAfterFailure).toBe(0);
+          const published = (await fs.readdir(path.join(parallel.destDir, "d"))).sort();
+          expect(published).toEqual(Array.from({ length: 8 }, (_, i) => `f0${i}`)
+            .filter((name) => name !== failingFile && name !== laterFailure));
+          expect(published.length).toBeLessThanOrEqual(Number(failingFile.slice(1)) + 8);
+          for (const name of published) {
+            expect(await fs.readFile(path.join(parallel.destDir, "d", name), "utf8")).toBe("NEW");
+          }
+          await expect(fs.lstat(path.join(parallel.destDir, "zz-later"))).rejects.toMatchObject({ code: "ENOENT" });
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          expect(unhandled).toEqual([]);
+        } finally {
+          release.resolve();
+          await extraction.catch(() => undefined);
+          process.off("unhandledRejection", onUnhandled);
+        }
+      });
+
+      it(`${kind}: joins all eight publications on deadline expiry and starts no next batch`, async () => {
+        useBackend();
+        const { destination } = await fixture(kind);
+        const entered = deferred();
+        const release = deferred();
+        const copyIn = RootHandle.prototype.copyIn;
+        let active = 0;
+        let started = 0;
+        let settled = false;
+        vi.spyOn(RootHandle.prototype, "copyIn").mockImplementation(async function (...args) {
+          started++;
+          if (++active === 8) entered.resolve();
+          try { await release.promise; await copyIn.apply(this, args); }
+          finally { active--; }
+        });
+        const options = await destination("timeout");
+        const extraction = extractArchive({ ...options, timeoutMs: 1000 });
+        void extraction.then(() => { settled = true; }, () => { settled = true; });
+        try {
+          await entered.promise;
+          await new Promise((resolve) => setTimeout(resolve, 1100));
+          expect(active).toBe(8);
+          expect(settled).toBe(false);
+        } finally { release.resolve(); }
+        await expect(extraction).rejects.toThrow(`extract ${kind} timed out after 1000ms`);
+        expect(active).toBe(0);
+        expect(started).toBe(8);
+        const published = await tree(options.destDir);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(await tree(options.destDir)).toEqual(published);
+      }, 10000);
+    }
+  });
+}

--- a/test/archive-zip-budget.test.ts
+++ b/test/archive-zip-budget.test.ts
@@ -1,0 +1,25 @@
+import { expect, it } from "vitest";
+import { createZipExtractionBudget } from "../src/archive-zip-budget.js";
+import { resolveExtractLimits } from "../src/archive-limits.js";
+
+it("reserves exact ZIP bytes before dispatch without sharing per-entry counters", () => {
+  const reserve = createZipExtractionBudget(resolveExtractLimits({ maxEntryBytes: 3, maxExtractedBytes: 24 }));
+  const writes = Array.from({ length: 8 }, () => reserve(3));
+  for (const write of writes) write(1);
+  for (const write of writes.toReversed()) write(2);
+  expect(() => reserve(1)).toThrow(expect.objectContaining({ code: "archive-extracted-size-exceeds-limit" }));
+});
+it("retains the per-entry limit during interleaved streams", () => {
+  const reserve = createZipExtractionBudget(resolveExtractLimits({ maxEntryBytes: 3, maxExtractedBytes: 24 }));
+  const first = reserve(3);
+  const second = reserve(3);
+  first(2); second(2);
+  expect(() => first(2)).toThrow(expect.objectContaining({ code: "archive-entry-extracted-size-exceeds-limit" }));
+});
+it("charges undeclared bytes in addition to all outstanding reservations", () => {
+  const reserve = createZipExtractionBudget(resolveExtractLimits({ maxEntryBytes: 10, maxExtractedBytes: 8 }));
+  const first = reserve(3);
+  const second = reserve(3);
+  first(4); second(4);
+  expect(() => first(1)).toThrow(expect.objectContaining({ code: "archive-extracted-size-exceeds-limit" }));
+});


### PR DESCRIPTION
After #245, archive publication still awaited each sibling file, and JavaScript ZIP staging wrote one entry at a time. This change overlaps up to eight sibling publications and eight independent ZIP staging writes while retaining the existing per-file guard, copy, mode, identity, and durability checks.

Each file captures its ancestor guards. Batches drain before directory recursion, so directory owners remain valid throughout each task. Path preparation stays per file because it also checks the output leaf for symlinks. ZIP admission and declared-byte reservations remain sequential, with independent actual-byte checks and aggregate excess accounting during streaming. Native Rust staging is unchanged; streaming TAR staging remains sequential because its payload iterators share one parser cursor and decoded chunk. The public unplanned merge helper retains its sequential behavior.

The merge remains nontransactional: already-started siblings may finish as complete atomic publications after another sibling fails. No further batch or directory starts. All in-flight tasks and their guarded cleanup are joined, and the first observed failure is preserved even if the deadline expires during that join. Defaults and deferred durability semantics remain unchanged.

## Validation

- `pnpm exec tsc -p tsconfig.json` passed. The prepared WASM asset was retained; the known unavailable local WASM build step was not used as build proof.
- `pnpm lint:file-size`, `pnpm lint:fs-boundary`, `pnpm docs:check`, `node scripts/check-pack.mjs`, and `git diff --check` passed.
- Focused concurrency/budget tests passed, covering TAR/ZIP in native auto/off, three-level trees, both mode policies, identical sequential results, and filesystem-call counts within +5% of sequential extraction.
- Final archive concurrency, timeout-lifetime, durability-pass, and adjacent-error tests: **48 passed** with `--maxWorkers=1`. Failure cases cover the first/eighth file, later sibling failures, first-error identity, deadline expiry while joining, complete remaining files, no later directory, and no unhandled rejections.
- Final `pnpm test:security`: **226 passed**, five files.
- Full `pnpm test` run: **8,134 passed, 83 skipped, 3 failed**. Two failures are the known pnpm lifecycle CLI failures. The third was an unchanged `store-stress` overlapping-read/write identity race, followed by its teardown error; an isolated rerun passed all eight cases on both this branch and the baseline. The subsequent deadline-error fix was verified by the final 48-test archive run and security suite above.
- Independent Codex autoreview: **scoped-clean at P0–P2** after fixing timeout precedence over an earlier sibling failure.

## Timing

The **3× native TAR/ZIP target was not reached**. Measurements vary widely, including the system-tar controls; some pairs regress. All results are included below.

Environment: Node v26.8.1, macOS arm64; native binding availability verified in both builds. Baseline: detached `origin/main` snapshot `18114434acede04a2764c4faea45d3a4a56e9cf5` (#245), compiled with TypeScript, shared dependencies, and the same prepared WASM asset. Candidate: `d3cc422`. The provided `arch.mjs` fixture uses 500 files in ten directories, default durability, one warmup and one measured extraction for TAR, gzip TAR, and ZIP. Each baseline/candidate pair ran back-to-back in auto and off modes, then repeated once. The final build's timing run had no task-owned tests running alongside it.

| Repeat | Native | Archive | Baseline ms | Branch ms | Baseline / branch |
| --- | --- | --- | ---: | ---: | ---: |
| 1 | auto | tar | 3325 | 3550 | 0.94× |
| 1 | auto | tgz | 3243 | 4114 | 0.79× |
| 1 | auto | zip | 2158 | 3261 | 0.66× |
| 1 | off | tar | 5242 | 5488 | 0.96× |
| 1 | off | tgz | 4659 | 7124 | 0.65× |
| 1 | off | zip | 3227 | 2526 | 1.28× |
| 2 | auto | tar | 7021 | 5933 | 1.18× |
| 2 | auto | tgz | 6485 | 4075 | 1.59× |
| 2 | auto | zip | 2891 | 1216 | 2.38× |
| 2 | off | tar | 3709 | 6329 | 0.59× |
| 2 | off | tgz | 8321 | 8763 | 0.95× |
| 2 | off | zip | 8433 | 6820 | 1.24× |

Ratios above 1 indicate faster extraction; below 1 indicate slower extraction.

<details>
<summary>All final timing output</summary>

```text
Repeat 1, native=auto, origin/main
native=auto, 500 files in 10 dirs
system tar x tar                                 953 ms/op
extractArchive tar                              3325 ms/op
system tar x tgz                                 261 ms/op
extractArchive tgz                              3243 ms/op
system unzip zip                                 133 ms/op
extractArchive zip                              2158 ms/op

Repeat 1, native=auto, branch
native=auto, 500 files in 10 dirs
system tar x tar                                 379 ms/op
extractArchive tar                              3550 ms/op
system tar x tgz                                 411 ms/op
extractArchive tgz                              4114 ms/op
system unzip zip                                 159 ms/op
extractArchive zip                              3261 ms/op

Repeat 1, native=off, origin/main
native=off, 500 files in 10 dirs
system tar x tar                                 691 ms/op
extractArchive tar                              5242 ms/op
system tar x tgz                                 301 ms/op
extractArchive tgz                              4659 ms/op
system unzip zip                                 385 ms/op
extractArchive zip                              3227 ms/op

Repeat 1, native=off, branch
native=off, 500 files in 10 dirs
system tar x tar                                 330 ms/op
extractArchive tar                              5488 ms/op
system tar x tgz                                 424 ms/op
extractArchive tgz                              7124 ms/op
system unzip zip                                 407 ms/op
extractArchive zip                              2526 ms/op

Repeat 2, native=auto, origin/main
native=auto, 500 files in 10 dirs
system tar x tar                                 397 ms/op
extractArchive tar                              7021 ms/op
system tar x tgz                                 370 ms/op
extractArchive tgz                              6485 ms/op
system unzip zip                                 211 ms/op
extractArchive zip                              2891 ms/op

Repeat 2, native=auto, branch
native=auto, 500 files in 10 dirs
system tar x tar                                 443 ms/op
extractArchive tar                              5933 ms/op
system tar x tgz                                 347 ms/op
extractArchive tgz                              4075 ms/op
system unzip zip                                 160 ms/op
extractArchive zip                              1216 ms/op

Repeat 2, native=off, origin/main
native=off, 500 files in 10 dirs
system tar x tar                                 222 ms/op
extractArchive tar                              3709 ms/op
system tar x tgz                                 391 ms/op
extractArchive tgz                              8321 ms/op
system unzip zip                                 123 ms/op
extractArchive zip                              8433 ms/op

Repeat 2, native=off, branch
native=off, 500 files in 10 dirs
system tar x tar                                 270 ms/op
extractArchive tar                              6329 ms/op
system tar x tgz                                 378 ms/op
extractArchive tgz                              8763 ms/op
system unzip zip                                 440 ms/op
extractArchive zip                              6820 ms/op
```

</details>

<details>
<summary>All preliminary timing output, before the deadline-error follow-up</summary>

These earlier measurements overlapped part of the follow-up test work and are retained for transparency; they are not the final candidate comparison above.

```text
Repeat 1, native=auto, origin/main
native=auto, 500 files in 10 dirs
system tar x tar                                 236 ms/op
extractArchive tar                              2451 ms/op
system tar x tgz                                 203 ms/op
extractArchive tgz                              2727 ms/op
system unzip zip                                 102 ms/op
extractArchive zip                              1295 ms/op

Repeat 1, native=auto, branch
native=auto, 500 files in 10 dirs
system tar x tar                                 249 ms/op
extractArchive tar                              2090 ms/op
system tar x tgz                                 226 ms/op
extractArchive tgz                              1989 ms/op
system unzip zip                                 101 ms/op
extractArchive zip                              1035 ms/op

Repeat 1, native=off, origin/main
native=off, 500 files in 10 dirs
system tar x tar                                 265 ms/op
extractArchive tar                              2744 ms/op
system tar x tgz                                 205 ms/op
extractArchive tgz                              4945 ms/op
system unzip zip                                 186 ms/op
extractArchive zip                              2822 ms/op

Repeat 1, native=off, branch
native=off, 500 files in 10 dirs
system tar x tar                                 278 ms/op
extractArchive tar                              2394 ms/op
system tar x tgz                                 277 ms/op
extractArchive tgz                              2234 ms/op
system unzip zip                                 138 ms/op
extractArchive zip                              1058 ms/op

Repeat 2, native=auto, origin/main
native=auto, 500 files in 10 dirs
system tar x tar                                 204 ms/op
extractArchive tar                              2145 ms/op
system tar x tgz                                 208 ms/op
extractArchive tgz                              2381 ms/op
system unzip zip                                 203 ms/op
extractArchive zip                              3339 ms/op

Repeat 2, native=auto, branch
native=auto, 500 files in 10 dirs
system tar x tar                                 558 ms/op
extractArchive tar                              7459 ms/op
system tar x tgz                                 598 ms/op
extractArchive tgz                              3536 ms/op
system unzip zip                                 112 ms/op
extractArchive zip                              1374 ms/op

Repeat 2, native=off, origin/main
native=off, 500 files in 10 dirs
system tar x tar                                 645 ms/op
extractArchive tar                             15046 ms/op
system tar x tgz                                1089 ms/op
extractArchive tgz                             13695 ms/op
system unzip zip                                 257 ms/op
extractArchive zip                              4308 ms/op

Repeat 2, native=off, branch
native=off, 500 files in 10 dirs
system tar x tar                                 286 ms/op
extractArchive tar                              2753 ms/op
system tar x tgz                                 280 ms/op
extractArchive tgz                              5810 ms/op
system unzip zip                                 563 ms/op
extractArchive zip                              1976 ms/op
```

</details>

## Remaining per-file cost

A separate instrumented native-auto run used the same fixture and final code in a scratch build. TAR/TGZ published **1,011 regular files**, while ZIP published **500**: macOS tar adds AppleDouble `._` members, including metadata for directories. A one-file producer probe confirmed this through `inspectTarArchive` (`._tree`, `tree/._file.txt`, and the real file); system tar's listing hides those metadata members. The provided benchmark was kept unchanged.

The table amortizes phase wall time over actual published regular files, including directory work. These diagnostic samples were also variable and should not be treated as a stable performance estimate.

| Phase, ms per published file | TAR (1,011 files) | TGZ (1,011 files) | ZIP (500 files) |
| --- | ---: | ---: | ---: |
| Admission, staging and cleanup outside merge | 1.214 | 0.268 | 0.624 |
| Guarded merge excluding final durability | 2.121 | 7.944 | 3.374 |
| Final durability and directory modes | 1.039 | 3.546 | 0.592 |
| Total | 4.374 | 11.759 | 4.590 |

Within the merge, accumulated task elapsed time per published file was:

| Overlapping component, ms per file | TAR | TGZ | ZIP |
| --- | ---: | ---: | ---: |
| Ancestor guard/owner verification | 6.230 | 21.711 | 9.036 |
| Output-path preparation | 3.403 | 3.905 | 5.537 |
| Guarded copyIn | 6.923 | 36.702 | 10.055 |
| Sequential merge entry admission | 0.170 | 0.227 | 0.377 |
| Sequential plan realpaths | 0.036 | 0.038 | 0.062 |

These component times overlap and must not be added: preparation includes guard checks, and sibling tasks run concurrently. Each ancestor owner still serializes its descriptor verification, per-file preparation and copy checks remain intact, manifest/source admission stays sequential, and the final durability pass remains necessary. Batching alone does not remove those costs. Native Rust staging (within the outside-merge phase) measured TAR 1.148 ms/file, TGZ 0.155 ms/file, ZIP 0.160 ms/file.

<details>
<summary>All instrumented timing output</summary>

```text
native=auto, 500 files in 10 dirs
system tar x tar                                6284 ms/op
PROFILE {"kind":"tar","totalMs":13801.246459000002,"stats":{"inspectArchiveNative":{"calls":1,"ms":6.597000000001572},"extractArchiveNative":{"calls":1,"ms":2639.2498750000013},"planRealpaths":{"calls":1,"ms":31.626584000001458},"ancestorGuards":{"calls":6130,"ms":15561.91492900005},"entryAdmission":{"calls":1022,"ms":301.65981999997894},"pathPreparation":{"calls":1022,"ms":4903.629039999982},"copyIn":{"calls":1011,"ms":27122.26941000005},"durability":{"calls":1,"ms":4095.8319580000025},"merge":{"calls":1,"ms":10485.361791000003}}}
PROFILE {"kind":"tar","totalMs":4421.762917,"stats":{"inspectArchiveNative":{"calls":1,"ms":4.0850419999987935},"extractArchiveNative":{"calls":1,"ms":1160.9465420000051},"planRealpaths":{"calls":1,"ms":36.11029100000451},"ancestorGuards":{"calls":6130,"ms":6298.515652000082},"entryAdmission":{"calls":1022,"ms":171.8131040001026},"pathPreparation":{"calls":1022,"ms":3440.1257690000057},"copyIn":{"calls":1011,"ms":6999.197201000134},"durability":{"calls":1,"ms":1049.9947919999977},"merge":{"calls":1,"ms":3194.0782499999987}}}
extractArchive tar                              4422 ms/op
system tar x tgz                                2562 ms/op
PROFILE {"kind":"tar","totalMs":6272.055,"stats":{"inspectArchiveNative":{"calls":1,"ms":2.5282079999960843},"extractArchiveNative":{"calls":1,"ms":389.78704200000357},"planRealpaths":{"calls":1,"ms":30.610625000001164},"ancestorGuards":{"calls":6130,"ms":6905.7277940002605},"entryAdmission":{"calls":1022,"ms":183.23129800015158},"pathPreparation":{"calls":1022,"ms":3492.134333000082},"copyIn":{"calls":1011,"ms":7976.9102939999575},"durability":{"calls":1,"ms":3399.1897499999977},"merge":{"calls":1,"ms":5752.505540999999}}}
PROFILE {"kind":"tar","totalMs":11887.885458999997,"stats":{"inspectArchiveNative":{"calls":1,"ms":2.0415830000056303},"extractArchiveNative":{"calls":1,"ms":156.4257080000025},"planRealpaths":{"calls":1,"ms":38.16695899999468},"ancestorGuards":{"calls":6130,"ms":21949.94874200014},"entryAdmission":{"calls":1022,"ms":229.96786300006352},"pathPreparation":{"calls":1022,"ms":3947.539039999858},"copyIn":{"calls":1011,"ms":37106.18870599986},"durability":{"calls":1,"ms":3585.188915999999},"merge":{"calls":1,"ms":11616.881041999994}}}
extractArchive tgz                             11889 ms/op
system unzip zip                                 155 ms/op
PROFILE {"kind":"zip","totalMs":3019.721666000005,"stats":{"inspectArchiveNative":{"calls":1,"ms":3.788250000005064},"extractArchiveNative":{"calls":1,"ms":832.3438340000066},"planRealpaths":{"calls":1,"ms":13.995625000003201},"ancestorGuards":{"calls":3077,"ms":4385.352615999916},"entryAdmission":{"calls":511,"ms":202.64711700003681},"pathPreparation":{"calls":511,"ms":2441.032619999867},"copyIn":{"calls":500,"ms":4945.6631269999925},"durability":{"calls":1,"ms":423.37908400000015},"merge":{"calls":1,"ms":2036.3837500000081}}}
PROFILE {"kind":"zip","totalMs":2295.135374999998,"stats":{"inspectArchiveNative":{"calls":1,"ms":2.4225830000068527},"extractArchiveNative":{"calls":1,"ms":80.21179199998733},"planRealpaths":{"calls":1,"ms":31.22716599999694},"ancestorGuards":{"calls":3077,"ms":4518.076355999874},"entryAdmission":{"calls":511,"ms":188.32091599989508},"pathPreparation":{"calls":511,"ms":2768.3641550000902},"copyIn":{"calls":500,"ms":5027.42549899999},"durability":{"calls":1,"ms":295.92312500000116},"merge":{"calls":1,"ms":1982.9242080000113}}}
extractArchive zip                              2296 ms/op
```

</details>
