### PR TITLE
fix(native): enforce Linux directory-only opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve Linux native directory-only open flags so non-directories are rejected by the kernel before FIFO blocking or truncation, while removing the redundant post-open stat.
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
 - Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -33,6 +33,7 @@ payload assertions run outside measurement. Reads cover 128 B, 64 KiB, 1 MiB,
 writes compare both durability settings without changing package defaults.
 ZIP reads and extraction also cover 1 MiB and 16 MiB stored and deflated members
 to expose payload integrity costs beyond tiny archive fixtures.
+The native directory-open case times admission separately from descriptor close.
 
 For a quick executable coverage check:
 

--- a/benchmarks/lifecycle.mjs
+++ b/benchmarks/lifecycle.mjs
@@ -3,7 +3,21 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 
-export async function registerLifecycle({ api: a, workspace: w, native, register: add, contract, onCleanup }) {
+export async function registerLifecycle({ api: a, workspace: w, native, binding, register: add, contract, onCleanup }) {
+  if (binding) {
+    const directory = path.join(w, "native-directory");
+    fs.mkdirSync(directory);
+    const flags = fs.constants.O_RDONLY | (fs.constants.O_DIRECTORY ?? 0);
+    const rootFd = fs.openSync(w, flags);
+    onCleanup(() => fs.closeSync(rootFd));
+    add("native.openBeneath/directory", () => binding.openBeneath(rootFd, "native-directory", flags), {
+      sync: true,
+      verify: (opened) => assert.ok(fs.fstatSync(opened.fd).isDirectory()),
+      after: (opened) => { if (opened) fs.closeSync(opened.fd); },
+    });
+  } else {
+    add("native.openBeneath/directory", () => {}, { skip: "native binding unavailable" });
+  }
   const input = path.join(w, "input.json");
   const data = Buffer.from("synthetic benchmark\n");
   const output = path.join(w, "lifecycle-output");

--- a/benchmarks/runner.mjs
+++ b/benchmarks/runner.mjs
@@ -76,7 +76,7 @@ const contract = (name, object) => {
   contracts.set(name, [...properties].sort());
 };
 const cleanups = [];
-const context = { api, workspace, native, register, exclude, contract, args, onCleanup: (fn) => cleanups.push(fn) };
+const context = { api, workspace, native, binding, register, exclude, contract, args, onCleanup: (fn) => cleanups.push(fn) };
 let cleanup;
 try {
   cleanup = await registerCore(context);

--- a/native/src/unix.rs
+++ b/native/src/unix.rs
@@ -66,30 +66,21 @@ pub fn open_beneath(root_fd: i32, rel_path: &str, flags: i32) -> NativeResult<i3
             .map(OwnedFd::into_raw_fd)
             .map_err(|error| os_error(error, "duplicate root descriptor"));
     }
-    let path = if rel_path.is_empty() { "." } else { rel_path };
-    let mut oflags = OFlags::from_bits_retain(flags as u32);
-    let require_directory = oflags.contains(OFlags::DIRECTORY);
-    oflags.remove(OFlags::DIRECTORY);
-    let mode = if oflags.intersects(OFlags::CREATE | OFlags::TMPFILE) {
+    let oflags = OFlags::from_bits_retain(flags as u32);
+    // O_TMPFILE contains O_DIRECTORY; a directory-only open still requires mode 0.
+    let mode = if oflags.contains(OFlags::CREATE) || oflags.contains(OFlags::TMPFILE) {
         Mode::from_bits_retain(0o600)
     } else {
         Mode::empty()
     };
     let fd = openat2(
         borrowed(root_fd),
-        path,
+        rel_path,
         oflags,
         mode,
         ResolveFlags::BENEATH | ResolveFlags::NO_MAGICLINKS,
     )
     .map_err(|error| os_error(error, "openat2 beneath root"))?;
-    if require_directory {
-        let stat = rustix::fs::fstat(fd.as_fd())
-            .map_err(|error| os_error(error, "fstat opened directory"))?;
-        if !FileType::from_raw_mode(stat.st_mode).is_dir() {
-            return Err(native_error("ENOTDIR", "opened path is not a directory"));
-        }
-    }
     Ok(fd.into_raw_fd())
 }
 

--- a/test/native-directory-admission.test.ts
+++ b/test/native-directory-admission.test.ts
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { hostNativeTarget } from "../scripts/native-targets.mjs";
+import { paxNative as native } from "./helpers/archive-pax-native.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const directoryFlags = fs.constants.O_RDONLY | fs.constants.O_DIRECTORY;
+
+describe.skipIf(process.platform !== "linux" || !native)("native directory admission", () => {
+  it("opens directories and creates regular files with the correct mode argument", async () => {
+    const dir = await tempRoot("fs-safe-native-directory-");
+    fs.mkdirSync(path.join(dir, "nested"));
+    const root = fs.openSync(dir, directoryFlags);
+    try {
+      const opened = native!.openBeneath(root, "nested", directoryFlags);
+      try { expect(fs.fstatSync(opened.fd).isDirectory()).toBe(true); }
+      finally { fs.closeSync(opened.fd); }
+      const file = native!.openBeneath(root, "created", fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL);
+      try { expect(fs.fstatSync(file.fd).isFile()).toBe(true); }
+      finally { fs.closeSync(file.fd); }
+    } finally { fs.closeSync(root); }
+  });
+
+  it("rejects regular files before applying a directory open's truncate flag", async () => {
+    const dir = await tempRoot("fs-safe-native-directory-type-");
+    const target = path.join(dir, "file");
+    fs.writeFileSync(target, "preserve these bytes");
+    const root = fs.openSync(dir, directoryFlags);
+    try {
+      for (const flags of [directoryFlags, fs.constants.O_WRONLY | fs.constants.O_DIRECTORY | fs.constants.O_TRUNC]) {
+        expect(() => native!.openBeneath(root, "file", flags)).toThrowError(expect.objectContaining({ code: "ENOTDIR" }));
+        expect(fs.readFileSync(target, "utf8")).toBe("preserve these bytes");
+      }
+    } finally { fs.closeSync(root); }
+  });
+
+  it.each(["open", "mkdir"])("rejects a writerless FIFO during %s without blocking", async (operation) => {
+    const dir = await tempRoot("fs-safe-native-directory-fifo-");
+    const fifo = path.join(dir, "fifo");
+    expect(spawnSync("mkfifo", [fifo]).status).toBe(0);
+    const artifact = fileURLToPath(new URL(`../native/${hostNativeTarget()!.artifact}`, import.meta.url));
+    // Only the potentially blocking operation is under the child deadline.
+    const child = spawnSync(process.execPath, ["-e", `
+      const assert = require("node:assert/strict");
+      const fs = require("node:fs");
+      const native = require(process.argv[1]);
+      const fd = fs.openSync(process.argv[2], fs.constants.O_RDONLY | fs.constants.O_DIRECTORY);
+      try {
+        assert.throws(() => process.argv[3] === "open"
+          ? native.openBeneath(fd, "fifo", fs.constants.O_RDONLY | fs.constants.O_DIRECTORY)
+          : native.mkdirBeneath(fd, "fifo/child", 0o700), { code: "ENOTDIR" });
+      } finally { fs.closeSync(fd); }
+    `, artifact, dir, operation], { encoding: "utf8", timeout: 3000, killSignal: "SIGKILL" });
+    expect(child.error, child.stderr).toBeUndefined();
+    expect(child.status, child.stderr).toBe(0);
+    expect(fs.lstatSync(fifo).isFIFO()).toBe(true);
+    expect(fs.readdirSync(dir)).toEqual(["fifo"]);
+  }, 10_000);
+});


### PR DESCRIPTION
Linux directory-only opens removed `O_DIRECTORY`, opened the path, and then checked its type with `fstat`. A writerless FIFO therefore blocked before rejection; combining a directory open with truncation could also erase a regular file before returning `ENOTDIR`.

Keep `O_DIRECTORY` in the kernel open and remove the redundant post-open stat. `O_TMPFILE` includes the directory bit, so creation-mode selection now tests the complete `O_TMPFILE` flag instead of any intersecting bit. Ordinary directory opens correctly pass mode zero; exclusive file creation retains mode 0600.

Regression proof uses real Linux files/FIFOs and child-process deadlines: the baseline fails three cases (two hangs and erased file content), while the candidate passes all four. `pnpm native:test` and full `pnpm check` passed on AWS Crabbox `cbx_8a8cf6b28b41` with the freshly built binding: 8,496 tests passed, 89 platform cases skipped. Independent autoreview is clean through P2 after supplying the unchanged early-return branch that handles empty/dot paths.

The added native directory-open benchmark excludes descriptor close from timing. Three alternating before/after runs, each with seven samples of 10,000 calls on Linux Node 24.18.1 / AMD EPYC 9R14, measured approximately 3.35 → 2.56 µs per call (24% lower latency). Builds record the actual loaded addon hash; these are warm-cache directory-open timings, not an across-the-library speedup claim.
