### PR TITLE
perf: add comprehensive method benchmarks and coverage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Check JavaScript fallback
         run: pnpm check
 
+      - name: Smoke method benchmarks with JavaScript fallback
+        if: matrix.node == 24
+        run: pnpm benchmark:methods --mode off --iterations 1 --samples 1 --warmup 0
+
       - name: Prove archive device admission and secret reads
         if: matrix.node == 24
         run: node scripts/device-path-proof.mjs off
@@ -130,6 +134,9 @@ jobs:
 
       - name: Build and stage host binding
         run: pnpm native:build
+
+      - name: Smoke method benchmarks with native binding
+        run: pnpm benchmark:methods --mode require --iterations 1 --samples 1 --warmup 0
 
       - name: Prove archive device admission and secret reads with native binding
         run: node scripts/device-path-proof.mjs require

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ release-artifacts*/
 *.tgz
 *.tsbuildinfo
 .clawpatch/
+.crabbox/
 .deepsec/
 .vscode
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a method-by-method benchmark with callable API coverage checks, native/fallback reports, and separate fixture timing.
+
 ## 0.9.0 - 2026-09-11
 
 **Highlights:** Faster bulk extraction and configurable durability, with Windows filesystem fixes and reliable mixed-version lock cleanup.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,55 @@
+# Method performance audit
+
+Run from a built checkout with the declared pnpm version:
+
+```sh
+pnpm build
+pnpm benchmark:methods --mode off --json /tmp/fs-safe-off.json
+pnpm native:build
+pnpm benchmark:methods --mode require --json /tmp/fs-safe-native.json
+```
+
+The runner inventories callable exports from every package subpath and checks
+methods on Root, stores, path scopes, locks, directory pins, staged files, and
+temporary workspaces. An uncovered callable fails before measurement. Re-exports
+share one case; constants and types are not calls. Test-only instrumentation and
+the deprecated Python configuration alias have explicit exclusion reasons.
+Native-only methods are recorded as skipped when unavailable. Windows ACL and
+private-directory operations require a real Windows run; POSIX does not time
+an unsupported-platform response as if it were useful work. Trash admission is
+measured on a rejected synthetic path so this command never writes to a user's
+real Trash. This is representative method coverage, not exhaustive branch or
+platform coverage; security and concurrency tests remain separate.
+
+Each row reports microseconds per call, all sample averages, their median, and
+minimum/maximum. Defaults are 100 iterations, five samples, and five warmup calls.
+Cheap synchronous functions run batches of 100 calls per requested iteration.
+Expensive archive and durable-store cases use fewer iterations, recorded per row.
+Inputs are synthetic. Fixture setup and cleanup run outside the timer; callback
+work and cleanup performed *by the method* remain inside it. Open and acquire
+cases exclude later close/release, which have their own rows. Representative
+payload assertions run outside measurement. Reads cover 128 B, 64 KiB, and 1 MiB;
+writes compare both durability settings without changing package defaults.
+
+For a quick executable coverage check:
+
+```sh
+pnpm benchmark:methods --mode off --iterations 1 --samples 1 --warmup 0
+```
+
+Use `--filter readFileDescriptorBounded` to repeat one family. Filtered reports
+are marked explicitly and do not imply all cases ran. `--dist /absolute/dist`
+lets the same harness measure a saved build; preserve the WASM asset alongside
+JavaScript. Reports identify the JavaScript/WASM build by a content hash and
+record a separate SHA-256 for the actual loaded native addon. They also record
+the harness checkout revision and a hash of the actual benchmark code, package
+manifest, and lockfile (including uncommitted edits), Node version, platform, CPU, requested native
+mode, and whether the binding loaded. The addon is resolved relative to that build, so
+keep its matching platform package available too.
+
+Compare builds on the same host, runtime, filesystem, and native mode. Alternate
+baseline/candidate runs and inspect sample spread; fsync timings and shared-host
+load can dwarf JavaScript changes. Warm-cache sequential latency does not measure
+cold storage, concurrent throughput, or event-loop responsiveness. This report is
+not a timing assertion in CI. CI smoke runs verify that the benchmark continues
+to exercise real callable APIs.

