### PR TITLE
fix(temp): preserve recreated paths after missing observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
 - Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.
+- Preserve recreated temporary paths when an exit-cleanup lookup observed the original name missing; absence no longer authorizes a forced removal.
 
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.
 - Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.

--- a/src/temp-cleanup.ts
+++ b/src/temp-cleanup.ts
@@ -26,8 +26,9 @@ function pathStillMatchesReceipt(entry: TempCleanupEntry): boolean {
     const current = fsSync.lstatSync(entry.path, { bigint: true });
     return (!entry.singleLinkFile || (current.isFile() && current.nlink === 1n)) &&
       sameFileIdentityForCleanup(current, entry.identity);
-  } catch (error) {
-    return !entry.singleLinkFile && (error as NodeJS.ErrnoException).code === "ENOENT";
+  } catch {
+    // A missing pathname grants no authority over an entry created after this lookup.
+    return false;
   }
 }
 

--- a/test/temp-cleanup-observation.test.ts
+++ b/test/temp-cleanup-observation.test.ts
@@ -1,0 +1,35 @@
+import fsSync from "node:fs";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import { __cleanupRegisteredTempPathForTest, registerTempPathForExit } from "../src/temp-cleanup.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useTempDirs();
+
+it.each([false, true])("preserves a replacement after a missing cleanup observation (directory=%s)", async (directory) => {
+  const root = await tempRoot("fs-safe-temp-cleanup-recreated-");
+  const tempPath = path.join(root, "entry");
+  const displaced = path.join(root, "original");
+  const write = (target: string, content: string) => {
+    if (directory) fsSync.mkdirSync(target);
+    fsSync.writeFileSync(directory ? path.join(target, "payload") : target, content);
+  };
+  write(tempPath, "owned");
+  const unregister = registerTempPathForExit(tempPath, { recursive: directory });
+  const lstat = vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => {
+    fsSync.renameSync(tempPath, displaced);
+    // Model a new entry arriving just after the kernel observed the old name absent.
+    write(tempPath, "replacement");
+    throw Object.assign(new Error("path disappeared"), { code: "ENOENT" });
+  });
+  try {
+    __cleanupRegisteredTempPathForTest(tempPath);
+    expect(fsSync.readFileSync(directory ? path.join(tempPath, "payload") : tempPath, "utf8"))
+      .toBe("replacement");
+    expect(fsSync.readFileSync(directory ? path.join(displaced, "payload") : displaced, "utf8"))
+      .toBe("owned");
+  } finally {
+    lstat.mockRestore();
+    unregister();
+  }
+});


### PR DESCRIPTION
Exit cleanup treated an `ENOENT` identity lookup as permission to force-remove the registered pathname. If another entry appeared after that lookup, cleanup could remove the replacement despite having no ownership evidence for it.

A failed lookup now skips removal. Successful identity checks still clean owned paths, and custom cleanup callbacks retain their existing behavior. The focused regressions model the lookup gap for both a file and a directory and verify that the replacement and displaced original contents survive; this does not claim atomic compare-and-unlink semantics.

Validation: built-package before/after probes reproduced deletion on the baseline and preservation on the candidate. The focused tests pass; independent autoreview is clean through P2. Full `pnpm check` passed with a freshly built native binding on AWS Crabbox `cbx_e7c5e5c92048`: 8,498 tests passed, 89 platform skips. Tests were placed in a separate file to stay within the repository's 500-line limit.
