### PR TITLE
perf(queue): reuse bounded buffers for entry reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
 - Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.
+- Read durable queue entries through the shared bounded buffer, using the admitted file size to reduce filesystem calls and chunk copies while retaining exact identity and byte-limit checks.
 - Preserve recreated temporary paths when an exit-cleanup lookup observed the original name missing; absence no longer authorizes a forced removal.
 
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.

--- a/src/bounded-read.ts
+++ b/src/bounded-read.ts
@@ -32,9 +32,15 @@ function finishReadBuffer(buffer: Buffer, total: number): Buffer {
   return total < buffer.length / 2 ? Buffer.from(result) : result;
 }
 
-function addReadBytes(total: number, bytesRead: number, maxBytes: number): number {
+function addReadBytes(
+  total: number,
+  bytesRead: number,
+  maxBytes: number,
+  createLimitError?: () => Error,
+): number {
   const next = total + bytesRead;
   if (next > maxBytes) {
+    if (createLimitError) throw createLimitError();
     throw new FsSafeError(
       "too-large",
       `file exceeds limit of ${maxBytes} bytes (got at least ${next})`,
@@ -43,14 +49,19 @@ function addReadBytes(total: number, bytesRead: number, maxBytes: number): numbe
   return next;
 }
 
-async function readBoundedAsync(
+export async function readBoundedAsync(
   maxBytes: number,
   readChunk: (scratch: Buffer, length: number) => Promise<number>,
-  observeRegularFileSize?: () => number | undefined,
+  options: {
+    observeRegularFileSize?: () => number | undefined;
+    initialSize?: number;
+    createLimitError?: () => Error;
+  } = {},
 ): Promise<Buffer> {
   normalizeMaxBytes(maxBytes);
   let total = 0;
-  const size = observeRegularFileSize?.();
+  const { observeRegularFileSize, createLimitError } = options;
+  const size = options.initialSize ?? observeRegularFileSize?.();
   let buffer = size === undefined ? createScratchBuffer(maxBytes) : createInitialBuffer(maxBytes, size);
   if (size !== undefined) {
     const bytesRead = await readChunk(buffer, buffer.length);
@@ -58,7 +69,7 @@ async function readBoundedAsync(
     // Short reads can occur before EOF. Only use the size shortcut on this
     // initial read; virtual files can report zero or stale sizes thereafter.
     const currentSize = bytesRead < buffer.length ? observeRegularFileSize?.() : undefined;
-    total = addReadBytes(total, bytesRead, maxBytes);
+    total = addReadBytes(total, bytesRead, maxBytes, createLimitError);
     if (currentSize !== undefined && bytesRead >= currentSize) return finishReadBuffer(buffer, total);
   }
   while (true) {
@@ -66,7 +77,7 @@ async function readBoundedAsync(
     const remaining = buffer.subarray(total);
     const bytesRead = await readChunk(remaining, remaining.length);
     if (bytesRead === 0) return finishReadBuffer(buffer, total);
-    total = addReadBytes(total, bytesRead, maxBytes);
+    total = addReadBytes(total, bytesRead, maxBytes, createLimitError);
   }
 }
 
@@ -83,7 +94,7 @@ export async function readFileHandleBounded(
   const fd = "fd" in handle && typeof handle.fd === "number" ? handle.fd : undefined;
   return await readBoundedAsync(maxBytes, async (scratch, length) => {
     return (await handle.read(scratch, 0, length, null)).bytesRead;
-  }, fd === undefined ? undefined : () => regularFileSize(fd));
+  }, { observeRegularFileSize: fd === undefined ? undefined : () => regularFileSize(fd) });
 }
 
 function regularFileSize(fd: number): number | undefined {
@@ -114,7 +125,7 @@ export async function readFileDescriptorBounded(fd: number, maxBytes: number): P
   normalizeMaxBytes(maxBytes);
   return await readBoundedAsync(maxBytes, async (scratch, length) => {
     return await readDescriptorChunk(fd, scratch, length);
-  }, () => regularFileSize(fd));
+  }, { observeRegularFileSize: () => regularFileSize(fd) });
 }
 
 /** Sync bounded read from a numeric descriptor. The caller owns the descriptor. */

--- a/src/json-durable-queue.ts
+++ b/src/json-durable-queue.ts
@@ -2,6 +2,7 @@ import fs, { type BigIntStats } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { normalizeMaxBytes } from "./byte-budget.js";
+import { readBoundedAsync } from "./bounded-read.js";
 import { syncDirectory } from "./directory-durability.js";
 import { syncQueueDirectoryCreation } from "./json-durable-queue-directory.js";
 import {
@@ -330,20 +331,16 @@ async function readBoundedUtf8File(params: {
       () => fs.fstatSync(handle.fd, { bigint: true }), params.maxBytes, initialStat,
     );
     await inspectQueueEntry(inspectPath, params.maxBytes, openedStat);
-    const chunks: Buffer[] = [];
-    const scratch = Buffer.allocUnsafe(Math.min(64 * 1024, params.maxBytes + 1));
-    let total = 0;
-    while (true) {
-      const { bytesRead } = await handle.read(scratch, 0, scratch.length, null);
-      if (bytesRead === 0) {
-        return Buffer.concat(chunks, total).toString("utf8");
-      }
-      total += bytesRead;
-      if (total > params.maxBytes) {
-        throw new Error(`queue entry exceeds ${params.maxBytes} bytes`);
-      }
-      chunks.push(Buffer.from(scratch.subarray(0, bytesRead)));
-    }
+    const bytes = await readBoundedAsync(
+      params.maxBytes,
+      async (buffer, length) => (await handle.read(buffer, 0, length, null)).bytesRead,
+      {
+        initialSize: openedStat.size >= 0n && Number.isSafeInteger(Number(openedStat.size))
+          ? Number(openedStat.size) : undefined,
+        createLimitError: () => new Error(`queue entry exceeds ${params.maxBytes} bytes`),
+      },
+    );
+    return bytes.toString("utf8");
   } finally {
     await handle.close();
   }

--- a/test/json-durable-queue-short-read.test.ts
+++ b/test/json-durable-queue-short-read.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { FsSafeError } from "../src/errors.js";
+import { readJsonDurableQueueEntry } from "../src/json-durable-queue.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+it("preserves UTF-8 across short reads with an exact byte budget", async () => {
+  const dir = await tempRoot("fs-safe-queue-short-read-");
+  const filePath = path.join(dir, "entry.json");
+  const entry = { text: "€🦞".repeat(200) };
+  const bytes = JSON.stringify(entry);
+  await fs.writeFile(filePath, bytes);
+  const open = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === filePath) {
+      const read = handle.read.bind(handle);
+      vi.spyOn(handle, "read").mockImplementation(async (buffer, offset, length, position) =>
+        await read(buffer, offset, Math.min(length, 7), position),
+      );
+    }
+    return handle;
+  });
+  await expect(readJsonDurableQueueEntry(filePath, { maxBytes: Buffer.byteLength(bytes) }))
+    .resolves.toEqual(entry);
+});
+
+it("preserves an underlying read error even when it uses the shared limit code", async () => {
+  const dir = await tempRoot("fs-safe-queue-read-error-");
+  const filePath = path.join(dir, "entry.json");
+  await fs.writeFile(filePath, "{}");
+  const error = new FsSafeError("too-large", "underlying read failed");
+  const open = fs.open.bind(fs);
+  let opened: fs.FileHandle | undefined;
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === filePath) {
+      opened = handle;
+      vi.spyOn(handle, "read").mockRejectedValue(error);
+    }
+    return handle;
+  });
+  await expect(readJsonDurableQueueEntry(filePath)).rejects.toBe(error);
+  expect(opened?.fd).toBe(-1);
+});


### PR DESCRIPTION
Durable queue reads copied every 64 KiB chunk and concatenated all chunks before parsing. Reuse the shared bounded reader with the admitted file size as an allocation hint, reducing read calls and copies while continuing to EOF and enforcing the byte limit if the file grows.

The queue retains its exact identity checks, underlying read errors, queue-specific limit message, and descriptor cleanup. New tests cover UTF-8 split across short reads and preservation of an underlying error that shares the bounded reader's limit code. The internal customization does not change package exports or public signatures.

Three alternating baseline/candidate rounds on AWS Crabbox `cbx_e7c5e5c92048` (AMD EPYC, Node 24) measured 1 MiB JSON reads at 1.38–1.71× faster and 8 MiB reads at 1.70–1.82× faster. The 8 MiB medians fell from 14.83–15.63 ms to 8.61–8.82 ms. These are warm synthetic-file measurements, not universal workload guarantees.

Validation: 89 focused tests passed; independent Codex review clean through P2; full native Linux `pnpm check` passed (8,509 tests, 89 skipped); `git diff --check` passed.