--- a/benchmarks/archives.mjs
+++ b/benchmarks/archives.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import JSZip from "jszip";
+import * as tar from "tar";
+
+export async function registerArchives({ api: a, workspace: w, register: add }) {
+  const source = path.join(w, "archive-source");
+  fs.mkdirSync(source);
+  fs.writeFileSync(path.join(source, "entry.json"), '{"ok":true}');
+  const zip = new JSZip();
+  zip.file("entry.json", '{"ok":true}');
+  const zipBytes = await zip.generateAsync({ type: "nodebuffer" });
+  const zipPath = path.join(w, "fixture.zip");
+  fs.writeFileSync(zipPath, zipBytes);
+  const tarPath = path.join(w, "fixture.tar");
+  const gzipPath = path.join(w, "fixture.tgz");
+  await tar.c({ cwd: source, file: tarPath, portable: true }, ["entry.json"]);
+  await tar.c({ cwd: source, file: gzipPath, portable: true, gzip: true }, ["entry.json"]);
+  const destination = path.join(w, "archive-destination");
+  fs.mkdirSync(destination);
+  const simple = {
+    isWindowsDrivePath: ["package/entry.json"], normalizeArchiveEntryPath: ["package\\entry.json"],
+    stripArchivePath: ["package/entry.json", 1], validateArchiveEntryPath: ["package/entry.json"],
+    resolveArchiveOutputPath: [{ rootDir: destination, relPath: "entry.json", originalPath: "entry.json" }],
+    resolveArchiveKind: ["fixture.tar.gz"], readZipCentralDirectoryEntryCount: [zipBytes],
+    createArchiveSymlinkTraversalError: ["fixture/link"],
+  };
+  for (const [name, values] of Object.entries(simple)) add(name, () => a[name](...values), { sync: true, batch: 100 });
+  add("ArchiveFormatError", () => new a.ArchiveFormatError("synthetic"), { sync: true, batch: 100 });
+  add("ArchiveSecurityError", () => new a.ArchiveSecurityError("entry-path", "synthetic"), { sync: true, batch: 100 });
+  add("ArchiveLimitError", () => new a.ArchiveLimitError(a.ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT), { sync: true, batch: 100 });
+  add("createTarEntryPreflightChecker", () => a.createTarEntryPreflightChecker({ rootDir: destination }), { sync: true });
+  add("createTarEntryPreflightChecker/call", (check) => check({ path: "entry.json", type: "File", size: 11 }), { sync: true, before: () => a.createTarEntryPreflightChecker({ rootDir: destination }) });
+  add("loadZipArchiveWithPreflight", () => a.loadZipArchiveWithPreflight(zipBytes));
+  add("prepareArchiveDestinationDir", () => a.prepareArchiveDestinationDir(destination));
+  add("prepareArchiveOutputPath", () => a.prepareArchiveOutputPath({ destinationDir: destination, destinationRealDir: destination, outPath: path.join(destination, "entry.json"), relPath: "entry.json", originalPath: "entry.json", isDirectory: false }));
+  add("resolvePackedRootDir", () => a.resolvePackedRootDir(source, { rootMarkers: ["entry.json"] }));
+  add("withStagedArchiveDestination", () => a.withStagedArchiveDestination({ destinationRealDir: destination, run: async () => 1 }));
+  add("mergeExtractedTreeIntoDestination", () => a.mergeExtractedTreeIntoDestination({ sourceDir: source, destinationDir: destination, destinationRealDir: destination }), {
+    before: () => { fs.writeFileSync(path.join(source, "entry.json"), '{"ok":true}'); },
+    after: () => fs.rmSync(path.join(destination, "entry.json"), { force: true }), divisor: 10,
+  });
+  for (const [kind, archivePath] of [["zip", zipPath], ["tar", tarPath], ["gzip", gzipPath]]) {
+    add(`extractArchive/${kind}`, () => a.extractArchive({ archivePath, destDir: destination, timeoutMs: 30_000 }), {
+      after: () => fs.rmSync(path.join(destination, "entry.json"), { force: true }), divisor: 10,
+      verify: () => assert.deepEqual(JSON.parse(fs.readFileSync(path.join(destination, "entry.json"), "utf8")), { ok: true }),
+    });
+    add(`readArchiveEntry/${kind}`, () => a.readArchiveEntry(archivePath, "entry.json", { maxBytes: 1024 }), { divisor: 10 });
+    if (kind !== "zip") add(`inspectTarArchive/${kind}`, () => a.inspectTarArchive({ archivePath, timeoutMs: 30_000 }), { divisor: 10 });
+  }
+}

