### PR TITLE
fix(errors): shorten home paths at directory boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Forward archive deadlines through a separate abort signal for each native pass, so completed inspection cannot mask cancellation of extraction.
 - Preserve Linux native directory-only open flags so non-directories are rejected by the kernel before FIFO blocking or truncation, while removing the redundant post-open stat.
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
+- Shorten only the home directory and its descendants in error messages, preserving sibling paths that share the same string prefix.
 - Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.
 - Preserve recreated temporary paths when an exit-cleanup lookup observed the original name missing; absence no longer authorizes a forced removal.

--- a/src/error-detail.ts
+++ b/src/error-detail.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import path from "node:path";
 
 const UNSAFE_ERROR_DETAIL_CHARACTERS =
   /[\u0000-\u001f\u007f-\u009f\u2028\u2029]/gu;
@@ -11,6 +12,8 @@ export function formatErrorDetail(value: string): string {
 
 export function shortPath(value: string): string {
   const home = os.homedir();
-  const shortened = value.startsWith(home) ? `~${value.slice(home.length)}` : value;
+  const prefix = home.endsWith(path.sep) ? home : `${home}${path.sep}`;
+  const shortened = value === home ? "~"
+    : value.startsWith(prefix) ? `~${path.sep}${value.slice(prefix.length)}` : value;
   return formatErrorDetail(shortened);
 }

--- a/test/error-detail.test.ts
+++ b/test/error-detail.test.ts
@@ -1,0 +1,23 @@
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { shortPath } from "../src/error-detail.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+it("shortens only the home directory and its descendants", () => {
+  const home = path.resolve("synthetic-home");
+  vi.spyOn(os, "homedir").mockReturnValue(home);
+  expect(shortPath(home)).toBe("~");
+  expect(shortPath(path.join(home, "file"))).toBe(`~${path.sep}file`);
+  expect(shortPath(`${home}-sibling`)).toBe(`${home}-sibling`);
+  expect(shortPath(path.join(`${home}-sibling`, "file"))).toBe(path.join(`${home}-sibling`, "file"));
+  expect(shortPath(path.join(home, "unsafe\nname"))).toBe(`~${path.sep}unsafe\\u000aname`);
+});
+
+it("preserves the separator when home is a filesystem root", () => {
+  const home = path.parse(process.cwd()).root;
+  vi.spyOn(os, "homedir").mockReturnValue(home);
+  expect(shortPath(home)).toBe("~");
+  expect(shortPath(path.join(home, "file"))).toBe(`~${path.sep}file`);
+});


### PR DESCRIPTION
Error messages shortened sibling paths whose names merely started with the home directory string. For example, a home ending in `/alice` also shortened `/alice-backup/file`, making diagnostics misleading.

Require an exact home match or a directory separator boundary, and preserve the separator when home itself is a filesystem root. Unsafe diagnostic characters are still escaped.

Validation: regression tests cover exact home, children, siblings, root-home paths, and newline escaping. Independent Codex review clean through P2; full native Linux `pnpm check` passed (8,509 tests, 89 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; `git diff --check` passed.
