### PR TITLE
fix(archive): isolate cancellation state for native passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Forward archive deadlines through a separate abort signal for each native pass, so completed inspection cannot mask cancellation of extraction.
 - Preserve Linux native directory-only open flags so non-directories are rejected by the kernel before FIFO blocking or truncation, while removing the redundant post-open stat.
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
 - Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.

--- a/src/archive-native.ts
+++ b/src/archive-native.ts
@@ -70,12 +70,13 @@ export async function extractNativeArchive(params: {
       destinationRealDir,
       run: async (stagingDir) => {
         params.deadline.check();
+        // N-API retains completed task state on its signal; each pass needs its own.
         const manifest = await params.binding
           .inspectArchiveNative(
             stagedArchive.path,
             params.kind,
             tarLimits,
-            params.deadline.signal,
+            AbortSignal.any([params.deadline.signal]),
           )
           .catch(throwMappedNativeArchiveError);
         params.deadline.check();
@@ -127,7 +128,7 @@ export async function extractNativeArchive(params: {
             directory.fd,
             plan.map((entry) => ({ ...entry, mode: entry.kind === "directory" ? 0o700 : 0o600 })),
             tarLimits,
-            params.deadline.signal,
+            AbortSignal.any([params.deadline.signal]),
           ).catch(throwMappedNativeArchiveError);
         } finally {
           await directory.close().catch(() => undefined);

--- a/test/archive-native-cancellation.test.ts
+++ b/test/archive-native-cancellation.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { extractNativeArchive } from "../src/archive-native.js";
+import { resolveExtractLimits, resolveTarMeterLimits } from "../src/archive-limits.js";
+import type { NativeBinding } from "../src/native.js";
+import { tarFixture } from "./helpers/archive-fuzz.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+
+it("cancels native extraction after inspection completes on the same deadline", async () => {
+  const dir = await tempRoot("fs-safe-native-cancel-");
+  const archivePath = path.join(dir, "fixture.tar");
+  const destDir = path.join(dir, "output");
+  await fs.writeFile(archivePath, tarFixture([{ path: "entry", body: "payload" }]));
+  await fs.mkdir(destDir);
+  await fs.writeFile(path.join(destDir, "sentinel"), "unchanged");
+  const controller = new AbortController();
+  const abortError = new Error("native extraction aborted");
+  type Task = { complete: boolean; abort(): void };
+  const tasks = new WeakMap<AbortSignal, Task[]>();
+  // N-API 3.12 keeps a stack per signal and stops abort dispatch at a completed task.
+  const registerTask = (signal: AbortSignal, task: Task) => {
+    const stack = tasks.get(signal) ?? [];
+    stack.push(task);
+    tasks.set(signal, stack);
+    signal.onabort = () => {
+      for (const entry of stack) {
+        if (entry.complete) return;
+        entry.abort();
+      }
+    };
+  };
+  let extractionAborted = false;
+  let release: (error: Error) => void = () => {};
+  let entered: () => void = () => {};
+  const extractionEntered = new Promise<void>((resolve) => { entered = resolve; });
+  const binding = {
+    async inspectArchiveNative(...args: Parameters<NativeBinding["inspectArchiveNative"]>) {
+      registerTask(args[3], { complete: true, abort() {} });
+      return [{ index: 0, path: "entry", kind: "file", size: 7, mode: 0o644 }];
+    },
+    extractArchiveNative(...args: Parameters<NativeBinding["extractArchiveNative"]>) {
+      const pending = new Promise<void>((_resolve, reject) => { release = reject; });
+      registerTask(args[5], { complete: false, abort() {
+        extractionAborted = true;
+        release(abortError);
+      } });
+      entered();
+      return pending;
+    },
+  } as NativeBinding;
+  const limits = resolveExtractLimits();
+  const operation = extractNativeArchive({
+    binding, archivePath, destDir, kind: "tar", limits, tarLimits: resolveTarMeterLimits(limits),
+    deadline: {
+      signal: controller.signal,
+      check: () => controller.signal.throwIfAborted(),
+      ownDestinationMutation: async (run) => await run(),
+      waitForDestinationMutations: async () => {},
+      dispose() {},
+    },
+  }).then(() => undefined, (error: unknown) => error);
+  try {
+    await Promise.race([extractionEntered, operation.then((error) => { throw error; })]);
+    controller.abort(abortError);
+    expect(extractionAborted).toBe(true);
+    expect(await operation).toBe(abortError);
+    expect(await fs.readdir(destDir)).toEqual(["sentinel"]);
+    expect(await fs.readFile(path.join(destDir, "sentinel"), "utf8")).toBe("unchanged");
+  } finally {
+    // Drain a broken implementation as well, without leaving its private stage live.
+    release(abortError);
+    await operation;
+  }
+});


### PR DESCRIPTION
Native archive extraction reused one abort signal for inspection and extraction. N-API retains per-task state on that signal, and a completed inspection can stop its abort dispatch before the extraction task sees cancellation. The public deadline still rejects, but the private native extraction can continue doing unnecessary work.

Give each native pass a dependent abort signal. The original deadline, destination-mutation ownership, and retained-descriptor lifetime remain intact. A deterministic dependency-protocol regression verifies that cancellation reaches extraction after completed inspection, all work drains, and existing destination contents stay unchanged.

Validation: a real Linux native two-task probe resolved after abort with the reused signal and rejected with isolated signals. Focused cancellation/lifetime tests passed, independent autoreview is clean through P2, and full `pnpm check` passed with the freshly built native binding on AWS Crabbox `cbx_e7c5e5c92048`: 8,497 tests passed, 89 platform skips.