--- a/benchmarks/core.mjs
+++ b/benchmarks/core.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+
+export async function registerCore({ api: a, workspace: w, register: add, contract }) {
+  const data = Buffer.from(' {"ok":true,"label":"synthetic benchmark"}\n');
+  const input = path.join(w, "input.json");
+  fs.writeFileSync(input, data, { mode: 0o600 });
+  fs.mkdirSync(path.join(w, "tree", "nested"), { recursive: true });
+  for (let i = 0; i < 100; i++) fs.writeFileSync(path.join(w, "tree", `entry-${i}`), data);
+  fs.writeFileSync(path.join(w, "tree", "nested", "entry"), data);
+  const safe = await a.root(w);
+  contract("Root", safe);
+  add("root", () => a.root(w));
+  for (const name of ["resolve", "read", "readBytes", "readText", "readJson", "exists", "stat"]) {
+    add(`Root.${name}`, () => safe[name]("input.json"));
+  }
+  add("Root.readAbsolute", () => safe.readAbsolute(input));
+  add("Root.reader", () => safe.reader(), { sync: true });
+  add("Root.reader/call", () => safe.reader()(input));
+  add("Root.open", () => safe.open("input.json"), { after: (r) => r?.handle.close() });
+  add("OpenResult.[Symbol.asyncDispose]", (r) => r[Symbol.asyncDispose](), { before: () => safe.open("input.json") });
+  contract("OpenResult", await (async () => { const r = await safe.open("input.json"); await r.handle.close(); return r; })());
+  add("Root.openWritable", () => safe.openWritable("writable.txt"), { after: (r) => r?.handle.close() });
+  const writable = await safe.openWritable("writable.txt");
+  contract("WritableOpenResult", writable);
+  await writable.handle.close();
+  add("WritableOpenResult.[Symbol.asyncDispose]", (r) => r[Symbol.asyncDispose](), { before: () => safe.openWritable("writable.txt") });
+  for (const durable of [true, false]) {
+    for (const name of ["write", "writeJson", "append", "copyIn", "create", "createJson"]) {
+      const rel = `root-${name}.json`;
+      const exclusive = name.startsWith("create");
+      add(`Root.${name}/durable=${durable}`, () => safe[name](rel, name.endsWith("Json") ? { ok: true } : name === "copyIn" ? input : data, { durable }), {
+        before: exclusive ? () => fs.rmSync(path.join(w, rel), { force: true })
+          : name === "append" ? () => fs.writeFileSync(path.join(w, rel), data) : undefined,
+      });
+    }
+  }
+  add("Root.mkdir", () => safe.mkdir("new-dir"), { after: () => fs.rmdirSync(path.join(w, "new-dir")) });
+  add("Root.ensureRoot", () => safe.ensureRoot());
+  add("Root.remove", () => safe.remove("remove.txt"), { before: () => fs.writeFileSync(path.join(w, "remove.txt"), data) });
+  add("Root.move", () => safe.move("move-from", "move-to"), {
+    before: () => fs.writeFileSync(path.join(w, "move-from"), data), after: () => fs.rmSync(path.join(w, "move-to"), { force: true }),
+  });
+  add("Root.list/names-100", () => safe.list("tree"));
+  add("Root.list/metadata-100", () => safe.list("tree", { withFileTypes: true }));
+  add("Root.walk", async () => { const entries = []; for await (const entry of safe.walk("tree", { symlinkPolicy: "skip" })) entries.push(entry); return entries; });
+  for (const name of ["walkDirectory", "walkDirectorySync"]) add(name, () => a[name](path.join(w, "tree")), { sync: name.endsWith("Sync"), verify: (r) => assert.equal(r.entries.length, 102) });
+  add("readLocalFileSafely", () => a.readLocalFileSafely({ filePath: input, maxBytes: 1024 }));
+  add("openLocalFileSafely", () => a.openLocalFileSafely({ filePath: input }), { after: (r) => r?.handle.close() });
+  add("resolveOpenedFileRealPathForHandle", (h) => a.resolveOpenedFileRealPathForHandle(h, input), { before: () => fsp.open(input, "r"), after: (_, h) => h.close() });
+  add("readSecureFile", () => a.readSecureFile({ filePath: input, io: { maxBytes: 1024 } }));
+  for (const name of ["readRegularFile", "readRegularFileSync", "statRegularFile", "statRegularFileSync"]) add(name, () => a[name](name.startsWith("stat") ? input : { filePath: input }), { sync: name.endsWith("Sync") });
+  for (const name of ["appendRegularFile", "appendRegularFileSync"]) add(name, () => a[name]({ filePath: path.join(w, "append.txt"), content: data }), { sync: name.endsWith("Sync"), before: () => fs.writeFileSync(path.join(w, "append.txt"), data) });
+  for (const name of ["openRootFile", "openRootFileSync"]) add(name, () => a[name]({ absolutePath: input, rootPath: w, boundaryLabel: "benchmark" }), { sync: name.endsWith("Sync"), verify: (r) => assert(r.ok), after: (r) => { if (r?.ok) fs.closeSync(r.fd); } });
+  for (const size of [128, 64 * 1024, 1024 * 1024]) {
+    const filePath = path.join(w, `bytes-${size}`);
+    const payload = Buffer.alloc(size, 120);
+    fs.writeFileSync(filePath, payload);
+    for (const name of ["readFileDescriptorBounded", "readFileDescriptorBoundedSync", "readFileHandleBounded"]) {
+      const handle = name === "readFileHandleBounded";
+      add(`${name}/${size}`, (opened) => a[name](opened, size), {
+        sync: name.endsWith("Sync"), before: () => handle ? fsp.open(filePath, "r") : fs.openSync(filePath, "r"),
+        after: (_, opened) => handle ? opened.close() : fs.closeSync(opened), verify: (r) => assert.deepEqual(r, payload),
+      });
+    }
+    add(`Root.readBytes/${size}`, () => safe.readBytes(`bytes-${size}`), { verify: (r) => assert.deepEqual(r, payload) });
+    add(`sha256File/${size}`, () => a.sha256File(filePath), { verify: (r) => assert.equal(r.bytes, size) });
+  }
+  for (const name of ["tryReadJson", "tryReadJsonSync", "readJson", "readJsonSync", "readJsonIfExists"]) add(name, () => a[name](input), { sync: name.endsWith("Sync"), verify: (r) => assert.equal(r.ok, true) });
+  for (const name of ["readRootJsonSync", "readRootJsonObjectSync", "readRootStructuredFileSync"]) add(name, () => a[name]({ rootDir: w, relativePath: "input.json", boundaryLabel: "benchmark", parse: JSON.parse }), { sync: true, verify: (r) => assert(r.ok) });
+  for (const name of ["writeJson", "writeJsonSync"]) add(name, () => a[name](path.join(w, `${name}.json`), { ok: true }), { sync: name.endsWith("Sync"), divisor: 10 });
+  add("JsonFileReadError", () => new a.JsonFileReadError("synthetic.json", "parse", new Error("fixture")), { sync: true });
+  for (const name of ["readSecretFile", "readSecretFileSync", "tryReadSecretFile", "tryReadSecretFileSync"]) add(name, () => a[name](input, "benchmark"), { sync: name.endsWith("Sync") });
+  for (const name of ["fileStore", "fileStoreSync"]) {
+    add(name, () => a[name]({ rootDir: w }), { sync: true });
+    const store = a[name]({ rootDir: w });
+    const type = name === "fileStore" ? "FileStore" : "FileStoreSync";
+    contract(type, store);
+    const sync = name.endsWith("Sync");
+    add(`${type}.path`, () => store.path("input.json"), { sync: true });
+    for (const method of ["readTextIfExists", "readJsonIfExists", ...(sync ? [] : ["read", "readBytes", "readText", "readJson", "exists"])]) add(`${type}.${method}`, () => store[method]("input.json"), { sync });
+    for (const durable of [true, false]) for (const method of ["write", "writeText", "writeJson"]) add(`${type}.${method}/durable=${durable}`, () => store[method](`store-${method}.json`, method === "writeJson" ? { ok: true } : data, { durable }), { sync, divisor: 10, before: () => {} });
+    if (sync) continue;
+    add(`${type}.root`, () => store.root());
+    add(`${type}.open`, () => store.open("input.json"), { after: (r) => r?.handle.close() });
+    add(`${type}.remove`, () => store.remove("store-remove"), { before: () => fs.writeFileSync(path.join(w, "store-remove"), data) });
+    add(`${type}.json`, () => store.json("input.json"), { sync: true });
+    add(`${type}.pruneExpired`, () => store.pruneExpired({ ttlMs: 24 * 3600_000 }));
+    add(`${type}.copyIn`, () => store.copyIn("store-copy", input));
+    add(`${type}.writeStream`, (stream) => store.writeStream("store-stream", stream), { before: () => Readable.from([data]) });
+  }
+  add("jsonStore", () => a.jsonStore({ filePath: input }), { sync: true });
+  const json = a.jsonStore({ filePath: path.join(w, "document.json"), durable: false });
+  contract("JsonStore", json);
+  await json.write({ ok: true });
+  for (const name of ["read", "readOr", "readRequired"]) add(`JsonStore.${name}`, () => json[name]({ ok: false }));
+  add("JsonStore.write", () => json.write({ ok: true }));
+  add("JsonStore.update", () => json.update((value) => value));
+  add("JsonStore.updateOr", () => json.updateOr({ ok: true }, (value) => value));
+  return () => {};
+}

