### PR TITLE
perf: observe metadata synchronously in archive, copy, publish, and move paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Extend synchronous metadata observations to archive extraction, copy, publication, move, and directory-mode paths, while data and structural I/O remain asynchronous and native canonical path spelling is preserved.
+- Extend synchronous metadata observations to archive extraction, copy, publication, move, and directory-mode paths, while data and structural I/O remain asynchronous and native canonical path spelling is preserved; update the Windows hash-identity proof to observe the synchronous checks.
 - Publish read-only modes (for example `0o400`) through the Windows JavaScript write fallback by keeping the placeholder and temporary file private at `0o600`, then applying the final mode through the retained handle after rename and before post-write verification.
 - Add `Root.copyIn({ durable: false })`, with per-call, root-default, then `true` precedence, to skip file and parent-directory fsync for reconstructible data.
 - Add `extractArchive({ durable: false })` to skip durability syncs for temporary or reconstructible extraction destinations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Extend synchronous metadata observations to archive extraction, copy, publication, move, and directory-mode paths, while data and structural I/O remain asynchronous and native canonical path spelling is preserved.
 - Publish read-only modes (for example `0o400`) through the Windows JavaScript write fallback by keeping the placeholder and temporary file private at `0o600`, then applying the final mode through the retained handle after rename and before post-write verification.
 - Add `Root.copyIn({ durable: false })`, with per-call, root-default, then `true` precedence, to skip file and parent-directory fsync for reconstructible data.
 - Add `extractArchive({ durable: false })` to skip durability syncs for temporary or reconstructible extraction destinations.

--- a/docs/reading.md
+++ b/docs/reading.md
@@ -14,6 +14,12 @@ const opened = await fs.open("large.log");               // FileHandle for strea
 
 Identity and containment checks use brief synchronous metadata calls, like Node's module resolution, while file data is read asynchronously. Canonical paths retain Node's native realpath spelling, including expansion of Windows short paths.
 
+The same observation rule applies to archive extraction, copy, publication, move,
+directory modes, and supporting lock, queue, and secret-file operations. Opens,
+data transfers, durability syncs, filesystem mutations, and closes retain their
+existing asynchronous behavior. Custom filesystem adapters retain their async
+metadata interface.
+
 Regardless of shape, every read goes through the same boundary checks:
 
 1. Resolve the input lexically against the canonical real root.

--- a/scripts/hash-identity-proof.mjs
+++ b/scripts/hash-identity-proof.mjs
@@ -2,9 +2,10 @@
 // Usage: node scripts/hash-identity-proof.mjs --repo BUILT_REPO --output NEW_DIR
 //   --variant baseline|patched [--source-ref COMMIT] [--require-windows] [--include-unscoped]
 // Companion stats are additional, non-atomic observations. Keep local smoke receipts private.
+// Companions use synchronous stats in both variants; retained-file evidence stays asynchronous.
 import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
