### PR TITLE
fix(queue): skip invalid delivered marker names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Skip invalid delivered-marker names during durable queue batch loading, preserving malformed files while continuing to load valid pending entries.
 - Forward archive deadlines through a separate abort signal for each native pass, so completed inspection cannot mask cancellation of extraction.
 - Preserve Linux native directory-only open flags so non-directories are rejected by the kernel before FIFO blocking or truncation, while removing the redundant post-open stat.
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.

--- a/src/json-durable-queue.ts
+++ b/src/json-durable-queue.ts
@@ -413,6 +413,7 @@ export async function loadPendingJsonDurableQueueEntries<T>(
   for (const file of files) {
     if (file.endsWith(".delivered")) {
       const id = file.slice(0, -".delivered".length);
+      try { assertSafeQueueEntryId(id); } catch { continue; }
       await completeDeliveredQueueEntry(resolveJsonDurableQueueEntryPaths(options.queueDir, id));
     } else if (options.cleanupTmpMaxAgeMs !== undefined && file.endsWith(".tmp")) {
       await unlinkStaleTmpBestEffort(

--- a/test/json-durable-queue-batch-durability.test.ts
+++ b/test/json-durable-queue-batch-durability.test.ts
@@ -314,7 +314,10 @@ describe("batch entry skip boundary", () => {
 
   it("skips invalid listed IDs while returning a valid entry", async () => {
     const { queueDir, paths, load } = await fixture();
-    const invalid = [".json", ".processing", ".hidden.json", "bad name.json"];
+    const invalid = [
+      ".json", ".processing", ".hidden.json", "bad name.json",
+      ".delivered", ".hidden.delivered", "bad name.delivered",
+    ];
     await Promise.all(invalid.map(async (name) => await fs.writeFile(path.join(queueDir, name), "invalid")));
     const realReaddir = fs.readdir.bind(fs);
     vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {


### PR DESCRIPTION
A malformed delivered-marker filename such as `.delivered` caused durable queue batch loading to reject before returning valid jobs. Pending entry names already followed the documented skip-invalid-name behavior.

Validate delivered IDs before resolving paths or cleaning markers. Invalid names remain untouched; failures while completing valid delivered entries still propagate. The existing mixed-entry regression now includes empty, hidden, and whitespace-containing delivered IDs and fails on the baseline.

Validation: 18 focused tests passed, independent Codex review clean through P2, full native Linux `pnpm check` passed (8,507 tests, 89 skipped) on AWS Crabbox `cbx_e7c5e5c92048`, and `git diff --check` passed.