--- a/benchmarks/lifecycle.mjs
+++ b/benchmarks/lifecycle.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+export async function registerLifecycle({ api: a, workspace: w, native, register: add, contract, onCleanup }) {
+  const input = path.join(w, "input.json");
+  const data = Buffer.from("synthetic benchmark\n");
+  const output = path.join(w, "lifecycle-output");
+  const secretRoot = path.join(w, "secret-writes");
+  fs.mkdirSync(secretRoot, { mode: 0o700 });
+  for (const name of ["replaceFileAtomic", "replaceFileAtomicSync"]) add(name, () => a[name]({ filePath: output, content: data }), { sync: name.endsWith("Sync") });
+  add("writeTextAtomic", () => a.writeTextAtomic(output, "synthetic benchmark"));
+  add("replaceDirectoryAtomic", () => a.replaceDirectoryAtomic({ stagedDir: path.join(w, "staged-dir"), targetDir: path.join(w, "target-dir") }), { before: () => fs.mkdirSync(path.join(w, "staged-dir")), after: () => fs.rmSync(path.join(w, "target-dir"), { recursive: true, force: true }) });
+  add("movePathWithCopyFallback", () => a.movePathWithCopyFallback({ from: path.join(w, "move-source"), to: output }), { before: () => fs.writeFileSync(path.join(w, "move-source"), data) });
+  for (const name of ["writeSecretFileAtomic", "createSecretFileAtomic"]) add(name, () => a[name]({ rootDir: secretRoot, filePath: path.join(secretRoot, "secret-out"), content: data }), {
+    before: () => name === "createSecretFileAtomic"
+      ? fs.rmSync(path.join(secretRoot, "secret-out"), { force: true })
+      : fs.writeFileSync(path.join(secretRoot, "secret-out"), data, { mode: 0o600 }),
+  });
+  add("writeExternalFileWithinRoot", () => a.writeExternalFileWithinRoot({ rootDir: w, path: "external-out", write: (p) => fsp.writeFile(p, data) }));
+  add("writeSiblingTempFile", () => a.writeSiblingTempFile({ dir: w, writeTemp: (p) => fsp.writeFile(p, data), resolveFinalPath: () => output }));
+  add("writeViaSiblingTempPath", () => a.writeViaSiblingTempPath({ rootDir: w, targetPath: output, writeTemp: (p) => fsp.writeFile(p, data) }));
+  const tempOptions = { rootDir: w, prefix: "fixture" };
+  add("resolveSecureTempRoot", () => a.resolveSecureTempRoot({ preferredDir: secretRoot, fallbackPrefix: "fs-safe-benchmark" }), { sync: true });
+  for (const suffix of ["", "Sync"]) {
+    const name = `tempWorkspace${suffix}`;
+    const type = `TempWorkspace${suffix}`;
+    const sync = suffix === "Sync";
+    add(name, () => a[name](tempOptions), { sync, after: (r) => r?.cleanup() });
+    add(`withTempWorkspace${suffix}`, () => a[`withTempWorkspace${suffix}`](tempOptions, sync ? () => 1 : async () => 1), { sync, before: () => {} });
+    const tmp = await a[name](tempOptions);
+    contract(type, tmp);
+    onCleanup(() => tmp.cleanup());
+    await tmp.write("input.json", data);
+    for (const method of ["path", "read", "write", "writeText", "writeJson", ...(sync ? [] : ["copyIn"])]) {
+      add(`${type}.${method}`, () => tmp[method](method === "read" || method === "path" ? "input.json" : "output.json", method === "writeJson" ? { ok: true } : method === "copyIn" ? input : data), { sync: sync || method === "path", before: method.startsWith("write") && sync ? () => {} : undefined });
+    }
+    add(`${type}.cleanup`, (r) => r.cleanup(), { sync, before: () => a[name](tempOptions) });
+    const symbol = sync ? Symbol.dispose : Symbol.asyncDispose;
+    add(`${type}.[${sync ? "Symbol.dispose" : "Symbol.asyncDispose"}]`, (r) => r[symbol](), { sync, before: () => a[name](tempOptions) });
+    // The fixture is owned by the runner's temporary workspace.
+  }
+  const tmp = await a.tempFile(tempOptions);
+  contract("TempFile", tmp);
+  onCleanup(() => tmp.cleanup());
+  add("tempFile", () => a.tempFile(tempOptions), { after: (r) => r?.cleanup() });
+  add("TempFile.file", () => tmp.file("fixture"), { sync: true, batch: 100 });
+  add("TempFile.cleanup", (r) => r.cleanup(), { before: () => a.tempFile(tempOptions) });
+  add("TempFile.[Symbol.asyncDispose]", (r) => r[Symbol.asyncDispose](), { before: () => a.tempFile(tempOptions) });
+  add("withTempFile", () => a.withTempFile(tempOptions, async () => 1));
+  for (const name of ["syncDirectory", "syncDirectorySync", "syncDirectoryBestEffort", "syncDirectoryBestEffortSync"]) add(name, () => a[name](w), { sync: name.endsWith("Sync"), before: () => {}, divisor: 10 });
+  add("ensureDurableDirectory", () => a.ensureDurableDirectory({ directoryPath: path.join(w, "durable-dir") }));
+  add("pinDirectory", () => a.pinDirectory(w), { after: (r) => r?.close() });
+  const pin = await a.pinDirectory(w);
+  contract("PinnedDirectory", pin);
+  await pin.close();
+  for (const method of ["assertCurrent", "sync", "close"]) add(`PinnedDirectory.${method}`, (r) => r[method](), { before: () => a.pinDirectory(w), after: (_, r) => r.close() });
+  for (const strategy of ["link-or-copy", "link-required", "rename-noreplace"]) {
+    add(`publishFileExclusive/${strategy}`, () => a.publishFileExclusive({ sourcePath: path.join(w, "publish-source"), targetPath: path.join(w, "publish-target"), strategy }), {
+      skip: strategy === "rename-noreplace" && !native ? "Native-only strategy." : undefined,
+      before: () => fs.writeFileSync(path.join(w, "publish-source"), data), after: () => fs.rmSync(path.join(w, "publish-target"), { force: true }),
+    });
+  }
+  const stagingSkip = !native || !["darwin", "linux"].includes(process.platform) ? "Retained-directory staging requires native Linux/macOS." : undefined;
+  const stage = () => a.stageFileInDirectory({ directory: w, content: data });
+  add("stageFileInDirectory", stage, { skip: stagingSkip, after: (r) => r?.cleanup() });
+  if (!stagingSkip) { const r = await stage(); contract("StagedFile", r); await r.cleanup(); }
+  for (const method of ["assertCurrent", "cleanup", "publish"]) add(`StagedFile.${method}`, (r) => method === "publish" ? r.publish("published-stage", { overwrite: true }) : r[method](), { skip: stagingSkip, before: stage, after: (_, r) => r.cleanup() });
+  add("StagedFile.[Symbol.asyncDispose]", (r) => r[Symbol.asyncDispose](), { skip: stagingSkip, before: stage });
+  const lockOptions = { payload: () => ({ pid: process.pid, createdAt: new Date().toISOString() }), timeoutMs: 1000 };
+  const lockPath = path.join(w, "locked");
+  for (const suffix of ["", "Sync"]) {
+    const sync = suffix === "Sync";
+    const acquire = () => a[`acquireFileLock${suffix}`](lockPath, lockOptions);
+    add(`acquireFileLock${suffix}`, acquire, { sync, after: (r) => r?.release() });
+    add(`withFileLock${suffix}`, () => a[`withFileLock${suffix}`](lockPath, lockOptions, sync ? () => 1 : async () => 1), { sync });
+    const r = await acquire();
+    const type = `FileLock${suffix}Handle`;
+    contract(type, r);
+    await r.release();
+    for (const method of ["verifyStillHeld", "release"]) add(`${type}.${method}`, (r) => r[method](), { sync, before: acquire, after: (_, r) => r.release() });
+    const symbol = sync ? Symbol.dispose : Symbol.asyncDispose;
+    add(`${type}.[${sync ? "Symbol.dispose" : "Symbol.asyncDispose"}]`, (r) => r[symbol](), { sync, before: acquire });
+  }
+  const manager = a.createFileLockManager("fs-safe-benchmark");
+  contract("FileLockManager", manager);
+  add("createFileLockManager", () => a.createFileLockManager("fs-safe-benchmark"), { sync: true });
+  add("FileLockManager.acquire", () => manager.acquire(lockPath, lockOptions), { after: (r) => r?.release() });
+  add("FileLockManager.withLock", () => manager.withLock(lockPath, lockOptions, async () => 1));
+  add("FileLockManager.heldEntries", () => manager.heldEntries(), { sync: true });
+  add("FileLockManager.drain", () => manager.drain());
+  add("FileLockManager.reset", () => manager.reset(), { sync: true });
+  const held = await manager.acquire(lockPath, lockOptions);
+  const heldEntry = manager.heldEntries()[0];
+  contract("FileLockHeldEntry", heldEntry);
+  await held.release();
+  add("FileLockHeldEntry.forceRelease", (entry) => entry.forceRelease(), { before: async () => { await manager.acquire(lockPath, lockOptions); return manager.heldEntries()[0]; }, after: () => manager.drain() });
+  const queueDir = path.join(w, "queue");
+  const failedDir = path.join(w, "failed");
+  await a.ensureJsonDurableQueueDirs({ queueDir, failedDir });
+  const queue = a.resolveJsonDurableQueueEntryPaths(queueDir, "fixture");
+  const resetQueue = () => { for (const p of Object.values(queue)) fs.rmSync(p, { force: true }); fs.rmSync(path.join(failedDir, "fixture.json"), { force: true }); fs.writeFileSync(queue.jsonPath, '{"ok":true}'); };
+  add("resolveJsonDurableQueueEntryPaths", () => a.resolveJsonDurableQueueEntryPaths(queueDir, "fixture"), { sync: true });
+  add("ensureJsonDurableQueueDirs", () => a.ensureJsonDurableQueueDirs({ queueDir, failedDir }));
+  add("writeJsonDurableQueueEntry", () => a.writeJsonDurableQueueEntry({ filePath: queue.jsonPath, entry: { ok: true }, tempPrefix: "bench" }));
+  add("jsonDurableQueueEntryExists", () => a.jsonDurableQueueEntryExists(queue.jsonPath), { before: resetQueue });
+  add("readJsonDurableQueueEntry", () => a.readJsonDurableQueueEntry(queue.jsonPath), { before: resetQueue, verify: (r) => assert(r.ok) });
+  add("loadJsonDurableQueueEntry", () => a.loadJsonDurableQueueEntry({ paths: queue, tempPrefix: "bench" }), { before: resetQueue, verify: (r) => assert(r.ok) });
+  add("loadPendingJsonDurableQueueEntries", () => a.loadPendingJsonDurableQueueEntries({ queueDir, tempPrefix: "bench" }), { before: resetQueue, verify: (r) => assert.equal(r.length, 1) });
+  const claim = async () => { resetQueue(); await a.loadJsonDurableQueueEntry({ paths: queue, tempPrefix: "bench" }); };
+  add("ackJsonDurableQueueEntry", () => a.ackJsonDurableQueueEntry(queue), { before: claim });
+  add("moveJsonDurableQueueEntryToFailed", () => a.moveJsonDurableQueueEntryToFailed({ queueDir, failedDir, id: "fixture" }), { before: claim });
+  add("unlinkBestEffort", () => a.unlinkBestEffort(queue.jsonPath), { before: resetQueue });
+}

