### PR TITLE
fix(lock): keep zero-delay retries finite after overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.
 - Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.
 - Add a method-by-method benchmark with callable API coverage checks, native/fallback reports, and separate fixture timing.
+- Keep zero-delay lock retries finite when a large backoff factor overflows, preventing synchronous waits from bypassing retry and timeout budgets.
 
 ## 0.9.0 - 2026-09-11
 

--- a/src/sidecar-lock-policy.ts
+++ b/src/sidecar-lock-policy.ts
@@ -37,7 +37,9 @@ export function computeSidecarLockDelayMs(retry: SidecarLockRetryOptions, attemp
   const minTimeout = retry.minTimeout ?? 50;
   const maxTimeout = retry.maxTimeout ?? 1000;
   const factor = retry.factor ?? 1;
-  const base = Math.min(maxTimeout, Math.max(minTimeout, minTimeout * factor ** attempt));
+  // Zero times an overflowing power is NaN, which makes Atomics.wait unbounded.
+  const scaled = minTimeout === 0 ? 0 : minTimeout * factor ** attempt;
+  const base = Math.min(maxTimeout, Math.max(minTimeout, scaled));
   const jitter = retry.randomize ? 1 + Math.random() : 1;
   return Math.min(maxTimeout, Math.round(base * jitter));
 }

--- a/test/file-lock-retry-budget.test.ts
+++ b/test/file-lock-retry-budget.test.ts
@@ -96,6 +96,21 @@ for (const mode of ["async", "Root async", "sync", "Root sync"] as const) {
       }
     });
 
+    it.each([false, true])("keeps zero delays finite when exponential backoff overflows (randomize=%s)", async (randomize) => {
+      const { holder, original, lockPath, payload, waits, acquire, cleanup } = await fixture(4);
+      try {
+        await expect(acquire({
+          retries: 3, minTimeout: 0, maxTimeout: 1000, factor: Number.MAX_VALUE, randomize,
+        }, 100)).rejects.toMatchObject({ code: "file_lock_timeout", lockPath });
+        expect(waits).toEqual([0, 0, 0]);
+        expect(payload).toHaveBeenCalledTimes(4);
+        expect(holder.verifyStillHeld()).toBe(true);
+        expect(fs.readFileSync(lockPath, "utf8")).toBe(original);
+      } finally {
+        await cleanup();
+      }
+    });
+
     it.each([
       { retry: undefined, timeoutMs: undefined }, { retry: {}, timeoutMs: undefined },
       { retry: undefined, timeoutMs: Infinity }, { retry: {}, timeoutMs: Infinity },


### PR DESCRIPTION
A valid zero minimum lock retry delay can become `NaN` when a large finite factor overflows during exponentiation (`0 * Infinity`). Synchronous retries then pass `NaN` to `Atomics.wait`, which waits indefinitely and bypasses both retry and timeout budgets.

Keep zero scaling at zero before computing the capped delay. Positive delays, validation, maximum-delay caps, jitter, stale policy, and ownership checks remain unchanged. The regression drives async, sync, and both Root-backed lock modes with and without jitter, checking retry exhaustion and preservation of the held sidecar.

Validation: 64 focused tests passed; independent autoreview is clean through P2. A real child-process probe timed out after 3 seconds on the baseline despite a 100 ms lock budget, while the fixed build returned `file_lock_timeout`. Full `pnpm check` passed with the freshly built native binding on AWS Crabbox `cbx_e7c5e5c92048`: 8,504 tests passed, 89 platform skips.
