### PR TITLE
perf(archive): accelerate ZIP integrity checks with native CRC32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.
 
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -31,6 +31,8 @@ cases exclude later close/release, which have their own rows. Representative
 payload assertions run outside measurement. Reads cover 128 B, 64 KiB, 1 MiB,
 2 MiB, the default Root budget of 16 MiB, and an explicit 32 MiB budget;
 writes compare both durability settings without changing package defaults.
+ZIP reads and extraction also cover 1 MiB and 16 MiB stored and deflated members
+to expose payload integrity costs beyond tiny archive fixtures.
 
 For a quick executable coverage check:
 

--- a/benchmarks/archives.mjs
+++ b/benchmarks/archives.mjs
@@ -49,4 +49,23 @@ export async function registerArchives({ api: a, workspace: w, register: add }) 
     add(`readArchiveEntry/${kind}`, () => a.readArchiveEntry(archivePath, "entry.json", { maxBytes: 1024 }), { divisor: 10 });
     if (kind !== "zip") add(`inspectTarArchive/${kind}`, () => a.inspectTarArchive({ archivePath, timeoutMs: 30_000 }), { divisor: 10 });
   }
+  for (const size of [1024 * 1024, 16 * 1024 * 1024]) {
+    const payload = Buffer.alloc(size, 0x61);
+    for (const compression of ["STORE", "DEFLATE"]) {
+      const largeZip = new JSZip();
+      largeZip.file("payload.bin", payload);
+      const archivePath = path.join(w, `large-${size}-${compression}.zip`);
+      fs.writeFileSync(archivePath, await largeZip.generateAsync({ type: "nodebuffer", compression }));
+      const label = `zip-${size / 1024 / 1024}MiB-${compression.toLowerCase()}`;
+      add(`readArchiveEntry/${label}`, () => a.readArchiveEntry(archivePath, "payload.bin", { maxBytes: size }), {
+        divisor: 10,
+        verify: (result) => assert.ok(result.equals(payload)),
+      });
+      add(`extractArchive/${label}`, () => a.extractArchive({ archivePath, destDir: destination, timeoutMs: 30_000 }), {
+        divisor: 10,
+        verify: () => assert.ok(fs.readFileSync(path.join(destination, "payload.bin")).equals(payload)),
+        after: () => fs.rmSync(path.join(destination, "payload.bin"), { force: true }),
+      });
+    }
+  }
 }

