### PR TITLE
fix(atomic): relinquish descriptor ownership before close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Preserve Linux native directory-only open flags so non-directories are rejected by the kernel before FIFO blocking or truncation, while removing the redundant post-open stat.
+- Close publication descriptors when initial inspection fails, and relinquish descriptor numbers before potentially failing closes so cleanup cannot close a reused descriptor.
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
 - Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.

--- a/src/publish-file.ts
+++ b/src/publish-file.ts
@@ -160,9 +160,9 @@ async function copyPinnedSource(params: {
       }
 
       let target: FileHandle | undefined;
-      let createdIdentity = fsSync.fstatSync(nativeFd, { bigint: true });
-      rememberCreatedTarget(params.failure, createdIdentity, "copy-verify");
       try {
+        let createdIdentity = fsSync.fstatSync(nativeFd, { bigint: true });
+        rememberCreatedTarget(params.failure, createdIdentity, "copy-verify");
         fsSync.fchmodSync(nativeFd, 0o600);
         createdIdentity = fsSync.fstatSync(nativeFd, { bigint: true });
         await getFsSafeTestHooks()?.afterPublishTargetCreated?.(
@@ -182,8 +182,9 @@ async function copyPinnedSource(params: {
           throw new FsSafeError("path-mismatch", "native publication target changed after copy");
         }
         const hashed = await hashFileHandle(target, params.native);
-        fsSync.closeSync(nativeFd);
+        const completedFd = nativeFd;
         nativeFd = undefined;
+        fsSync.closeSync(completedFd);
         return {
           handle: target,
           exactIdentity: opened,
@@ -200,9 +201,9 @@ async function copyPinnedSource(params: {
   }
 
   const target = await fs.open(params.targetPath, "wx+", 0o600);
-  const createdIdentity = fsSync.fstatSync(target.fd, { bigint: true });
-  rememberCreatedTarget(params.failure, createdIdentity, "copy-verify");
   try {
+    const createdIdentity = fsSync.fstatSync(target.fd, { bigint: true });
+    rememberCreatedTarget(params.failure, createdIdentity, "copy-verify");
     await target.chmod(0o600);
     const exactIdentity = fsSync.fstatSync(target.fd, { bigint: true });
     await getFsSafeTestHooks()?.afterPublishTargetCreated?.(

--- a/src/replace-file-temp-owner.ts
+++ b/src/replace-file-temp-owner.ts
@@ -369,7 +369,9 @@ export class SyncAtomicTempOwner {
       if (sha256Hex(fsModule.readFileSync(publishedFd)) !== expectedHash) {
         throw new FsSafeError("path-mismatch", `Atomic replace published content changed: ${pathname}`);
       }
-      fsModule.closeSync(this.#fd!);
+      const previousFd = this.#fd!;
+      this.#fd = undefined;
+      fsModule.closeSync(previousFd);
       this.#fd = publishedFd;
       this.#identity = identity;
       publishedFd = undefined;
@@ -411,8 +413,10 @@ export class SyncAtomicTempOwner {
     }
     if (cleanupComplete) this.#unregister();
     if (this.#fd !== undefined) {
+      const fd = this.#fd;
+      this.#fd = undefined;
       try {
-        params.fsModule.closeSync(this.#fd);
+        params.fsModule.closeSync(fd);
       } catch (closeError) {
         deferredError = deferredError
           ? new AggregateError([deferredError, closeError], "Atomic temp cleanup and close failed")

--- a/test/descriptor-close-ownership.test.ts
+++ b/test/descriptor-close-ownership.test.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { publishFileExclusive } from "../src/publish-file.js";
+import { replaceFileAtomicSync } from "../src/replace-file.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __resetNativeLoaderForTest, __setNativeLoaderForTest, type NativeBinding } from "../src/native.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetNativeLoaderForTest();
+  __resetFsSafeNativeConfigForTest();
+});
+
+const failure = () => Object.assign(new Error("late filesystem failure"), { code: "EIO" });
+function isOpen(fd: number, stat = fsSync.fstatSync): boolean {
+  try { stat(fd); return true; } catch { return false; }
+}
+function nativeCopy(target: string, created: (fd: number) => void): NativeBinding {
+  return {
+    linkBeneath() { throw Object.assign(new Error("cross-device"), { code: "EXDEV" }); },
+    cloneFileExclusive(sourceFd: number) {
+      const bytes = Buffer.alloc(fsSync.fstatSync(sourceFd).size);
+      fsSync.readSync(sourceFd, bytes, 0, bytes.length, 0);
+      const fd = fsSync.openSync(target, "wx", 0o600);
+      fsSync.writeSync(fd, bytes);
+      created(fd);
+      return fd;
+    },
+    async sha256File(fd: number) {
+      const bytes = Buffer.alloc(fsSync.fstatSync(fd).size);
+      fsSync.readSync(fd, bytes, 0, bytes.length, 0);
+      return { bytes: bytes.length, digest: createHash("sha256").update(bytes).digest("hex") };
+    },
+  } as NativeBinding;
+}
+
+it.each([false, true])("closes a created publication descriptor after initial stat failure (native=%s)", async (native) => {
+  const dir = await tempRoot("fs-safe-publication-stat-");
+  const source = path.join(dir, "source"), target = path.join(dir, "target");
+  await fs.writeFile(source, "source bytes");
+  let createdFd: number | undefined;
+  let createdHandle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  const stat = fsSync.fstatSync, error = failure();
+  if (native) {
+    configureFsSafeNative({ mode: "auto" });
+    __setNativeLoaderForTest(() => nativeCopy(target, (fd) => { createdFd = fd; }));
+  } else {
+    configureFsSafeNative({ mode: "off" });
+    vi.spyOn(fs, "link").mockRejectedValue(Object.assign(new Error("cross-device"), { code: "EXDEV" }));
+    const open = fs.open;
+    vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+      const handle = await open(...args);
+      if (args[0] === target) { createdFd = handle.fd; createdHandle = handle; }
+      return handle;
+    });
+  }
+  let injected = false;
+  vi.spyOn(fsSync, "fstatSync").mockImplementation((...args: Parameters<typeof fsSync.fstatSync>) => {
+    if (args[0] === createdFd && !injected) { injected = true; throw error; }
+    return stat(...args);
+  });
+  try {
+    await expect(publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-or-copy" }))
+      .rejects.toBe(error);
+    expect(injected).toBe(true);
+    expect(isOpen(createdFd!, stat)).toBe(false);
+    expect(await fs.readFile(source, "utf8")).toBe("source bytes");
+  } finally {
+    vi.restoreAllMocks();
+    if (createdHandle) await createdHandle.close().catch(() => {});
+    else if (createdFd !== undefined && isOpen(createdFd, stat)) fsSync.closeSync(createdFd);
+  }
+});
+
+it("does not retry a native publication close after the descriptor number was released", async () => {
+  const dir = await tempRoot("fs-safe-publication-close-");
+  const source = path.join(dir, "source"), target = path.join(dir, "target"), other = path.join(dir, "other");
+  await fs.writeFile(source, "source bytes");
+  await fs.writeFile(other, "unrelated bytes");
+  let nativeFd: number | undefined, otherFd: number | undefined;
+  let injected = false;
+  const close = fsSync.closeSync, error = failure();
+  configureFsSafeNative({ mode: "auto" });
+  __setNativeLoaderForTest(() => nativeCopy(target, (fd) => { nativeFd = fd; }));
+  vi.spyOn(fsSync, "closeSync").mockImplementation((fd) => {
+    if (fd === nativeFd && !injected) {
+      injected = true;
+      close(fd);
+      otherFd = fsSync.openSync(other, "r");
+      throw error;
+    }
+    close(fd);
+  });
+  try {
+    await expect(publishFileExclusive({ sourcePath: source, targetPath: target, strategy: "link-or-copy" }))
+      .rejects.toMatchObject({ cause: error });
+    expect(injected).toBe(true);
+    expect(isOpen(otherFd!)).toBe(true);
+    expect(fsSync.readFileSync(otherFd!, "utf8")).toBe("unrelated bytes");
+  } finally {
+    vi.restoreAllMocks();
+    if (otherFd !== undefined && isOpen(otherFd)) close(otherFd);
+  }
+});
+
+it("does not retry an atomic temp close after content verification adopts a new inode", async () => {
+  const dir = await tempRoot("fs-safe-atomic-close-");
+  const target = path.join(dir, "target"), other = path.join(dir, "other");
+  await fs.writeFile(other, "unrelated bytes");
+  let tempFd: number | undefined, otherFd: number | undefined;
+  let injected = false;
+  const error = failure();
+  const fileSystem = {
+    ...fsSync,
+    openSync(...args: Parameters<typeof fsSync.openSync>) {
+      const fd = fsSync.openSync(...args);
+      if (args[1] === "wx") tempFd = fd;
+      return fd;
+    },
+    renameSync(from: fsSync.PathLike, to: fsSync.PathLike) {
+      fsSync.copyFileSync(from, to);
+      fsSync.unlinkSync(from);
+    },
+    closeSync(fd: number) {
+      if (fd === tempFd && !injected) {
+        injected = true;
+        fsSync.closeSync(fd);
+        otherFd = fsSync.openSync(other, "r");
+        throw error;
+      }
+      fsSync.closeSync(fd);
+    },
+  };
+  try {
+    expect(() => replaceFileAtomicSync({ filePath: target, content: "replacement", fileSystem,
+      renameIdentity: "verify-content-with-lock" })).toThrow(error);
+    expect(injected).toBe(true);
+    expect(isOpen(otherFd!)).toBe(true);
+    expect(fsSync.readFileSync(otherFd!, "utf8")).toBe("unrelated bytes");
+  } finally {
+    if (otherFd !== undefined && isOpen(otherFd)) fsSync.closeSync(otherFd);
+  }
+});


### PR DESCRIPTION
A late close error can occur after the operating system releases the descriptor number. Publication and synchronous atomic replacement retained that number until close succeeded, allowing error cleanup to close an unrelated file that reused it. Initial publication stat failures also escaped the descriptor cleanup scope.

Move initial inspection into the cleanup scope and relinquish numeric descriptor ownership before closing. Keep identity checks, publication cleanup authority, and existing error reporting intact.

Validation: four focused regression tests pass; built-package fault injection now closes descriptors after failed initial stat and preserves unrelated descriptors after late close failures. Independent Codex review found no actionable P0–P2 issues. Full native Linux `pnpm check` passed (8,500 tests, 89 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; `git diff --check` passed.
