### PR TITLE
perf(hash): batch large JavaScript reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.
+
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.
 
 ## 0.9.0 - 2026-09-11

--- a/src/file-hash.ts
+++ b/src/file-hash.ts
@@ -27,7 +27,9 @@ export async function hashFileHandle(
   }
 
   const hash = createHash("sha256");
-  const buffer = Buffer.allocUnsafe(64 * 1024);
+  const buffer = Buffer.allocUnsafe(
+    Math.min(256 * 1024, Math.max(64 * 1024, stat.size)),
+  );
   let position = 0;
   while (true) {
     const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);

--- a/test/file-hash.test.ts
+++ b/test/file-hash.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -41,6 +42,26 @@ afterEach(async () => {
 });
 
 describe("sha256File", () => {
+  it("batches large fallback reads in bounded buffers", async () => {
+    const directory = await tempRoot();
+    const filePath = path.join(directory, "large.bin");
+    const payload = Buffer.alloc(1024 * 1024, "x");
+    await fs.writeFile(filePath, payload);
+    configureFsSafeNative({ mode: "off" });
+    const handle = await fs.open(filePath, "r");
+    const read = vi.spyOn(handle, "read");
+    try {
+      await expect(sha256File(handle)).resolves.toEqual({
+        bytes: payload.length,
+        digest: createHash("sha256").update(payload).digest("hex"),
+      });
+      expect(read.mock.calls.length).toBeLessThanOrEqual(5);
+      for (const call of read.mock.calls) expect(call[2]).toBeLessThanOrEqual(256 * 1024);
+    } finally {
+      await handle.close();
+    }
+  });
+
   it("streams a path through the JavaScript fallback", async () => {
     const root = await tempRoot();
     const filePath = path.join(root, "payload.bin");


### PR DESCRIPTION
The JavaScript SHA-256 fallback read every file in 64 KiB chunks, paying an asynchronous filesystem round-trip per chunk. Scale the reusable buffer from 64 KiB up to a fixed 256 KiB cap using the size already observed during regular-file admission. A 1 MiB file needs five reads including EOF instead of seventeen.

Small files retain the 64 KiB buffer. The explicit-position loop, complete-content digest, growth and short-read handling, identity checks, descriptor ownership, and native implementation are unchanged. The tradeoff is at most 256 KiB of scratch memory per large fallback hash.

Validation: build, 117 hash/identity tests, and independent P0–P2 autoreview passed. Alternating macOS samples measured about 1.25x faster hashing at 1 MiB and 1.5x at 16 MiB; filesystem noise limits precision. Combined before/after Linux measurements and full cross-platform CI are being run.
