### PR TITLE
fix(path): expand home prefixes before parent segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.
 
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -126,7 +126,7 @@ component is followed by another segment, both helpers throw
 |---|---|---|
 | `safeDirName`, `safePathSegmentHashed`, `resolveSafeInstallDir`, `assertCanonicalPathWithinBase` | [install-path.md](install-path.md) | Build install-target directories from caller-supplied identifiers. |
 | `sanitizeUntrustedFileName` | [filename.md](filename.md) | Coerce an untrusted string into a safe filename. |
-| `resolveHomeRelativePath` | – | Expand `~`-prefixed paths. |
+| `resolveHomeRelativePath` | – | Expand a leading `~` before resolving `.` and `..`; tildes inside relative paths stay literal. |
 
 ### Temp targets and sibling-temp writes
 

--- a/src/home-dir.ts
+++ b/src/home-dir.ts
@@ -2,6 +2,11 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeOptionalString } from "./string-coerce.js";
 
+function hasHomePrefix(input: string): boolean {
+  return input === "~" || input.startsWith("~/") ||
+    (path.sep === "\\" && input.startsWith("~\\"));
+}
+
 function normalize(value: string | undefined): string | undefined {
   const trimmed = normalizeOptionalString(value);
   if (!trimmed) {
@@ -26,8 +31,7 @@ function resolveRawHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): strin
   if (!explicitHome) {
     return resolveRawOsHomeDir(env, homedir);
   }
-  const segments = path.normalize(explicitHome).split(path.sep);
-  if (segments[0] !== "~") {
+  if (!hasHomePrefix(explicitHome)) {
     return explicitHome;
   }
   // OPENCLAW_HOME starts with "~"; expand against the os home dir. Fall
@@ -75,8 +79,7 @@ export function expandHomePrefix(
     homedir?: () => string;
   },
 ): string {
-  const segments = path.normalize(input).split(path.sep);
-  if (segments[0] !== "~") {
+  if (!hasHomePrefix(input)) {
     return input;
   }
   const home =
@@ -85,7 +88,8 @@ export function expandHomePrefix(
   if (!home) {
     return input;
   }
-  return path.join(home, ...segments.slice(1));
+  // Expand before normalizing so a following .. traverses the actual home.
+  return path.join(home, input.slice(2));
 }
 
 export function resolveHomeRelativePath(
@@ -98,8 +102,7 @@ export function resolveHomeRelativePath(
   if (!input) {
     return input;
   }
-  const segments = path.normalize(input).split(path.sep)
-  if (segments[0] !== "~") {
+  if (!hasHomePrefix(input)) {
     return path.resolve(input);
   }
   const expanded = expandHomePrefix(input, {

--- a/test/home-dir.test.ts
+++ b/test/home-dir.test.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { expandHomePrefix, resolveEffectiveHomeDir, resolveHomeRelativePath } from "../src/home-dir.js";
+import { readLocalFileFromRoots } from "../src/local-roots.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+afterEach(() => vi.unstubAllEnvs());
+
+describe("home prefix resolution", () => {
+  const home = path.resolve("synthetic", "home");
+
+  it.each(["~/../shared", "~/child/../../shared", "~//../shared"])(
+    "expands the home before parent traversal: %s", (input) => {
+      const expected = path.join(home, "..", "shared");
+      expect(expandHomePrefix(input, { home })).toBe(expected);
+      expect(resolveHomeRelativePath(input, { env: { HOME: home } })).toBe(expected);
+      expect(resolveEffectiveHomeDir({ HOME: home, OPENCLAW_HOME: input })).toBe(expected);
+    },
+  );
+
+  it.each(["./~/file", "child/../~/file", "~other/file"])(
+    "keeps a non-leading tilde literal: %s", (input) => {
+      expect(expandHomePrefix(input, { home })).toBe(input);
+      expect(resolveHomeRelativePath(input, { env: { HOME: home } })).toBe(path.resolve(input));
+    },
+  );
+
+  it("preserves bare tilde, missing home, and empty input behavior", () => {
+    expect(expandHomePrefix("~", { home })).toBe(home);
+    expect(expandHomePrefix("~/../shared", { env: {}, homedir: () => "" })).toBe("~/../shared");
+    expect(resolveHomeRelativePath("", { env: { HOME: home } })).toBe("");
+  });
+
+  it.skipIf(process.platform !== "win32")("supports backslash and mixed Windows separators", () => {
+    for (const input of ["~\\..\\shared", "~/child\\..\\..\\shared"]) {
+      expect(expandHomePrefix(input, { home })).toBe(path.join(home, "..", "shared"));
+    }
+  });
+
+  it("reads a parent-relative home path through the configured root boundary", async () => {
+    const dir = await tempRoot("fs-safe-home-prefix-");
+    const fixtureHome = path.join(dir, "home");
+    await fs.mkdir(fixtureHome);
+    await fs.writeFile(path.join(dir, "shared.txt"), "shared contents");
+    vi.stubEnv("OPENCLAW_HOME", fixtureHome);
+    const input = { filePath: "~/../shared.txt", roots: [dir] };
+    const result = await readLocalFileFromRoots(input);
+    expect(result?.buffer.toString()).toBe("shared contents");
+    expect(await readLocalFileFromRoots({ ...input, roots: [fixtureHome] })).toBeNull();
+  });
+});


### PR DESCRIPTION
`resolveHomeRelativePath("~/../shared")` currently normalizes away `~` before expanding it, so it resolves against the working directory rather than the home directory's parent. Expand only a literal leading home prefix before joining and normalizing the rest of the path. This also keeps tildes inside relative paths literal and handles both Windows separator forms.

Regression tests cover parent traversal, nested traversal, non-leading tildes, bare tilde, unavailable homes, and Windows separators. A real-file test reads the intended sibling through an allowed root and confirms that a root limited to the home directory still rejects it.

Validation: baseline reproduction confirmed; 23 focused tests passed locally (one Windows-only case skipped); independent autoreview is clean through P2. Full `pnpm check` passed on Linux via AWS Crabbox `cbx_e50c30199c1a` (5,640 passed; 2,735 platform/native cases skipped without a local native build).

The existing resolveHomeRelativePath benchmark also improved from 0.563 to 0.239 µs/call (2.36×), using three alternating before/after rounds with seven samples each on the same Linux Node 24.18.1 AWS host. This workload uses an ordinary path (see benchmarks/paths.mjs); the new parent-relative behavior is covered by regression tests.

After integration with main, the combined `pnpm check` also passed on the same Linux host: 5,644 passed, 2,735 platform/native cases skipped. The only integration conflict was the changelog; both entries are retained, and final independent autoreview is clean through P2.