--- a/benchmarks/paths.mjs
+++ b/benchmarks/paths.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export async function registerPaths({ api: a, workspace: w, register: add, contract, exclude, args, native }) {
+  const input = path.join(w, "input.json");
+  const error = Object.assign(new Error("synthetic"), { code: "ENOENT" });
+  const simple = {
+    assertNoNulPathInput: ["tree/nested/file"], hasNodeErrorCode: [error, "ENOENT"], isNodeError: [error],
+    isNotFoundPathError: [error], isSymlinkOpenError: [error], isPathInside: [w, input],
+    isPathRelativeEscape: ["tree/file"], isWithinDir: [w, input],
+    normalizeWindowsPathForComparison: ["C:\\workspace\\tree\\file.json"],
+    resolveSafeBaseDir: [w], resolveSafeRelativePath: [w, "tree/nested/file"], splitSafeRelativePath: ["tree/nested/file"],
+    assertAbsolutePathInput: [input], assertNoUnsafeDeviceReadPath: [input], isUnsafeDeviceReadPath: [input], matchUnsafeDeviceReadPath: [input],
+    assertNoWindowsNetworkPath: [input], basenameFromMediaSource: [pathToFileURL(input).href],
+    hasEncodedFileUrlSeparator: ["file:///workspace/a%20b.json"], isWindowsDriveLetterPath: ["C:\\workspace\\file", "win32"],
+    isWindowsNetworkPath: ["\\\\server\\share\\file", "win32"], safeFileURLToPath: [pathToFileURL(input).href], trySafeFileURLToPath: [pathToFileURL(input).href],
+    safeDirName: ["package/module"], safePathSegmentHashed: ["ordinary-safe-name"], sanitizeUntrustedFileName: ["ordinary-safe-name.json", "fallback"],
+    sanitizeTempFileName: ["ordinary-safe-name.json"], resolveRegularFileAppendFlags: [],
+    sameFileIdentity: [{ dev: 1, ino: 123 }, { dev: 1, ino: 123 }],
+    resolveSafeInstallDir: [{ baseDir: w, id: "module", invalidNameMessage: "invalid" }],
+    buildRandomTempFilePath: [{ rootDir: w, prefix: "bench" }], resolveHomeRelativePath: [input],
+    canUseRootFileOpen: [fs],
+    matchRootFileOpenFailure: [{ ok: false, reason: "path", error }, { path: () => null, validation: () => null, io: () => null, fallback: () => null }],
+    modeBits: [0o100600], formatOctal: [0o600], formatPosixMode: [0o100600],
+    isGroupReadable: [0o600], isGroupWritable: [0o600], isWorldReadable: [0o600], isWorldWritable: [0o600],
+    isHardlinkFallbackError: [Object.assign(new Error("synthetic"), { code: "EXDEV" })],
+    categorizeFsSafeError: ["outside-workspace"],
+  };
+  for (const [name, values] of Object.entries(simple)) add(name, () => a[name](...values), { sync: true, batch: 100 });
+  add("FsSafeError", () => new a.FsSafeError("invalid-path", "synthetic"), { sync: true, batch: 100 });
+  for (const name of ["safeRealpathSync", "safeStatSync", "pathExistsSync"]) add(name, () => a[name](input), { sync: true });
+  for (const name of ["pathExists", "safeStat", "inspectPathPermissions"]) add(name, () => a[name](input));
+  add("isPathInsideWithRealpath", () => a.isPathInsideWithRealpath(w, input), { sync: true });
+  for (const name of ["findExistingAncestor", "canonicalPathFromExistingAncestor"]) add(name, () => a[name](input));
+  for (const name of ["resolveAbsolutePathForRead", "resolveAbsolutePathForWrite"]) add(name, () => a[name](input));
+  add("ensureAbsoluteDirectory", () => a.ensureAbsoluteDirectory(path.join(w, "tree")));
+  add("assertCanonicalPathWithinBase", () => a.assertCanonicalPathWithinBase({ baseDir: w, candidatePath: path.join(w, "tree"), boundaryLabel: "benchmark" }));
+  for (const name of ["assertNoSymlinkParents", "assertNoSymlinkParentsSync"]) add(name, () => a[name]({ rootDir: w, targetPath: input }), { sync: name.endsWith("Sync") });
+  add("assertNoHardlinkedFinalPath", () => a.assertNoHardlinkedFinalPath({ filePath: input, root: w, boundaryLabel: "benchmark" }));
+  const rootParams = { absolutePath: input, rootPath: w, boundaryLabel: "benchmark" };
+  for (const name of ["resolveRootPath", "resolveRootPathSync", "assertNoPathAliasEscape"]) add(name, () => a[name](rootParams), { sync: name.endsWith("Sync") });
+  add("resolvePathViaExistingAncestorSync", () => a.resolvePathViaExistingAncestorSync(input), { sync: true });
+  for (const name of ["resolveLocalPathFromRootsSync", "readLocalFileFromRoots"]) add(name, () => a[name]({ filePath: input, roots: [w] }), { sync: name.endsWith("Sync") });
+  const base = { rootDir: w, scopeLabel: "benchmark" };
+  for (const name of ["resolvePathWithinRoot", "resolveWritablePathWithinRoot", "ensureDirectoryWithinRoot"]) add(name, () => a[name]({ ...base, requestedPath: name === "ensureDirectoryWithinRoot" ? "tree" : "input.json" }), { sync: name === "resolvePathWithinRoot" });
+  for (const name of ["resolvePathsWithinRoot", "resolveExistingPathsWithinRoot", "resolveStrictExistingPathsWithinRoot"]) add(name, () => a[name]({ ...base, requestedPaths: ["input.json"] }), { sync: name === "resolvePathsWithinRoot" });
+  add("pathScope", () => a.pathScope(w, { label: "benchmark" }), { sync: true, batch: 100 });
+  const scope = a.pathScope(w, { label: "benchmark" });
+  contract("PathScope", scope);
+  for (const name of ["resolve", "resolveAll", "existing", "files", "writable", "ensureDir"]) add(`PathScope.${name}`, () => scope[name](["resolveAll", "existing", "files"].includes(name) ? ["input.json"] : name === "ensureDir" ? "tree" : "input.json"), { sync: name.startsWith("resolve") });
+  add("getFsSafeNativeConfig", () => a.getFsSafeNativeConfig(), { sync: true, batch: 100 });
+  add("configureFsSafeNative", () => a.configureFsSafeNative({ mode: args.mode }), { sync: true });
+  add("getFsSafeLockConfig", () => a.getFsSafeLockConfig(), { sync: true, batch: 100 });
+  add("configureFsSafeLocks", () => a.configureFsSafeLocks({}), { sync: true });
+  exclude("configureFsSafePython", "Deprecated startup alias of configureFsSafeNative; warning side effect, not an I/O hot path.");
+  for (const name of ["__setFsSafeTestHooksForTest", "getFsSafeTestHooks", "drainFileLockManagerForTest", "resetFileLockManagerForTest"]) exclude(name, "Test instrumentation; covered by the test suite, excluded from production timing.");
+  const perms = await a.inspectPathPermissions(input);
+  add("formatPermissionDetail", () => a.formatPermissionDetail("fixture.json", perms), { sync: true, batch: 100 });
+  add("formatPermissionRemediation", () => a.formatPermissionRemediation({ targetPath: "fixture.json", perms, isDir: false, posixMode: 0o600 }), { sync: true, batch: 100 });
+  const env = { USERNAME: "benchmark", USERDOMAIN: "FIXTURE", USERSID: "S-1-5-21-111-222-333-1001" };
+  const aclOutput = "C:\\fixture.json S-1-5-18:(F)\n S-1-1-0:(R)";
+  const entries = a.parseIcaclsOutput(aclOutput, "C:\\fixture.json");
+  const summary = { ok: true, entries, ...a.summarizeWindowsAcl(entries, env) };
+  add("parseIcaclsOutput", () => a.parseIcaclsOutput(aclOutput, "C:\\fixture.json"), { sync: true, batch: 100 });
+  add("summarizeWindowsAcl", () => a.summarizeWindowsAcl(entries, env), { sync: true, batch: 100 });
+  add("formatWindowsAclSummary", () => a.formatWindowsAclSummary(summary), { sync: true, batch: 100 });
+  add("resolveWindowsUserPrincipal", () => a.resolveWindowsUserPrincipal(env), { sync: true, batch: 100 });
+  for (const name of ["createIcaclsResetCommand", "formatIcaclsResetCommand"]) add(name, () => a[name]("C:\\fixture.json", { isDir: false, env }), { sync: true, batch: 100 });
+  add("inspectWindowsAcl", () => a.inspectWindowsAcl(input), { divisor: 100, skip: process.platform !== "win32" ? "Windows live ACL inspection requires Windows." : undefined, verify: (r) => assert(r.ok) });
+  add("readOwnerAndDacl", () => a.readOwnerAndDacl(input), { sync: true, skip: process.platform !== "win32" || !native ? "Requires Windows native binding; no unsupported-platform timing substituted." : undefined });
+  add("createPrivateDirectory", () => a.createPrivateDirectory(path.join(w, "private-dir")), {
+    skip: process.platform !== "win32" || !native ? "Requires Windows native binding." : undefined,
+    after: () => fs.rmdirSync(path.join(w, "private-dir")),
+  });
+  add("createAsyncLock", () => a.createAsyncLock(), { sync: true, batch: 100 });
+  const lock = a.createAsyncLock();
+  add("createAsyncLock/call", () => lock(async () => 1));
+  add("withTimeout", () => a.withTimeout(Promise.resolve(1), 1000, "benchmark"));
+  // Measure admission without sending files to the user's real Trash.
+  add("movePathToTrash/rejection", () => a.movePathToTrash(input, { allowedRoots: [path.join(w, "tree")] }), {
+    expectError: true, verify: (error) => assert.match(error.message, /outside allowed roots/),
+  });
+}

