### PR TITLE
fix(root): honor Windows fallback durability with owned cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Forward archive deadlines through a separate abort signal for each native pass, so completed inspection cannot mask cancellation of extraction.
+- Honor Root durability defaults and per-call overrides in the Windows JavaScript write/create fallback, and preserve unowned staging replacements when a write or sync fails.
 - Preserve Linux native directory-only open flags so non-directories are rejected by the kernel before FIFO blocking or truncation, while removing the redundant post-open stat.
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
 - Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -99,8 +99,9 @@ writes but skips file and parent-directory fsync calls. Create-only and append
 publication behavior, permissions, identity checks, and error codes are unchanged.
 Use it only for reconstructible data: a crash may lose the write or leave the
 previous file. `move` and streaming `openWritable` do not use this option.
-The existing pure-JavaScript Windows writer performs no fsync calls in either
-setting; native Windows writes honor the option. Directory sync remains best-effort.
+Native and pure-JavaScript Windows writers honor the option. Replacement writes
+sync staged content before rename and the final mode through the retained file
+handle. Directory sync remains best-effort.
 
 POSIX modes without read permission, including `0o000` and `0o200`, succeed:
 final verification uses a descriptor retained by the writer rather than reopening

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1591,7 +1591,7 @@ async function writeFileFallback(
   });
   const destinationPath = target.realPath;
   const mode = params.mode ?? (target.stat.mode & 0o777);
