### PR TITLE
test: drain durable publication work before fixture cleanup

### DIFF
--- a/test/native-publish-equivalence.test.ts
+++ b/test/native-publish-equivalence.test.ts
@@ -23,6 +23,7 @@ try {
   // JS-only jobs intentionally exercise the fallback without a built binding.
 }
 const tempDirs: string[] = [];
+let pendingPublication: Promise<void> | undefined;
 
 async function tempRoot(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "fs-safe-native-publish-"));
@@ -31,6 +32,9 @@ async function tempRoot(): Promise<string> {
 }
 
 afterEach(async () => {
+  // A Vitest deadline does not cancel durable filesystem work or restore umask.
+  await pendingPublication?.catch(() => undefined);
+  pendingPublication = undefined;
   vi.restoreAllMocks();
   __resetFsSafeNativeConfigForTest();
   __resetNativeLoaderForTest();
@@ -211,44 +215,51 @@ const publishBackends = native
 describe.each(publishBackends)("%s publication fallback", (backend) => {
   it.each([0o022, 0o200, 0o777])(
     "publishes identical bytes with an exclusive 0600 target under umask %s",
-    async (umask) => {
-      const root = await tempRoot();
-      const sourcePath = path.join(root, "source");
-      const targetPath = path.join(root, "target");
-      const payload = Buffer.alloc(256 * 1024, 0x5a);
-      await fs.writeFile(sourcePath, payload, { mode: 0o644 });
-
-      if (backend === "native") {
-        __setNativeLoaderForTest(() => ({
-          ...native!,
-          linkBeneath() {
-            throw Object.assign(new Error("force copy"), { code: "EXDEV" });
-          },
-        }));
-        configureFsSafeNative({ mode: "require" });
-      } else {
-        configureFsSafeNative({ mode: "off" });
-        vi.spyOn(fs, "link").mockRejectedValue(
-          Object.assign(new Error("force copy"), { code: "EXDEV" }),
-        );
-      }
-
-      const previousUmask = process.umask(umask);
-      let result: Awaited<ReturnType<typeof publishFileExclusive>>;
-      try {
-        result = await publishFileExclusive({
-          sourcePath,
-          targetPath,
-          strategy: "link-or-copy",
-        });
-      } finally {
-        process.umask(previousUmask);
-      }
-      expect(result.method).toBe("exclusive-copy");
-      await expect(fs.readFile(targetPath)).resolves.toEqual(payload);
-      if (process.platform !== "win32") {
-        expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o600);
-      }
+    (umask) => {
+      pendingPublication = checkPublication(umask);
+      return pendingPublication;
     },
+    // Real fsync calls can exceed the default five seconds under coverage load.
+    30_000,
   );
+
+  async function checkPublication(umask: number): Promise<void> {
+    const root = await tempRoot();
+    const sourcePath = path.join(root, "source");
+    const targetPath = path.join(root, "target");
+    const payload = Buffer.alloc(256 * 1024, 0x5a);
+    await fs.writeFile(sourcePath, payload, { mode: 0o644 });
+
+    if (backend === "native") {
+      __setNativeLoaderForTest(() => ({
+        ...native!,
+        linkBeneath() {
+          throw Object.assign(new Error("force copy"), { code: "EXDEV" });
+        },
+      }));
+      configureFsSafeNative({ mode: "require" });
+    } else {
+      configureFsSafeNative({ mode: "off" });
+      vi.spyOn(fs, "link").mockRejectedValue(
+        Object.assign(new Error("force copy"), { code: "EXDEV" }),
+      );
+    }
+
+    const previousUmask = process.umask(umask);
+    let result: Awaited<ReturnType<typeof publishFileExclusive>>;
+    try {
+      result = await publishFileExclusive({
+        sourcePath,
+        targetPath,
+        strategy: "link-or-copy",
+      });
+    } finally {
+      process.umask(previousUmask);
+    }
+    expect(result.method).toBe("exclusive-copy");
+    await expect(fs.readFile(targetPath)).resolves.toEqual(payload);
+    if (process.platform !== "win32") {
+      expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o600);
+    }
+  }
 });


### PR DESCRIPTION
The default-branch coverage run timed out during real durable publication under restrictive umask. Vitest deadlines do not cancel filesystem promises, so immediate teardown can also restore mocks and remove fixtures while publication is still running.

Give these integration cases a 30-second I/O budget and drain pending work before restoring mocks or removing fixtures. Every byte, mode, and backend assertion remains intact.

Validation:
- Injected a six-second source-open delay: the original test fails at five seconds; the repaired test passes in 7.12 seconds.
- Fresh macOS arm64 native build: 12 applicable publication tests pass.
- Fresh Linux build: pnpm check passes (5,608 tests), followed by native coverage collection (8,456 tests).
- Built-package device-path and native-required integration probes pass.
- Codex local and branch reviews: no actionable P0–P2 findings.

Release notes are consolidated in #257, which should land last. Hosted [CI](https://github.com/openclaw/fs-safe/actions/runs/34651572900) and [merged coverage](https://github.com/openclaw/fs-safe/actions/runs/34651572920) both pass at the exact PR head.
