### PR TITLE
perf(archive): extract without per-file fsync by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
+- **Compatibility:** `extractArchive` no longer fsyncs extracted files and directories by default to avoid per-entry sync costs during bulk imports; pass `durable: true` to restore the previous behavior.
 - Extend synchronous metadata observations to archive extraction, copy, publication, move, and directory-mode paths, while data and structural I/O remain asynchronous and native canonical path spelling is preserved; update the Windows hash-identity proof to observe the synchronous checks.
 - Publish read-only modes (for example `0o400`) through the Windows JavaScript write fallback by keeping the placeholder and temporary file private at `0o600`, then applying the final mode through the retained handle after rename and before post-write verification.
 - Add `Root.copyIn({ durable: false })`, with per-call, root-default, then `true` precedence, to skip file and parent-directory fsync for reconstructible data.
-- Add `extractArchive({ durable: false })` to skip durability syncs for temporary or reconstructible extraction destinations.
-- Speed up archive extraction by omitting private staging syncs, deferring publication durability to one bounded file/directory pass, and sharing duplicate destination guards without weakening containment checks.
+- Add `extractArchive({ durable: true })` to opt into durability syncs; temporary or reconstructible extraction destinations skip them by default.
+- Speed up archive extraction by omitting private staging syncs, deferring opted-in publication durability to one bounded file/directory pass, and sharing duplicate destination guards without weakening containment checks.
 - Add store-level and per-call `durable` options to FileStore writes, streams, copies, and synchronous writes, plus JSON-store durability defaults, so reconstructible data can skip file and parent fsync while preserving guarded atomic publication.
 - Preserve Windows file identity across open-induced `ctime` changes during guarded move fallback, and recreate directory junctions without requiring symlink privileges.
 

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -43,7 +43,7 @@ type ExtractArchiveOptions = {
   archivePath: string;          // absolute path to the archive
   destDir: string;              // absolute destination directory; must already exist
   timeoutMs: number;            // positive wall-clock budget; <= 0/non-finite disables it
-  durable?: boolean;            // true; sync published files and directories before completion
+  durable?: boolean;            // false; opt into syncing published files and directories before completion
   kind?: ArchiveKind;           // "zip" | "tar" | "tar-zstd" | "tar-bzip2"
   stripComponents?: number;     // strip N leading dirs from entry paths
   tarGzip?: boolean;            // when archive is .tar.gz/.tgz
@@ -56,8 +56,8 @@ type ExtractArchiveOptions = {
 };
 ```
 
-`durable` defaults to `true`. Private staging never fsyncs, and publication copies
-defer durability until the complete merge succeeds. The final pass syncs each
+`durable` defaults to `false`. Private staging never fsyncs, and publication copies
+defer opted-in durability until the complete merge succeeds. With `durable: true`, the final pass syncs each
 published file once (at most eight concurrently), then each published directory
 once, deepest first, and finally the destination directory. All work stays inside
 the extraction deadline; active syncs are joined before rejection. File sync
@@ -71,11 +71,20 @@ Existing inaccessible directories are never widened; an existing search-only
 directory must become readable in its final mode if no readable sync descriptor
 can be acquired before chmod.
 
-Use `durable: false` for extractions into temporary or reconstructible locations.
+The default suits extractions into temporary or reconstructible locations.
 It skips all file and directory syncs while preserving atomic file publication,
-mode enforcement, identity checks, and containment checks. Successful default
+mode enforcement, identity checks, and containment checks. Successful `durable: true`
 extraction syncs file contents and directory entries before returning; failures
 can leave a partially published tree as described below.
+
+For a crash-safe install workflow, extract with the default into a scratch
+directory, then apply the caller's durability policy: sync the staged files and
+directories before publishing with [`replaceDirectoryAtomic`](atomic.md#replacedirectoryatomic),
+and sync the affected parent directories afterward. The directory swap alone
+does not sync the staged tree. Alternatively, pass `durable: true` when extracted
+files must be on stable storage before the extraction call returns, subject to
+the platform's flushing guarantees. A plain fsync on macOS does not flush the
+drive cache.
 
 `entryModes` defaults to `"clamp"`: directories become `0o755`; files become
 `0o644`, or `0o755` when the archived owner-execute bit is set. `"preserve"`

--- a/src/archive-merge.ts
+++ b/src/archive-merge.ts
@@ -30,7 +30,7 @@ type MergeParams = {
 export async function mergePlannedArchiveIntoDestination(
   params: MergeParams & { entries: readonly ArchivePublicationEntry[]; durable?: boolean },
 ): Promise<void> {
-  await mergeTree(params, params.entries, params.durable !== false);
+  await mergeTree(params, params.entries, params.durable === true);
 }
 
 export async function mergeExtractedTreeIntoDestination(params: MergeParams): Promise<void> {

--- a/src/archive-options.ts
+++ b/src/archive-options.ts
@@ -15,6 +15,7 @@ export type ExtractArchiveOptions = {
   archivePath: string;
   destDir: string;
   timeoutMs: number;
+  /** Sync published files and directories before returning. Defaults to false. */
   durable?: boolean;
   kind?: ArchiveKind;
   stripComponents?: number;

--- a/test/archive-durability-pass.test.ts
+++ b/test/archive-durability-pass.test.ts
@@ -38,7 +38,7 @@ it.each(["file", "directory"])("propagates %s sync failure", async (kind) => {
     }
     await sync.call(this);
   });
-  await expect(extractArchive(options)).rejects.toMatchObject({ code: "invalid-path", cause: { code: "EIO" } });
+  await expect(extractArchive({ ...options, durable: true })).rejects.toMatchObject({ code: "invalid-path", cause: { code: "EIO" } });
   expect(failed).toBe(true);
 });
 
@@ -59,7 +59,7 @@ it("bounds file syncs at eight and joins them on timeout before rejecting", asyn
     await release.promise;
     try { await sync.call(this); } finally { active--; }
   });
-  const extraction = extractArchive({ ...options, timeoutMs: 1000 });
+  const extraction = extractArchive({ ...options, durable: true, timeoutMs: 1000 });
   void extraction.then(() => { settled = true; }, () => { settled = true; });
   try {
     await entered.promise;
@@ -72,7 +72,7 @@ it("bounds file syncs at eight and joins them on timeout before rejecting", asyn
   expect(started).toBe(8);
 }, 10000);
 
-it.each([true, false])("keeps restrictive file and directory modes with durable %s", async (durable) => {
+it.each([undefined, false, true])("keeps restrictive file and directory modes with durable %s", async (durable) => {
   const { options } = await fixture();
   await fs.writeFile(options.archivePath, await modeArchive("tar", [
     { path: "closed/", directory: true, mode: 0 },

--- a/test/archive-fsync-budget.test.ts
+++ b/test/archive-fsync-budget.test.ts
@@ -10,7 +10,7 @@ import { observeArchiveFs } from "./helpers/archive-fs-counts.js";
 import { useRealTempDirs } from "./helpers/vitest.js";
 
 const { tempRoot } = useRealTempDirs();
-// macOS measurements for the 20-file/3-directory fixture; default then durable:false.
+// macOS measurements for the 20-file/3-directory fixture; durable:true then false/default.
 // Include every fs/promises call and async FileHandle method, including own close.
 const budgets = {
   auto: { tar: { async: [268, 196], total: [3131, 2500] }, zip: { async: [268, 196], total: [3140, 2510] } },
@@ -25,7 +25,7 @@ afterEach(() => {
 for (const backend of ["auto", "off"] as const) {
   describe.skipIf(backend === "auto" && !paxNative)(`archive sync budget: native ${backend}`, () => {
     for (const kind of ["tar", "zip"] as const) {
-      it.each([undefined, false])(`${kind}: durable %s`, async (durable) => {
+      it.each([undefined, false, true])(`${kind}: durable %s`, async (durable) => {
         if (paxNative) __setNativeLoaderForTest(() => paxNative);
         configureFsSafeNative({ mode: backend });
         const base = await tempRoot("fs-safe-fsync-budget-");
@@ -41,12 +41,12 @@ for (const backend of ["auto", "off"] as const) {
         // Native archive extraction has no Rust fsync; native pinned writers use
         // fs.fsyncSync, so all active sync routes are included in these counters.
         const diagnostic = JSON.stringify({ backend, kind, durable, calls: observed.total(), counts: observed.counts });
-        expect(observed.syncs.filter((type) => type === "file").length, diagnostic).toBe(durable === false ? 0 : 20);
+        expect(observed.syncs.filter((type) => type === "file").length, diagnostic).toBe(durable === true ? 20 : 0);
         const directorySyncs = observed.syncs.filter((type) => type === "directory").length;
-        if (process.platform === "win32" && durable !== false) expect(directorySyncs, diagnostic).toBeLessThanOrEqual(4);
-        else expect(directorySyncs, diagnostic).toBe(durable === false ? 0 : 4);
+        if (process.platform === "win32" && durable === true) expect(directorySyncs, diagnostic).toBeLessThanOrEqual(4);
+        else expect(directorySyncs, diagnostic).toBe(durable === true ? 4 : 0);
         const budget = budgets[backend][kind];
-        const index = durable === false ? 1 : 0;
+        const index = durable === true ? 0 : 1;
         expect(observed.asyncTotal(), diagnostic).toBeLessThanOrEqual(Math.ceil(budget.async[index] * 1.1));
         expect(observed.total(), diagnostic).toBeLessThanOrEqual(Math.ceil(budget.total[index] * 1.1));
         for (const name of ["p.lstat", "p.stat", "p.realpath", "h.stat"]) {


### PR DESCRIPTION
Archive extraction is a nontransactional bulk import. Avoiding per-entry fsync removes device-bound work from the default path and lets callers apply installation durability once at publication, consistent with ordinary archive and package extraction workflows.

Compatibility: extractArchive now defaults to durable: false. Pass durable: true to restore the existing deferred durability pass: one sync per published file, one per directory, then the destination. The public unplanned merge helper has independent parameters and retains its per-copy durability. Root writers, FileStore, jsonStore, replaceFileAtomic, and writeJson defaults are unchanged. Both archive backends already forward the option unchanged.

The sync-budget tests now cover omitted/undefined, false, and true on native and JavaScript TAR/ZIP paths. Default and false perform zero syncs; true preserves exact file and directory counts. Sync-error and timeout tests explicitly opt in, and restrictive-mode coverage includes the new default. Identity and containment assertions are unchanged. Docs and the Unreleased compatibility note describe the new default, caller-owned staged-tree and publication syncing, and the macOS drive-cache limitation.

Single paired runs on macOS arm64 with Node 26.8.1, using a scratch TypeScript build of origin/main at 686c19315a8627e8f92d0a7641b6a78ea4cbfd18 and the supplied 500-file benchmark. Values are milliseconds per extraction, before to after:

Native auto: TAR 3098 to 1796; TGZ 5232 to 1819; ZIP 1087 to 1117.
Native off: TAR 2766 to 2735; TGZ 4611 to 2953; ZIP 1385 to 1349.

These are single-run measurements; native ZIP and JavaScript TAR/ZIP were effectively flat. Both builds resolved the prepared native binding in auto mode. The repository benchmark has no extraction case and was left unchanged.

Validation: pnpm exec tsc -p tsconfig.json; pnpm lint:file-size; pnpm lint:fs-boundary; pnpm docs:check; node scripts/check-pack.mjs; git diff --check. TypeScript compilation is the build proof because the local WASM build step is known to fail; tests and package checks used the prepared WASM artifact. Focused durability tests: 18 passed. Security suite: 226 passed across 5 files. Autoreview: no actionable P0-P2 findings after clarifying the staged-tree sync requirement.

Full pnpm test --maxWorkers=1 result: 8454 passed, 87 skipped, 3 failed; 237 test files passed, 5 skipped, 2 failed. Two failures are the known local consumer-pnpm-lifecycle failures. The third is the ClawSweeper dispatch fixture timing out at 10 seconds; it also reproduces in isolation on untouched origin/main. All archive tests passed. No unrelated workflow or lifecycle code was changed.