-  const destinationGuard = await createAsyncDirectoryGuard(path.dirname(destinationPath)).catch(async error => {
+  const destinationGuard = await createAsyncDirectoryGuard(path.dirname(destinationPath), { bigint: true }).catch(async error => {
     await target.handle.close().catch(() => undefined);
     throw error;
   });
@@ -1681,7 +1681,7 @@ async function writeMissingFileFallback(
   const targetPath = params.mkdir === false
     ? resolved
     : await prepareRootWriteTarget(rootReal, resolved);
-  const parentGuard = await createAsyncDirectoryGuard(path.dirname(targetPath));
+  const parentGuard = await createAsyncDirectoryGuard(path.dirname(targetPath), { bigint: true });
   let created = false;
   let createdIdentity: BigIntStats | undefined;
   let writtenHandle: FileHandle | undefined;

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1574,16 +1574,7 @@ async function movePathFallback(
 
 async function writeFileFallback(
   root: RootContext,
-  params: {
-    relativePath: string;
-    data: string | Buffer;
-    encoding?: BufferEncoding;
-    mkdir?: boolean;
-    mode?: number;
-    denyMutations?: DenyMutationPolicy;
-    overwrite?: boolean;
-    durable?: boolean;
-  },
+  params: RootWriteOptions & { relativePath: string; data: string | Buffer },
 ): Promise<void> {
   if (params.overwrite === false) {
     await writeMissingFileFallback(root, params);
@@ -1626,6 +1617,13 @@ async function writeFileFallback(
         root, targetPath: commitTempPath, fd: commitHandle.fd,
         expectedIdentity: commitIdentity, parentGuard: destinationGuard,
       });
+      if (target.createdForWrite) {
+        await cleanupPinnedFilePath({
+          pathname: destinationPath, handle: target.handle, identity: placeholderIdentity, parentGuard: destinationGuard,
+        });
+      }
+      // Windows cannot replace a destination while its old handle remains open.
+      await target.handle.close();
       await fs.rename(commitTempPath, destinationPath);
       tempPath = null;
       published = true;
@@ -1674,15 +1672,7 @@ async function writeFileFallback(
 
 async function writeMissingFileFallback(
   root: RootContext,
-  params: {
-    relativePath: string;
-    data: string | Buffer;
-    encoding?: BufferEncoding;
-    mkdir?: boolean;
-    mode?: number;
-    denyMutations?: DenyMutationPolicy;
-    durable?: boolean;
-  },
+  params: RootWriteOptions & { relativePath: string; data: string | Buffer },
 ): Promise<void> {
   const { rootReal, resolved } = await resolveGuardedWritePathInRoot(root, {
     relativePath: params.relativePath,

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -40,6 +40,7 @@ import {
   isSymlinkOpenError,
 } from "./path.js";
 import { readOpenedFileSafely, type ReadResult } from "./read-opened-file.js";
+import { cleanupPinnedFilePath } from "./replace-file-temp-owner.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { isNonRegularWriteOpenError, resolveNonblockingWriteFlag } from "./write-open-flags.js";
 import { resolveRootPath } from "./root-path.js";
@@ -813,29 +814,6 @@ async function prepareRootWriteTarget(rootReal: string, targetPath: string): Pro
   return path.join(parentPath, path.basename(targetPath));
 }
 
-async function writeTempFileForAtomicReplace(params: {
-  tempPath: string;
-  data: string | Buffer;
-  encoding?: BufferEncoding;
-  mode: number;
-}): Promise<{ handle: FileHandle; identity: BigIntStats }> {
-  const tempHandle = await fs.open(params.tempPath, OPEN_WRITE_CREATE_FLAGS, params.mode);
-  try {
-    if (typeof params.data === "string") {
-      await tempHandle.writeFile(params.data, params.encoding ?? "utf8");
-    } else {
-      await tempHandle.writeFile(params.data);
-    }
-    return {
-      handle: tempHandle,
-      identity: fsSync.fstatSync(tempHandle.fd, { bigint: true }),
-    };
-  } catch (error) {
-    await tempHandle.close().catch(() => {});
-    throw error;
-  }
-}
-
 type GuardedWritePath = Awaited<ReturnType<typeof resolvePathInRoot>>;
 
 async function resolveGuardedWritePathInRoot(
@@ -1604,6 +1582,7 @@ async function writeFileFallback(
     mode?: number;
     denyMutations?: DenyMutationPolicy;
     overwrite?: boolean;
+    durable?: boolean;
   },
 ): Promise<void> {
   if (params.overwrite === false) {
@@ -1621,53 +1600,74 @@ async function writeFileFallback(
   });
   const destinationPath = target.realPath;
   const mode = params.mode ?? (target.stat.mode & 0o777);
-  await target.handle.close().catch(() => {});
-  const destinationGuard = await createAsyncDirectoryGuard(path.dirname(destinationPath));
+  const destinationGuard = await createAsyncDirectoryGuard(path.dirname(destinationPath)).catch(async error => {
+    await target.handle.close().catch(() => undefined);
+    throw error;
+  });
   let tempPath: string | null = null;
   let unregisterTempPath: TempPathRegistration | null = null;
   let writtenHandle: FileHandle | undefined;
+  let writtenIdentity: BigIntStats | undefined;
+  let placeholderIdentity: BigIntStats | undefined;
+  let published = false;
   try {
+    if (target.createdForWrite) placeholderIdentity = fsSync.fstatSync(target.handle.fd, { bigint: true });
     tempPath = buildAtomicWriteTempPath(destinationPath);
-    unregisterTempPath = registerTempPathForExit(tempPath);
-    const written = await writeTempFileForAtomicReplace({
-      tempPath,
-      data: params.data,
-      encoding: params.encoding,
-      mode: 0o600,
-    });
-    writtenHandle = written.handle;
-    unregisterTempPath.setIdentity(written.identity);
+    writtenHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, 0o600);
+    writtenIdentity = fsSync.fstatSync(writtenHandle.fd, { bigint: true });
+    unregisterTempPath = registerTempPathForExit(tempPath, { identity: writtenIdentity, singleLinkFile: true });
+    await writtenHandle.writeFile(params.data, params.encoding ?? "utf8");
+    if (params.durable !== false) await writtenHandle.sync();
     const commitTempPath = tempPath;
+    const commitHandle = writtenHandle;
+    const commitIdentity = writtenIdentity;
     await withAsyncDirectoryGuards([destinationGuard], async () => {
+      await verifyAtomicWriteResult({
+        root, targetPath: commitTempPath, fd: commitHandle.fd,
+        expectedIdentity: commitIdentity, parentGuard: destinationGuard,
+      });
       await fs.rename(commitTempPath, destinationPath);
       tempPath = null;
+      published = true;
     });
     unregisterTempPath();
     unregisterTempPath = null;
     // Final mode via the retained handle after publication, as the native writer does.
     try {
-      await written.handle.chmod(mode);
+      await writtenHandle.chmod(mode);
     } catch (error) {
-      await removePathIfIdentityUnchanged(destinationPath, written.identity).catch(() => {});
+      await cleanupPinnedFilePath({
+        pathname: destinationPath, handle: writtenHandle, identity: writtenIdentity, parentGuard: destinationGuard,
+      });
       throw error;
     }
+    if (params.durable !== false) await writtenHandle.sync();
     try {
       await verifyAtomicWriteResult({
         root,
         targetPath: destinationPath,
-        expectedIdentity: written.identity,
-        fd: written.handle.fd,
+        expectedIdentity: writtenIdentity,
+        fd: writtenHandle.fd,
         parentGuard: destinationGuard,
       });
     } catch (err) {
       emitWriteBoundaryWarning(`post-write verification failed: ${String(err)}`);
       throw err;
     }
+    if (params.durable !== false) await syncDirectoryBestEffort(path.dirname(destinationPath));
   } finally {
-    await writtenHandle?.close().catch(() => undefined);
-    if (tempPath) {
-      await fs.rm(tempPath, { force: true }).catch(() => {});
+    if (!published && target.createdForWrite) {
+      await cleanupPinnedFilePath({
+        pathname: destinationPath, handle: target.handle, identity: placeholderIdentity, parentGuard: destinationGuard,
+      });
     }
+    await target.handle.close().catch(() => undefined);
+    if (tempPath && writtenHandle) {
+      await cleanupPinnedFilePath({
+        pathname: tempPath, handle: writtenHandle, identity: writtenIdentity, parentGuard: destinationGuard,
+      });
+    }
+    await writtenHandle?.close().catch(() => undefined);
     unregisterTempPath?.();
   }
 }
@@ -1681,6 +1681,7 @@ async function writeMissingFileFallback(
     mkdir?: boolean;
     mode?: number;
     denyMutations?: DenyMutationPolicy;
+    durable?: boolean;
   },
 ): Promise<void> {
   const { rootReal, resolved } = await resolveGuardedWritePathInRoot(root, {
@@ -1692,7 +1693,7 @@ async function writeMissingFileFallback(
     : await prepareRootWriteTarget(rootReal, resolved);
   const parentGuard = await createAsyncDirectoryGuard(path.dirname(targetPath));
   let created = false;
-  let createdIdentity: FileIdentityStat | undefined;
+  let createdIdentity: BigIntStats | undefined;
   let writtenHandle: FileHandle | undefined;
   let verifyingPublication = false;
   try {
@@ -1700,25 +1701,17 @@ async function writeMissingFileFallback(
       [parentGuard],
       async () => {
         const handle = await fs.open(targetPath, OPEN_WRITE_CREATE_FLAGS, params.mode ?? 0o600).catch((error) => recordExclusiveCreateFailure(error, targetPath));
+        writtenHandle = handle;
         created = true;
-        try {
-          createdIdentity = fsSync.fstatSync(handle.fd);
-          const writtenStat = fsSync.fstatSync(handle.fd, { bigint: true });
-          if (typeof params.data === "string") {
-            await handle.writeFile(params.data, params.encoding ?? "utf8");
-          } else {
-            await handle.writeFile(params.data);
-          }
-          return { handle, writtenStat };
-        } catch (error) {
-          await handle.close().catch(() => undefined);
-          throw error;
-        }
+        const writtenStat = fsSync.fstatSync(handle.fd, { bigint: true });
+        createdIdentity = writtenStat;
+        await handle.writeFile(params.data, params.encoding ?? "utf8");
+        if (params.durable !== false) await handle.sync();
+        return { handle, writtenStat };
       },
       {
-        onPostGuardFailure: async ({ handle }) => {
+        onPostGuardFailure: () => {
           created = false; // Parent is untrusted now; skip outer path cleanup by name.
-          await handle.close().catch(() => undefined);
         },
       },
     );
@@ -1732,6 +1725,7 @@ async function writeMissingFileFallback(
       fd: handle.fd,
       parentGuard,
     });
+    if (params.durable !== false) await syncDirectoryBestEffort(path.dirname(targetPath));
   } catch (err) {
     if (verifyingPublication) throw err;
     if (hasNodeErrorCode(err, "EEXIST")) {
@@ -1741,9 +1735,11 @@ async function writeMissingFileFallback(
     }
     throw err;
   } finally {
-    await writtenHandle?.close().catch(() => undefined);
-    if (created && createdIdentity) {
-      await removePathIfIdentityUnchanged(targetPath, createdIdentity).catch(() => undefined);
+    if (created && writtenHandle) {
+      await cleanupPinnedFilePath({
+        pathname: targetPath, handle: writtenHandle, identity: createdIdentity, parentGuard,
+      });
     }
+    await writtenHandle?.close().catch(() => undefined);
   }
 }

--- a/test/platform-fallback-coverage.test.ts
+++ b/test/platform-fallback-coverage.test.ts
@@ -201,6 +201,7 @@ describe("platform fallback coverage", () => {
     const scoped = await openRoot(rootDir, { mkdir: false });
     let swapped = false;
     vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+      if (params.targetPath !== target) return await verifyPublished(params);
       expect(params.targetPath).toBe(target);
       swapped = true;
       await fs.rename(parent, `${parent}-original`);
@@ -235,6 +236,7 @@ describe("platform fallback coverage", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     let swapped = false;
     vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+      if (params.targetPath !== target) return await verifyPublished(params);
       expect(params.targetPath).toBe(target);
       swapped = true;
       await fs.rename(parent, `${parent}-original`);

--- a/test/root-durable-option.test.ts
+++ b/test/root-durable-option.test.ts
@@ -193,6 +193,7 @@ describe.skipIf(process.platform === "win32")("Windows writer branch simulation"
       return handle;
     });
     vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+      if (params.targetPath !== target) return await verifyPublished(params);
       events.push("verify");
       expect((await fs.stat(target)).mode & 0o777).toBe(0o400);
       await verifyPublished(params);
@@ -234,7 +235,7 @@ describe.skipIf(process.platform === "win32")("Windows writer branch simulation"
     expect(await fs.readdir(directory)).toEqual([]);
   });
 
-  it.each([true, false])("preserves the unsynced JS writer with durable %s", async (durable) => {
+  it.each([true, false])("gates Windows JS writer syncs with durable %s", async (durable) => {
     configureFsSafeNative({ mode: "off" });
     Object.defineProperty(process, "platform", { value: "win32" });
     const directory = await tempRoot("fs-safe-durable-win-js-");
@@ -242,7 +243,7 @@ describe.skipIf(process.platform === "win32")("Windows writer branch simulation"
     const { events } = await observeSyncs(directory);
     await safe.create("created", "created");
     await safe.write("created", "replaced");
-    expect(events).toEqual([]);
+    expect(events).toEqual(durable ? ["file", "parent", "file", "file", "parent"] : []);
     expect(await fs.readFile(path.join(directory, "created"), "utf8")).toBe("replaced");
   });
 

--- a/test/root-durable-option.test.ts
+++ b/test/root-durable-option.test.ts
@@ -79,7 +79,7 @@ for (const backend of ["auto", "off"] as const) {
           } else {
             await safe[method]("target", "payload", { ...options, mode });
           }
-          if (!sync || (process.platform === "win32" && backend === "off" && method !== "append" && method !== "copyIn")) {
+          if (!sync) {
             expect(asyncSpy).not.toHaveBeenCalled();
             expect(syncSpy).not.toHaveBeenCalled();
           } else if (process.platform === "win32") {
@@ -135,6 +135,7 @@ for (const backend of ["auto", "off"] as const) {
       const target = path.join(directory, "target");
       const safe = await root(directory, { durable: false });
       vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+        if (params.targetPath !== target) return await verifyPublished(params);
         await fs.rename(target, path.join(directory, "published"));
         await fs.writeFile(target, "substitute");
         await verifyPublished(params);

--- a/test/root-windows-write-durability.test.ts
+++ b/test/root-windows-write-durability.test.ts
@@ -37,9 +37,11 @@ it.each(operations.flatMap(operation => settings.map(setting => ({ operation, ..
     const { dir, scoped, target } = await fixture(defaultDurable);
     if (operation === "replace") await fs.writeFile(target, "original");
     const events: string[] = [];
+    const destinationHandles: fs.FileHandle[] = [];
     const open = fs.open.bind(fs);
     vi.spyOn(fs, "open").mockImplementation(async (...args) => {
       const handle = await open(...args);
+      if (String(args[0]) === target) destinationHandles.push(handle);
       const write = handle.writeFile.bind(handle);
       vi.spyOn(handle, "writeFile").mockImplementation(async (...writeArgs) => {
         events.push("write");
@@ -52,7 +54,11 @@ it.each(operations.flatMap(operation => settings.map(setting => ({ operation, ..
       return handle;
     });
     const rename = fs.rename.bind(fs);
-    vi.spyOn(fs, "rename").mockImplementation(async (...args) => { events.push("rename"); await rename(...args); });
+    vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+      expect(destinationHandles.every(handle => handle.fd === -1)).toBe(true);
+      events.push("rename");
+      await rename(...args);
+    });
     const parentSync = vi.spyOn(durability, "syncDirectoryBestEffort").mockImplementation(async () => {
       events.push("directory");
     });

--- a/test/root-windows-write-durability.test.ts
+++ b/test/root-windows-write-durability.test.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { configureFsSafeNative, root } from "../src/index.js";
+import * as durability from "../src/directory-durability.js";
+import { __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", platform);
+  __resetFsSafeNativeConfigForTest();
+});
+
+async function fixture(defaultDurable?: boolean) {
+  const dir = await tempRoot("fs-safe-windows-write-durable-");
+  Object.defineProperty(process, "platform", { value: "win32" });
+  configureFsSafeNative({ mode: "off" });
+  const scoped = await root(dir, { durable: defaultDurable });
+  return { dir, scoped, target: path.join(dir, "target") };
+}
+
+const operations = ["write", "replace", "create", "exclusive", "writeJson", "createJson"] as const;
+const settings = [
+  { label: "default", enabled: true },
+  { label: "disabled default", root: false, enabled: false },
+  { label: "disabled call", call: false, enabled: false },
+  { label: "enabled override", root: false, call: true, enabled: true },
+  { label: "disabled override", root: true, call: false, enabled: false },
+];
+
+it.each(operations.flatMap(operation => settings.map(setting => ({ operation, ...setting }))))(
+  "$operation honors $label durability through Windows fallback dispatch",
+  async ({ operation, enabled, root: defaultDurable, call }) => {
+    const { dir, scoped, target } = await fixture(defaultDurable);
+    if (operation === "replace") await fs.writeFile(target, "original");
+    const events: string[] = [];
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      const write = handle.writeFile.bind(handle);
+      vi.spyOn(handle, "writeFile").mockImplementation(async (...writeArgs) => {
+        events.push("write");
+        return await write(...writeArgs);
+      });
+      const sync = handle.sync.bind(handle);
+      vi.spyOn(handle, "sync").mockImplementation(async () => { events.push("sync"); await sync(); });
+      const chmod = handle.chmod.bind(handle);
+      vi.spyOn(handle, "chmod").mockImplementation(async mode => { events.push("chmod"); await chmod(mode); });
+      return handle;
+    });
+    const rename = fs.rename.bind(fs);
+    vi.spyOn(fs, "rename").mockImplementation(async (...args) => { events.push("rename"); await rename(...args); });
+    const parentSync = vi.spyOn(durability, "syncDirectoryBestEffort").mockImplementation(async () => {
+      events.push("directory");
+    });
+    const options = { durable: call };
+    if (operation === "writeJson" || operation === "createJson") await scoped[operation]("target", { value: 1 }, options);
+    else if (operation === "create") await scoped.create("target", "new bytes", options);
+    else await scoped.write("target", "new bytes", { ...options, overwrite: operation !== "exclusive" });
+    const replacing = ["write", "replace", "writeJson"].includes(operation);
+    const expected = replacing
+      ? ["write", "sync", "rename", "chmod", "sync", "directory"]
+      : ["write", "sync", "directory"];
+    expect(events).toEqual(enabled ? expected : expected.filter(event => event !== "sync" && event !== "directory"));
+    expect(parentSync).toHaveBeenCalledTimes(enabled ? 1 : 0);
+    if (enabled) expect(parentSync).toHaveBeenCalledWith(dir);
+    expect(await fs.readFile(target, "utf8")).toBe(operation.endsWith("Json") ? '{"value":1}\n' : "new bytes");
+  },
+);
+
+it.each(["write", "replace", "create"] as const)("%s reports file sync failure and cleans only the owned new file", async operation => {
+  const { dir, scoped, target } = await fixture();
+  if (operation === "replace") await fs.writeFile(target, "original");
+  const error = Object.assign(new Error("sync failed"), { code: "EIO" });
+  const open = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    vi.spyOn(handle, "sync").mockRejectedValue(error);
+    return handle;
+  });
+  await expect(scoped[operation === "replace" ? "write" : operation]("target", "new bytes")).rejects.toBe(error);
+  expect(await fs.readdir(dir)).toEqual(operation === "replace" ? ["target"] : []);
+  if (operation === "replace") expect(await fs.readFile(target, "utf8")).toBe("original");
+});
+
+it.each(["write failure", "sync failure", "successful sync"] as const)(
+  "preserves a staging replacement after %s",
+  async fault => {
+    const { dir, scoped, target } = await fixture();
+    await fs.writeFile(target, "original");
+    const moved = path.join(dir, "displaced");
+    let stagingPath!: string;
+    let opened: fs.FileHandle | undefined;
+    const error = Object.assign(new Error("injected failure"), { code: "EIO" });
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      const pathname = String(args[0]);
+      if (!path.basename(pathname).startsWith(".fs-safe-")) return handle;
+      stagingPath = pathname;
+      opened = handle;
+      const swap = async () => {
+        await fs.rename(pathname, moved);
+        await fs.writeFile(pathname, "unowned replacement");
+        if (fault !== "successful sync") throw error;
+      };
+      if (fault === "write failure") {
+        vi.spyOn(handle, "writeFile").mockImplementation(swap);
+      } else {
+        vi.spyOn(handle, "sync").mockImplementation(swap);
+      }
+      return handle;
+    });
+    const result = scoped.write("target", "new bytes");
+    if (fault === "successful sync") await expect(result).rejects.toMatchObject({ code: "path-mismatch" });
+    else await expect(result).rejects.toBe(error);
+    expect(await fs.readFile(target, "utf8")).toBe("original");
+    expect(await fs.readFile(stagingPath, "utf8")).toBe("unowned replacement");
+    expect((await fs.stat(moved)).isFile()).toBe(true);
+    expect(opened?.fd).toBe(-1);
+  },
+);
+
+it("preserves a substituted destination placeholder after staging sync failure", async () => {
+  const { dir, scoped, target } = await fixture();
+  const displaced = path.join(dir, "placeholder");
+  const error = Object.assign(new Error("sync failed"), { code: "EIO" });
+  const open = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (path.basename(String(args[0])).startsWith(".fs-safe-")) {
+      vi.spyOn(handle, "sync").mockImplementation(async () => {
+        await fs.rename(target, displaced);
+        await fs.writeFile(target, "unowned destination");
+        throw error;
+      });
+    }
+    return handle;
+  });
+  await expect(scoped.write("target", "new bytes")).rejects.toBe(error);
+  expect(await fs.readFile(target, "utf8")).toBe("unowned destination");
+  expect(await fs.readFile(displaced, "utf8")).toBe("");
+  expect((await fs.readdir(dir)).sort()).toEqual(["placeholder", "target"]);
+});

--- a/test/root-windows-write-durability.test.ts
+++ b/test/root-windows-write-durability.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import fsSync from "node:fs";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import { configureFsSafeNative, root } from "../src/index.js";
@@ -77,9 +78,17 @@ it.each(operations.flatMap(operation => settings.map(setting => ({ operation, ..
   },
 );
 
-it.each(["write", "replace", "create"] as const)("%s reports file sync failure and cleans only the owned new file", async operation => {
+it.each(["write", "replace", "create"] as const)("%s reports file sync failure and cleans only the owned new file with a large parent inode", async operation => {
   const { dir, scoped, target } = await fixture();
   if (operation === "replace") await fs.writeFile(target, "original");
+  const lstat = fsSync.lstatSync.bind(fsSync);
+  vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+    const stat = lstat(...args);
+    if (String(args[0]) === dir && typeof stat.ino === "bigint") {
+      return Object.assign(Object.create(stat), { ino: 9007199254740993n });
+    }
+    return stat;
+  });
   const error = Object.assign(new Error("sync failed"), { code: "EIO" });
   const open = fs.open.bind(fs);
   vi.spyOn(fs, "open").mockImplementation(async (...args) => {

--- a/test/root-write-exact-identity.test.ts
+++ b/test/root-write-exact-identity.test.ts
@@ -196,6 +196,7 @@ for (const route of routes) {
         let callbacks = 0;
         let fd: number | undefined;
         const check: typeof verify = async (params) => {
+          if (params.targetPath !== target) return await verify(params);
           callbacks++;
           fd = params.fd;
           expect(params.expectedIdentity).toMatchObject({ dev: device, ino: inode });
@@ -301,6 +302,7 @@ for (const backend of ["fallback", "native"] as const) {
         }
         const verifier = vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(
           async (params) => {
+            if (params.targetPath !== target) return await verify(params);
             expect(params.targetPath).toBe(target);
             retainedFd = params.fd;
             if (swapped) {
@@ -317,7 +319,7 @@ for (const backend of ["fallback", "native"] as const) {
         if (swapped) await expect(pending).rejects.toMatchObject({ code: "path-mismatch" });
         else if (behavior === "read error") await expect(pending).rejects.toBe(failure);
         else await expect(pending).resolves.toBeUndefined();
-        expect(verifier).toHaveBeenCalledTimes(1);
+        expect(verifier.mock.calls.filter(([params]) => params.targetPath === target)).toHaveLength(1);
         expect(reopens).toBe(behavior === "known identity" ? 0 : 1);
         expect(reopened.every((handle) => handle.fd === -1)).toBe(true);
         expect(() => fsSync.fstatSync(retainedFd!)).toThrowError(expect.objectContaining({ code: "EBADF" }));

--- a/test/root-write-lifetime.test.ts
+++ b/test/root-write-lifetime.test.ts
@@ -171,6 +171,7 @@ for (const backend of ["javascript", "native", "windows fallback branch"] as con
         let fdChecks = 0;
         let unknownPathChecked = false;
         vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+          if (params.targetPath !== target) return await verifyPublished(params);
           retainedFd = params.fd;
           const realFstat = fsSync.fstatSync.bind(fsSync);
           vi.spyOn(fsSync, "fstatSync").mockImplementation(((...args: Parameters<typeof fsSync.fstatSync>) => {
@@ -223,7 +224,9 @@ for (const backend of ["javascript", "native", "windows fallback branch"] as con
           handles.push(handle);
           return handle;
         });
-        vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async ({ fd }) => {
+        vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+          if (params.targetPath !== target) return await verifyPublished(params);
+          const { fd } = params;
           retainedFd = fd;
           if (backend === "native") {
             const realClose = fsSync.closeSync.bind(fsSync);

--- a/test/root-write-verification.test.ts
+++ b/test/root-write-verification.test.ts
@@ -101,6 +101,7 @@ for (const backend of ["javascript", "native", "windows fallback branch"] as con
           }
         };
         const verifier = vi.spyOn(verification, "verifyAtomicWriteResult").mockImplementation(async (params) => {
+          if (params.targetPath !== target) return await verifyPublished(params);
           retainedFd = params.fd;
           expect(fsSync.fstatSync(params.fd).mode & 0o777).toBe(mode);
           expect(fsSync.fstatSync(params.fd).isFile()).toBe(true);
@@ -140,7 +141,7 @@ for (const backend of ["javascript", "native", "windows fallback branch"] as con
             : ["path-mismatch"];
           expect(acceptable).toContain((error as FsSafeError).code);
         }
-        expect(verifier).toHaveBeenCalledTimes(1);
+        expect(verifier.mock.calls.filter(([params]) => params.targetPath === target)).toHaveLength(1);
         expect(injected).toBe(true);
         expect(retainedFd).toBeTypeOf("number");
         expect(() => fsSync.fstatSync(retainedFd!)).toThrowError(expect.objectContaining({ code: "EBADF" }));

--- a/test/sidecar-lock-root-create-denial.test.ts
+++ b/test/sidecar-lock-root-create-denial.test.ts
@@ -259,6 +259,8 @@ describe("Root exclusive-create denial (synthetic Windows/errno; real files)", (
     await expect(manager.acquire(target, options)).rejects.toBe(error);
     expect(attempts).toBe(1);
     expect(manager.heldEntries()).toEqual([]);
-    expect(await fsp.readdir(directory)).toEqual([]);
+    // A failed first exact stat provides no cleanup authority over the pathname.
+    expect(await fsp.readdir(directory)).toEqual(operation === "stat" ? ["state.lock"] : []);
+    if (operation === "stat") expect(await fsp.readFile(lockPath, "utf8")).toBe("");
   });
 });


### PR DESCRIPTION
The Windows JavaScript Root writer ignored `durable`, including the default `true`. Its staging cleanup could also delete a substituted pathname after a write failure. A real-file baseline fault probe reproduced that deletion.

Honor root defaults and per-call overrides for write/create and JSON variants. Sync staged bytes before replacement, sync the final mode through the retained handle, and request best-effort parent sync after verification. Validate the staging identity before rename. Retain exact identities and open handles for staging files, create-only targets, and new-destination placeholders so failed writes clean only owned files; preserve an entry when the first exact identity inspection fails.

Validation: 37 new cases cover durability ordering and overrides, sync failures, substituted staging files/placeholders, and handle lifetime. The focused suite passed 304 tests; full native Linux `pnpm check` passed 8,544 tests with 89 skips on AWS Crabbox `cbx_e7c5e5c92048`; `git diff --check` passed. Windows dispatch was also exercised through the built package on macOS; native Windows CI supplies OS validation.

Independent review is clean through P2. Existing publication-race tests keep their injections at the post-publication boundary while the new tests cover the earlier staging check.
