### PR TITLE
perf(read): preserve large-read throughput under allocation cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.
 
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.
-- Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 1 MiB without extra chunk copies.
+- Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.
 - Add a method-by-method benchmark with callable API coverage checks, native/fallback reports, and separate fixture timing.
 
 ## 0.9.0 - 2026-09-11

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,11 +24,12 @@ platform coverage; security and concurrency tests remain separate.
 Each row reports microseconds per call, all sample averages, their median, and
 minimum/maximum. Defaults are 100 iterations, five samples, and five warmup calls.
 Cheap synchronous functions run batches of 100 calls per requested iteration.
-Expensive archive and durable-store cases use fewer iterations, recorded per row.
+Expensive archive, durable-store, and large-payload cases use fewer iterations, recorded per row.
 Inputs are synthetic. Fixture setup and cleanup run outside the timer; callback
 work and cleanup performed *by the method* remain inside it. Open and acquire
 cases exclude later close/release, which have their own rows. Representative
-payload assertions run outside measurement. Reads cover 128 B, 64 KiB, and 1 MiB;
+payload assertions run outside measurement. Reads cover 128 B, 64 KiB, 1 MiB,
+2 MiB, and the default Root budget of 16 MiB;
 writes compare both durability settings without changing package defaults.
 
 For a quick executable coverage check:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -29,7 +29,7 @@ Inputs are synthetic. Fixture setup and cleanup run outside the timer; callback
 work and cleanup performed *by the method* remain inside it. Open and acquire
 cases exclude later close/release, which have their own rows. Representative
 payload assertions run outside measurement. Reads cover 128 B, 64 KiB, 1 MiB,
-2 MiB, and the default Root budget of 16 MiB;
+2 MiB, the default Root budget of 16 MiB, and an explicit 32 MiB budget;
 writes compare both durability settings without changing package defaults.
 
 For a quick executable coverage check:

--- a/benchmarks/core.mjs
+++ b/benchmarks/core.mjs
@@ -55,7 +55,7 @@ export async function registerCore({ api: a, workspace: w, register: add, contra
   for (const name of ["readRegularFile", "readRegularFileSync", "statRegularFile", "statRegularFileSync"]) add(name, () => a[name](name.startsWith("stat") ? input : { filePath: input }), { sync: name.endsWith("Sync") });
   for (const name of ["appendRegularFile", "appendRegularFileSync"]) add(name, () => a[name]({ filePath: path.join(w, "append.txt"), content: data }), { sync: name.endsWith("Sync"), before: () => fs.writeFileSync(path.join(w, "append.txt"), data) });
   for (const name of ["openRootFile", "openRootFileSync"]) add(name, () => a[name]({ absolutePath: input, rootPath: w, boundaryLabel: "benchmark" }), { sync: name.endsWith("Sync"), verify: (r) => assert(r.ok), after: (r) => { if (r?.ok) fs.closeSync(r.fd); } });
-  for (const size of [128, 64 * 1024, 1024 * 1024, 2 * 1024 * 1024, 16 * 1024 * 1024]) {
+  for (const size of [128, 64 * 1024, 1024 * 1024, 2 * 1024 * 1024, 16 * 1024 * 1024, 32 * 1024 * 1024]) {
     const divisor = size > 1024 * 1024 ? 10 : 1;
     const filePath = path.join(w, `bytes-${size}`);
     const payload = Buffer.alloc(size, 120);
@@ -67,7 +67,7 @@ export async function registerCore({ api: a, workspace: w, register: add, contra
         after: (_, opened) => handle ? opened.close() : fs.closeSync(opened), verify: (r) => assert.deepEqual(r, payload),
       });
     }
-    add(`Root.readBytes/${size}`, () => safe.readBytes(`bytes-${size}`), { divisor, verify: (r) => assert.deepEqual(r, payload) });
+    add(`Root.readBytes/${size}`, () => safe.readBytes(`bytes-${size}`, size > 16 * 1024 * 1024 ? { maxBytes: size } : undefined), { divisor, verify: (r) => assert.deepEqual(r, payload) });
     add(`sha256File/${size}`, () => a.sha256File(filePath), { divisor, verify: (r) => assert.equal(r.bytes, size) });
   }
   for (const name of ["tryReadJson", "tryReadJsonSync", "readJson", "readJsonSync", "readJsonIfExists"]) add(name, () => a[name](input), { sync: name.endsWith("Sync"), verify: (r) => assert.equal(r.ok, true) });

--- a/benchmarks/core.mjs
+++ b/benchmarks/core.mjs
@@ -55,19 +55,20 @@ export async function registerCore({ api: a, workspace: w, register: add, contra
   for (const name of ["readRegularFile", "readRegularFileSync", "statRegularFile", "statRegularFileSync"]) add(name, () => a[name](name.startsWith("stat") ? input : { filePath: input }), { sync: name.endsWith("Sync") });
   for (const name of ["appendRegularFile", "appendRegularFileSync"]) add(name, () => a[name]({ filePath: path.join(w, "append.txt"), content: data }), { sync: name.endsWith("Sync"), before: () => fs.writeFileSync(path.join(w, "append.txt"), data) });
   for (const name of ["openRootFile", "openRootFileSync"]) add(name, () => a[name]({ absolutePath: input, rootPath: w, boundaryLabel: "benchmark" }), { sync: name.endsWith("Sync"), verify: (r) => assert(r.ok), after: (r) => { if (r?.ok) fs.closeSync(r.fd); } });
-  for (const size of [128, 64 * 1024, 1024 * 1024]) {
+  for (const size of [128, 64 * 1024, 1024 * 1024, 2 * 1024 * 1024, 16 * 1024 * 1024]) {
+    const divisor = size > 1024 * 1024 ? 10 : 1;
     const filePath = path.join(w, `bytes-${size}`);
     const payload = Buffer.alloc(size, 120);
     fs.writeFileSync(filePath, payload);
     for (const name of ["readFileDescriptorBounded", "readFileDescriptorBoundedSync", "readFileHandleBounded"]) {
       const handle = name === "readFileHandleBounded";
       add(`${name}/${size}`, (opened) => a[name](opened, size), {
-        sync: name.endsWith("Sync"), before: () => handle ? fsp.open(filePath, "r") : fs.openSync(filePath, "r"),
+        divisor, sync: name.endsWith("Sync"), before: () => handle ? fsp.open(filePath, "r") : fs.openSync(filePath, "r"),
         after: (_, opened) => handle ? opened.close() : fs.closeSync(opened), verify: (r) => assert.deepEqual(r, payload),
       });
     }
-    add(`Root.readBytes/${size}`, () => safe.readBytes(`bytes-${size}`), { verify: (r) => assert.deepEqual(r, payload) });
-    add(`sha256File/${size}`, () => a.sha256File(filePath), { verify: (r) => assert.equal(r.bytes, size) });
+    add(`Root.readBytes/${size}`, () => safe.readBytes(`bytes-${size}`), { divisor, verify: (r) => assert.deepEqual(r, payload) });
+    add(`sha256File/${size}`, () => a.sha256File(filePath), { divisor, verify: (r) => assert.equal(r.bytes, size) });
   }
   for (const name of ["tryReadJson", "tryReadJsonSync", "readJson", "readJsonSync", "readJsonIfExists"]) add(name, () => a[name](input), { sync: name.endsWith("Sync"), verify: (r) => assert.equal(r.ok, true) });
   for (const name of ["readRootJsonSync", "readRootJsonObjectSync", "readRootStructuredFileSync"]) add(name, () => a[name]({ rootDir: w, relativePath: "input.json", boundaryLabel: "benchmark", parse: JSON.parse }), { sync: true, verify: (r) => assert(r.ok) });

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -83,8 +83,10 @@ The bounded descriptor helpers cap their initial speculative allocation at
 16 MiB plus the overflow-probe byte, even when a file reports a much larger
 size. Regular files up to that size can return from one read without copying
 chunks; larger files and short reads continue incrementally under the same
-byte limit. Known files above that size use 1 MiB continuation chunks to keep
-filesystem round-trips bounded; unknown-size inputs retain 64 KiB chunks.
+byte limit. Continuation buffers grow only after filling with actual bytes,
+up to the byte budget plus its probe; file-size hints cannot force that growth.
+Unknown-size inputs start with at most 64 KiB. This avoids per-chunk copies and
+a final concatenation when a file exceeds the initial allocation.
 
 The bounded descriptor helpers start at the descriptor's current offset and
 leave ownership with the caller. They are intended for the second half of a

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -83,7 +83,8 @@ The bounded descriptor helpers cap their initial speculative allocation at
 16 MiB plus the overflow-probe byte, even when a file reports a much larger
 size. Regular files up to that size can return from one read without copying
 chunks; larger files and short reads continue incrementally under the same
-byte limit.
+byte limit. Known files above that size use 1 MiB continuation chunks to keep
+filesystem round-trips bounded; unknown-size inputs retain 64 KiB chunks.
 
 The bounded descriptor helpers start at the descriptor's current offset and
 leave ownership with the caller. They are intended for the second half of a

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -80,7 +80,7 @@ Windows identities receive one re-inspection without reopening, then fail
 validation if still unknown.
 
 The bounded descriptor helpers cap their initial speculative allocation at
-1 MiB plus the overflow-probe byte, even when a file reports a much larger
+16 MiB plus the overflow-probe byte, even when a file reports a much larger
 size. Regular files up to that size can return from one read without copying
 chunks; larger files and short reads continue incrementally under the same
 byte limit.

--- a/src/bounded-read.ts
+++ b/src/bounded-read.ts
@@ -4,6 +4,7 @@ import { normalizeMaxBytes } from "./byte-budget.js";
 import { FsSafeError } from "./errors.js";
 
 const READ_CHUNK_BYTES = 64 * 1024;
+const LARGE_FILE_CHUNK_BYTES = 1024 * 1024;
 // Preserve one-read performance through the default Root byte budget.
 const MAX_INITIAL_READ_BYTES = 16 * 1024 * 1024;
 
@@ -14,10 +15,12 @@ function createInitialBuffer(maxBytes: number, size: number): Buffer {
   return Buffer.allocUnsafe(Math.min(maxBytes, size, MAX_INITIAL_READ_BYTES) + 1);
 }
 
-function createScratchBuffer(maxBytes: number): Buffer {
+function createScratchBuffer(maxBytes: number, size?: number): Buffer {
+  const chunkBytes = size !== undefined && size > MAX_INITIAL_READ_BYTES
+    ? LARGE_FILE_CHUNK_BYTES : READ_CHUNK_BYTES;
   const initialReadBytes = Number.isFinite(maxBytes)
-    ? Math.min(READ_CHUNK_BYTES, maxBytes + 1)
-    : READ_CHUNK_BYTES;
+    ? Math.min(chunkBytes, maxBytes + 1)
+    : chunkBytes;
   return Buffer.allocUnsafe(Math.max(1, initialReadBytes));
 }
 
@@ -64,7 +67,7 @@ async function readBoundedAsync(
     if (currentSize !== undefined && bytesRead >= currentSize) return first.subarray(0, bytesRead);
     total = appendChunk({ chunks, scratch: first, bytesRead, total, maxBytes });
   }
-  const scratch = createScratchBuffer(maxBytes);
+  const scratch = createScratchBuffer(maxBytes, size);
   while (true) {
     const length = nextReadLength(total, maxBytes, scratch.length);
     const bytesRead = await readChunk(scratch, length);
@@ -138,7 +141,7 @@ export function readFileDescriptorBoundedSync(fd: number, maxBytes: number): Buf
     if (currentSize !== undefined && bytesRead >= currentSize) return first.subarray(0, bytesRead);
     total = appendChunk({ chunks, scratch: first, bytesRead, total, maxBytes });
   }
-  const scratch = createScratchBuffer(maxBytes);
+  const scratch = createScratchBuffer(maxBytes, size);
   while (true) {
     const length = nextReadLength(total, maxBytes, scratch.length);
     const bytesRead = fs.readSync(fd, scratch, 0, length, null);

--- a/src/bounded-read.ts
+++ b/src/bounded-read.ts
@@ -4,7 +4,6 @@ import { normalizeMaxBytes } from "./byte-budget.js";
 import { FsSafeError } from "./errors.js";
 
 const READ_CHUNK_BYTES = 64 * 1024;
-const LARGE_FILE_CHUNK_BYTES = 1024 * 1024;
 // Preserve one-read performance through the default Root byte budget.
 const MAX_INITIAL_READ_BYTES = 16 * 1024 * 1024;
 
@@ -15,37 +14,33 @@ function createInitialBuffer(maxBytes: number, size: number): Buffer {
   return Buffer.allocUnsafe(Math.min(maxBytes, size, MAX_INITIAL_READ_BYTES) + 1);
 }
 
-function createScratchBuffer(maxBytes: number, size?: number): Buffer {
-  const chunkBytes = size !== undefined && size > MAX_INITIAL_READ_BYTES
-    ? LARGE_FILE_CHUNK_BYTES : READ_CHUNK_BYTES;
-  const initialReadBytes = Number.isFinite(maxBytes)
-    ? Math.min(chunkBytes, maxBytes + 1)
-    : chunkBytes;
-  return Buffer.allocUnsafe(Math.max(1, initialReadBytes));
+function createScratchBuffer(maxBytes: number): Buffer {
+  return Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, maxBytes + 1));
 }
 
-function nextReadLength(total: number, maxBytes: number, capacity: number): number {
-  return Number.isFinite(maxBytes)
-    ? Math.min(capacity, maxBytes - total + 1)
-    : capacity;
+function growReadBuffer(buffer: Buffer, maxBytes: number): Buffer {
+  // Grow only after consuming the whole buffer, never from an unchecked size hint.
+  const capacity = Math.min(maxBytes + 1, Math.max(READ_CHUNK_BYTES, buffer.length * 2));
+  const grown = Buffer.allocUnsafe(capacity);
+  buffer.copy(grown);
+  return grown;
 }
 
-function appendChunk(params: {
-  chunks: Buffer[];
-  scratch: Buffer;
-  bytesRead: number;
-  total: number;
-  maxBytes: number;
-}): number {
-  const total = params.total + params.bytesRead;
-  if (total > params.maxBytes) {
+function finishReadBuffer(buffer: Buffer, total: number): Buffer {
+  if (total === 0) return Buffer.alloc(0);
+  const result = buffer.subarray(0, total);
+  return total < buffer.length / 2 ? Buffer.from(result) : result;
+}
+
+function addReadBytes(total: number, bytesRead: number, maxBytes: number): number {
+  const next = total + bytesRead;
+  if (next > maxBytes) {
     throw new FsSafeError(
       "too-large",
-      `file exceeds limit of ${params.maxBytes} bytes (got at least ${total})`,
+      `file exceeds limit of ${maxBytes} bytes (got at least ${next})`,
     );
   }
-  params.chunks.push(Buffer.from(params.scratch.subarray(0, params.bytesRead)));
-  return total;
+  return next;
 }
 
 async function readBoundedAsync(
@@ -54,27 +49,24 @@ async function readBoundedAsync(
   observeRegularFileSize?: () => number | undefined,
 ): Promise<Buffer> {
   normalizeMaxBytes(maxBytes);
-  const chunks: Buffer[] = [];
   let total = 0;
   const size = observeRegularFileSize?.();
+  let buffer = size === undefined ? createScratchBuffer(maxBytes) : createInitialBuffer(maxBytes, size);
   if (size !== undefined) {
-    const first = createInitialBuffer(maxBytes, size);
-    const bytesRead = await readChunk(first, first.length);
-    if (bytesRead === 0) return first.subarray(0, 0);
-    // Short reads can occur before EOF. Only accept one when a fresh fd size
-    // observation proves we consumed at least the entire current file size.
-    const currentSize = bytesRead < first.length ? observeRegularFileSize?.() : undefined;
-    if (currentSize !== undefined && bytesRead >= currentSize) return first.subarray(0, bytesRead);
-    total = appendChunk({ chunks, scratch: first, bytesRead, total, maxBytes });
+    const bytesRead = await readChunk(buffer, buffer.length);
+    if (bytesRead === 0) return finishReadBuffer(buffer, 0);
+    // Short reads can occur before EOF. Only use the size shortcut on this
+    // initial read; virtual files can report zero or stale sizes thereafter.
+    const currentSize = bytesRead < buffer.length ? observeRegularFileSize?.() : undefined;
+    total = addReadBytes(total, bytesRead, maxBytes);
+    if (currentSize !== undefined && bytesRead >= currentSize) return finishReadBuffer(buffer, total);
   }
-  const scratch = createScratchBuffer(maxBytes, size);
   while (true) {
-    const length = nextReadLength(total, maxBytes, scratch.length);
-    const bytesRead = await readChunk(scratch, length);
-    if (bytesRead === 0) {
-      return Buffer.concat(chunks, total);
-    }
-    total = appendChunk({ chunks, scratch, bytesRead, total, maxBytes });
+    if (total === buffer.length) buffer = growReadBuffer(buffer, maxBytes);
+    const remaining = buffer.subarray(total);
+    const bytesRead = await readChunk(remaining, remaining.length);
+    if (bytesRead === 0) return finishReadBuffer(buffer, total);
+    total = addReadBytes(total, bytesRead, maxBytes);
   }
 }
 
@@ -128,26 +120,22 @@ export async function readFileDescriptorBounded(fd: number, maxBytes: number): P
 /** Sync bounded read from a numeric descriptor. The caller owns the descriptor. */
 export function readFileDescriptorBoundedSync(fd: number, maxBytes: number): Buffer {
   normalizeMaxBytes(maxBytes);
-  const chunks: Buffer[] = [];
   let total = 0;
   // Small budgets already bound the first allocation without a size lookup.
   const size = maxBytes <= READ_CHUNK_BYTES ? maxBytes : regularFileSize(fd);
+  let buffer = size === undefined ? createScratchBuffer(maxBytes) : createInitialBuffer(maxBytes, size);
   if (size !== undefined) {
-    const first = createInitialBuffer(maxBytes, size);
-    const bytesRead = fs.readSync(fd, first, 0, first.length, null);
-    if (bytesRead === 0) return first.subarray(0, 0);
-    // A short read alone is not EOF, including on regular files.
-    const currentSize = bytesRead < first.length ? regularFileSize(fd) : undefined;
-    if (currentSize !== undefined && bytesRead >= currentSize) return first.subarray(0, bytesRead);
-    total = appendChunk({ chunks, scratch: first, bytesRead, total, maxBytes });
+    const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+    if (bytesRead === 0) return finishReadBuffer(buffer, 0);
+    const currentSize = bytesRead < buffer.length ? regularFileSize(fd) : undefined;
+    total = addReadBytes(total, bytesRead, maxBytes);
+    if (currentSize !== undefined && bytesRead >= currentSize) return finishReadBuffer(buffer, total);
   }
-  const scratch = createScratchBuffer(maxBytes, size);
   while (true) {
-    const length = nextReadLength(total, maxBytes, scratch.length);
-    const bytesRead = fs.readSync(fd, scratch, 0, length, null);
-    if (bytesRead === 0) {
-      return Buffer.concat(chunks, total);
-    }
-    total = appendChunk({ chunks, scratch, bytesRead, total, maxBytes });
+    if (total === buffer.length) buffer = growReadBuffer(buffer, maxBytes);
+    const remaining = buffer.subarray(total);
+    const bytesRead = fs.readSync(fd, remaining, 0, remaining.length, null);
+    if (bytesRead === 0) return finishReadBuffer(buffer, total);
+    total = addReadBytes(total, bytesRead, maxBytes);
   }
 }

--- a/src/bounded-read.ts
+++ b/src/bounded-read.ts
@@ -4,7 +4,8 @@ import { normalizeMaxBytes } from "./byte-budget.js";
 import { FsSafeError } from "./errors.js";
 
 const READ_CHUNK_BYTES = 64 * 1024;
-const MAX_INITIAL_READ_BYTES = 1024 * 1024;
+// Preserve one-read performance through the default Root byte budget.
+const MAX_INITIAL_READ_BYTES = 16 * 1024 * 1024;
 
 type ReadableFileHandle = Pick<FileHandle, "read">;
 

--- a/test/bounded-read-allocation.test.ts
+++ b/test/bounded-read-allocation.test.ts
@@ -27,7 +27,7 @@ describe("bounded read allocation", () => {
     vi.spyOn(Buffer, "allocUnsafe").mockImplementation((size) => {
       largestAllocation = Math.max(largestAllocation, size);
       // Make a speculative OOM deterministic without allocating large memory.
-      if (size > 1024 * 1024 + 1) throw new RangeError("oversized speculative allocation");
+      if (size > 16 * 1024 * 1024 + 1) throw new RangeError("oversized speculative allocation");
       return allocate(size);
     });
     try {
@@ -35,13 +35,13 @@ describe("bounded read allocation", () => {
         : reader === "descriptor" ? await readFileDescriptorBounded(handle.fd, Infinity)
           : readFileDescriptorBoundedSync(handle.fd, Infinity);
       expect(result.length).toBe(0);
-      expect(largestAllocation).toBeLessThanOrEqual(1024 * 1024 + 1);
+      expect(largestAllocation).toBeLessThanOrEqual(16 * 1024 * 1024 + 1);
     } finally {
       await handle.close();
     }
   });
 
-  it.each([0, 4, 128 * 1024, 1024 * 1024])("reads a %s-byte regular file synchronously without a second read or a copy", async (size) => {
+  it.each([0, 4, 128 * 1024, 1024 * 1024, 2 * 1024 * 1024, 16 * 1024 * 1024])("reads a %s-byte regular file synchronously without a second read or a copy", async (size) => {
     const filePath = await fixture("x".repeat(size));
     const fd = fsSync.openSync(filePath, "r");
     const read = vi.spyOn(fsSync, "readSync");
@@ -91,7 +91,7 @@ describe("bounded read allocation", () => {
   });
 
   it.each(["handle", "sync"] as const)("reads beyond the initial allocation and enforces an exact large cap (%s)", async (reader) => {
-    const content = "y".repeat(2 * 1024 * 1024);
+    const content = "y".repeat(32 * 1024 * 1024);
     const filePath = await fixture(content);
     const handle = await fs.open(filePath, "r");
     try {

--- a/test/bounded-read-allocation.test.ts
+++ b/test/bounded-read-allocation.test.ts
@@ -90,6 +90,26 @@ describe("bounded read allocation", () => {
     }
   });
 
+  it.each(["handle", "sync"] as const)("does not treat later short reads as EOF for zero-size virtual files (%s)", async (reader) => {
+    const filePath = await fixture("abcdef");
+    const handle = await fs.open(filePath, "r");
+    const stat = fsSync.fstatSync(handle.fd);
+    vi.spyOn(fsSync, "fstatSync").mockReturnValue(Object.assign(Object.create(stat), { size: 0 }));
+    const read = handle.read.bind(handle);
+    const readSync = fsSync.readSync;
+    vi.spyOn(handle, "read").mockImplementation((buffer, offset, length, position) =>
+      read(buffer, offset, Math.min(length, 1), position));
+    vi.spyOn(fsSync, "readSync").mockImplementation((fd, buffer, offset, length, position) =>
+      readSync(fd, buffer, offset, Math.min(length, 1), position));
+    try {
+      const result = reader === "handle" ? await readFileHandleBounded(handle, Infinity)
+        : readFileDescriptorBoundedSync(handle.fd, Infinity);
+      expect(result.toString()).toBe("abcdef");
+    } finally {
+      await handle.close();
+    }
+  });
+
   it.each(["handle", "sync"] as const)("reads beyond the initial allocation and enforces an exact large cap (%s)", async (reader) => {
     const content = "y".repeat(32 * 1024 * 1024);
     const filePath = await fixture(content);

--- a/test/bounded-read.test.ts
+++ b/test/bounded-read.test.ts
@@ -39,13 +39,13 @@ afterEach(async () => {
 });
 
 describe("bounded descriptor reads", () => {
-  it.each([0, 4, 128 * 1024])("reads a known regular file of %s bytes in one call", async (size) => {
+  it.each([0, 4, 128 * 1024, 2 * 1024 * 1024, 16 * 1024 * 1024])("reads a known regular file of %s bytes in one call", async (size) => {
     const filePath = await tempFile("x".repeat(size));
     const handle = await fs.open(filePath, "r");
     const read = vi.spyOn(handle, "read");
     try {
       const result = await readFileHandleBounded(handle, size);
-      expect(result).toEqual(Buffer.alloc(size, "x"));
+      expect(result.equals(Buffer.alloc(size, "x"))).toBe(true);
       expect(read).toHaveBeenCalledTimes(1);
       expect(read.mock.calls[0]?.[2]).toBe(size + 1);
     } finally {


### PR DESCRIPTION
A final payload-size sweep exposed a performance cliff in #258's new 1 MiB allocation cap: 2 MiB and 16 MiB async reads fell from one read to eighteen and 242 reads. Larger continuations also copied each chunk and concatenated the complete result afterward.

Keep the first allocation capped at 16 MiB plus the overflow-probe byte, matching the default Root budget. This preserves one-read async performance throughout that budget and extends the synchronous fast path to it. Beyond the first buffer, read into remaining capacity and grow geometrically only after actual data fills the buffer, never from an unchecked file-size hint. Growth remains capped by maxBytes + 1; underfilled results are compacted and empty reads retain no oversized backing allocation.

The initial regular-file read retains its existing fresh-size EOF shortcut. Later reads require actual EOF, so zero-size or stale-size virtual files cannot be truncated by a short read. Descriptor ownership, current offsets, byte caps, and filesystem boundary/identity checks remain unchanged.

Expand the permanent benchmark to 2 MiB, 16 MiB, and an explicit 32 MiB budget, with reduced iteration counts for large payloads (337 cases total). Extend one-read, beyond-cap, and zero-stat-size/short-read coverage. Validation: 152 focused tests, build, 32 MiB benchmark cases, independent P0–P2 review, and the full Linux `pnpm check` gate with 8,480 passing tests. The complete 337-workload before/after reports passed on the same Linux runner, and all cross-platform CI is green. One existing Windows docs-site test hit its 5-second timeout; the exact job passed on rerun without a code change.