--- a/benchmarks/runner.mjs
+++ b/benchmarks/runner.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { performance } from "node:perf_hooks";
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import { registerCore } from "./core.mjs";
+import { registerPaths } from "./paths.mjs";
+import { registerLifecycle } from "./lifecycle.mjs";
+import { registerArchives } from "./archives.mjs";
+
+const args = { iterations: 100, samples: 5, warmup: 5, mode: "off" };
+for (let i = 2; i < process.argv.length; i++) {
+  const key = process.argv[i].replace(/^--/, "");
+  if (key === "") continue;
+  if (!["iterations", "samples", "warmup", "mode", "json", "filter", "dist"].includes(key)) throw new Error(`Unknown argument: ${key}`);
+  const value = process.argv[++i];
+  if (value === undefined) throw new Error(`Missing value for ${key}`);
+  args[key] = ["iterations", "samples", "warmup"].includes(key) ? Number(value) : value;
+}
+for (const key of ["iterations", "samples", "warmup"]) {
+  assert(Number.isSafeInteger(args[key]) && args[key] >= (key === "warmup" ? 0 : 1), `Invalid ${key}`);
+}
+assert(["off", "require", "auto"].includes(args.mode), "Invalid native mode");
+const packageRoot = path.resolve(import.meta.dirname, "..");
+const dist = path.resolve(args.dist ?? path.join(packageRoot, "dist"));
+const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
+const harnessHash = createHash("sha256");
+for (const name of fs.readdirSync(import.meta.dirname).filter((name) => name.endsWith(".mjs")).sort()) {
+  harnessHash.update(name).update(fs.readFileSync(path.join(import.meta.dirname, name)));
+}
+for (const name of ["package.json", "pnpm-lock.yaml"]) harnessHash.update(fs.readFileSync(path.join(packageRoot, name)));
+const harnessDigest = harnessHash.digest("hex");
+const api = {};
+const exportsByName = new Map();
+for (const [subpath, target] of Object.entries(manifest.exports)) {
+  if (typeof target === "string") continue;
+  const module = await import(pathToFileURL(path.join(dist, path.basename(target.default))));
+  for (const [name, value] of Object.entries(module)) {
+    if (typeof value !== "function") { api[name] = value; continue; }
+    if (name in api) assert.equal(api[name], value, `Ambiguous export: ${name}`);
+    api[name] = value;
+    exportsByName.set(name, [...(exportsByName.get(name) ?? []), subpath]);
+  }
+}
+api.configureFsSafeNative({ mode: args.mode });
+const { getNativeBinding } = await import(pathToFileURL(path.join(dist, "native.js")));
+const binding = getNativeBinding();
+const native = Boolean(binding);
+const loadedAddon = native ? Object.values(createRequire(import.meta.url).cache)
+  .find((module) => module?.filename.endsWith(".node") && module.exports === binding) : undefined;
+assert(!native || loadedAddon, "Could not identify the loaded native addon");
+const nativeHash = loadedAddon
+  ? createHash("sha256").update(fs.readFileSync(loadedAddon.filename)).digest("hex") : null;
+const workspace = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), "fs-safe-methods-")));
+const cases = [];
+const exclusions = new Map();
+const contracts = new Map();
+const register = (name, run, options = {}) => {
+  assert(!cases.some((c) => c.name === name), `Duplicate case: ${name}`);
+  cases.push({ name, run, covers: [name.split("/")[0]], ...options });
+};
+const exclude = (name, reason) => exclusions.set(name, reason);
+const contract = (name, object) => {
+  const properties = new Set();
+  for (let current = object; current && current !== Object.prototype; current = Object.getPrototypeOf(current)) {
+    for (const key of Reflect.ownKeys(current)) {
+      if (key === "constructor" || key === "context" || key === "mutationOptions") continue;
+      const descriptor = Object.getOwnPropertyDescriptor(current, key);
+      if (typeof descriptor?.value === "function") properties.add(typeof key === "symbol" ? (key === Symbol.asyncDispose ? "[Symbol.asyncDispose]" : key === Symbol.dispose ? "[Symbol.dispose]" : `[${key.description}]`) : key);
+    }
+  }
+  contracts.set(name, [...properties].sort());
+};
+const cleanups = [];
+const context = { api, workspace, native, register, exclude, contract, args, onCleanup: (fn) => cleanups.push(fn) };
+let cleanup;
+try {
+  cleanup = await registerCore(context);
+  await registerPaths(context);
+  await registerLifecycle(context);
+  await registerArchives(context);
+  const covered = new Set(cases.flatMap((c) => c.covers));
+  const required = [...exportsByName.keys(), ...[...contracts].flatMap(([type, keys]) => keys.map((key) => `${type}.${key}`))];
+  const missing = required.filter((name) => !covered.has(name) && !exclusions.has(name));
+  assert.deepEqual(missing, [], `Unmeasured methods: ${missing.join(", ")}`);
+  const results = [];
+  for (const c of cases) {
+    if (args.filter && !c.name.includes(args.filter)) continue;
+    if (c.skip) { results.push({ name: c.name, skipped: c.skip }); continue; }
+    const iterations = c.sync && !c.before && !c.after ? args.iterations * (c.batch ?? 1) : Math.max(1, Math.floor(args.iterations / (c.divisor ?? 1)));
+    const once = async (timed) => {
+      const input = await c.before?.();
+      let output;
+      try {
+        const start = performance.now();
+        let rejected = false;
+        try {
+          output = c.sync ? c.run(input) : await c.run(input);
+        } catch (error) {
+          if (!c.expectError) throw error;
+          output = error;
+          rejected = true;
+        }
+        const elapsed = performance.now() - start;
+        if (c.expectError && !rejected) throw new Error(`${c.name} unexpectedly succeeded`);
+        if (!timed) c.verify?.(output);
+        return elapsed;
+      } finally { await c.after?.(output, input); }
+    };
+    const samplesUs = [];
+    for (let i = 0; i < args.warmup; i++) await once(false);
+    // Always run one checked call, including --warmup 0.
+    await once(false);
+    for (let sample = 0; sample < args.samples; sample++) {
+      let elapsed = 0;
+      if (c.sync && !c.before && !c.after) {
+        const start = performance.now();
+        for (let i = 0; i < iterations; i++) c.run();
+        elapsed = performance.now() - start;
+      } else {
+        for (let i = 0; i < iterations; i++) elapsed += await once(true);
+      }
+      samplesUs.push(elapsed * 1000 / iterations);
+    }
+    const sorted = [...samplesUs].sort((a, b) => a - b);
+    const medianUs = (sorted[Math.floor((sorted.length - 1) / 2)] + sorted[Math.floor(sorted.length / 2)]) / 2;
+    const result = { name: c.name, iterations, samplesUs, medianUs, minUs: sorted[0], maxUs: sorted.at(-1) };
+    results.push(result);
+    process.stderr.write(`${c.name}: ${medianUs.toFixed(2)} us/call\n`);
+  }
+  const report = {
+    schemaVersion: 1,
+    metadata: { harnessHash: harnessDigest, nativeHash, distHash: createHash("sha256").update(fs.readdirSync(dist).filter((name) => /\.(js|wasm)$/.test(name)).sort().map((name) => name + createHash("sha256").update(fs.readFileSync(path.join(dist, name))).digest("hex")).join("\n")).digest("hex"), harnessRevision: execFileSync("git", ["rev-parse", "HEAD"], { cwd: packageRoot, encoding: "utf8" }).trim(), node: process.version, platform: process.platform, arch: process.arch, cpu: os.cpus()[0]?.model, mode: args.mode, native, samples: args.samples, date: new Date().toISOString() },
+    coverage: { exports: Object.fromEntries(exportsByName), methods: Object.fromEntries(contracts), exclusions: Object.fromEntries(exclusions), registeredCases: cases.length, filtered: Boolean(args.filter) },
+    results,
+  };
+  if (args.json) fs.writeFileSync(path.resolve(args.json), `${JSON.stringify(report, null, 2)}\n`);
+  process.stdout.write(`Measured ${results.filter((r) => !r.skipped).length} cases; ${required.length} callable exports/methods accounted for. Native ${args.mode}: ${native ? "loaded" : "off/unavailable"}.\n`);
+} finally {
+  await cleanup?.();
+  for (const fn of cleanups.reverse()) await fn();
+  fs.rmSync(workspace, { recursive: true, force: true });
+}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,6 +68,13 @@ pnpm check
 This runs the filesystem boundary checks, build, tests, and package
 tarball/import validation.
 