--- a/src/archive-crc32.ts
+++ b/src/archive-crc32.ts
@@ -1,4 +1,8 @@
-const CRC32_TABLE = Array.from({ length: 256 }, (_, index) => {
+import zlib from "node:zlib";
+
+const nativeCrc32 = (zlib as Partial<Pick<typeof zlib, "crc32">>).crc32;
+// Node 22.0–22.1 are supported but predate zlib.crc32.
+const CRC32_TABLE = nativeCrc32 ? undefined : Array.from({ length: 256 }, (_, index) => {
   let value = index;
   for (let bit = 0; bit < 8; bit += 1) {
     value = (value & 1) !== 0 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
@@ -7,9 +11,10 @@ const CRC32_TABLE = Array.from({ length: 256 }, (_, index) => {
 });
 
 export function updateCrc32(previous: number, buffer: Buffer): number {
+  if (nativeCrc32) return nativeCrc32(buffer, previous >>> 0);
   let crc = previous ^ -1;
   for (const byte of buffer) {
-    crc = (crc >>> 8) ^ (CRC32_TABLE[(crc ^ byte) & 0xff] ?? 0);
+    crc = (crc >>> 8) ^ (CRC32_TABLE![(crc ^ byte) & 0xff] ?? 0);
   }
   return (crc ^ -1) >>> 0;
 }

--- a/test/archive-crc32.test.ts
+++ b/test/archive-crc32.test.ts
@@ -1,0 +1,38 @@
+import zlib from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe.each(["automatic", "Node 22.0 fallback"])("ZIP CRC32: %s", (backend) => {
+  let update: typeof import("../src/archive-crc32.js").updateCrc32;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    if (backend !== "automatic") {
+      vi.doMock("node:zlib", () => ({ default: { ...zlib, crc32: undefined } }));
+    }
+    update = (await import("../src/archive-crc32.js")).updateCrc32;
+  });
+
+  afterEach(() => vi.doUnmock("node:zlib"));
+
+  it("matches standard vectors and preserves the seed for empty input", () => {
+    expect(update(0, Buffer.from("123456789"))).toBe(0xcbf43926);
+    expect(update(0, Buffer.alloc(0))).toBe(0);
+    expect(update(0xdeadbeef, Buffer.alloc(0))).toBe(0xdeadbeef);
+    expect(update(-1, Buffer.alloc(0))).toBe(0xffffffff);
+  });
+
+  it("chains arbitrary chunks, including empty chunks and nonzero buffer offsets", () => {
+    const storage = Buffer.alloc(256 * 1024 + 7);
+    for (let i = 0; i < storage.length; i++) storage[i] = (i * 31 + (i >>> 8)) & 0xff;
+    const input = storage.subarray(3, storage.length - 4);
+    for (const [seed, expected] of [[0, 0xb22274f8], [1, 0x4d2a9117], [0xffffffff, 0xafd36125]]) {
+      let actual = seed;
+      for (let start = 0; start < input.length; start += 1009) {
+        actual = update(actual, input.subarray(start, start + 1009));
+        actual = update(actual, Buffer.alloc(0));
+      }
+      expect(actual).toBe(expected);
+      expect(update(seed, input)).toBe(actual);
+    }
+  });
+});


### PR DESCRIPTION
ZIP reads and extraction currently compute integrity checks byte by byte in JavaScript. Use Node's native CRC32 on Node 22.2 and newer while keeping the portable implementation for supported Node 22.0–22.1 installations. Unsigned seed handling, streamed checksum checks, byte limits, and corruption rejection remain intact.

Add fixed checksum vectors for seeded, chunked, empty, and offset buffers, plus 1 MiB and 16 MiB stored/deflated ZIP benchmarks with payload verification outside the timer.

Validation: focused CRC32/ZIP-integrity tests passed; independent autoreview found no actionable P0–P2 findings after correcting the test oracle's early-Node-22 compatibility. Full `pnpm check` passed on Linux (5,636 passed, 2,734 platform/native cases skipped without a local native build) using AWS Crabbox `cbx_e50c30199c1a`.

Controlled measurements: three alternating before/after rounds on AWS Crabbox `cbx_e50c30199c1a` (c7a.8xlarge, AMD EPYC 9R14, v24.18.1, Linux), native addon off. Each row is the median of the three run medians, each built from five samples of ten calls, plus warmup. Baseline changes only archive-crc32 back to the implementation at 0e704de; the rest of the build and benchmark harness are identical. Warm-cache latency; not a cold-storage or concurrency claim.

| ZIP operation | Before (ms) | After (ms) | Speedup |
|---|---:|---:|---:|
| readArchiveEntry/zip-1MiB-store | 8.87 | 4.36 | 2.03× |
| extractArchive/zip-1MiB-store | 13.21 | 9.09 | 1.45× |
| readArchiveEntry/zip-1MiB-deflate | 8.64 | 3.80 | 2.27× |
| extractArchive/zip-1MiB-deflate | 12.64 | 7.76 | 1.63× |
| readArchiveEntry/zip-16MiB-store | 136.79 | 62.52 | 2.19× |
| extractArchive/zip-16MiB-store | 151.26 | 85.00 | 1.78× |
| readArchiveEntry/zip-16MiB-deflate | 116.37 | 47.36 | 2.46× |
| extractArchive/zip-16MiB-deflate | 144.97 | 71.23 | 2.04× |
