### PR TITLE
fix(timing): honor delays above the Node timer limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.
 - Add a method-by-method benchmark with callable API coverage checks, native/fallback reports, and separate fixture timing.
 - Keep zero-delay lock retries finite when a large backoff factor overflows, preventing synchronous waits from bypassing retry and timeout budgets.
+- Honor finite timeouts and retry delays above Node's single-timer limit by rearming bounded timers instead of expiring after approximately 1 ms.
 
 ## 0.9.0 - 2026-09-11
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -148,7 +148,7 @@ component is followed by another segment, both helpers throw
 | Export | Page | Notes |
 |---|---|---|
 | `createAsyncLock` | – | In-process async lock (separate from cross-process file locks). |
-| `withTimeout` | [timing.md](timing.md) | Wrap a promise with a timeout that raises `FsSafeError("timeout")`. |
+| `withTimeout` | [timing.md](timing.md) | Wrap a promise with a timeout that raises `Error` by default, or an error supplied by `createError`. |
 | `movePathToTrash`, `MovePathToTrashOptions` | – | Best-effort move to the platform trash. |
 
 ## Stability
@@ -158,5 +158,5 @@ Items in this surface can change shape between minor versions if a higher-level 
 ## Related pages
 
 - [Root API](root.md) — built on top of these helpers.
-- [Errors](errors.md) — every helper here surfaces failures as `FsSafeError`.
+- [Errors](errors.md) — shared filesystem error codes; generic timing helpers retain their documented error types.
 - [Security model](security-model.md) — what the underlying boundary checks promise.

--- a/docs/timing.md
+++ b/docs/timing.md
@@ -22,6 +22,8 @@ function withTimeout<T>(
 
 If `timeoutMs` is `0`, negative, `Infinity`, or `NaN`, the helper is a no-op and simply awaits the original promise.
 
+Finite delays above Node's single-timer limit (2,147,483,647 ms, about 24.9 days) are scheduled in bounded intervals without expiring early. The timer is still cleared if the wrapped promise settles first.
+
 ## Examples
 
 ### Simple ceiling

--- a/src/archive-deadline.ts
+++ b/src/archive-deadline.ts
@@ -1,3 +1,5 @@
+import { scheduleTimeout } from "./timing.js";
+
 export type ExtractionDeadline = {
   signal: AbortSignal;
   check: () => void;
@@ -99,16 +101,14 @@ function createExtractionDeadline(timeoutMs: number, label: string): ExtractionD
       dispose: () => undefined,
     };
   }