+### Method benchmarks
+
+`pnpm benchmark:methods` measures the callable library surface against synthetic
+fixtures and fails on uncovered exports or returned methods. See the
+[benchmark guide](https://github.com/openclaw/fs-safe/tree/main/benchmarks) for native/fallback runs, per-call
+timings, exclusions, and comparison methodology. Run `pnpm build` first.
+
 ### Real TAR producers
 
 After installing the freshly packed root (and optionally its freshly built host

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
   },
   "scripts": {
     "benchmark": "node scripts/benchmark.mjs",
+    "benchmark:methods": "node benchmarks/runner.mjs",
     "benchmark:publish": "pnpm build && node scripts/bench-publish.mjs",
     "build": "node scripts/prepack-build.mjs",
     "lint:file-size": "node scripts/check-file-size.mjs",


### PR DESCRIPTION
Add `pnpm benchmark:methods` to audit the library method by method. The runner inventories callable exports and returned-object methods, fails on uncovered APIs, and records per-call sample timings with JavaScript/WASM, native-addon, and harness fingerprints. Fixtures and assertions stay outside the timer; creates, existing-file appends, replacements, descriptor cleanup, locks, stores, walking, archives, and pure path helpers have explicit cases.

The suite registers 322 workloads across 194 exported callables and up to 98 returned methods. Linux runs measure 313 fallback and 319 native cases, with explicit Windows/native-only skips and documented test/deprecation exclusions. Add smoke execution to Node 24 CI on Linux, macOS, and Windows, in fallback and native modes. Ignore generated Crabbox runtime state and document repeatable comparisons, saved-build layout, and timing limitations.

This audit drove the separately landed improvements in #258, #259, and #260. Validation: full `pnpm check` on AWS Crabbox `cbx_a29a31be70d3` with 8,474 passing tests; complete five-sample before/after runs in both modes on that same host; macOS fallback/native smoke; docs-site build; `git diff --check`; and independent P0–P2 autoreview. Full CI passed, including live Windows benchmark smoke with 314 fallback and 317 native cases. Timing values are report-only, not brittle CI thresholds.