-import { constants, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import fsSync, { constants, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import crypto from 'node:crypto';
 import { createRequire, syncBuiltinESMExports } from 'node:module';
 import path from 'node:path';
@@ -55,6 +56,7 @@ const summary = {
   ],
 };
 const actual = Object.fromEntries(['open', 'lstat', 'readFile', 'writeFile', 'rename'].map(k => [k, fs[k].bind(fs)]));
+const actualSync = { lstat: fsSync.lstatSync.bind(fsSync), fstat: fsSync.fstatSync.bind(fsSync) };
 let activeCase;
 let timer;
 let fingerprintBefore;
@@ -139,7 +141,7 @@ try {
     let targetOpenEntered = false;
     let previewReturned = 0;
     let hashStarted = false;
-    let openSpy, lstatSpy, hashSpy;
+    let openSpy, lstatSpy, fstatSpy, hashSpy;
     const handles = [];
     const event = (type, data = {}) => {
       assert(receipt.events.length < 150, 'event bound exceeded');
@@ -166,13 +168,13 @@ try {
       event('additional-retained-evidence', record);
       return record;
     }
-    async function companion(method, stage, call, originalOptions, originalEvent) {
+    function companion(method, stage, call, originalOptions, originalEvent) {
       if (values.companions !== 'after') return;
       const options = { bigint: !originalOptions?.bigint };
       receipt.counts.companionStats++;
       const start = event('additional-stat-enter', { method, stage, options: atom(options), afterOriginalEvent: originalEvent });
       try {
-        const stat = await call(options);
+        const stat = call(options);
         event('additional-stat-return', { entered: start.order, method, stage, result: stats(stat),
           separateSyscall: true, atomicWithOriginal: false });
       } catch (error) {
@@ -211,17 +213,17 @@ try {
       const handle = await actual.open(...args);
       event('open-spy-return', { entered: entry.order, classification, fd: handle.fd });
       const raw = { stat: handle.stat.bind(handle), read: handle.read.bind(handle), close: handle.close.bind(handle) };
-      const tracked = { handle, raw, classification, closed: false };
+      const tracked = { handle, fd: handle.fd, raw, classification, closed: false };
       handles.push(tracked);
       if (classification === 'target') {
-        handle.stat = async (...statArgs) => {
+        if (values.variant === 'baseline') handle.stat = async (...statArgs) => {
           assert(++receipt.counts.descriptorStats <= 4, 'descriptor stat bound');
           const start = event('algorithm-stat-enter', { method: 'FileHandle.stat', stage: 'descriptor',
             descriptorOrdinal: receipt.counts.descriptorStats, arguments: argsRecord(statArgs) });
           const stat = await raw.stat(...statArgs);
           const end = event('algorithm-stat-return', { entered: start.order, method: 'FileHandle.stat',
             stage: 'descriptor', result: stats(stat) });
-          await companion('FileHandle.stat', 'descriptor', raw.stat, statArgs[0], end.order);
+          companion('fs.fstatSync', 'descriptor', options => actualSync.fstat(tracked.fd, options), statArgs[0], end.order);
           return stat;
         };
         handle.read = async (...readArgs) => {
@@ -272,17 +274,42 @@ try {
       openSpy = spyOn(fs, 'open');
       openSpy.mockImplementation((...args) => trackOpen(args, kind === 'replacement' && armed && classify(args[0]) === 'target'));
       if (kind === 'unscoped') openSpy.mockImplementationOnce((...args) => trackOpen(args, true));
-      lstatSpy = spyOn(fs, 'lstat').mockImplementation(async (...args) => {
+      if (values.variant === 'baseline') lstatSpy = spyOn(fs, 'lstat').mockImplementation(async (...args) => {
         assert.equal(classify(args[0]), 'target', 'unexpected non-target lstat');
         assert(++receipt.counts.algorithmLstats <= 4, 'pathname stat bound');
         const stage = targetOpenEntered ? 'current-path' : 'preview';
         const start = event('algorithm-stat-enter', { method: 'fs.lstat', stage, arguments: argsRecord(args) });
         const stat = await actual.lstat(...args);
         const end = event('algorithm-stat-return', { entered: start.order, method: 'fs.lstat', stage, result: stats(stat) });
-        await companion('fs.lstat', stage, options => actual.lstat(args[0], options), args[1], end.order);
+        companion('fs.lstatSync', stage, options => actualSync.lstat(args[0], options), args[1], end.order);
         if (stage === 'preview') previewReturned++;
         return stat;
       });
+      else {
+        lstatSpy = spyOn(fsSync, 'lstatSync').mockImplementation((...args) => {
+          assert.equal(classify(args[0]), 'target', 'unexpected non-target lstat');
+          assert(++receipt.counts.algorithmLstats <= 4, 'pathname stat bound');
+          const stage = targetOpenEntered ? 'current-path' : 'preview';
+          const start = event('algorithm-stat-enter', { method: 'fs.lstatSync', stage, arguments: argsRecord(args) });
+          const stat = actualSync.lstat(...args);
+          const end = event('algorithm-stat-return', { entered: start.order, method: 'fs.lstatSync', stage, result: stats(stat) });
+          companion('fs.lstatSync', stage, options => actualSync.lstat(args[0], options), args[1], end.order);
+          if (stage === 'preview') previewReturned++;
+          return stat;
+        });
+        fstatSpy = spyOn(fsSync, 'fstatSync').mockImplementation((...args) => {
+          const tracked = handles.find(entry => entry.fd === args[0] && !entry.closed);
+          assert(tracked?.classification === 'target', 'unexpected non-target fstat');
+          assert(++receipt.counts.descriptorStats <= 4, 'descriptor stat bound');
+          const start = event('algorithm-stat-enter', { method: 'fs.fstatSync', stage: 'descriptor',
+            descriptorOrdinal: receipt.counts.descriptorStats, arguments: argsRecord(args) });
+          const stat = actualSync.fstat(...args);
+          const end = event('algorithm-stat-return', { entered: start.order, method: 'fs.fstatSync',
+            stage: 'descriptor', result: stats(stat) });
+          companion('fs.fstatSync', 'descriptor', options => actualSync.fstat(tracked.fd, options), args[1], end.order);
+          return stat;
+        });
+      }
       // Deliberate exported fs.open before sha256File and its first lstat, not an inferred coverage event.
       event('controlled-unrelated-open-before-algorithm');
       const auxiliary = await fs.open(unrelated, 'r');
@@ -300,6 +327,7 @@ try {
       receipt.lstatSpyInvocationOrder = [...lstatSpy.mock.invocationCallOrder];
       openSpy.mockRestore(); openSpy = undefined;
       lstatSpy.mockRestore(); lstatSpy = undefined;
+      fstatSpy?.mockRestore(); fstatSpy = undefined;
       receipt.finalTarget = await retained(swapped ? 'replacement' : 'unchanged original', target);
       if (swapped) receipt.finalDisplaced = await retained('rename-retained original', displaced);
       const expectedContent = kind === 'stable' ? 'original' : 'replacement';
@@ -339,10 +367,10 @@ try {
         check('baseline stat options remain numeric defaults', algorithmStats.every(e =>
           e.method === 'fs.lstat' ? e.arguments.length === 1 : e.arguments.length === 0));
       } else {
-        check('patched pathname identity stats request bigint', algorithmStats.filter(e => e.method === 'fs.lstat')
+        check('patched pathname identity stats request bigint', algorithmStats.filter(e => e.method === 'fs.lstatSync')
           .every(e => e.arguments[1]?.value?.bigint === true));
-        const firstDescriptor = algorithmStats.find(e => e.method === 'FileHandle.stat');
-        check('patched descriptor identity stat requests bigint', firstDescriptor?.arguments[0]?.value?.bigint === true);
+        const firstDescriptor = algorithmStats.find(e => e.method === 'fs.fstatSync');
+        check('patched descriptor identity stat requests bigint', firstDescriptor?.arguments[1]?.value?.bigint === true);
       }
       const targetCall = receipt.openSpyCalls.find(e => e.classification === 'target');
       const flags = targetCall?.arguments[1]?.value;
@@ -356,7 +384,7 @@ try {
         rejected ? 'replacement rejected before read' : 'stable original hashed';
     } catch (error) { receipt.harnessError = errorInfo(error); }
     finally {
-      openSpy?.mockRestore(); lstatSpy?.mockRestore();
+      openSpy?.mockRestore(); lstatSpy?.mockRestore(); fstatSpy?.mockRestore();
       hashSpy?.mockRestore(); syncBuiltinESMExports();
       __resetNativeLoaderForTest(); __resetFsSafeNativeConfigForTest();
       for (const tracked of handles) if (!tracked.closed) {

--- a/src/archive-durability.ts
+++ b/src/archive-durability.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+import fsSync from "node:fs";
 import path from "node:path";
 import { ownExtractionDestinationMutation, type ExtractionDeadline } from "./archive-deadline.js";
 import { assertDirectoryIdentityGuard, assertResolvedInsideDestination, createArchiveSymlinkTraversalError } from "./archive-staging.js";
@@ -55,13 +55,13 @@ export async function finalizeArchivePublication(params: {
               throw error;
             });
           check();
-          await inspectFileIdentity(() => opened.handle.stat({ bigint: true }), file.identity);
+          await inspectFileIdentity(() => fsSync.fstatSync(opened.handle.fd, { bigint: true }), file.identity);
           check();
           await syncFileBestEffort(opened.handle).catch((error: unknown) => { throw normalizePinnedWriteError(error); });
           check();
           await assertGuards(file.guards);
           await inspectFileIdentity(async () => {
-            const stat = await fs.lstat(opened.realPath, { bigint: true });
+            const stat = fsSync.lstatSync(opened.realPath, { bigint: true });
             if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink > 1n) {
               throw new FsSafeError("path-mismatch", "archive file changed during durability pass");
             }

--- a/src/archive-gzip-tail.ts
+++ b/src/archive-gzip-tail.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { Writable } from "node:stream";
 import type { Gunzip } from "node:zlib";
@@ -49,7 +50,7 @@ export async function validateGzipContainerTail(filePath: string, consumed: numb
   signal?.throwIfAborted();
   const handle = await fs.open(filePath, "r");
   try {
-    const { size } = await handle.stat();
+    const { size } = fsSync.fstatSync(handle.fd);
     if (!Number.isSafeInteger(consumed) || consumed <= 0 || consumed > size) {
       throw new ArchiveFormatError("invalid gzip consumed-input boundary");
     }

--- a/src/archive-input.ts
+++ b/src/archive-input.ts
@@ -1,4 +1,4 @@
-import { constants as fsConstants } from "node:fs";
+import fsSync, { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -48,7 +48,7 @@ export async function stageArchiveFileForExtraction(params: {
   params.deadline.check();
   const sourcePath = path.resolve(params.archivePath);
   const initialStat = await inspectFileIdentity(async () => {
-    const stat = await fs.lstat(sourcePath, { bigint: true });
+    const stat = fsSync.lstatSync(sourcePath, { bigint: true });
     if (stat.isSymbolicLink() || !stat.isFile()) {
       throw new Error(`archive is not a regular file: ${params.archivePath}`);
     }
@@ -66,12 +66,12 @@ export async function stageArchiveFileForExtraction(params: {
       fileName: path.basename(sourcePath),
     });
     const opened = await inspectFileIdentity(async () => {
-      const stat = await handle.stat({ bigint: true });
+      const stat = fsSync.fstatSync(handle.fd, { bigint: true });
       if (!stat.isFile()) throw new Error("archive changed during validation");
       return stat;
     }, initialStat);
     await inspectFileIdentity(async () => {
-      const stat = await fs.lstat(sourcePath, { bigint: true });
+      const stat = fsSync.lstatSync(sourcePath, { bigint: true });
       if (stat.isSymbolicLink() || !stat.isFile()) throw new Error("archive changed during validation");
       return stat;
     }, opened);

--- a/src/archive-kind.ts
+++ b/src/archive-kind.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
@@ -50,7 +51,7 @@ async function hasPackedRootMarker(extractDir: string, rootMarkers: string[]): P
       continue;
     }
     try {
-      await fs.stat(path.join(extractDir, trimmed));
+      fsSync.statSync(path.join(extractDir, trimmed));
       return true;
     } catch {
       // ignore
@@ -65,7 +66,7 @@ export async function resolvePackedRootDir(
 ): Promise<string> {
   const direct = path.join(extractDir, "package");
   try {
-    const stat = await fs.stat(direct);
+    const stat = fsSync.statSync(direct);
     if (stat.isDirectory()) {
       return direct;
     }

--- a/src/archive-merge.ts
+++ b/src/archive-merge.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ownExtractionDestinationMutation, type ExtractionDeadline } from "./archive-deadline.js";
@@ -51,7 +52,7 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
   for (const entry of publication ?? []) {
     // Resolve admitted spelling in private staging, preserving the volume's case
     // and Unicode behavior without assigning explicit modes to distinct parents.
-    const stagedPath = await fs.realpath(path.join(params.sourceDir, entry.path));
+    const stagedPath = fsSync.realpathSync.native(path.join(params.sourceDir, entry.path));
     check();
     if (!isPathInside(sourceGuard.realPath, stagedPath) || plan!.has(stagedPath)) {
       throw new FsSafeError("path-mismatch", "archive publication paths changed in staging");
@@ -81,10 +82,10 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
       const relPath = path.relative(params.sourceDir, sourcePath);
       const originalPath = relPath.split(path.sep).join("/");
       const destinationPath = path.join(params.destinationDir, relPath);
-      const sourceStat = await fs.lstat(sourcePath);
+      const sourceStat = fsSync.lstatSync(sourcePath);
       check();
       if (sourceStat.isSymbolicLink()) throw createArchiveSymlinkTraversalError(originalPath);
-      const sourceReal = await fs.realpath(sourcePath);
+      const sourceReal = fsSync.realpathSync.native(sourcePath);
       check();
       if (!isPathInside(sourceGuard.realPath, sourceReal)) throw createArchiveSymlinkTraversalError(originalPath);
       if (!sourceStat.isFile() && !sourceStat.isDirectory()) {
@@ -174,7 +175,7 @@ async function mergeTree(params: MergeParams, publication?: readonly ArchivePubl
               destinationRealDir: params.destinationRealDir, targetPath: destinationPath, originalPath,
             });
             check();
-            const stat = await fs.lstat(destinationPath);
+            const stat = fsSync.lstatSync(destinationPath);
             check();
             if (stat.isSymbolicLink() || (stat.isFile() && stat.nlink > 1)) {
               throw createArchiveSymlinkTraversalError(originalPath);

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -1,4 +1,5 @@
 import { classifyArchiveParserError } from "./archive-parser-errors.js";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { Readable } from "node:stream";
 import { readFileHandleBounded } from "./bounded-read.js";
@@ -95,9 +96,9 @@ async function stageArchiveInput(archivePath: string): Promise<{
   buffer: Buffer;
   cleanup(): Promise<void>;
 }> {
-  const resolved = await fs.realpath(archivePath);
+  const resolved = fsSync.realpathSync.native(archivePath);
   const before = await inspectFileIdentity(async () => {
-    const stat = await fs.lstat(archivePath, { bigint: true });
+    const stat = fsSync.lstatSync(archivePath, { bigint: true });
     if (stat.isSymbolicLink() || !stat.isFile()) {
       throw new Error(`archive is not a regular file: ${archivePath}`);
     }
@@ -108,12 +109,12 @@ async function stageArchiveInput(archivePath: string): Promise<{
   try {
     staged = await tempFile({ prefix: "fs-safe-archive-read", fileName: "archive.bin" });
     const opened = await inspectFileIdentity(async () => {
-      const stat = await handle.stat({ bigint: true });
+      const stat = fsSync.fstatSync(handle.fd, { bigint: true });
       if (!stat.isFile()) throw new Error("archive changed during validation");
       return stat;
     }, before);
     await inspectFileIdentity(async () => {
-      const stat = await fs.lstat(resolved, { bigint: true });
+      const stat = fsSync.lstatSync(resolved, { bigint: true });
       if (stat.isSymbolicLink() || !stat.isFile()) throw new Error("archive changed during validation");
       return stat;
     }, opened);

--- a/src/archive-staging.ts
+++ b/src/archive-staging.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -65,7 +66,7 @@ export async function assertDirectoryIdentityGuard(guard: AsyncDirectoryGuard): 
 }
 
 export async function prepareArchiveDestinationDir(destDir: string): Promise<string> {
-  const stat = await fs.lstat(destDir);
+  const stat = fsSync.lstatSync(destDir);
   if (stat.isSymbolicLink()) {
     throw new ArchiveSecurityError("destination-symlink", "archive destination is a symlink");
   }
@@ -75,9 +76,9 @@ export async function prepareArchiveDestinationDir(destDir: string): Promise<str
       "archive destination is not a directory",
     );
   }
-  const realPath = await fs.realpath(destDir);
-  const realStat = await fs.stat(realPath);
-  const postStat = await fs.lstat(destDir);
+  const realPath = fsSync.realpathSync.native(destDir);
+  const realStat = fsSync.statSync(realPath);
+  const postStat = fsSync.lstatSync(destDir);
   if (
     realStat.dev !== stat.dev ||
     realStat.ino !== stat.ino ||
@@ -105,7 +106,7 @@ async function assertNoSymlinkTraversal(params: {
     current = path.join(current, part);
     let stat: Awaited<ReturnType<typeof fs.lstat>>;
     try {
-      stat = await fs.lstat(current);
+      stat = fsSync.lstatSync(current);
     } catch (err) {
       if (isNotFoundPathError(err)) {
         continue;
@@ -125,7 +126,7 @@ export async function assertResolvedInsideDestination(params: {
 }): Promise<void> {
   let resolved: string;
   try {
-    resolved = await fs.realpath(params.targetPath);
+    resolved = fsSync.realpathSync.native(params.targetPath);
   } catch (err) {
     if (isNotFoundPathError(err)) {
       return;

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -2,7 +2,7 @@ import { createTarEntryPlanner } from "./archive-tar.js";
 import { inspectTar, replayTar } from "./archive-tar-stream.js";
 import type { AdmittedTarMember } from "./archive-tar-wasm.js";
 import { runPinnedWriteHelper } from "./pinned-write.js";
-import { constants as fsConstants } from "node:fs";
+import fsSync, { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -241,7 +241,7 @@ async function extractZip(params: {
     await withStagedArchiveDestination({
       destinationRealDir,
       run: async (stagingDir) => {
-        const stagingRealDir = await fs.realpath(stagingDir);
+        const stagingRealDir = fsSync.realpathSync.native(stagingDir);
         const acceptedEntries: ArchivePublicationEntry[] = [];
         for (const entry of entries) {
           params.deadline.check();
@@ -371,7 +371,7 @@ async function extractWasmTar(params: {
   deadline.check();
   const destinationRealDir = await prepareArchiveDestinationDir(options.destDir);
   await withStagedArchiveDestination({ destinationRealDir, run: async (stagingPath) => {
-    const stagingDir = await fs.realpath(stagingPath);
+    const stagingDir = fsSync.realpathSync.native(stagingPath);
     const planEntry = createTarEntryPlanner({ ...options, rootDir: destinationRealDir, limits: params.limits });
     const accepted = manifest.flatMap((entry) => {
       deadline.check();

--- a/src/directory-mode-node.ts
+++ b/src/directory-mode-node.ts
@@ -1,4 +1,4 @@
-import { constants, type BigIntStats } from "node:fs";
+import fsSync, { constants, type BigIntStats } from "node:fs";
 import fs from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { inspectDirectoryIdentity } from "./directory-guard.js";
@@ -49,7 +49,7 @@ export async function pinNodeDirectoryForMode(
   });
   try {
     const inspect = async () => {
-      const opened = await inspectFileIdentity(() => handle.stat({ bigint: true }), expected);
+      const opened = await inspectFileIdentity(() => fsSync.fstatSync(handle.fd, { bigint: true }), expected);
       assertOwnedDirectory(expected, opened);
       assertOwner(opened);
       await inspectDirectoryIdentity(dirPath, expected);
@@ -63,8 +63,8 @@ export async function pinNodeDirectoryForMode(
       if (namespace.type !== 0x9fa0n) {
         throw new FsSafeError("path-mismatch", "directory mode requires a trusted procfs fd namespace");
       }
-      const opened = await inspectFileIdentity(() => handle.stat({ bigint: true }), expected);
-      const followed = await inspectFileIdentity(() => fs.stat(procPath, { bigint: true }), expected);
+      const opened = await inspectFileIdentity(() => fsSync.fstatSync(handle.fd, { bigint: true }), expected);
+      const followed = await inspectFileIdentity(() => fsSync.statSync(procPath, { bigint: true }), expected);
       assertOwnedDirectory(opened, followed);
       assertOwner(opened);
       assertOwner(followed);

--- a/src/file-hash.ts
+++ b/src/file-hash.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import fsSync from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
@@ -17,7 +18,7 @@ export async function hashFileHandle(
   handle: FileHandle,
   native: NativeBinding | undefined = getNativeBinding(),
 ): Promise<Sha256FileResult> {
-  const stat = await handle.stat();
+  const stat = fsSync.fstatSync(handle.fd);
   if (!stat.isFile()) {
     throw new FsSafeError("not-file", "SHA-256 input is not a regular file");
   }
@@ -40,7 +41,7 @@ export async function hashFileHandle(
 
 async function hashPath(filePath: string): Promise<Sha256FileResult> {
   const before = await inspectFileIdentity(async () => {
-    const stat = await fs.lstat(filePath, { bigint: true });
+    const stat = fsSync.lstatSync(filePath, { bigint: true });
     if (stat.isSymbolicLink()) {
       throw new FsSafeError("symlink", "SHA-256 path must not be a symbolic link");
     }
@@ -64,14 +65,14 @@ async function hashPath(filePath: string): Promise<Sha256FileResult> {
 
   try {
     const opened = await inspectFileIdentity(async () => {
-      const stat = await handle.stat({ bigint: true });
+      const stat = fsSync.fstatSync(handle.fd, { bigint: true });
       if (!stat.isFile()) {
         throw new FsSafeError("not-file", "SHA-256 path is not a regular file");
       }
       return stat;
     }, before);
     await inspectFileIdentity(async () => {
-      const stat = await fs.lstat(filePath, { bigint: true });
+      const stat = fsSync.lstatSync(filePath, { bigint: true });
       if (stat.isSymbolicLink() || !stat.isFile()) {
         throw new FsSafeError("path-mismatch", "SHA-256 path changed while opening");
       }

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import fsp from "node:fs/promises";
 
 /**
  * Returns true when `fs.stat()` can stat the path.
@@ -9,7 +8,7 @@ import fsp from "node:fs/promises";
  */
 export async function pathExists(filePath: string): Promise<boolean> {
   try {
-    await fsp.stat(filePath);
+    fs.statSync(filePath);
     return true;
   } catch {
     return false;

--- a/src/guarded-mutation.ts
+++ b/src/guarded-mutation.ts
@@ -80,7 +80,7 @@ export async function guardedRename(params: {
     [sourceGuard, targetGuard],
     async () => {
       if (params.onSourceInspected) {
-        params.onSourceInspected(await fs.lstat(params.from, { bigint: true }));
+        params.onSourceInspected(fsSync.lstatSync(params.from, { bigint: true }));
       }
       // Authority must survive all awaited guards; do not yield before rename dispatch.
       params.assertBeforeRename?.();

--- a/src/install-path.ts
+++ b/src/install-path.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import fs from "node:fs/promises";
+import fsSync from "node:fs";
 import path from "node:path";
 import { isPathInside } from "./path.js";
 
@@ -68,9 +68,9 @@ export async function assertCanonicalPathWithinBase(params: {
     throw new Error(`Invalid path: must stay within ${params.boundaryLabel}`);
   }
 
-  const baseLstat = await fs.lstat(baseDir);
+  const baseLstat = fsSync.lstatSync(baseDir);
   if (baseLstat.isSymbolicLink()) {
-    const baseStat = await fs.stat(baseDir);
+    const baseStat = fsSync.statSync(baseDir);
     if (!baseStat.isDirectory()) {
       throw new Error(
         `Invalid ${params.boundaryLabel}: base directory must resolve to a directory`,
@@ -79,23 +79,23 @@ export async function assertCanonicalPathWithinBase(params: {
   } else if (!baseLstat.isDirectory()) {
     throw new Error(`Invalid ${params.boundaryLabel}: base directory must be a directory`);
   }
-  const baseRealPath = await fs.realpath(baseDir);
+  const baseRealPath = fsSync.realpathSync.native(baseDir);
 
   const validateDirectory = async (dirPath: string): Promise<void> => {
     const resolvedDirPath = path.resolve(dirPath);
-    const dirLstat = await fs.lstat(dirPath);
+    const dirLstat = fsSync.lstatSync(dirPath);
     if (dirLstat.isSymbolicLink()) {
       if (resolvedDirPath !== baseDir) {
         throw new Error(`Invalid path: must stay within ${params.boundaryLabel}`);
       }
-      const dirStat = await fs.stat(dirPath);
+      const dirStat = fsSync.statSync(dirPath);
       if (!dirStat.isDirectory()) {
         throw new Error(`Invalid path: must stay within ${params.boundaryLabel}`);
       }
     } else if (!dirLstat.isDirectory()) {
       throw new Error(`Invalid path: must stay within ${params.boundaryLabel}`);
     }
-    const dirRealPath = await fs.realpath(dirPath);
+    const dirRealPath = fsSync.realpathSync.native(dirPath);
     if (!isPathInside(baseRealPath, dirRealPath)) {
       throw new Error(`Invalid path: must stay within ${params.boundaryLabel}`);
     }

--- a/src/json-durable-queue-directory.ts
+++ b/src/json-durable-queue-directory.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+import fsSync from "node:fs";
 import path from "node:path";
 import { syncDirectory } from "./directory-durability.js";
 import { isPathRelativeEscape } from "./path.js";
@@ -7,8 +7,8 @@ export async function syncQueueDirectoryCreation(
   dir: string,
   validationBase: string,
 ): Promise<void> {
-  const baseReal = await fs.realpath(validationBase);
-  const targetReal = await fs.realpath(dir);
+  const baseReal = fsSync.realpathSync.native(validationBase);
+  const targetReal = fsSync.realpathSync.native(dir);
   const relative = path.relative(baseReal, targetReal);
   if (isPathRelativeEscape(relative)) {
     throw new Error(`durable queue directory escapes validation base: ${dir}`);

--- a/src/json-durable-queue-ownership.ts
+++ b/src/json-durable-queue-ownership.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { withSidecarLock } from "./sidecar-lock.js";
-import type { BigIntStats } from "node:fs";
+import fsSync, { type BigIntStats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { syncDirectory } from "./directory-durability.js";
@@ -201,7 +201,7 @@ export function getErrorCode(error: unknown): string | null {
 
 async function lstatOrNull(filePath: string): Promise<BigIntStats | null> {
   try {
-    return await fs.lstat(filePath, { bigint: true });
+    return fsSync.lstatSync(filePath, { bigint: true });
   } catch (error) {
     if (getErrorCode(error) === "ENOENT") return null;
     throw error;
@@ -247,7 +247,7 @@ async function ensureRetirementRoot(jsonPath: string): Promise<string> {
   await fs.mkdir(rootPath, { mode: 0o700 }).catch((error) => {
     if (getErrorCode(error) !== "EEXIST") throw error;
   });
-  const root = await fs.lstat(rootPath, { bigint: true });
+  const root = fsSync.lstatSync(rootPath, { bigint: true });
   assertDirectory(root, "queue retirement root");
   await syncDirectory(parentPath);
   return rootPath;

--- a/src/json-durable-queue.ts
+++ b/src/json-durable-queue.ts
@@ -53,7 +53,7 @@ export async function unlinkBestEffort(filePath: string): Promise<void> {
 
 export async function jsonDurableQueueEntryExists(filePath: string): Promise<boolean> {
   try {
-    const stat = await fs.promises.lstat(filePath);
+    const stat = fs.lstatSync(filePath);
     return stat.isFile();
   } catch (error) {
     if (getErrorCode(error) === "ENOENT") {
@@ -69,7 +69,7 @@ async function unlinkStaleTmpBestEffort(
   maxAgeMs: number,
 ): Promise<void> {
   try {
-    const stat = await fs.promises.stat(filePath);
+    const stat = fs.statSync(filePath);
     if (stat.isFile() && now - stat.mtimeMs >= maxAgeMs) {
       await unlinkBestEffort(filePath);
     }
@@ -177,10 +177,11 @@ async function isDarwinSystemAlias(
   if (resolved !== "/tmp" && resolved !== "/var") {
     return false;
   }
-  return await fs.promises.realpath(resolved).then(
-    (realPath) => realPath === `/private${resolved}`,
-    () => false,
-  );
+  try {
+    return fs.realpathSync.native(resolved) === `/private${resolved}`;
+  } catch {
+    return false;
+  }
 }
 
 async function assertNoSymlinkDirectorySegments(
@@ -191,16 +192,16 @@ async function assertNoSymlinkDirectorySegments(
   let base = path.resolve(validationRoot.path);
   let target = path.resolve(dir);
   let current = base;
-  let baseStat = await fs.promises.lstat(base);
+  let baseStat = fs.lstatSync(base);
   if (baseStat.isSymbolicLink() && validationRoot.allowSymlinkBase) {
     const relative = path.relative(base, target);
     if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
       throw new Error(`durable queue path is not a directory: ${dir}`);
     }
-    base = await fs.promises.realpath(base);
+    base = fs.realpathSync.native(base);
     target = path.join(base, ...relative.split(path.sep).filter(Boolean));
     current = base;
-    baseStat = await fs.promises.lstat(base);
+    baseStat = fs.lstatSync(base);
   }
   if (baseStat.isSymbolicLink() || !baseStat.isDirectory()) {
     throw new Error(`durable queue path is not a directory: ${dir}`);
@@ -214,7 +215,7 @@ async function assertNoSymlinkDirectorySegments(
     current = path.join(current, segment);
     let stat: Awaited<ReturnType<typeof fs.promises.lstat>>;
     try {
-      stat = await fs.promises.lstat(current);
+      stat = fs.lstatSync(current);
     } catch (error) {
       if (allowMissing && (error as NodeJS.ErrnoException).code === "ENOENT") {
         return;
@@ -224,7 +225,7 @@ async function assertNoSymlinkDirectorySegments(
     if (stat.isSymbolicLink() || !stat.isDirectory()) {
       if (stat.isSymbolicLink() && validationRoot.allowSymlinkBase) {
         if (await isDarwinSystemAlias(current, stat)) {
-          current = await fs.promises.realpath(current);
+          current = fs.realpathSync.native(current);
           continue;
         }
       }
@@ -246,7 +247,7 @@ async function chmodQueueDirectory(dir: string): Promise<void> {
     let handle: FileHandle | undefined;
     try {
       handle = await fs.promises.open(dir, fs.constants.O_RDONLY | noFollow | directoryFlag);
-      const stat = await handle.stat();
+      const stat = fs.fstatSync(handle.fd);
       if (!stat.isDirectory()) {
         throw new Error(`durable queue path is not a directory: ${dir}`);
       }
@@ -264,7 +265,7 @@ async function chmodQueueDirectory(dir: string): Promise<void> {
       }
     }
   }
-  const stat = await fs.promises.lstat(dir);
+  const stat = fs.lstatSync(dir);
   if (stat.isSymbolicLink() || !stat.isDirectory()) {
     throw new Error(`durable queue path is not a directory: ${dir}`);
   }
@@ -290,7 +291,7 @@ export async function writeJsonDurableQueueEntry(params: {
 }
 
 async function inspectQueueEntry(
-  inspect: () => Promise<BigIntStats>,
+  inspect: () => BigIntStats,
   maxBytes: number,
   expected?: BigIntStats,
 ): Promise<BigIntStats> {
@@ -298,7 +299,7 @@ async function inspectQueueEntry(
   try {
     return await inspectFileIdentity(async () => {
       try {
-        const stat = await inspect();
+        const stat = inspect();
         if (stat.isSymbolicLink() || !stat.isFile()) {
           throw new Error("queue entry is not a regular file");
         }
@@ -321,12 +322,12 @@ async function readBoundedUtf8File(params: {
   filePath: string;
   maxBytes: number;
 }): Promise<string> {
-  const inspectPath = () => fs.promises.lstat(params.filePath, { bigint: true });
+  const inspectPath = () => fs.lstatSync(params.filePath, { bigint: true });
   const initialStat = await inspectQueueEntry(inspectPath, params.maxBytes);
   const handle = await fs.promises.open(params.filePath, resolveReadOpenFlags());
   try {
     const openedStat = await inspectQueueEntry(
-      () => handle.stat({ bigint: true }), params.maxBytes, initialStat,
+      () => fs.fstatSync(handle.fd, { bigint: true }), params.maxBytes, initialStat,
     );
     await inspectQueueEntry(inspectPath, params.maxBytes, openedStat);
     const chunks: Buffer[] = [];

--- a/src/move-path-cleanup.ts
+++ b/src/move-path-cleanup.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -76,7 +77,7 @@ export async function assertSourceStillMatches(
   sourcePath: string,
   identity: EntryIdentity,
 ): Promise<void> {
-  if (!sameIdentity(identity, entryIdentity(await fs.lstat(sourcePath)))) {
+  if (!sameIdentity(identity, entryIdentity(fsSync.lstatSync(sourcePath)))) {
     throw sourceChangedError(sourcePath);
   }
 }
@@ -163,7 +164,7 @@ async function observeOwnedAliasUnlink(
 
   let observed: Awaited<ReturnType<typeof fs.lstat>>;
   try {
-    observed = await fs.lstat(remainingPath);
+    observed = fsSync.lstatSync(remainingPath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       return poisonAliasGroup(group);
@@ -199,7 +200,7 @@ export async function cleanupCopiedEntry(
 
   let currentStat: Awaited<ReturnType<typeof fs.lstat>>;
   try {
-    currentStat = await fs.lstat(sourcePath);
+    currentStat = fsSync.lstatSync(sourcePath);
   } catch (error) {
     if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
       return aliasGroup ? poisonAliasGroup(aliasGroup) : "removed";

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
+import fsSync, { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -71,7 +71,7 @@ async function preflightSourceHardlinks(sourcePath: string): Promise<void> {
 
   while (pending.length > 0) {
     const current = pending.pop()!;
-    const stat = await fs.lstat(current);
+    const stat = fsSync.lstatSync(current);
     if (stat.isFile() && stat.nlink > 1) {
       throw hardlinkedSourceError(current);
     }
@@ -102,21 +102,19 @@ async function assertCopyDestinationOutsideSource(
   targetPath: string,
   expectedIdentity?: EntryIdentity,
 ): Promise<EntryIdentity> {
-  const sourceStat = await fs.lstat(sourcePath);
+  const sourceStat = fsSync.lstatSync(sourcePath);
   const sourceIdentity = entryIdentity(sourceStat);
   if (expectedIdentity && !sameIdentity(expectedIdentity, sourceIdentity)) {
     throw sourceChangedError(sourcePath);
   }
   const normalizedSource = path.resolve(sourcePath);
   const normalizedTarget = path.resolve(targetPath);
-  const [sourceParentReal, targetParentReal] = await Promise.all([
-    fs.realpath(path.dirname(normalizedSource)),
-    fs.realpath(path.dirname(normalizedTarget)),
-  ]);
+  const sourceParentReal = fsSync.realpathSync.native(path.dirname(normalizedSource));
+  const targetParentReal = fsSync.realpathSync.native(path.dirname(normalizedTarget));
   const sourceCandidate = path.join(sourceParentReal, path.basename(normalizedSource));
   const targetCandidate = path.join(targetParentReal, path.basename(normalizedTarget));
   const sourceBoundary = sourceStat.isDirectory()
-    ? await fs.realpath(sourcePath)
+    ? fsSync.realpathSync.native(sourcePath)
     : sourceCandidate;
   const unsafeTarget = sourceStat.isDirectory()
     ? isSameOrDescendant(sourceBoundary, targetCandidate)
@@ -177,7 +175,7 @@ async function copyRegularFilePinned(params: {
     throw error;
   }
   try {
-    const openedStat = await sourceHandle.stat();
+    const openedStat = fsSync.fstatSync(sourceHandle.fd);
     openedIdentity = entryIdentity(openedStat);
     if (params.rejectHardlinks && openedStat.nlink > 1) {
       throw hardlinkedSourceError(params.from);
@@ -216,7 +214,7 @@ async function copyRegularFilePinned(params: {
       }
       // Re-check the opened source before the staged tree can be committed. If
       // it changed while we copied, the caller should retry the move.
-      const finalSourceStat = await sourceHandle.stat();
+      const finalSourceStat = fsSync.fstatSync(sourceHandle.fd);
       if (params.rejectHardlinks && finalSourceStat.nlink > 1) {
         throw hardlinkedSourceError(params.from);
       }
@@ -247,7 +245,7 @@ async function copyEntryWithManifest(
   },
   expectedIdentity?: EntryIdentity,
 ): Promise<CopiedEntryManifest> {
-  const sourceStat = await fs.lstat(from);
+  const sourceStat = fsSync.lstatSync(from);
   const identity = entryIdentity(sourceStat);
   if (expectedIdentity && !sameIdentity(expectedIdentity, identity)) {
     throw sourceChangedError(from);
@@ -256,7 +254,7 @@ async function copyEntryWithManifest(
   if (sourceStat.isSymbolicLink()) {
     const target = await fs.readlink(from);
     const targetType =
-      process.platform === "win32" && (await fs.stat(from)).isDirectory() ? "junction" : undefined;
+      process.platform === "win32" && fsSync.statSync(from).isDirectory() ? "junction" : undefined;
     await fs.symlink(target, to, targetType);
     // readlink() is path-based; verify the symlink we copied is still the one
     // we inspected before letting the staged destination become visible.
@@ -395,7 +393,7 @@ export async function movePathWithCopyFallback(
       sourceIdentity,
     );
     const cleanupState = createCleanupCopiedEntryState(sourcePath, manifest);
-    unregisterStaged.setIdentity(await fs.lstat(staged, { bigint: true }));
+    unregisterStaged.setIdentity(fsSync.lstatSync(staged, { bigint: true }));
     await assertCopyDestinationOutsideSource(sourcePath, targetPath, manifest);
     await guardedRename({
       from: staged,
@@ -419,7 +417,7 @@ export async function movePathWithCopyFallback(
   } finally {
     if (!destinationPublished) {
       try {
-        const stagedIdentity = await fs.lstat(staged, { bigint: true });
+        const stagedIdentity = fsSync.lstatSync(staged, { bigint: true });
         if (!stagedIdentity.isSymbolicLink()) unregisterStaged.setIdentity(stagedIdentity);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === "ENOENT") {

--- a/src/opened-file-failure.ts
+++ b/src/opened-file-failure.ts
@@ -1,4 +1,4 @@
-import type { BigIntStats } from "node:fs";
+import fsSync, { type BigIntStats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
@@ -32,7 +32,7 @@ export async function recordPreOpenFileChange(
     ![0n, 1n].includes(before.nlink) || ![0n, 1n].includes(opened.nlink)) return;
   try {
     await inspectFileIdentity(async () => before);
-    const current = await inspectFileIdentity(() => handle.stat({ bigint: true }), opened);
+    const current = await inspectFileIdentity(() => fsSync.fstatSync(handle.fd, { bigint: true }), opened);
     if (current.isFile() && [0n, 1n].includes(current.nlink) &&
       (before.dev !== current.dev || before.ino !== current.ino)) {
       // A stale pathname sample is not proof that its former inode was unlinked.
@@ -52,7 +52,7 @@ export async function recordOpenedFileFailure(
   if ((!isFileObservationFailure(error, "resolution") && !isFileObservationFailure(error, "identity")) ||
     !identity.isFile() || identity.nlink > 1n) return;
   try {
-    const current = await inspectFileIdentity(() => handle.stat({ bigint: true }), identity);
+    const current = await inspectFileIdentity(() => fsSync.fstatSync(handle.fd, { bigint: true }), identity);
     if (current.isFile() && current.nlink === 0n) recordFileObservationFailure(error, `unlinked:${filePath}`);
   } catch {
     // A closed, changed, or unknown descriptor provides no retry evidence.

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+import fsSync from "node:fs";
 import type { PermissionCommandFailure } from "./permission-exec.js";
 import {
   formatIcaclsResetCommand,
@@ -66,7 +66,7 @@ export type SafeStatResult = {
 
 export async function safeStat(targetPath: string): Promise<SafeStatResult> {
   try {
-    const lst = await fs.lstat(targetPath);
+    const lst = fsSync.lstatSync(targetPath);
     return {
       ok: true,
       isSymlink: lst.isSymbolicLink(),
@@ -113,7 +113,7 @@ export async function inspectPathPermissions(
   let effectiveIsDir = st.isDir;
   if (st.isSymlink) {
     try {
-      const target = await fs.stat(targetPath);
+      const target = fsSync.statSync(targetPath);
       effectiveMode = typeof target.mode === "number" ? target.mode : st.mode;
       effectiveIsDir = target.isDirectory();
     } catch {

--- a/src/private-temp-workspace.ts
+++ b/src/private-temp-workspace.ts
@@ -136,7 +136,7 @@ function throwTempWorkspaceOpenFailure(failure: RootFileOpenFailure): never {
 
 async function ensurePrivateDirectory(dir: string, mode: number): Promise<void> {
   await fs.mkdir(dir, { recursive: true, mode });
-  const stat = await fs.stat(dir);
+  const stat = fsSync.statSync(dir);
   if (!stat.isDirectory()) {
     throw new Error(`Temp root must be a directory: ${dir}`);
   }
@@ -163,7 +163,12 @@ async function createTempWorkspace(
   const mode = options.mode ?? 0o600;
   const cleanupSafety = resolveTempWorkspaceCleanupSafety(options.cleanupSafety);
   const requestedRoot = path.resolve(options.rootDir);
-  const root = await fs.realpath(requestedRoot).catch(() => requestedRoot);
+  let root = requestedRoot;
+  try {
+    root = fsSync.realpathSync.native(requestedRoot);
+  } catch {
+    root = requestedRoot;
+  }
   await ensurePrivateDirectory(root, dirMode);
   const capability = new TempWorkspaceCleanupCapability(root, cleanupSafety);
   let dir: string;
@@ -173,7 +178,7 @@ async function createTempWorkspace(
   try {
     dir = await fs.mkdtemp(path.join(root, sanitizeTempPrefix(options.prefix)));
     await fs.chmod(dir, dirMode).catch(() => undefined);
-    stat = await fs.lstat(dir, { bigint: true });
+    stat = fsSync.lstatSync(dir, { bigint: true });
     if (stat.isSymbolicLink() || !stat.isDirectory()) {
       throw new Error(`Temp workspace must be a directory: ${dir}`);
     }

--- a/src/publish-file.ts
+++ b/src/publish-file.ts
@@ -85,8 +85,8 @@ async function openNativeParent(filePath: string): Promise<{
   const parentPath = path.dirname(filePath);
   const handle = await fs.open(parentPath, directoryOpenFlags());
   try {
-    const pathname = await fs.lstat(parentPath, { bigint: true });
-    const opened = await handle.stat({ bigint: true });
+    const pathname = fsSync.lstatSync(parentPath, { bigint: true });
+    const opened = fsSync.fstatSync(handle.fd, { bigint: true });
     if (pathname.isSymbolicLink() || !sameFileIdentity(pathname, opened)) {
       throw new FsSafeError("path-mismatch", "publication parent changed while opening");
     }
@@ -104,8 +104,8 @@ async function assertPinnedSourceCurrent(params: {
 }): Promise<void> {
   // Windows file indexes can exceed Number.MAX_SAFE_INTEGER, so publication
   // fences must compare bigint stats instead of rounded numeric identities.
-  const opened = await params.handle.stat({ bigint: true });
-  const current = await fs.lstat(params.sourcePath, { bigint: true });
+  const opened = fsSync.fstatSync(params.handle.fd, { bigint: true });
+  const current = fsSync.lstatSync(params.sourcePath, { bigint: true });
   if (
     !opened.isFile() ||
     current.isSymbolicLink() ||
@@ -170,9 +170,9 @@ async function copyPinnedSource(params: {
           params.targetPath,
           createdIdentity,
         );
-        const identity = await fs.lstat(params.targetPath, { bigint: true });
+        const identity = fsSync.lstatSync(params.targetPath, { bigint: true });
         target = await fs.open(params.targetPath, sourceOpenFlags());
-        const opened = await target.stat({ bigint: true });
+        const opened = fsSync.fstatSync(target.fd, { bigint: true });
         if (
           identity.isSymbolicLink() ||
           !identity.isFile() ||
@@ -200,11 +200,11 @@ async function copyPinnedSource(params: {
   }
 
   const target = await fs.open(params.targetPath, "wx+", 0o600);
-  const createdIdentity = await target.stat({ bigint: true });
+  const createdIdentity = fsSync.fstatSync(target.fd, { bigint: true });
   rememberCreatedTarget(params.failure, createdIdentity, "copy-verify");
   try {
     await target.chmod(0o600);
-    const exactIdentity = await target.stat({ bigint: true });
+    const exactIdentity = fsSync.fstatSync(target.fd, { bigint: true });
     await getFsSafeTestHooks()?.afterPublishTargetCreated?.(
       "exclusive-copy",
       params.targetPath,
@@ -250,7 +250,7 @@ async function removeCreatedTargetIfUnchanged(
     return "unknown";
   }
   try {
-    const current = await fs.lstat(targetPath, { bigint: true });
+    const current = fsSync.lstatSync(targetPath, { bigint: true });
     if (!current.isSymbolicLink() && sameFileIdentityForCleanup(current, identity)) {
       await fs.rm(targetPath);
       return "removed";
@@ -298,7 +298,7 @@ export async function publishFileExclusive(params: {
     throw new FsSafeError("path-mismatch", "publication parent receipt does not match target parent");
   }
 
-  const sourcePathStat = await fs.lstat(sourcePath);
+  const sourcePathStat = fsSync.lstatSync(sourcePath);
   if (sourcePathStat.isSymbolicLink() || !sourcePathStat.isFile()) {
     throw new FsSafeError("not-file", "publication source must be a regular file");
   }
@@ -315,9 +315,9 @@ export async function publishFileExclusive(params: {
     parent = await pinDirectory(params.parentReceipt ?? parentPath, {
       label: "publication parent",
     });
-    const sourceIdentity = await source.stat();
-    const sourceExactIdentity = await source.stat({ bigint: true });
-    const sourcePathExactIdentity = await fs.lstat(sourcePath, { bigint: true });
+    const sourceIdentity = fsSync.fstatSync(source.fd);
+    const sourceExactIdentity = fsSync.fstatSync(source.fd, { bigint: true });
+    const sourcePathExactIdentity = fsSync.lstatSync(sourcePath, { bigint: true });
     if (
       sourcePathExactIdentity.isSymbolicLink() ||
       !sourcePathExactIdentity.isFile() ||
@@ -360,7 +360,7 @@ export async function publishFileExclusive(params: {
         targetPath,
         sourceExactIdentity,
       );
-      const targetExactIdentity = await fs.lstat(targetPath, { bigint: true });
+      const targetExactIdentity = fsSync.lstatSync(targetPath, { bigint: true });
       if (
         targetExactIdentity.isSymbolicLink() ||
         !targetExactIdentity.isFile() ||
@@ -369,7 +369,7 @@ export async function publishFileExclusive(params: {
         throw new FsSafeError("path-mismatch", "no-replace publication target changed");
       }
       try {
-        await fs.lstat(sourcePath);
+        fsSync.lstatSync(sourcePath);
         throw new FsSafeError("path-mismatch", "no-replace publication source still exists");
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -377,7 +377,7 @@ export async function publishFileExclusive(params: {
         }
       }
       syncFileBestEffortSync(sourceNativeParent!.handle.fd);
-      const targetIdentity = await fs.lstat(targetPath);
+      const targetIdentity = fsSync.lstatSync(targetPath);
       return {
         method: "rename-noreplace",
         identity: targetIdentity,
@@ -407,7 +407,7 @@ export async function publishFileExclusive(params: {
         targetPath,
         sourceExactIdentity,
       );
-      const targetExactIdentity = await fs.lstat(targetPath, { bigint: true });
+      const targetExactIdentity = fsSync.lstatSync(targetPath, { bigint: true });
       if (
         targetExactIdentity.isSymbolicLink() ||
         !targetExactIdentity.isFile() ||
@@ -416,7 +416,7 @@ export async function publishFileExclusive(params: {
         throw new FsSafeError("path-mismatch", "hardlink publication target changed");
       }
       await assertPinnedSourceCurrent({ sourcePath, handle: source, identity: sourceExactIdentity });
-      const targetIdentity = await fs.lstat(targetPath);
+      const targetIdentity = fsSync.lstatSync(targetPath);
       return {
         method: "hardlink",
         identity: targetIdentity,
@@ -449,9 +449,9 @@ export async function publishFileExclusive(params: {
         failure,
       });
       target = copied.handle;
-      targetIdentity = await target.stat();
-      const targetPathStat = await fs.lstat(targetPath);
-      const targetPathExactStat = await fs.lstat(targetPath, { bigint: true });
+      targetIdentity = fsSync.fstatSync(target.fd);
+      const targetPathStat = fsSync.lstatSync(targetPath);
+      const targetPathExactStat = fsSync.lstatSync(targetPath, { bigint: true });
       const copiedBack = await hashFileHandle(target, native);
       const sourceAfter = await hashFileHandle(source, native);
       if (

--- a/src/replace-file-copy-fallback.ts
+++ b/src/replace-file-copy-fallback.ts
@@ -1,5 +1,5 @@
 import syncFs, { type BigIntStats, type Stats } from "node:fs";
-import type { FileHandle } from "node:fs/promises";
+import fs, { type FileHandle } from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
 import { readOwnedCopySource, readOwnedCopySourceSync } from "./replace-file-copy-source.js";
@@ -70,10 +70,13 @@ async function openPinnedDestination(
   dest: string,
   hardlinks?: ReplaceFileDestinationHardlinkPolicy,
 ): Promise<{ handle: FileHandle; stat: Stats } | null> {
-  const preview = await fsModule.lstat(dest).catch((error) => {
+  let preview: Stats | null;
+  try {
+    preview = fsModule === fs ? syncFs.lstatSync(dest) : await fsModule.lstat(dest);
+  } catch (error) {
     if (notFound(error)) return null;
     throw error;
-  });
+  }
   if (!preview) return null;
   if (preview.isSymbolicLink()) {
     throw new FsSafeError("symlink", `Refusing copy fallback through symlink destination: ${dest}`);
@@ -81,8 +84,8 @@ async function openPinnedDestination(
 
   const handle = await fsModule.open(dest, OPEN_READ_WRITE_FLAGS);
   try {
-    const opened = await handle.stat();
-    const current = await fsModule.lstat(dest);
+    const opened = fsModule === fs ? syncFs.fstatSync(handle.fd) : await handle.stat();
+    const current = fsModule === fs ? syncFs.lstatSync(dest) : await fsModule.lstat(dest);
     assertPinnedDestination(current, opened, dest, hardlinks);
     return { handle, stat: opened };
   } catch (error) {
@@ -124,16 +127,19 @@ export async function assertDestinationHardlinkPolicy(
   policy?: ReplaceFileDestinationHardlinkPolicy,
 ): Promise<void> {
   if (policy !== "reject") return;
-  const preview = await fsModule.lstat(dest).catch((error) => {
-    if (notFound(error)) return null;
+  let preview: Stats | null;
+  try {
+    preview = fsModule === fs ? syncFs.lstatSync(dest) : await fsModule.lstat(dest);
+  } catch (error) {
+    if (notFound(error)) return;
     throw error;
-  });
+  }
   if (!preview || preview.isSymbolicLink() || !preview.isFile()) return;
 
   const handle = await fsModule.open(dest, OPEN_READ_FLAGS);
   try {
-    const opened = await handle.stat();
-    const current = await fsModule.lstat(dest);
+    const opened = fsModule === fs ? syncFs.fstatSync(handle.fd) : await handle.stat();
+    const current = fsModule === fs ? syncFs.lstatSync(dest) : await fsModule.lstat(dest);
     if (current.isSymbolicLink() || !current.isFile() || !sameFileIdentity(current, opened)) {
       throw new FsSafeError("path-mismatch", `Atomic replace destination changed while opening: ${dest}`);
     }
@@ -249,12 +255,13 @@ function restoreFailure(
 }
 
 async function replacePinnedWithRestore(
+  fsModule: AsyncFallbackFs,
   handle: FileHandle,
   replacement: Buffer,
   maxRestoreBytes: number,
   replacementMode: number,
 ): Promise<void> {
-  const originalMode = (await handle.stat()).mode;
+  const originalMode = (fsModule === fs ? syncFs.fstatSync(handle.fd) : await handle.stat()).mode;
   const original = await readBounded(handle, maxRestoreBytes);
   try {
     await writeAll(handle, replacement);
@@ -331,6 +338,7 @@ export async function copyFallbackReplace(params: {
       if (pinned) {
         destHandle = pinned.handle;
         await replacePinnedWithRestore(
+          params.fsModule,
           destHandle,
           replacement,
           params.maxRestoreBytes!,
@@ -340,10 +348,13 @@ export async function copyFallbackReplace(params: {
     }
 
     if (!destHandle) {
-      const destStat = await params.fsModule.lstat(params.dest).catch((error) => {
-        if (notFound(error)) return null;
-        throw error;
-      });
+      let destStat: Stats | null = null;
+      try {
+        destStat = params.fsModule === fs
+          ? syncFs.lstatSync(params.dest) : await params.fsModule.lstat(params.dest);
+      } catch (error) {
+        if (!notFound(error)) throw error;
+      }
       if (destStat?.isSymbolicLink()) {
         throw new FsSafeError("symlink", `Refusing copy fallback through symlink destination: ${params.dest}`);
       }

--- a/src/replace-file-copy-source.ts
+++ b/src/replace-file-copy-source.ts
@@ -1,5 +1,5 @@
 import syncFs, { type BigIntStats } from "node:fs";
-import type { FileHandle } from "node:fs/promises";
+import fs, { type FileHandle } from "node:fs/promises";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
@@ -72,21 +72,25 @@ export async function readOwnedCopySource(params: {
   src: string;
   expectedIdentity?: BigIntStats;
 }): Promise<{ replacement: Buffer; mode: number }> {
-  assertSourcePreview(await params.fsModule.lstat(params.src), params.src);
+  assertSourcePreview(params.fsModule === fs
+    ? syncFs.lstatSync(params.src) : await params.fsModule.lstat(params.src), params.src);
   const handle = await openSource(params.fsModule, params.src);
   try {
     if (params.expectedIdentity) {
       const exact = await inspectFileIdentity(
-        () => handle.stat({ bigint: true }),
+        () => params.fsModule === fs
+          ? syncFs.fstatSync(handle.fd, { bigint: true }) : handle.stat({ bigint: true }),
         params.expectedIdentity,
       );
       await inspectFileIdentity(
-        () => params.fsModule.lstat(params.src, { bigint: true }),
+        () => params.fsModule === fs
+          ? syncFs.lstatSync(params.src, { bigint: true }) : params.fsModule.lstat(params.src, { bigint: true }),
         exact,
       );
     }
-    const opened = await handle.stat();
-    const current = await params.fsModule.lstat(params.src);
+    const opened = params.fsModule === fs ? syncFs.fstatSync(handle.fd) : await handle.stat();
+    const current = params.fsModule === fs
+      ? syncFs.lstatSync(params.src) : await params.fsModule.lstat(params.src);
     if (!opened.isFile() || current.isSymbolicLink() || !sameFileIdentity(opened, current)) {
       throw new FsSafeError("path-mismatch", `Copy fallback source changed while opening: ${params.src}`);
     }

--- a/src/replace-file.ts
+++ b/src/replace-file.ts
@@ -243,12 +243,16 @@ async function resolveMode(options: ReplaceFileAtomicOptions): Promise<number> {
   if (!options.preserveExistingMode) {
     return defaultMode;
   }
-  const stat = await (options.fileSystem?.promises ?? fs).stat(options.filePath).catch((error) => {
+  const fsModule = options.fileSystem?.promises ?? fs;
+  let stat: import("node:fs").Stats | null;
+  try {
+    stat = fsModule === fs ? syncFs.statSync(options.filePath) : await fsModule.stat(options.filePath);
+  } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
+      return defaultMode;
     }
     throw error;
-  });
+  }
   return stat ? stat.mode : defaultMode;
 }
 

--- a/src/secret-read-async.ts
+++ b/src/secret-read-async.ts
@@ -22,8 +22,8 @@ export async function readSecretFile(
   const { resolvedPath, maxBytes } = resolveSecretReadPolicy(filePath, label, options);
   async function inspectInput(symlinkMessage: string): Promise<fsSync.BigIntStats> {
     const stat = options.rejectSymlink
-      ? await fs.lstat(resolvedPath, { bigint: true })
-      : await fs.stat(resolvedPath, { bigint: true });
+      ? fsSync.lstatSync(resolvedPath, { bigint: true })
+      : fsSync.statSync(resolvedPath, { bigint: true });
     if (options.rejectSymlink && stat.isSymbolicLink()) {
       throw new FsSafeError("symlink", symlinkMessage);
     }
@@ -47,19 +47,19 @@ export async function readSecretFile(
   let handle: fs.FileHandle | undefined;
   let raw: string;
   try {
-    const realPath = await fs.realpath(resolvedPath);
+    const realPath = fsSync.realpathSync.native(resolvedPath);
     assertNoUnsafeDeviceReadPath(realPath);
     handle = await fs.open(realPath, resolveReadOpenFlags());
     const openedHandle = handle;
     const openedStat = await inspectFileIdentity(async () => {
-      const stat = await openedHandle.stat({ bigint: true });
+      const stat = fsSync.fstatSync(openedHandle.fd, { bigint: true });
       if (!stat.isFile() || (options.rejectHardlinks !== false && stat.nlink > 1n)) {
         throw new FsSafeError("path-mismatch", "security validation failed");
       }
       return stat;
     }, previewStat);
     await inspectFileIdentity(async () => {
-      const stat = await fs.lstat(realPath, { bigint: true });
+      const stat = fsSync.lstatSync(realPath, { bigint: true });
       if (!stat.isFile()) throw new FsSafeError("path-mismatch", "security validation failed");
       return stat;
     }, openedStat);

--- a/src/secure-file.ts
+++ b/src/secure-file.ts
@@ -1,4 +1,4 @@
-import type { Stats } from "node:fs";
+import fsSync, { type Stats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -82,11 +82,14 @@ async function openSecureHandle(options: SecureFileReadOptions, maxBytes: number
     throw new FsSafeError("invalid-path", `${label(options)} must be an absolute path.`);
   }
 
-  const preStat = await fs.lstat(options.filePath).catch((err: unknown) => {
+  let preStat: Stats;
+  try {
+    preStat = fsSync.lstatSync(options.filePath);
+  } catch (err) {
     throw new FsSafeError("not-found", `${label(options)} is not readable: ${options.filePath}`, {
       cause: err,
     });
-  });
+  }
   if (preStat.isSymbolicLink()) {
     if (!options.trust?.allowSymlink) {
       throw new FsSafeError("symlink", `${label(options)} must not be a symlink: ${options.filePath}`);
@@ -108,22 +111,22 @@ async function openSecureHandle(options: SecureFileReadOptions, maxBytes: number
   }
 
   try {
-    const openedStat = await handle.stat();
+    const openedStat = fsSync.fstatSync(handle.fd);
     if (!openedStat.isFile()) {
       throw new FsSafeError("not-file", `${label(options)} must be a file: ${options.filePath}`);
     }
-    const openedIdentity = await inspectFileIdentity(() => handle.stat({ bigint: true }));
+    const openedIdentity = await inspectFileIdentity(() => fsSync.fstatSync(handle.fd, { bigint: true }));
     await inspectFileIdentity(async () => {
       const pathStat = options.trust?.allowSymlink
-        ? await fs.stat(options.filePath, { bigint: true })
-        : await fs.lstat(options.filePath, { bigint: true });
+        ? fsSync.statSync(options.filePath, { bigint: true })
+        : fsSync.lstatSync(options.filePath, { bigint: true });
       if (!options.trust?.allowSymlink && pathStat.isSymbolicLink()) {
         throw new FsSafeError("symlink", `${label(options)} must not be a symlink: ${options.filePath}`);
       }
       return pathStat;
     }, openedIdentity);
-    const realPath = await fs.realpath(options.filePath);
-    await inspectFileIdentity(() => fs.stat(realPath, { bigint: true }), openedIdentity);
+    const realPath = fsSync.realpathSync.native(options.filePath);
+    await inspectFileIdentity(() => fsSync.statSync(realPath, { bigint: true }), openedIdentity);
     if (maxBytes !== undefined && openedStat.size > maxBytes) {
       throw new FsSafeError("too-large", `${label(options)} exceeded maxBytes (${maxBytes}).`);
     }
@@ -141,7 +144,11 @@ async function assertTrustedDirs(options: SecureFileReadOptions, realPath: strin
   const trusted = await Promise.all(
     options.trust.trustedDirs.map(async (dir) => {
       const resolved = path.resolve(dir);
-      return await fs.realpath(resolved).catch(() => resolved);
+      try {
+        return fsSync.realpathSync.native(resolved);
+      } catch {
+        return resolved;
+      }
     }),
   );
   if (!trusted.some((dir) => isPathInside(dir, realPath))) {

--- a/src/sibling-staged-file.ts
+++ b/src/sibling-staged-file.ts
@@ -22,9 +22,9 @@ function assertRegularFile(stat: BigIntStats): void {
   }
 }
 
-async function inspectStage(inspect: () => Promise<BigIntStats>, expected?: BigIntStats) {
+async function inspectStage(inspect: () => BigIntStats, expected?: BigIntStats) {
   return await inspectFileIdentity(async () => {
-    const stat = await inspect();
+    const stat = inspect();
     assertRegularFile(stat);
     return stat;
   }, expected);
@@ -46,10 +46,10 @@ export async function writeCallbackSibling<T>(params: {
 }): Promise<{ filePath: string; result: T }> {
   const parent = path.dirname(params.tempPath);
   const guard = await createAsyncDirectoryGuard(parent);
-  const parentIdentity = await inspectFileIdentity(() => fs.lstat(parent, { bigint: true }));
+  const parentIdentity = await inspectFileIdentity(() => fsSync.lstatSync(parent, { bigint: true }));
   const assertParent = async () => {
     await assertAsyncDirectoryGuard(guard);
-    await inspectFileIdentity(() => fs.lstat(parent, { bigint: true }), parentIdentity);
+    await inspectFileIdentity(() => fsSync.lstatSync(parent, { bigint: true }), parentIdentity);
   };
   let handle: FileHandle | undefined;
   let identity: BigIntStats | undefined;
@@ -57,10 +57,10 @@ export async function writeCallbackSibling<T>(params: {
   let renamed = false;
   let failure: { error: unknown } | undefined;
   const inspectPath = (pathname: string, expected?: BigIntStats) =>
-    inspectStage(() => fs.lstat(pathname, { bigint: true }), expected);
+    inspectStage(() => fsSync.lstatSync(pathname, { bigint: true }), expected);
   const assertCurrent = async (pathname: string) => {
     await assertParent();
-    const opened = await inspectStage(() => handle!.stat({ bigint: true }), identity);
+    const opened = await inspectStage(() => fsSync.fstatSync(handle!.fd, { bigint: true }), identity);
     const current = await inspectPath(pathname, opened);
     if (
       params.maxBytes !== undefined &&
@@ -84,7 +84,7 @@ export async function writeCallbackSibling<T>(params: {
       }
       throw error;
     }
-    const opened = await inspectStage(() => handle!.stat({ bigint: true }), before);
+    const opened = await inspectStage(() => fsSync.fstatSync(handle!.fd, { bigint: true }), before);
     await inspectPath(params.tempPath, opened);
     await assertParent();
     identity = opened;
@@ -128,7 +128,7 @@ export async function writeCallbackSibling<T>(params: {
       if (!renamed && identity) {
         try {
           await assertParent();
-          await inspectStage(() => handle!.stat({ bigint: true }), identity);
+          await inspectStage(() => fsSync.fstatSync(handle!.fd, { bigint: true }), identity);
           await inspectPath(params.tempPath, identity);
           await fs.unlink(params.tempPath);
           unregister?.();

--- a/src/sibling-temp.ts
+++ b/src/sibling-temp.ts
@@ -1,4 +1,5 @@
 import crypto, { randomUUID } from "node:crypto";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard } from "./directory-guard.js";
@@ -91,14 +92,17 @@ export async function writeViaSiblingTempPath(params: {
   fallbackFileName?: string;
   tempPrefix?: string;
 }): Promise<void> {
-  const rootDir = await fs
-    .realpath(path.resolve(params.rootDir))
-    .catch(() => path.resolve(params.rootDir));
+  let rootDir: string;
+  try { rootDir = fsSync.realpathSync.native(path.resolve(params.rootDir)); }
+  catch { rootDir = path.resolve(params.rootDir); }
   const requestedTargetPath = path.resolve(params.targetPath);
-  const targetPath = await fs
-    .realpath(path.dirname(requestedTargetPath))
-    .then((realDir) => path.join(realDir, path.basename(requestedTargetPath)))
-    .catch(() => requestedTargetPath);
+  let targetPath: string;
+  try {
+    const realDir = fsSync.realpathSync.native(path.dirname(requestedTargetPath));
+    targetPath = path.join(realDir, path.basename(requestedTargetPath));
+  } catch {
+    targetPath = requestedTargetPath;
+  }
   const relativeTargetPath = path.relative(rootDir, targetPath);
   if (
     !relativeTargetPath ||

--- a/src/sidecar-lock-acquire.ts
+++ b/src/sidecar-lock-acquire.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { canonicalPathFromExistingAncestor } from "./absolute-path.js";
@@ -31,7 +32,7 @@ import {
 import type { SidecarLockAcquireOptions, SidecarLockHandle } from "./sidecar-lock-types.js";
 import { createSuppressedError } from "./suppressed-error.js";
 
-type SidecarFileHandle = Pick<NativeFileHandle, "close" | "stat" | "writeFile">;
+type SidecarFileHandle = Pick<NativeFileHandle, "fd" | "close" | "stat" | "writeFile">;
 
 export type HeldSidecarLock = {
   refCount: number;
@@ -73,7 +74,7 @@ async function resolveNormalizedTargetPath(targetPath: string, lockRoot?: Root):
   }
   await fs.mkdir(dir, { recursive: true });
   try {
-    return path.join(await fs.realpath(dir), path.basename(resolved));
+    return path.join(fsSync.realpathSync.native(dir), path.basename(resolved));
   } catch {
     return resolved;
   }
@@ -216,7 +217,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
           }
           await handle.writeFile(raw, "utf8");
         }
-        const snapshot = { raw, payload, stat: await handle.stat(), ownershipToken };
+        const snapshot = { raw, payload, stat: fsSync.fstatSync(handle.fd), ownershipToken };
         if (snapshot.stat.nlink === 0) {
           await handle.close();
           handle = null;
@@ -268,7 +269,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
           if (handle) {
             const failedSnapshot: SidecarLockSnapshot = createdSnapshot ?? { payload: null };
             try {
-              failedSnapshot.stat = await handle.stat();
+              failedSnapshot.stat = fsSync.fstatSync(handle.fd);
             } catch {
               // Best-effort cleanup of a failed exclusive create.
             }

--- a/src/sidecar-lock-policy.ts
+++ b/src/sidecar-lock-policy.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+import fsSync from "node:fs";
 import type { SidecarLockRetryOptions } from "./sidecar-lock-types.js";
 
 function assertFiniteNonNegative(value: number, label: string): void {
@@ -77,7 +77,7 @@ export async function defaultSidecarLockShouldReclaim(params: {
   const createdAtMs = sidecarLockPayloadCreatedAtMs(params.payload);
   if (createdAtMs !== null) return params.nowMs - createdAtMs > params.staleMs;
   try {
-    return params.nowMs - (await fs.stat(params.lockPath)).mtimeMs > params.staleMs;
+    return params.nowMs - fsSync.statSync(params.lockPath).mtimeMs > params.staleMs;
   } catch {
     return true;
   }

--- a/src/sidecar-lock-reclaim.ts
+++ b/src/sidecar-lock-reclaim.ts
@@ -142,7 +142,9 @@ export async function readSidecarLockRawSnapshot(
         await opened.handle.close().catch(() => undefined);
       }
     }
-    const before = await fs.lstat(lockPath).catch(missingSnapshotPath);
+    let before: Stats | null;
+    try { before = fsSync.lstatSync(lockPath); }
+    catch (error) { before = missingSnapshotPath(error); }
     if (!before) return null;
     if (!before.isFile() || before.isSymbolicLink()) {
       if (options.rejectNonFile) {
@@ -172,7 +174,7 @@ export async function readSidecarLockRawSnapshot(
       options.onOpenFailure?.(error);
       throw error;
     }
-    const opened = await handle.stat();
+    const opened = fsSync.fstatSync(handle.fd);
     if (!opened.isFile()) {
       if (options.rejectNonFile) {
         throw new FsSafeError("not-file", `sidecar lock is not a regular file: ${lockPath}`);
@@ -181,7 +183,9 @@ export async function readSidecarLockRawSnapshot(
     }
     if (!options.allowDescriptorIdentityDrift && !sameFileIdentity(before, opened)) return null;
     const raw = (await readFileHandleBounded(handle, MAX_LOCK_PAYLOAD_BYTES)).toString("utf8");
-    const after = await fs.lstat(lockPath).catch(missingSnapshotPath);
+    let after: Stats | null;
+    try { after = fsSync.lstatSync(lockPath); }
+    catch (error) { after = missingSnapshotPath(error); }
     if (!after || !after.isFile() || !sameFileIdentity(before, after)) return null;
     return { raw, stat: after };
   } finally {
@@ -313,7 +317,7 @@ export async function sidecarLockSnapshotStillPresent(
 
 export async function sidecarReclaimGuardExists(pathname: string): Promise<boolean> {
   try {
-    await fs.lstat(pathname);
+    fsSync.lstatSync(pathname);
     return true;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {

--- a/src/temp-target.ts
+++ b/src/temp-target.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { sameFileIdentityForCleanup, type FileIdentityStat } from "./file-identity.js";
@@ -116,12 +117,15 @@ async function cleanupTempDir(
   onCleanupError?: (error: unknown) => void,
 ) {
   try {
-    const current = await fs.lstat(dir, { bigint: true }).catch((error: unknown) => {
+    let current: fsSync.BigIntStats | undefined;
+    try {
+      current = fsSync.lstatSync(dir, { bigint: true });
+    } catch (error) {
       if (isNodeErrorWithCode(error, "ENOENT")) {
-        return undefined;
+        return;
       }
       throw error;
-    });
+    }
     if (!current || !sameFileIdentityForCleanup(current, identity)) {
       return;
     }
@@ -148,7 +152,7 @@ export async function tempFile(params: {
   const dir = await fs.mkdtemp(path.join(rootDir, prefix));
   // Windows file indexes can exceed Number.MAX_SAFE_INTEGER. Cleanup receipts
   // must retain the exact identity or adjacent directories can compare equal.
-  const identity = await fs.lstat(dir, { bigint: true });
+  const identity = fsSync.lstatSync(dir, { bigint: true });
   const unregisterTempDir = registerTempPathForExit(dir, { recursive: true, identity });
   const file = (fileName?: string) =>
     path.join(dir, sanitizeTempFileName(fileName ?? params.fileName ?? "download.bin"));

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -126,7 +126,7 @@ async function resolveAsyncKind(fullPath: string, dirent: fsSync.Dirent, symlink
   if (symlinks === "skip") return null;
   if (symlinks === "include") return "symlink";
   try {
-    const stat = await fs.stat(fullPath);
+    const stat = fsSync.statSync(fullPath);
     if (stat.isDirectory()) return "directory";
     if (stat.isFile()) return "file";
   } catch {
@@ -216,7 +216,7 @@ export async function walkDirectory(
     if (options.maxDepth !== undefined && depth > options.maxDepth) return;
     let realDir: string;
     try {
-      realDir = await fs.realpath(dir);
+      realDir = fsSync.realpathSync.native(dir);
     } catch (error) {
       recordFailedDir(result, root, dir, depth, error);
       return;

--- a/src/write-open-flags.ts
+++ b/src/write-open-flags.ts
@@ -1,5 +1,4 @@
 import fsSync from "node:fs";
-import fs from "node:fs/promises";
 import { hasNodeErrorCode } from "./path.js";
 
 export function resolveNonblockingWriteFlag(
@@ -25,7 +24,7 @@ export async function isNonRegularWriteOpenError(
 ): Promise<boolean> {
   if (!isNonblockingWriteEnxio(error, flags)) return false;
   try {
-    return !(await fs.lstat(filePath)).isFile();
+    return !fsSync.lstatSync(filePath).isFile();
   } catch {
     return false;
   }

--- a/test/additional-boundary-bypass.test.ts
+++ b/test/additional-boundary-bypass.test.ts
@@ -92,7 +92,7 @@ describe("additional helper boundary bypass attempts", () => {
 
   it("captures exact directory identities for temp file cleanup", async () => {
     const layout = await makeTempLayout("fs-safe-temp-exact-identity", tempDirs);
-    const lstat = vi.spyOn(fsp, "lstat");
+    const lstat = vi.spyOn(fs, "lstatSync");
     const target = await tempFile({ rootDir: layout.root, prefix: "download" });
     expect(lstat).toHaveBeenCalledWith(target.dir, { bigint: true });
 

--- a/test/archive-adjacent-errors.test.ts
+++ b/test/archive-adjacent-errors.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -140,7 +141,7 @@ describe("archive input staging failures", () => {
     const root = await tempRoot("fs-safe-stage-race-");
     const archivePath = path.join(root, "archive");
     await fs.writeFile(archivePath, "archive");
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     const originalStat = await realLstat(archivePath, { bigint: true });
     const changedStat = new Proxy(originalStat, {
       get(target, property) {
@@ -154,9 +155,9 @@ describe("archive input staging failures", () => {
       },
     });
     let archiveLstats = 0;
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
       if (String(args[0]) === archivePath && ++archiveLstats === 2) return changedStat;
-      return await realLstat(...args);
+      return realLstat(...args);
     });
 
     await expect(stageArchiveFileForExtraction({

--- a/test/archive-fsync-budget.test.ts
+++ b/test/archive-fsync-budget.test.ts
@@ -10,6 +10,12 @@ import { observeArchiveFs } from "./helpers/archive-fs-counts.js";
 import { useRealTempDirs } from "./helpers/vitest.js";
 
 const { tempRoot } = useRealTempDirs();
+// macOS measurements for the 20-file/3-directory fixture; default then durable:false.
+// Include every fs/promises call and async FileHandle method, including own close.
+const budgets = {
+  auto: { tar: { async: [268, 196], total: [3131, 2500] }, zip: { async: [268, 196], total: [3140, 2510] } },
+  off: { tar: { async: [455, 383], total: [4148, 3517] }, zip: { async: [530, 458], total: [4702, 4072] } },
+} as const;
 afterEach(() => {
   vi.restoreAllMocks();
   configureFsSafeNative({ mode: "auto" });
@@ -39,9 +45,13 @@ for (const backend of ["auto", "off"] as const) {
         const directorySyncs = observed.syncs.filter((type) => type === "directory").length;
         if (process.platform === "win32" && durable !== false) expect(directorySyncs, diagnostic).toBeLessThanOrEqual(4);
         else expect(directorySyncs, diagnostic).toBe(durable === false ? 0 : 4);
-        // Baseline JS-visible fs calls for this 20-file/3-directory fixture, plus 20%.
-        const baseline = backend === "auto" ? (kind === "tar" ? 2535 : 2544) : kind === "tar" ? 4132 : 4348;
-        expect(observed.total() / 20, diagnostic).toBeLessThanOrEqual(Math.ceil(baseline * 1.2) / 20);
+        const budget = budgets[backend][kind];
+        const index = durable === false ? 1 : 0;
+        expect(observed.asyncTotal(), diagnostic).toBeLessThanOrEqual(Math.ceil(budget.async[index] * 1.1));
+        expect(observed.total(), diagnostic).toBeLessThanOrEqual(Math.ceil(budget.total[index] * 1.1));
+        for (const name of ["p.lstat", "p.stat", "p.realpath", "h.stat"]) {
+          expect(observed.counts[name] ?? 0, diagnostic).toBe(0);
+        }
         vi.restoreAllMocks();
         for (let f = 0; f < 20; f++) expect(await fs.readFile(path.join(destDir, `d${f % 3}/f${f}`), "utf8")).toBe("NEW");
       });

--- a/test/archive.test.ts
+++ b/test/archive.test.ts
@@ -27,40 +27,27 @@ beforeEach(() => {
 });
 
 
-async function createRebindableDirectoryAlias(params: {
-  aliasPath: string;
-  targetPath: string;
-}): Promise<void> {
-  await fs.rm(params.aliasPath, { recursive: true, force: true });
-  await fs.symlink(
-    params.targetPath,
-    params.aliasPath,
-    process.platform === "win32" ? "junction" : undefined,
-  );
-}
-
 async function withRealpathSymlinkRebindRace<T>(params: {
   shouldFlip: (realpathInput: string) => boolean;
   symlinkPath: string;
   symlinkTarget: string;
   run: () => Promise<T>;
 }): Promise<T> {
-  const realRealpath = fs.realpath.bind(fs);
+  const realRealpath = fsSync.realpathSync.native;
   let flipped = false;
   const realpathSpy = vi
-    .spyOn(fs, "realpath")
-    .mockImplementation(async (...args: Parameters<typeof fs.realpath>) => {
+    .spyOn(fsSync.realpathSync, "native")
+    .mockImplementation((...args: Parameters<typeof fsSync.realpathSync.native>) => {
       const filePath = String(args[0]);
       if (!flipped && params.shouldFlip(filePath)) {
         flipped = true;
-        const resolved = await realRealpath(...args);
-        await createRebindableDirectoryAlias({
-          aliasPath: params.symlinkPath,
-          targetPath: params.symlinkTarget,
-        });
+        const resolved = realRealpath(...args);
+        fsSync.rmSync(params.symlinkPath, { recursive: true, force: true });
+        fsSync.symlinkSync(params.symlinkTarget, params.symlinkPath,
+          process.platform === "win32" ? "junction" : undefined);
         return resolved;
       }
-      return await realRealpath(...args);
+      return realRealpath(...args);
     });
   try {
     return await params.run();
@@ -392,13 +379,13 @@ describe("archive extraction", () => {
     replacement.file("owned.txt", "owned");
     await fs.writeFile(replacementPath, await replacement.generateAsync({ type: "nodebuffer" }));
 
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     let swapped = false;
-    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const stat = await realLstat(...args);
+    const lstatSpy = vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const stat = realLstat(...args);
       if (!swapped && String(args[0]) === archivePath) {
         swapped = true;
-        await fs.rename(replacementPath, archivePath);
+        fsSync.renameSync(replacementPath, archivePath);
       }
       return stat;
     });

--- a/test/atomic-publication-stress.test.ts
+++ b/test/atomic-publication-stress.test.ts
@@ -1,5 +1,5 @@
 import fsSync from "node:fs";
-import fs, { type FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -174,9 +174,7 @@ describe("atomic publication stress regressions", () => {
 
   it("keeps a failed sibling output temp registered when immediate cleanup fails", async () => {
     const root = await tempRoot("fs-safe-output-cleanup-");
-    const probeHandle = await fs.open(path.join(root, "stat-probe"), "w");
-    const stat = vi.spyOn(Object.getPrototypeOf(probeHandle) as FileHandle, "stat");
-    await probeHandle.close();
+    const stat = vi.spyOn(fsSync, "fstatSync");
     let tempPath = "";
     let cleanupAttempts = 0;
     const realRename = fs.rename.bind(fs);
@@ -203,7 +201,7 @@ describe("atomic publication stress regressions", () => {
         await fs.writeFile(candidate, "partial");
       },
     })).rejects.toMatchObject({ code: "EACCES" });
-    expect(stat).toHaveBeenCalledWith({ bigint: true });
+    expect(stat).toHaveBeenCalledWith(expect.any(Number), { bigint: true });
     await expect(fs.stat(tempPath)).resolves.toBeTruthy();
 
     __cleanupRegisteredTempPathsForTest();

--- a/test/clawpatch-regression.test.ts
+++ b/test/clawpatch-regression.test.ts
@@ -89,15 +89,15 @@ describe("clawpatch regression coverage", () => {
     const outside = path.join(base, "outside");
     await fs.mkdir(dest);
     await fs.mkdir(outside);
-    const realRealpath = fs.realpath;
+    const realRealpath = fsSync.realpathSync.native;
     let swapped = false;
-    vi.spyOn(fs, "realpath").mockImplementation(async (target, options) => {
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementation((target, options) => {
       if (!swapped && target === dest) {
         swapped = true;
-        await fs.rename(dest, path.join(base, "dest-real"));
-        await fs.symlink(outside, dest, "dir");
+        fsSync.renameSync(dest, path.join(base, "dest-real"));
+        fsSync.symlinkSync(outside, dest, "dir");
       }
-      return await realRealpath(target, options as never);
+      return realRealpath(target, options as never);
     });
 
     await expect(prepareArchiveDestinationDir(dest)).rejects.toMatchObject({
@@ -112,19 +112,19 @@ describe("clawpatch regression coverage", () => {
     const original = path.join(base, "dest-original");
     await fs.mkdir(dest);
     await fs.mkdir(outside);
-    const realRealpath = fs.realpath;
+    const realRealpath = fsSync.realpathSync.native;
     let swapped = false;
-    vi.spyOn(fs, "realpath").mockImplementation(async (target, options) => {
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementation((target, options) => {
       if (!swapped && target === dest) {
         swapped = true;
-        await fs.rename(dest, original);
-        await fs.symlink(outside, dest, "dir");
-        const result = await realRealpath(target, options as never);
-        await fs.unlink(dest);
-        await fs.rename(original, dest);
+        fsSync.renameSync(dest, original);
+        fsSync.symlinkSync(outside, dest, "dir");
+        const result = realRealpath(target, options as never);
+        fsSync.unlinkSync(dest);
+        fsSync.renameSync(original, dest);
         return result;
       }
-      return await realRealpath(target, options as never);
+      return realRealpath(target, options as never);
     });
 
     await expect(prepareArchiveDestinationDir(dest)).rejects.toMatchObject({

--- a/test/directory-mode-proc.test.ts
+++ b/test/directory-mode-proc.test.ts
@@ -46,11 +46,11 @@ async function simulatedProcRoute() {
     return { type: 0x9fa0n } as Awaited<ReturnType<typeof fs.statfs>>;
   });
   const procPath = `/proc/self/fd/${fd}`;
-  const realStat = fs.stat.bind(fs);
-  vi.spyOn(fs, "stat").mockImplementation((async (candidate: fsSync.PathLike, options?: { bigint?: boolean }) => {
-    if (candidate === procPath) return await handle.stat({ bigint: true });
-    return await realStat(candidate, options as { bigint: true });
-  }) as typeof fs.stat);
+  const realStat = fsSync.statSync.bind(fsSync);
+  vi.spyOn(fsSync, "statSync").mockImplementation(((candidate: fsSync.PathLike, options?: { bigint?: boolean }) => {
+    if (candidate === procPath) return fsSync.fstatSync(handle.fd, { bigint: true });
+    return realStat(candidate, options as { bigint: true });
+  }) as typeof fsSync.statSync);
   const realChmod = fs.chmod.bind(fs);
   const dispatch = vi.spyOn(fs, "chmod").mockImplementation(async (candidate, mode) => {
     if (candidate === procPath) await handle.chmod(mode);
@@ -121,7 +121,7 @@ describe.skipIf(process.platform === "win32")("mocked Linux directory proc-fd au
   it("authenticates the exact followed fd identity before dispatch", async () => {
     const fixture = await simulatedProcRoute();
     const wrong = await fs.stat(fixture.dir, { bigint: true });
-    vi.mocked(fs.stat).mockResolvedValue(wrong);
+    vi.mocked(fsSync.statSync).mockReturnValue(wrong);
     try {
       await expect(fixture.owner.apply(0o755)).rejects.toMatchObject({ code: "path-mismatch" });
       expect(fixture.dispatch).not.toHaveBeenCalled();

--- a/test/file-hash.test.ts
+++ b/test/file-hash.test.ts
@@ -84,10 +84,12 @@ describe("sha256File", () => {
         await handle.read(Buffer.alloc(2), 0, 2, null);
         const close = vi.spyOn(handle, "close");
         const open = vi.spyOn(fs, "open");
-        const lstat = vi.spyOn(fs, "lstat");
+        const lstat = vi.spyOn(fsSync, "lstatSync");
         if (failureAt === "native") {
           const nativeHash = vi.fn(async () => { throw failure; });
           __setNativeLoaderForTest(() => ({ sha256File: nativeHash }) as unknown as NativeBinding);
+        } else if (failureAt === "stat") {
+          vi.spyOn(fsSync, "fstatSync").mockImplementationOnce(() => { throw failure; });
         } else {
           vi.spyOn(handle, failureAt).mockRejectedValueOnce(failure);
         }
@@ -194,7 +196,7 @@ describe("sha256File", () => {
     await fs.writeFile(filePath, "original");
     await fs.writeFile(unrelatedPath, "auxiliary");
     configureFsSafeNative({ mode: "off" });
-    const originalLstat = fs.lstat.bind(fs);
+    const originalLstat = fsSync.lstatSync.bind(fsSync);
     const originalOpen = fs.open.bind(fs);
     const identity = (stat: fsSync.Stats | fsSync.BigIntStats) => ({ dev: stat.dev, ino: stat.ino });
     const before = identity(await originalLstat(filePath, { bigint: true }));
@@ -222,8 +224,8 @@ describe("sha256File", () => {
       observations.push({ stage, bigint, raw, delivered: identity(stat) });
       return stat;
     }
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const stat = await originalLstat(...args);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const stat = originalLstat(...args);
       return args[0] === filePath
         ? observe(opened ? "current" : "preview", stat, args[1]?.bigint === true)
         : stat;
@@ -247,10 +249,9 @@ describe("sha256File", () => {
       opened = handle;
       close = vi.spyOn(handle, "close");
       read = vi.spyOn(handle, "read");
-      const stat = handle.stat.bind(handle);
-      vi.spyOn(handle, "stat").mockImplementation(async (options) =>
-        observe("descriptor", await stat(options), options?.bigint === true),
-      );
+      const stat = fsSync.fstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) =>
+        fd === handle.fd ? observe("descriptor", stat(fd, options), options?.bigint === true) : stat(fd, options));
       if (armed && timing === "after-open") await replace();
       return handle;
     });

--- a/test/helpers/archive-fs-counts.ts
+++ b/test/helpers/archive-fs-counts.ts
@@ -16,8 +16,8 @@ export async function observeArchiveFs(directory: string) {
   const record = (fd: number) => syncs.push(fstat(fd).isFile() ? "file" : "directory");
   const groups = [
     [fsSync, "s", ["fsyncSync", "fdatasyncSync", "copyFileSync", "openSync", "renameSync", "lstatSync", "statSync", "fstatSync"]],
-    [fs, "p", ["open", "rename", "copyFile", "mkdir", "readFile", "writeFile", "lstat", "stat", "realpath", "unlink", "rm", "readdir", "link"]],
-    [prototype, "h", ["sync", "datasync", "stat", "read", "write", "writeFile", "readFile", "chmod", "close"]],
+    [fs, "p", Object.keys(fs)],
+    [prototype, "h", ["appendFile", "chmod", "chown", "datasync", "read", "readFile", "readv", "stat", "sync", "truncate", "utimes", "write", "writeFile", "writev"]],
   ] as const;
   for (const [object, prefix, names] of groups) {
     for (const name of names) {
@@ -28,7 +28,19 @@ export async function observeArchiveFs(directory: string) {
         bump(`${prefix}.${name}`);
         if (["sync", "datasync"].includes(name)) record(this.fd);
         if (["fsyncSync", "fdatasyncSync"].includes(name)) record(args[0] as number);
-        return original.apply(this, args);
+        const result = original.apply(this, args);
+        if (prefix === "p" && name === "open") {
+          return (result as Promise<FileHandle>).then((handle) => {
+            // FileHandle.close is an own property, not a prototype method.
+            const close = handle.close.bind(handle);
+            vi.spyOn(handle, "close").mockImplementation(() => {
+              bump("h.close");
+              return close();
+            });
+            return handle;
+          });
+        }
+        return result;
       });
     }
   }
@@ -37,5 +49,11 @@ export async function observeArchiveFs(directory: string) {
     bump("s.realpathSync.native");
     return realpath(...args);
   });
-  return { counts, syncs, total: () => Object.values(counts).reduce((sum, count) => sum + count, 0) };
+  return {
+    counts, syncs,
+    total: () => Object.values(counts).reduce((sum, count) => sum + count, 0),
+    asyncTotal: () => Object.entries(counts)
+      .filter(([name]) => name.startsWith("p.") || name.startsWith("h."))
+      .reduce((sum, [, count]) => sum + count, 0),
+  };
 }

--- a/test/helpers/file-hash-identity.ts
+++ b/test/helpers/file-hash-identity.ts
@@ -60,9 +60,9 @@ export async function observeHashPath(
     return stat;
   }
 
-  const lstat = fs.lstat.bind(fs);
-  vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-    const stat = await lstat(...args);
+  const lstat = fsSync.lstatSync.bind(fsSync);
+  vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+    const stat = lstat(...args);
     if (args[0] !== filePath) return stat;
     return observe(handles.length === 0 ? "preview" : "current", stat, args[1]?.bigint === true);
   });
@@ -72,9 +72,10 @@ export async function observeHashPath(
     if (args[0] !== filePath) return handle;
     events.push("open");
     handles.push(handle);
-    const stat = handle.stat.bind(handle);
-    vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-      const result = await stat(options);
+    const stat = fsSync.fstatSync.bind(fsSync);
+    vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+      const result = stat(fd, options);
+      if (fd !== handle.fd) return result;
       if (!options?.bigint) {
         events.push("hash-stat");
         return result;

--- a/test/helpers/queue-read-identity.ts
+++ b/test/helpers/queue-read-identity.ts
@@ -1,4 +1,4 @@
-import { type BigIntStats, type Stats } from "node:fs";
+import fsSync, { type BigIntStats, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { vi } from "vitest";
@@ -44,9 +44,9 @@ export async function observeQueueRead(directory: string, samples: QueueSamples 
     return stat;
   }
 
-  const lstat = fs.lstat.bind(fs);
-  vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-    const stat = await lstat(...args);
+  const lstat = fsSync.lstatSync.bind(fsSync);
+  vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+    const stat = lstat(...args);
     if (args[0] !== filePath) return stat;
     return observe(handles.length === 0 ? "preview" : "current", stat, args[1]?.bigint === true);
   });
@@ -56,10 +56,9 @@ export async function observeQueueRead(directory: string, samples: QueueSamples 
     if (args[0] !== filePath) return handle;
     events.push("open");
     handles.push(handle);
-    const stat = handle.stat.bind(handle);
-    vi.spyOn(handle, "stat").mockImplementation(async (options) =>
-      observe("descriptor", await stat(options), options?.bigint === true),
-    );
+    const stat = fsSync.fstatSync.bind(fsSync);
+    vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) =>
+      fd === handle.fd ? observe("descriptor", stat(fd, options), options?.bigint === true) : stat(fd, options));
     const actualRead = handle.read.bind(handle);
     vi.spyOn(handle, "read").mockImplementation(async (...args) => {
       events.push("read");

--- a/test/json-durable-queue-batch-durability.test.ts
+++ b/test/json-durable-queue-batch-durability.test.ts
@@ -99,15 +99,15 @@ describe("batch queue transition failures", () => {
     const { paths, load } = await fixture();
     const failure = new FsSafeError("path-mismatch", "injected claim validation failure");
     const realLink = fs.link.bind(fs);
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     let linked = false;
     vi.spyOn(fs, "link").mockImplementation(async (source, target) => {
       await realLink(source, target);
       if (target === paths.processingPath) linked = true;
     });
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
       if (linked && args[0] === paths.processingPath) throw failure;
-      return await realLstat(...args);
+      return realLstat(...args);
     });
 
     await expect(load()).rejects.toBe(failure);
@@ -245,9 +245,9 @@ describe("batch entry skip boundary", () => {
   it("skips unverifiable initial pending identity while the single loader still rejects", async () => {
     const { paths, load } = await fixture();
     Object.defineProperty(process, "platform", { value: "win32" });
-    const realLstat = fs.lstat.bind(fs);
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const stat = await realLstat(...args);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const stat = realLstat(...args);
       if (args[0] === paths.jsonPath) Object.assign(stat, { ino: 0n });
       return stat;
     });
@@ -267,9 +267,10 @@ describe("batch entry skip boundary", () => {
     vi.spyOn(fs, "open").mockImplementation(async (...args) => {
       const handle = await realOpen(...args);
       if (args[0] === paths.processingPath) {
-        const realStat = handle.stat.bind(handle);
-        vi.spyOn(handle, "stat").mockImplementation(async (...statArgs) => {
-          const stat = await realStat(...statArgs);
+        const realStat = fsSync.fstatSync.bind(fsSync);
+        vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+          const stat = realStat(fd, options);
+          if (fd !== handle.fd) return stat;
           return Object.assign(stat, { ino: BigInt(stat.ino) + 1n });
         });
       }

--- a/test/json-durable-queue-failure.test.ts
+++ b/test/json-durable-queue-failure.test.ts
@@ -82,7 +82,7 @@ describe("durable JSON queue failure recovery", () => {
     const filePath = path.join(queueDir, "job.json");
     await fs.writeFile(filePath, "{}");
     const denied = Object.assign(new Error("inspection denied"), { code: "EACCES" });
-    vi.spyOn(fs, "lstat").mockRejectedValueOnce(denied);
+    vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => { throw denied; });
     await expect(jsonDurableQueueEntryExists(filePath)).rejects.toBe(denied);
 
     const readdirDenied = Object.assign(new Error("listing denied"), { code: "EACCES" });
@@ -213,7 +213,7 @@ describe("durable JSON queue failure recovery", () => {
     const tempPath = path.join(queueDir, "orphan.tmp");
     await fs.writeFile(tempPath, "tmp");
     const denied = Object.assign(new Error("temp inspection denied"), { code: "EACCES" });
-    vi.spyOn(fs, "stat").mockRejectedValueOnce(denied);
+    vi.spyOn(fsSync, "statSync").mockImplementationOnce(() => { throw denied; });
     await expect(loadPendingJsonDurableQueueEntries({
       queueDir,
       tempPrefix: "queue",

--- a/test/move-path-mutation-receipt.test.ts
+++ b/test/move-path-mutation-receipt.test.ts
@@ -79,9 +79,9 @@ describe("move publication receipts and mutation authority", () => {
   it("retains bigint identity bits from the admitted rename source", async () => {
     const move = await fixture(routes[0]);
     const identity = { dev: 9007199254740995n, ino: 9007199254740997n };
-    const lstat = fs.lstat;
-    vi.spyOn(fs, "lstat").mockImplementation(async (candidate, options) => {
-      const stat = await lstat(candidate, options as never);
+    const lstat = fsSync.lstatSync;
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((candidate, options) => {
+      const stat = lstat(candidate, options as never);
       if (candidate === move.source && options && typeof options === "object" && options.bigint) {
         return Object.assign(stat, identity);
       }
@@ -97,7 +97,7 @@ describe("move publication receipts and mutation authority", () => {
   });
 
   describe.each(routes.slice(1))("$name source cleanup", (route) => {
-    it.each(["publication", "awaited stat", "first unlink", "last unlink"] as const)(
+    it.each(["publication", "stat observation", "first unlink", "last unlink"] as const)(
       "preserves remaining source after revocation at %s", async (boundary) => {
         const move = await fixture(route);
         const expired = Object.assign(new Error("owner expired"), { code: "ENOTEMPTY" });
@@ -113,10 +113,10 @@ describe("move publication receipts and mutation authority", () => {
             active = false;
           }
         });
-        const lstat = fs.lstat;
-        vi.spyOn(fs, "lstat").mockImplementation(async (candidate, options) => {
-          const stat = await lstat(candidate, options as never);
-          if (boundary === "awaited stat" && published && path.dirname(String(candidate)) === move.source) {
+        const lstat = fsSync.lstatSync;
+        vi.spyOn(fsSync, "lstatSync").mockImplementation((candidate, options) => {
+          const stat = lstat(candidate, options as never);
+          if (boundary === "stat observation" && published && path.dirname(String(candidate)) === move.source) {
             active = false;
           }
           return stat;

--- a/test/move-path-regression.test.ts
+++ b/test/move-path-regression.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -106,12 +107,12 @@ describe("movePathWithCopyFallback regressions", () => {
     const dest = path.join(base, "dest.txt");
     const moveOptions: MovePathWithCopyFallbackOptions = { from: source, sourceHardlinks: "reject", to: dest };
     await fsp.writeFile(source, "source");
-    const realLstat = fsp.lstat;
+    const realLstat = fs.lstatSync;
     let sourceInspections = 0;
-    vi.spyOn(fsp, "lstat").mockImplementation(async (candidate, options) => {
-      const stat = await realLstat(candidate, options as never);
+    vi.spyOn(fs, "lstatSync").mockImplementation((candidate, options) => {
+      const stat = realLstat(candidate, options as never);
       if (candidate === source && ++sourceInspections === 1) {
-        await fsp.link(source, hardlink);
+        fs.linkSync(source, hardlink);
         if (changeOptions) moveOptions.sourceHardlinks = "allow";
       }
       return stat;
@@ -188,9 +189,7 @@ describe("movePathWithCopyFallback regressions", () => {
       }
     });
 
-    await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({
-      code: "ESTALE",
-    });
+    await expect(movePathWithCopyFallback({ from: source, to: dest })).rejects.toMatchObject({ code: "ESTALE" });
 
     await expect(fsp.readFile(path.join(dest, "copied.txt"), "utf8")).resolves.toBe("copied");
     await expect(fsp.readFile(path.join(source, "copied.txt"), "utf8")).resolves.toBe(
@@ -479,14 +478,14 @@ describe("movePathWithCopyFallback regressions", () => {
       }
       return await rename(from, to);
     });
-    const realLstat = fsp.lstat;
+    const realLstat = fs.lstatSync;
     let swapped = false;
-    vi.spyOn(fsp, "lstat").mockImplementation(async (candidate, options) => {
-      const stat = await realLstat(candidate, options as never);
+    vi.spyOn(fs, "lstatSync").mockImplementation((candidate, options) => {
+      const stat = realLstat(candidate, options as never);
       if (!swapped && candidate === source) {
         swapped = true;
-        await fsp.rm(source);
-        await fsp.symlink(outsideFile, source, "file");
+        fs.rmSync(source);
+        fs.symlinkSync(outsideFile, source, "file");
       }
       return stat;
     });

--- a/test/opened-file-change.test.ts
+++ b/test/opened-file-change.test.ts
@@ -1,17 +1,18 @@
-import type { BigIntStats } from "node:fs";
+import fsSync, { type BigIntStats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import { afterEach, expect, it, vi } from "vitest";
 import { fileObservation, recordFileObservationFailure } from "../src/file-observation.js";
 import { recordPreOpenFileChange } from "../src/opened-file-failure.js";
 
 const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
-afterEach(() => Object.defineProperty(process, "platform", platform));
+afterEach(() => { vi.restoreAllMocks(); Object.defineProperty(process, "platform", platform); });
 const stat = (ino: bigint) => ({ dev: 1n, ino, nlink: 1n, isFile: () => true }) as BigIntStats;
 
 it.each([0n, 1n])("records a distinct pre-open generation with current nlink %s, not an unlink receipt", async (nlink) => {
   const observation = fileObservation(), error = new Error("identity mismatch");
   const before = stat(1n), opened = stat(2n), current = { ...opened, nlink };
-  const handle = { stat: vi.fn(async () => current) } as unknown as FileHandle;
+  const handle = { fd: 123 } as FileHandle;
+  vi.spyOn(fsSync, "fstatSync").mockReturnValue(current);
   await observation.run(async () => {
     recordFileObservationFailure(error, "identity");
     await recordPreOpenFileChange(error, handle, "state.lock", before, opened);
@@ -36,10 +37,11 @@ it.each([
   }
   if (kind === "same") before.ino = opened.ino;
   if (kind === "current-drift") current.ino = 3n;
-  const handle = { stat: vi.fn(async () => {
+  const handle = { fd: 123 } as FileHandle;
+  vi.spyOn(fsSync, "fstatSync").mockImplementation(() => {
     if (kind === "closed" || kind === "EACCES") throw Object.assign(new Error("stat failed"), { code: kind === "closed" ? "EBADF" : kind });
     return current;
-  }) } as unknown as FileHandle;
+  });
   await observation.run(async () => {
     if (kind !== "unmarked") recordFileObservationFailure(error, "identity");
     await recordPreOpenFileChange(error, handle, "state.lock",
@@ -51,7 +53,8 @@ it.each([
 
 it("does not reuse a changed-file receipt in a later observation", async () => {
   const first = fileObservation(), next = fileObservation(), error = new Error("identity mismatch");
-  const handle = { stat: vi.fn(async () => stat(2n)) } as unknown as FileHandle;
+  const handle = { fd: 123 } as FileHandle;
+  vi.spyOn(fsSync, "fstatSync").mockReturnValue(stat(2n));
   await first.run(async () => {
     recordFileObservationFailure(error, "identity");
     await recordPreOpenFileChange(error, handle, "state.lock", stat(1n), stat(2n));

--- a/test/permission-secret-stress.test.ts
+++ b/test/permission-secret-stress.test.ts
@@ -82,10 +82,10 @@ describe("permission and secret stress matrix", () => {
       expect.objectContaining({ code: "too-large" }),
     );
 
-    const realpath = fs.realpath.bind(fs);
-    vi.spyOn(fs, "realpath").mockImplementationOnce(async (target, options) => {
-      await fs.appendFile(asyncPath, "def");
-      return await realpath(target, options as never);
+    const realpath = fsSync.realpathSync.native;
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementationOnce((target, options) => {
+      fsSync.appendFileSync(asyncPath, "def");
+      return realpath(target, options as never);
     });
     await expect(readSecretFile(asyncPath, "async token", { maxBytes: 3 })).rejects.toMatchObject({
       code: "too-large",

--- a/test/secret-directory-admission.test.ts
+++ b/test/secret-directory-admission.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -205,10 +206,11 @@ describe("secret directory admission", () => {
     vi.spyOn(fs, "open").mockImplementation(async (...args) => {
       const handle = await open(...args);
       if (String(args[0]) === parent) {
-        const stat = handle.stat.bind(handle);
+        const stat = fsSync.fstatSync.bind(fsSync);
         let inspections = 0;
-        vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-          const value = await stat(options);
+        vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+          const value = stat(fd, options);
+          if (fd !== handle.fd) return value;
           if (++inspections > 1) {
             changedOwner = true;
             Object.assign(value, { uid: typeof value.uid === "bigint" ? value.uid + 1n : value.uid + 1 });

--- a/test/secret-file-failure.test.ts
+++ b/test/secret-file-failure.test.ts
@@ -148,11 +148,11 @@ describe("secret file refusal paths", () => {
     });
     expectFsSafeErrorSync(() => readSecretFileSync(syncLink, "sync token"), "path-mismatch");
 
-    const realpath = fs.realpath.bind(fs);
-    vi.spyOn(fs, "realpath").mockImplementationOnce(async (candidate, options) => {
-      await fs.unlink(asyncLink);
-      await fs.symlink(replacementPath, asyncLink);
-      return await realpath(candidate, options as never);
+    const realpath = fsSync.realpathSync.native;
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementationOnce((candidate, options) => {
+      fsSync.unlinkSync(asyncLink);
+      fsSync.symlinkSync(replacementPath, asyncLink);
+      return realpath(candidate, options as never);
     });
     await expectFsSafeError(readSecretFile(asyncLink, "async token"), "path-mismatch");
   });

--- a/test/secret-read-identity.test.ts
+++ b/test/secret-read-identity.test.ts
@@ -21,31 +21,11 @@ describe.each(["sync", "async"] as const)("%s secret identity", (kind) => {
     const filePath = path.join(root, "token");
     await fs.writeFile(filePath, "secret");
     const inspections: string[] = [];
-    if (kind === "sync") {
-      for (const operation of ["statSync", "lstatSync", "fstatSync"] as const) {
-        const real = fsSync[operation].bind(fsSync);
-        vi.spyOn(fsSync, operation).mockImplementation((...args) => {
-          if (args[1]?.bigint) inspections.push(operation.replace("Sync", ""));
-          return real(...args as Parameters<typeof real>);
-        });
-      }
-    } else {
-      for (const operation of ["stat", "lstat"] as const) {
-        const real = fs[operation].bind(fs);
-        vi.spyOn(fs, operation).mockImplementation(async (...args) => {
-          if (args[1]?.bigint) inspections.push(operation);
-          return await real(...args);
-        });
-      }
-      const open = fs.open.bind(fs);
-      vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
-        const handle = await open(...args);
-        const stat = handle.stat.bind(handle);
-        vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-          if (options?.bigint) inspections.push("fstat");
-          return await stat(options);
-        });
-        return handle;
+    for (const operation of ["statSync", "lstatSync", "fstatSync"] as const) {
+      const real = fsSync[operation].bind(fsSync);
+      vi.spyOn(fsSync, operation).mockImplementation((...args) => {
+        if (args[1]?.bigint) inspections.push(operation.replace("Sync", ""));
+        return real(...args as Parameters<typeof real>);
       });
     }
     await expect(read(filePath, rejectSymlink)).resolves.toBe("secret");
@@ -107,11 +87,11 @@ describe.each(["sync", "async"] as const)("%s secret identity", (kind) => {
         return realpath(...args);
       });
     } else {
-      const realpath = fs.realpath.bind(fs);
-      vi.spyOn(fs, "realpath").mockImplementationOnce(async (...args) => {
-        await fs.rename(filePath, path.join(root, "original"));
-        await fs.writeFile(filePath, "replacement");
-        return await realpath(...args);
+      const realpath = fsSync.realpathSync.native;
+      vi.spyOn(fsSync.realpathSync, "native").mockImplementationOnce((...args) => {
+        fsSync.renameSync(filePath, path.join(root, "original"));
+        fsSync.writeFileSync(filePath, "replacement");
+        return realpath(...args);
       });
     }
     await expect(read(filePath)).rejects.toMatchObject({ code: "path-mismatch" });

--- a/test/secure-file-failure.test.ts
+++ b/test/secure-file-failure.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -71,12 +72,12 @@ describe("secure file inspection failures", () => {
     const root = await tempRoot("fs-safe-secure-permission-inspect-");
     const filePath = path.join(root, "secret");
     await fs.writeFile(filePath, "secret", { mode: 0o600 });
-    const realLstat = fs.lstat.bind(fs);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
     let calls = 0;
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
       calls += 1;
       if (calls === 3) throw Object.assign(new Error("permission inspection denied"), { code: "EACCES" });
-      return await realLstat(...args);
+      return realLstat(...args);
     });
     await expect(
       readSecureFile({ filePath, inject: { platform: "win32" } }),
@@ -110,7 +111,7 @@ describe("secure file inspection failures", () => {
     const realOpen = fs.open.bind(fs);
     vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
       const handle = await realOpen(...args);
-      vi.spyOn(handle, "stat").mockResolvedValueOnce(directoryStat);
+      vi.spyOn(fsSync, "fstatSync").mockReturnValueOnce(directoryStat);
       return handle;
     });
     await expect(readSecureFile({ filePath })).rejects.toMatchObject({ code: "not-file" });
@@ -122,9 +123,9 @@ describe("secure file inspection failures", () => {
     const otherPath = path.join(root, "other");
     await fs.writeFile(filePath, "secret", { mode: 0o600 });
     await fs.writeFile(otherPath, "other", { mode: 0o600 });
-    const realStat = fs.stat.bind(fs);
-    const changedIdentity = vi.spyOn(fs, "stat").mockImplementationOnce(async (...args) => {
-      return await realStat(otherPath, args[1]);
+    const realStat = fsSync.statSync.bind(fsSync);
+    const changedIdentity = vi.spyOn(fsSync, "statSync").mockImplementationOnce((...args) => {
+      return realStat(otherPath, args[1]);
     });
     await expect(readSecureFile({ filePath })).rejects.toMatchObject({ code: "path-mismatch" });
     expect(changedIdentity).toHaveBeenCalledTimes(1);
@@ -138,7 +139,7 @@ describe("secure file inspection failures", () => {
     vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
       const handle = await realOpen(...args);
       const actual = await handle.stat();
-      vi.spyOn(handle, "stat").mockResolvedValueOnce({
+      vi.spyOn(fsSync, "fstatSync").mockReturnValueOnce({
         ...actual,
         uid: (process.getuid?.() ?? actual.uid) + 1,
         isDirectory: () => false,

--- a/test/secure-file-identity.test.ts
+++ b/test/secure-file-identity.test.ts
@@ -1,4 +1,4 @@
-import { Stats } from "node:fs";
+import fsSync, { Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -48,11 +48,11 @@ describe("secure file exact identity", () => {
     const root = await tempRoot("fs-safe-secure-real-swap-");
     const filePath = path.join(root, "secret");
     await fs.writeFile(filePath, "original", { mode: 0o600 });
-    const realpath = fs.realpath.bind(fs);
-    vi.spyOn(fs, "realpath").mockImplementationOnce(async (...args) => {
-      await fs.rename(filePath, path.join(root, "original"));
-      await fs.writeFile(filePath, "replacement", { mode: 0o600 });
-      return await realpath(...args);
+    const realpath = fsSync.realpathSync.native;
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementationOnce((...args) => {
+      fsSync.renameSync(filePath, path.join(root, "original"));
+      fsSync.writeFileSync(filePath, "replacement", { mode: 0o600 });
+      return realpath(...args);
     });
     await expect(readSecureFile({ filePath, permissions: { allowInsecure: true } }))
       .rejects.toMatchObject({ code: "path-mismatch" });
@@ -80,9 +80,10 @@ describe("secure file exact identity", () => {
     await fs.writeFile(filePath, "secret", { mode: 0o600 });
     let numeric: Stats;
     onNextOpen((handle) => {
-      const stat = handle.stat.bind(handle);
-      vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-        const result = await stat(options);
+      const stat = fsSync.fstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+        const result = stat(fd, options);
+        if (fd !== handle.fd) return result;
         if (!options?.bigint) numeric = result as Stats;
         return result;
       });
@@ -103,23 +104,24 @@ describe("secure file exact identity", () => {
     await fs.writeFile(filePath, "secret", { mode: 0o600 });
     const ino = 9007199254740992n;
     onNextOpen((handle) => {
-      const stat = handle.stat.bind(handle);
-      vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-        const result = await stat(options);
+      const stat = fsSync.fstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+        const result = stat(fd, options);
+        if (fd !== handle.fd) return result;
         result.ino = options?.bigint ? ino : Number(ino);
         return result;
       });
     });
-    const lstat = fs.lstat.bind(fs);
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const result = await lstat(...args);
+    const lstat = fsSync.lstatSync.bind(fsSync);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const result = lstat(...args);
       const value = boundary === "path" ? ino + 1n : ino;
       result.ino = args[1]?.bigint ? value : Number(value);
       return result;
     });
-    const stat = fs.stat.bind(fs);
-    vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
-      const result = await stat(...args);
+    const stat = fsSync.statSync.bind(fsSync);
+    vi.spyOn(fsSync, "statSync").mockImplementation((...args) => {
+      const result = stat(...args);
       result.ino = args[1]?.bigint ? ino + 1n : Number(ino + 1n);
       return result;
     });
@@ -137,9 +139,10 @@ describe("secure file exact identity", () => {
     const open = onNextOpen((handle) => {
       close = vi.spyOn(handle, "close");
       read = vi.spyOn(handle, "readFile");
-      const stat = handle.stat.bind(handle);
-      vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-        const result = await stat(options);
+      const stat = fsSync.fstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+        const result = stat(fd, options);
+        if (fd !== handle.fd) return result;
         if (boundary === "descriptor" && options?.bigint) {
           inspections++;
           result.ino = 0n;
@@ -147,18 +150,18 @@ describe("secure file exact identity", () => {
         return result;
       });
     });
-    const lstat = fs.lstat.bind(fs);
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const result = await lstat(...args);
+    const lstat = fsSync.lstatSync.bind(fsSync);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const result = lstat(...args);
       if (boundary === "path" && args[1]?.bigint) {
         inspections++;
         result.ino = 0n;
       }
       return result;
     });
-    const stat = fs.stat.bind(fs);
-    vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
-      const result = await stat(...args);
+    const stat = fsSync.statSync.bind(fsSync);
+    vi.spyOn(fsSync, "statSync").mockImplementation((...args) => {
+      const result = stat(...args);
       if (boundary === "realpath" && args[1]?.bigint) {
         inspections++;
         result.ino = 0n;
@@ -180,10 +183,10 @@ describe("secure file exact identity", () => {
     const root = await tempRoot("fs-safe-secure-transient-");
     const filePath = path.join(root, "secret");
     await fs.writeFile(filePath, "secret", { mode: 0o600 });
-    const lstat = fs.lstat.bind(fs);
+    const lstat = fsSync.lstatSync.bind(fsSync);
     let inspections = 0;
-    vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-      const result = await lstat(...args);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const result = lstat(...args);
       if (args[1]?.bigint && ++inspections === 1) result.ino = 0n;
       return result;
     });

--- a/test/sibling-temp-durability.test.ts
+++ b/test/sibling-temp-durability.test.ts
@@ -268,7 +268,7 @@ it.each(["unchanged", "replaced", "hardlinked"] as const)("bounds cleanup retrie
 
 it("preserves a replacement appearing after cleanup starts", async () => {
   const f = await fixture();
-  const rename = fs.rename.bind(fs);
+  const rename = fsSync.renameSync.bind(fsSync);
   const open = fs.open.bind(fs);
   let cleanup = false;
   vi.spyOn(fs, "rename").mockImplementation(async () => {
@@ -278,15 +278,15 @@ it("preserves a replacement appearing after cleanup starts", async () => {
   vi.spyOn(fs, "open").mockImplementation(async (...args) => {
     const handle = await open(...args);
     if (args[0] === f.temp()) {
-      const stat = handle.stat.bind(handle);
-      vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-        if (cleanup) {
+      const stat = fsSync.fstatSync.bind(fsSync);
+      vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+        if (fd === handle.fd && cleanup) {
           cleanup = false;
-          await rename(f.temp(), path.join(f.dir, "moved"));
-          await fs.mkdir(f.temp());
-          await fs.writeFile(path.join(f.temp(), "sentinel"), "keep");
+          rename(f.temp(), path.join(f.dir, "moved"));
+          fsSync.mkdirSync(f.temp());
+          fsSync.writeFileSync(path.join(f.temp(), "sentinel"), "keep");
         }
-        return await stat(options);
+        return stat(fd, options);
       });
     }
     return handle;

--- a/test/sibling-temp-platform.test.ts
+++ b/test/sibling-temp-platform.test.ts
@@ -21,13 +21,13 @@ it.each(["known", "transient-unknown", "unknown", "rounded-replacement"] as cons
     let opened = false;
     let inspections = 0;
     const open = fs.open.bind(fs);
-    const lstat = fs.lstat.bind(fs);
+    const lstat = fsSync.lstatSync.bind(fsSync);
     const originalIno = 2n ** 53n;
     const replacementIno = originalIno + 1n;
     expect(Number(originalIno)).toBe(Number(replacementIno));
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    vi.spyOn(fs, "lstat").mockImplementation(async (candidate, options) => {
-      const stat = await lstat(candidate, options);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((candidate, options) => {
+      const stat = lstat(candidate, options);
       if ((candidate === temporary || candidate === final) && options?.bigint) {
         inspections++;
         const unknown = state === "unknown" || (state === "transient-unknown" && inspections === 1);
@@ -45,9 +45,10 @@ it.each(["known", "transient-unknown", "unknown", "rounded-replacement"] as cons
       if (candidate === temporary) {
         expect(flags).toBe(fsSync.constants.O_RDONLY);
         opened = true;
-        const stat = handle.stat.bind(handle);
-        vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-          return Object.assign(await stat(options), { dev: 1n, ino: originalIno });
+        const stat = fsSync.fstatSync.bind(fsSync);
+        vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+          const result = stat(fd, options);
+          return fd === handle.fd ? Object.assign(result, { dev: 1n, ino: originalIno }) : result;
         });
         if (state === "rounded-replacement") {
           await fs.rename(temporary, path.join(dir, "moved"));

--- a/test/sidecar-lock-acquire-failure.test.ts
+++ b/test/sidecar-lock-acquire-failure.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -164,7 +165,9 @@ describe("asynchronous sidecar lock acquisition failures", () => {
     configureFsSafeNative({ mode: "off" });
     const directory = await tempRoot("fs-safe-sidecar-realpath-failure-");
     const targetPath = path.join(directory, "state.json");
-    vi.spyOn(fs, "realpath").mockRejectedValueOnce(Object.assign(new Error("unavailable"), { code: "EIO" }));
+    vi.spyOn(fsSync.realpathSync, "native").mockImplementationOnce(() => {
+      throw Object.assign(new Error("unavailable"), { code: "EIO" });
+    });
     const manager = createSidecarLockManager(`realpath-failure-${Date.now()}-${Math.random()}`);
     const lock = await manager.acquire({ targetPath, payload: async () => ({ owner: "one" }) });
     expect(lock.normalizedTargetPath).toBe(path.resolve(targetPath));

--- a/test/sidecar-lock-helpers-failure.test.ts
+++ b/test/sidecar-lock-helpers-failure.test.ts
@@ -208,7 +208,7 @@ describe("sidecar lock helper failure handling", () => {
     expect(guards.has(guard)).toBe(false);
 
     const denied = Object.assign(new Error("guard denied"), { code: "EACCES" });
-    vi.spyOn(fs, "lstat").mockRejectedValueOnce(denied);
+    vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => { throw denied; });
     await expect(sidecarReclaimGuardExists(guard)).rejects.toBe(denied);
     vi.spyOn(fs, "mkdir").mockRejectedValueOnce(denied);
     await expect(tryAcquireSidecarReclaimGuard(guards, guard)).rejects.toBe(denied);
@@ -283,14 +283,14 @@ describe("sidecar lock helper failure handling", () => {
     const realOpen = fs.open.bind(fs);
     vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
       const handle = await realOpen(...args);
-      vi.spyOn(handle, "stat").mockResolvedValueOnce(directoryStat);
+      vi.spyOn(fsSync, "fstatSync").mockReturnValueOnce(directoryStat);
       return handle;
     });
     await expect(readSidecarLockSnapshot(lockPath)).resolves.toBeNull();
 
     vi.spyOn(fs, "open").mockImplementationOnce(async (...args) => {
       const handle = await realOpen(...args);
-      vi.spyOn(handle, "stat").mockResolvedValueOnce(directoryStat);
+      vi.spyOn(fsSync, "fstatSync").mockReturnValueOnce(directoryStat);
       return handle;
     });
     await expect(readSidecarLockSnapshot(lockPath, { rejectNonFile: true }))

--- a/test/sidecar-lock-ownership-token.test.ts
+++ b/test/sidecar-lock-ownership-token.test.ts
@@ -50,9 +50,9 @@ describe("sidecar lock ownership tokens", () => {
       staleMs: 1,
       payload: async () => ({ createdAt: new Date().toISOString(), owner: "caller" }),
     });
-    const realLstat = fsp.lstat.bind(fsp);
-    vi.spyOn(fsp, "lstat").mockImplementation(async (...args) => {
-      const stat = await realLstat(...args);
+    const realLstat = fsSync.lstatSync.bind(fsSync);
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const stat = realLstat(...args);
       if (String(args[0]) !== lockPath) {
         return stat;
       }

--- a/test/sidecar-lock-root-admission.test.ts
+++ b/test/sidecar-lock-root-admission.test.ts
@@ -1,7 +1,9 @@
+import fsSync from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import { createFileLockManager } from "../src/file-lock.js";
+import * as boundedRead from "../src/bounded-read.js";
 import { root } from "../src/root.js";
 import { readSidecarLockSnapshot } from "../src/sidecar-lock-reclaim.js";
 import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
@@ -319,12 +321,23 @@ posix("creator cleanup retains its token when a later stat fails over a replacem
   vi.spyOn(capability, "open").mockImplementationOnce(async (...args) => {
     const opened = await open(...args);
     descriptor = opened.handle;
-    const stat = opened.handle.stat.bind(opened.handle);
-    vi.spyOn(opened.handle, "stat").mockImplementationOnce(async () => {
-      await fs.rename(lockPath, `${lockPath}.displaced`);
-      await fs.writeFile(lockPath, '{"owner":"replacement"}');
+    const stat = fsSync.fstatSync.bind(fsSync);
+    const read = boundedRead.readFileHandleBounded;
+    let readFinished = false;
+    vi.spyOn(boundedRead, "readFileHandleBounded").mockImplementation(async (handle, maxBytes) => {
+      const result = await read(handle, maxBytes);
+      if (handle === opened.handle) readFinished = true;
+      return result;
+    });
+    let injected = false;
+    vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+      // Arm only after payload admission; bounded-read size hints also use fstatSync.
+      if (fd !== opened.handle.fd || !readFinished || injected) return stat(fd, options);
+      injected = true;
+      fsSync.renameSync(lockPath, `${lockPath}.displaced`);
+      fsSync.writeFileSync(lockPath, '{"owner":"replacement"}');
       throw failure;
-    }).mockImplementation(stat);
+    });
     return opened;
   });
   await expect(manager.acquire(target, { lockRoot: capability, payload: () => ({ owner: "creator" }) })).rejects.toBe(failure);

--- a/test/sidecar-lock-root-resolver.test.ts
+++ b/test/sidecar-lock-root-resolver.test.ts
@@ -87,9 +87,10 @@ it.each(["numeric", "unknown", "closed", "changed", "linked", "multiple-links"])
         if (control === "multiple-links") await fs.unlink(`${lockPath}.link`);
         if (control === "closed") await handle.close();
         if (["numeric", "unknown", "changed"].includes(control)) {
-          const stat = handle.stat.bind(handle);
-          vi.spyOn(handle, "stat").mockImplementation(async (options) => {
-            const value = await stat(options);
+          const stat = fsSync.fstatSync.bind(fsSync);
+          vi.spyOn(fsSync, "fstatSync").mockImplementation((fd, options) => {
+            const value = stat(fd, options);
+            if (fd !== handle.fd) return value;
             if (options?.bigint) Object.assign(value, {
               ino: control === "numeric" ? Number(value.ino) : control === "unknown" ? 0n : BigInt(value.ino) + 1n,
             });


### PR DESCRIPTION
Complete the synchronous-observation rule introduced in PR #238. Archive extraction, copy, publication, move, and directory-mode paths now use synchronous Node metadata observations, preserving native realpath spelling. This removes metadata work from the libuv queue while retaining asynchronous data and structural I/O.

Every existing containment, identity, hardlink, symlink, permission, ownership, deadline, and publication check remains in order. Error codes and application error messages are unchanged. Awaited production test hooks remain in place; no fsync, open, read, write, rename, mkdir, unlink, or close operation was converted or removed.

Scope and exceptions

The source-wide audit also covers sibling staging, temporary workspace cleanup, hashing, secret and secure reads, install paths, walking, lock acquisition/reclamation, queue ownership, and guarded move receipts. Custom filesystem adapters retain their asynchronous metadata contract; the real Node branch uses synchronous observations. Root capability stat calls retain their public async signatures and already use synchronous metadata internally. Linux procfs statfs authentication retains its existing awaited authority-lifetime checks. The default branch in replace-file-descriptor was already synchronous on the baseline and needed no edit.

CHANGELOG.md has one Unreleased entry, and docs/reading.md documents the expanded rule. No generated dist artifacts are committed.

20-file extraction budgets

The fixture contains 20 files in three directories. Counters include all fs/promises functions, async FileHandle methods, and FileHandle.close own properties. Both native auto and off run against the prepared native binding. The tests require zero async lstat, stat, realpath, and FileHandle.stat observations, and pin total async calls to the measured value plus 10 percent. Total filesystem calls are unchanged between baseline and this branch with the same instrumentation.

Backend / format / durability: async calls before to after; reduction
- auto / TAR / default: 619 to 268; 56.7 percent
- auto / TAR / false: 507 to 196; 61.3 percent
- auto / ZIP / default: 619 to 268; 56.7 percent
- auto / ZIP / false: 507 to 196; 61.3 percent
- off / TAR / default: 873 to 455; 47.9 percent
- off / TAR / false: 761 to 383; 49.7 percent
- off / ZIP / default: 1308 to 530; 59.5 percent
- off / ZIP / false: 1196 to 458; 61.7 percent

The 80 percent total-async-call reduction target was not reached. All targeted async metadata calls are gone; the remaining calls perform data or structural I/O. For default durable TAR, auto retains 73 opens, 93 close calls, 42 reads, 24 syncs, 23 mkdirs, and 13 other async calls. Off retains 94 opens, 114 close calls, 44 reads, 41 writes, 24 syncs, 66 mkdirs, 43 handle chmods, 20 renames, and nine other async calls.

Supplied 500-file benchmarks

Baseline: origin/main at 651df2e, built in a detached scratch worktree with the same dependencies, prepared WASM, and native artifact. Node 26.8.1, pnpm 11.25.0, macOS arm64. The supplied awaittime and arch harnesses were run in both native modes. The TAR fixture includes AppleDouble entries; the default durability pass still makes 1,023 sync calls. These are single paired runs, not statistical confidence estimates. The final branch measurements ran after the test and packaging jobs finished.

awaittime TAR wall time, milliseconds before to after:
- auto / default: 3109 to 2374; 23.6 percent faster
- auto / durable:false: 2517 to 1916; 23.9 percent faster
- off / default: 4050 to 2458; 39.3 percent faster
- off / durable:false: 3436 to 1953; 43.2 percent faster

arch warmed extraction, milliseconds per operation before to after:
- auto / TAR: 2733 to 1871; 31.5 percent faster
- auto / TGZ: 2776 to 1712; 38.3 percent faster
- auto / ZIP: 1586 to 921; 41.9 percent faster
- off / TAR: 3204 to 2308; 28.0 percent faster
- off / TGZ: 3063 to 2529; 17.4 percent faster
- off / ZIP: 1979 to 1416; 28.4 percent faster

The 30 percent wall-time target was met for the profiled off-mode default and durable:false runs and the warmed auto runs. It was missed for the profiled auto runs and warmed off runs. Remaining default-TAR costs include 53,136 native realpath observations in auto and 86,546 in off, taking 578 and 826 ms respectively; opens take 271 and 515 ms. The 1,023 sync calls accumulate 729 and 1462 ms of wait time respectively. Attribution overlaps during the bounded durability batches and must not be summed as exclusive wall time. No checks or durability calls were removed to chase the target.

Validation

- pnpm exec tsc --pretty false: passed.
- pnpm lint:file-size, pnpm lint:fs-boundary, pnpm docs:check, node scripts/check-pack.mjs, git diff --check: passed.
- pnpm test:security: 226 passed across five files.
- pnpm test --maxWorkers=1: 8449 passed, 87 skipped, three known local failures; 237 files passed, five skipped, two failed. All re-pointed tests and all eight archive budget cases passed.
- Two failures are in consumer-pnpm-lifecycle.test.ts because the local pnpm executable does not expose the required lifecycle JavaScript CLI.
- The third is the known private-store overlapping-read race in store-stress.test.ts, rejecting with path-mismatch. Its first isolated rerun also reported seven passed and that one failure. Baseline isolation passed all eight. No store-stress assertion or identity check was changed.
- pnpm check reached the known missing wasm32-unknown-unknown Rust target failure. The prepared WASM was restored and the remaining component proofs were run separately. An earlier file-size check caught the added import taking move-path-regression.test.ts one line over budget; formatting the existing assertion fixed it without changing its meaning.
- Independent Codex autoreview: scoped-clean through P2; no accepted or actionable findings.
- Final isolated store-stress rerun: all eight tests passed. The initial full-run and first-isolation failures remain reported above; no tests were weakened.

Security-suite coordinator exception

The only security-suite edit is test/additional-boundary-bypass.test.ts, "captures exact directory identities for temp file cleanup": change the spy from fsp.lstat to fs.lstatSync. Both toHaveBeenCalledWith(target.dir, { bigint: true }) assertions and the intervening mockClear are byte-for-byte unchanged. The initial security run stopped on that mechanism-spy failure; the coordinator explicitly authorized this one-line change, after which all 226 security tests passed. No other security-suite test needed an exception.

Re-pointed tests and shared fixtures

All scenarios and parameterized cases are retained. Synthetic filesystem swaps inside synchronous spies use synchronous fixture operations at the same observation point.

- test/archive-adjacent-errors.test.ts: archive identity changes after open.
- test/archive.test.ts: archive input pinning before extraction, and the realpath rebind fixture used by the out-of-destination clobber regression.
- test/atomic-publication-stress.test.ts: failed sibling output remains registered when immediate cleanup fails; the fstat assertion additionally identifies the descriptor argument.
- test/clawpatch-regression.test.ts: destination swapped before realpath settles, and destination swapped only during realpath.
- test/directory-mode-proc.test.ts: the shared simulated proc-fd stat route and exact followed-fd identity rejection. Existing timeout and descriptor-lifetime barriers remain on statfs/chmod.
- test/file-hash.test.ts: caller-owned handle remains open with its offset unchanged on failure; real retained replacements before and after open, including high-bigint identities.
- test/helpers/file-hash-identity.ts: the complete file-hash-identity.test.ts preview, descriptor, current-path, retry, failure, and native-dispatch matrices.
- test/helpers/queue-read-identity.ts: the complete json-durable-queue-identity.test.ts preview, descriptor, current-path, retry, symlink, and size-admission matrices.
- test/json-durable-queue-batch-durability.test.ts: post-link path-mismatch propagation; unverifiable initial pending identity; post-claim read-identity failure preserves owned state.
- test/json-durable-queue-failure.test.ts: inspection errors are not missing files; stale-temp inspection errors propagate.
- test/move-path-mutation-receipt.test.ts: exact bigint rename-source receipt; source cleanup stops after authority revocation during the metadata observation. The scenario label now says stat observation.
- test/move-path-regression.test.ts: late hardlink with and without caller-option mutation; source swapped after validation cannot commit bytes.
- test/opened-file-change.test.ts: distinct pre-open generation receipts; all non-authorizing evidence cases; receipts do not carry into a later observation.
- test/permission-secret-stress.test.ts: concurrent size increase remains too-large in both readers.
- test/secret-directory-admission.test.ts: both writers reject changed descriptor ownership before initialization.
- test/secret-file-failure.test.ts: secret path retargeted after preview in sync and async readers.
- test/secret-read-identity.test.ts: ordered preview/descriptor/target/input observations for both symlink policies; replacement between preview and realpath resolution.
- test/secure-file-failure.test.ts: permission inspection failure; non-file descriptor; mismatched realpath identity; unexpected descriptor uid.
- test/secure-file-identity.test.ts: realpath replacement; numeric public Stats receipt; rounded identity collisions; persistent unknown identity; Windows transient-identity retry.
- test/sibling-temp-durability.test.ts: replacement appears after cleanup starts.
- test/sibling-temp-platform.test.ts: known, transient-unknown, unknown, and rounded-replacement Windows identity cases.
- test/sidecar-lock-acquire-failure.test.ts: resolved-target fallback after parent realpath failure.
- test/sidecar-lock-helpers-failure.test.ts: reclaim-guard inspection failures; non-file opened snapshot with both rejection policies.
- test/sidecar-lock-ownership-token.test.ts: release when descriptor/pathname identity drifts.
- test/sidecar-lock-root-admission.test.ts: creator cleanup retains its token when a later stat fails over a replacement. The injection is armed after payload admission so bounded-read size hints do not consume the fault; all original assertions remain.
- test/sidecar-lock-root-resolver.test.ts: Windows resolver failures with numeric, unknown, and changed descriptor evidence.
- test/archive-fsync-budget.test.ts and test/helpers/archive-fs-counts.ts: the existing TAR/ZIP, auto/off, default/false matrix now pins async and total calls and rejects async metadata observations.

The read-admission helper already intercepted both synchronous and asynchronous observations from PR #238; its read and archive-input identity matrices pass without changing the helper or dropping any cases.