-  const timeoutId = setTimeout(() => {
+  const cancelTimeout = scheduleTimeout(() => {
     controller.abort(timeoutError);
   }, timeoutMs);
   return {
     signal: controller.signal,
     check,
     ...mutationOwner,
-    dispose: () => {
-      clearTimeout(timeoutId);
-    },
+    dispose: cancelTimeout,
   };
 }
 

--- a/src/secure-file.ts
+++ b/src/secure-file.ts
@@ -22,6 +22,7 @@ import {
   type PermissionCheckOptions,
 } from "./permissions.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
+import { scheduleTimeout } from "./timing.js";
 
 export type SecureFileReadOptions = {
   filePath: string;
@@ -234,19 +235,19 @@ async function readHandleWithTimeout(
   if (timeoutMs === undefined || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return await read();
   }
-  let timeout: NodeJS.Timeout | undefined;
+  let cancelTimeout: (() => void) | undefined;
   try {
     return await Promise.race([
       read(),
       new Promise<never>((_resolve, reject) => {
-        timeout = setTimeout(() => {
+        cancelTimeout = scheduleTimeout(() => {
           void handle.close().catch(() => undefined);
           reject(new FsSafeError("timeout", `secure file read timed out after ${timeoutMs}ms`));
         }, timeoutMs);
       }),
     ]);
   } finally {
-    if (timeout) clearTimeout(timeout);
+    cancelTimeout?.();
   }
 }
 

--- a/src/sidecar-lock-acquire.ts
+++ b/src/sidecar-lock-acquire.ts
@@ -31,6 +31,7 @@ import {
 } from "./sidecar-lock-reclaim.js";
 import type { SidecarLockAcquireOptions, SidecarLockHandle } from "./sidecar-lock-types.js";
 import { createSuppressedError } from "./suppressed-error.js";
+import { sleep } from "./timing.js";
 
 type SidecarFileHandle = Pick<NativeFileHandle, "fd" | "close" | "stat" | "writeFile">;
 
@@ -148,7 +149,7 @@ export async function acquireSidecarLock<TPayload extends Record<string, unknown
         : Math.max(0, options.timeoutMs - elapsed);
     const delay = Math.min(computeSidecarLockDelayMs(retry, attempt), remaining);
     attempt += 1;
-    await new Promise((resolve) => setTimeout(resolve, delay));
+    await sleep(delay);
   };
   // Waiting can fail on the caller's own retry or deadline limits. Classifying
   // a denial as contention must not cost them the original diagnosis, so hand

--- a/src/timing.ts
+++ b/src/timing.ts
@@ -1,5 +1,25 @@
+const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+
+export function scheduleTimeout(callback: () => void, ms: number): () => void {
+  let timer: ReturnType<typeof setTimeout>;
+  if (Number.isFinite(ms) && ms > MAX_TIMER_DELAY_MS) {
+    const startedAt = performance.now();
+    const tick = (): void => {
+      const remaining = ms - (performance.now() - startedAt);
+      if (remaining <= 0) callback();
+      else timer = setTimeout(tick, Math.min(remaining, MAX_TIMER_DELAY_MS));
+    };
+    // Node clamps overflowing delays to 1 ms. Rearm bounded timers against a
+    // monotonic clock so clock changes and event-loop stalls cannot shorten them.
+    timer = setTimeout(tick, MAX_TIMER_DELAY_MS);
+  } else {
+    timer = setTimeout(callback, ms);
+  }
+  return () => clearTimeout(timer);
+}
+
 export function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve) => { scheduleTimeout(resolve, ms); });
 }
 
 export function sleepSync(ms: number): void {
@@ -25,12 +45,12 @@ export async function withTimeout<T>(
     options.createError ??
     (() =>
       new Error(options.message ?? `${options.label ?? "operation"} timed out after ${timeoutMs}ms`));
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let cancelTimeout: (() => void) | undefined;
   try {
     return await Promise.race([
       promise,
       new Promise<T>((_, reject) => {
-        timeoutId = setTimeout(() => {
+        cancelTimeout = scheduleTimeout(() => {
           try {
             reject(createError());
           } catch (error) {
@@ -40,8 +60,6 @@ export async function withTimeout<T>(
       }),
     ]);
   } finally {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
+    cancelTimeout?.();
   }
 }

--- a/test/timing-large-delay.test.ts
+++ b/test/timing-large-delay.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { withExtractionDeadline } from "../src/archive-deadline.js";
+import { readSecureFile } from "../src/secure-file.js";
+import { sleep, withTimeout } from "../src/timing.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const MAX_DELAY = 2 ** 31 - 1;
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function fakeTimers(): void {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+}
+
+it("waits through multiple timer intervals before expiring", async () => {
+  fakeTimers();
+  const error = new Error("deadline reached");
+  const createError = vi.fn(() => error);
+  const result = withTimeout(new Promise(() => {}), MAX_DELAY * 2 + 25, { createError });
+  const rejected = expect(result).rejects.toBe(error);
+  await vi.advanceTimersByTimeAsync(MAX_DELAY * 2);
+  expect(createError).not.toHaveBeenCalled();
+  await vi.advanceTimersByTimeAsync(24);
+  expect(createError).not.toHaveBeenCalled();
+  await vi.advanceTimersByTimeAsync(1);
+  await rejected;
+  expect(createError).toHaveBeenCalledTimes(1);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("clears the rearmed timer when the wrapped operation settles", async () => {
+  fakeTimers();
+  let finish!: (value: string) => void;
+  const result = withTimeout(new Promise<string>((resolve) => { finish = resolve; }), MAX_DELAY + 50);
+  await vi.advanceTimersByTimeAsync(MAX_DELAY);
+  expect(vi.getTimerCount()).toBe(1);
+  finish("done");
+  await expect(result).resolves.toBe("done");
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("honors a large sleep used by asynchronous retries", async () => {
+  fakeTimers();
+  const finished = vi.fn();
+  const sleeping = sleep(MAX_DELAY + 2).then(finished);
+  await vi.advanceTimersByTimeAsync(MAX_DELAY + 1);
+  expect(finished).not.toHaveBeenCalled();
+  await vi.advanceTimersByTimeAsync(1);
+  await sleeping;
+  expect(finished).toHaveBeenCalledTimes(1);
+});
+
+it("aborts an extraction only when its full large deadline elapses", async () => {
+  fakeTimers();
+  let signal!: AbortSignal;
+  const result = withExtractionDeadline(MAX_DELAY + 20, "archive", async (deadline) => {
+    signal = deadline.signal;
+    return await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve()));
+  });
+  const rejected = expect(result).rejects.toThrow(`archive timed out after ${MAX_DELAY + 20}ms`);
+  await vi.advanceTimersByTimeAsync(MAX_DELAY + 19);
+  expect(signal.aborted).toBe(false);
+  await vi.advanceTimersByTimeAsync(1);
+  await rejected;
+  expect(signal.aborted).toBe(true);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("clears a large extraction timer on successful completion", async () => {
+  fakeTimers();
+  await expect(withExtractionDeadline(Number.MAX_VALUE, "archive", async () => "done"))
+    .resolves.toBe("done");
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("keeps a secure read open through an oversized timeout", async () => {
+  const dir = await tempRoot("fs-safe-large-read-timeout-");
+  const filePath = path.join(dir, "secret");
+  await fs.writeFile(filePath, "secret bytes", { mode: 0o600 });
+  const handle = await fs.open(filePath, "r");
+  let finish!: (value: Buffer) => void;
+  let reading!: () => void;
+  const entered = new Promise<void>((resolve) => { reading = resolve; });
+  const content = new Promise<Buffer>((resolve) => { finish = resolve; });
+  vi.spyOn(fs, "open").mockResolvedValue(handle);
+  vi.spyOn(handle, "readFile").mockImplementation(() => { reading(); return content; });
+  const close = vi.spyOn(handle, "close");
+  fakeTimers();
+  const result = readSecureFile({ filePath, permissions: { allowInsecure: true }, io: { timeoutMs: MAX_DELAY + 20 } });
+  // Attach rejection handling before ticking even against the broken implementation.
+  const success = expect(result).resolves.toMatchObject({ buffer: Buffer.from("secret bytes") });
+  try {
+    await entered;
+    await vi.advanceTimersByTimeAsync(MAX_DELAY + 19);
+    expect(close).not.toHaveBeenCalled();
+    finish(Buffer.from("secret bytes"));
+    await success;
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    finish(Buffer.from("secret bytes"));
+    await result.catch(() => undefined);
+    await handle.close().catch(() => undefined);
+  }
+});


### PR DESCRIPTION
Node reduces timers above 2,147,483,647 ms to approximately 1 ms. Valid large timeouts therefore rejected or aborted work immediately, and large asynchronous lock retry delays did not honor their configured wait.

Use bounded timer intervals measured against a monotonic clock for oversized finite delays. Apply the scheduler to generic timeouts, secure reads, archive deadlines, and asynchronous retry sleeps; clear the current timer when an operation completes. Existing disabled-timeout behavior and cancellation ownership remain intact. Correct the advanced API table to describe the generic helper's existing `Error` default.

Validation: six new large-delay tests cover multiple intervals, exact expiry, cancellation after rearming, secure-file handle lifetime, and archive aborts. All 58 focused tests pass. A built-package 30 ms operation with a 2^31 ms deadline fails immediately on the baseline and completes on the candidate. Independent Codex review is clean through P2. Full native Linux `pnpm check` passed (8,513 tests, 89 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; `git diff --check` passed. The first local archive test run lacked the generated WASM artifact; building the package and rerunning resolved that setup failure.
