### PR TITLE
perf(read): bound speculative buffers and accelerate sync reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 1 MiB without extra chunk copies.
+
 ## 0.9.0 - 2026-09-11
 
 **Highlights:** Faster bulk extraction and configurable durability, with Windows filesystem fixes and reliable mixed-version lock cleanup.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -79,6 +79,12 @@ receipts remain numeric. Custom `ioFs` adapters must honor `{ bigint: true }` fo
 Windows identities receive one re-inspection without reopening, then fail
 validation if still unknown.
 
+The bounded descriptor helpers cap their initial speculative allocation at
+1 MiB plus the overflow-probe byte, even when a file reports a much larger
+size. Regular files up to that size can return from one read without copying
+chunks; larger files and short reads continue incrementally under the same
+byte limit.
+
 The bounded descriptor helpers start at the descriptor's current offset and
 leave ownership with the caller. They are intended for the second half of a
 safe read: first open and validate the path using the boundary appropriate to

--- a/src/bounded-read.ts
+++ b/src/bounded-read.ts
@@ -126,7 +126,8 @@ export function readFileDescriptorBoundedSync(fd: number, maxBytes: number): Buf
   normalizeMaxBytes(maxBytes);
   const chunks: Buffer[] = [];
   let total = 0;
-  const size = regularFileSize(fd);
+  // Small budgets already bound the first allocation without a size lookup.
+  const size = maxBytes <= READ_CHUNK_BYTES ? maxBytes : regularFileSize(fd);
   if (size !== undefined) {
     const first = createInitialBuffer(maxBytes, size);
     const bytesRead = fs.readSync(fd, first, 0, first.length, null);

--- a/src/bounded-read.ts
+++ b/src/bounded-read.ts
@@ -4,8 +4,14 @@ import { normalizeMaxBytes } from "./byte-budget.js";
 import { FsSafeError } from "./errors.js";
 
 const READ_CHUNK_BYTES = 64 * 1024;
+const MAX_INITIAL_READ_BYTES = 1024 * 1024;
 
 type ReadableFileHandle = Pick<FileHandle, "read">;
+
+function createInitialBuffer(maxBytes: number, size: number): Buffer {
+  // A size hint can describe a huge sparse file or an already exhausted fd.
+  return Buffer.allocUnsafe(Math.min(maxBytes, size, MAX_INITIAL_READ_BYTES) + 1);
+}
 
 function createScratchBuffer(maxBytes: number): Buffer {
   const initialReadBytes = Number.isFinite(maxBytes)
@@ -48,7 +54,7 @@ async function readBoundedAsync(
   let total = 0;
   const size = observeRegularFileSize?.();
   if (size !== undefined) {
-    const first = Buffer.allocUnsafe(Math.min(maxBytes, size) + 1);
+    const first = createInitialBuffer(maxBytes, size);
     const bytesRead = await readChunk(first, first.length);
     if (bytesRead === 0) return first.subarray(0, 0);
     // Short reads can occur before EOF. Only accept one when a fresh fd size
@@ -119,8 +125,18 @@ export async function readFileDescriptorBounded(fd: number, maxBytes: number): P
 export function readFileDescriptorBoundedSync(fd: number, maxBytes: number): Buffer {
   normalizeMaxBytes(maxBytes);
   const chunks: Buffer[] = [];
-  const scratch = createScratchBuffer(maxBytes);
   let total = 0;
+  const size = regularFileSize(fd);
+  if (size !== undefined) {
+    const first = createInitialBuffer(maxBytes, size);
+    const bytesRead = fs.readSync(fd, first, 0, first.length, null);
+    if (bytesRead === 0) return first.subarray(0, 0);
+    // A short read alone is not EOF, including on regular files.
+    const currentSize = bytesRead < first.length ? regularFileSize(fd) : undefined;
+    if (currentSize !== undefined && bytesRead >= currentSize) return first.subarray(0, bytesRead);
+    total = appendChunk({ chunks, scratch: first, bytesRead, total, maxBytes });
+  }
+  const scratch = createScratchBuffer(maxBytes);
   while (true) {
     const length = nextReadLength(total, maxBytes, scratch.length);
     const bytesRead = fs.readSync(fd, scratch, 0, length, null);

--- a/test/bounded-read-allocation.test.ts
+++ b/test/bounded-read-allocation.test.ts
@@ -1,0 +1,105 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileDescriptorBounded, readFileDescriptorBoundedSync, readFileHandleBounded } from "../src/bounded-read.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+async function fixture(content: string) {
+  const dir = await tempRoot("fs-safe-read-allocation-");
+  const filePath = path.join(dir, "input");
+  await fs.writeFile(filePath, content);
+  return filePath;
+}
+
+describe("bounded read allocation", () => {
+  it.each(["handle", "descriptor", "sync"] as const)("does not allocate a huge size hint before reaching EOF (%s)", async (reader) => {
+    const filePath = await fixture("");
+    const handle = await fs.open(filePath, "r");
+    const stat = fsSync.fstatSync(handle.fd);
+    const hintedStat = Object.assign(Object.create(stat), { size: Number.MAX_SAFE_INTEGER });
+    vi.spyOn(fsSync, "fstatSync").mockReturnValue(hintedStat);
+    const allocate = Buffer.allocUnsafe;
+    let largestAllocation = 0;
+    vi.spyOn(Buffer, "allocUnsafe").mockImplementation((size) => {
+      largestAllocation = Math.max(largestAllocation, size);
+      // Make a speculative OOM deterministic without allocating large memory.
+      if (size > 1024 * 1024 + 1) throw new RangeError("oversized speculative allocation");
+      return allocate(size);
+    });
+    try {
+      const result = reader === "handle" ? await readFileHandleBounded(handle, Infinity)
+        : reader === "descriptor" ? await readFileDescriptorBounded(handle.fd, Infinity)
+          : readFileDescriptorBoundedSync(handle.fd, Infinity);
+      expect(result.length).toBe(0);
+      expect(largestAllocation).toBeLessThanOrEqual(1024 * 1024 + 1);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it.each([0, 4, 128 * 1024, 1024 * 1024])("reads a %s-byte regular file synchronously without a second read or a copy", async (size) => {
+    const filePath = await fixture("x".repeat(size));
+    const fd = fsSync.openSync(filePath, "r");
+    const read = vi.spyOn(fsSync, "readSync");
+    const concat = vi.spyOn(Buffer, "concat");
+    try {
+      const result = readFileDescriptorBoundedSync(fd, size);
+      expect(result).toEqual(Buffer.alloc(size, "x"));
+      expect(read).toHaveBeenCalledTimes(1);
+      expect(concat).not.toHaveBeenCalled();
+    } finally {
+      fsSync.closeSync(fd);
+    }
+  });
+
+  it.each([false, true])("continues synchronous short reads and enforces the cap after growth (%s)", async (grow) => {
+    const filePath = await fixture("abcd");
+    const fd = fsSync.openSync(filePath, "r");
+    const originalRead = fsSync.readSync;
+    vi.spyOn(fsSync, "readSync").mockImplementationOnce((descriptor, buffer, offset, _length, position) => {
+      if (grow) fsSync.appendFileSync(filePath, "efgh");
+      return originalRead(descriptor, buffer, offset, 1, position);
+    });
+    try {
+      if (grow) {
+        expect(() => readFileDescriptorBoundedSync(fd, 4)).toThrow(expect.objectContaining({ code: "too-large" }));
+        const next = Buffer.alloc(1);
+        originalRead(fd, next, 0, 1, null);
+        expect(next.toString()).toBe("f");
+      } else {
+        expect(readFileDescriptorBoundedSync(fd, 4).toString()).toBe("abcd");
+      }
+    } finally {
+      fsSync.closeSync(fd);
+    }
+  });
+
+  it("starts at the current synchronous descriptor offset and retains ownership", async () => {
+    const filePath = await fixture("prefix-tail");
+    const fd = fsSync.openSync(filePath, "r");
+    try {
+      fsSync.readSync(fd, Buffer.alloc(7), 0, 7, null);
+      expect(readFileDescriptorBoundedSync(fd, 4).toString()).toBe("tail");
+      expect(fsSync.fstatSync(fd).isFile()).toBe(true);
+    } finally {
+      fsSync.closeSync(fd);
+    }
+  });
+
+  it.each(["handle", "sync"] as const)("reads beyond the initial allocation and enforces an exact large cap (%s)", async (reader) => {
+    const content = "y".repeat(2 * 1024 * 1024);
+    const filePath = await fixture(content);
+    const handle = await fs.open(filePath, "r");
+    try {
+      const result = reader === "handle" ? await readFileHandleBounded(handle, content.length)
+        : readFileDescriptorBoundedSync(handle.fd, content.length);
+      expect(result.toString()).toBe(content);
+    } finally {
+      await handle.close();
+    }
+  });
+});

--- a/test/bounded-read-allocation.test.ts
+++ b/test/bounded-read-allocation.test.ts
@@ -48,7 +48,7 @@ describe("bounded read allocation", () => {
     const concat = vi.spyOn(Buffer, "concat");
     try {
       const result = readFileDescriptorBoundedSync(fd, size);
-      expect(result).toEqual(Buffer.alloc(size, "x"));
+      expect(result.equals(Buffer.alloc(size, "x"))).toBe(true);
       expect(read).toHaveBeenCalledTimes(1);
       expect(concat).not.toHaveBeenCalled();
     } finally {


### PR DESCRIPTION
Bounded reads used the entire regular-file size hint for their first allocation. A large or sparse file could cause an oversized allocation before any data was read, including when the descriptor was already at EOF. Cap that speculative allocation at 1 MiB plus the overflow-probe byte, then continue incrementally.

The synchronous reader now uses the one-read regular-file path, avoiding chunk copies and concatenation for files up to 1 MiB. Small explicit budgets avoid an unnecessary initial size lookup. Current-offset semantics, descriptor ownership, fresh EOF-size verification, and the maxBytes + 1 consumption limit are preserved; public options and defaults are unchanged.

Validation: focused bounded-read and budget tests, full Node 22/24 CI on Linux/macOS/Windows, native and package checks, merged coverage, and independent P0–P2 autoreview passed. The combined candidate also passed `pnpm check` on AWS Crabbox `cbx_a29a31be70d3` with 8,474 tests. The 1 MiB synchronous case dropped from seventeen read calls to one. Repeated same-host Linux measurements showed about 1.3x faster 128-byte reads, 2.8–3x at 64 KiB, and 2.2–2.4x at 1 MiB.

CI also exposed two test issues: recursive Buffer equality was expensive at 1 MiB, so the regression uses exact native `Buffer.equals`; and the existing overlapping-store stress test incorrectly required every racing read to succeed. It now accepts only the documented typed `path-mismatch`, validates every returned document and the final stable read, and drains all operations before propagating unexpected failures.
