### PR TITLE
fix(trash): bound reservation names and handle root separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.
 - Add a method-by-method benchmark with callable API coverage checks, native/fallback reports, and separate fixture timing.
 - Keep zero-delay lock retries finite when a large backoff factor overflows, preventing synchronous waits from bypassing retry and timeout budgets.
+- Allow explicitly authorized filesystem-root descendants in Trash moves and keep reservation-directory names bounded for long source filenames.
 
 ## 0.9.0 - 2026-09-11
 

--- a/src/trash.ts
+++ b/src/trash.ts
@@ -26,7 +26,7 @@ function isTrashDestinationCollision(error: unknown): boolean {
 }
 
 function isSameOrChildPath(candidate: string, parent: string): boolean {
-  return candidate === parent || candidate.startsWith(`${parent}${path.sep}`);
+  return candidate === parent || candidate.startsWith(parent.endsWith(path.sep) ? parent : `${parent}${path.sep}`);
 }
 
 function resolveAllowedTrashRoots(allowedRoots?: Iterable<string>): string[] {
@@ -133,7 +133,7 @@ function resolveContainedPath(root: string, leaf: string): string {
 }
 
 function reserveTrashDestination(trashDir: string, base: string, timestamp: number): string {
-  const containerPrefix = resolveContainedPath(trashDir, `${base}-${timestamp}-`);
+  const containerPrefix = resolveContainedPath(trashDir, `.fs-safe-trash-${timestamp}-`);
   const container = fs.mkdtempSync(containerPrefix);
   const resolvedContainer = path.resolve(container);
   const resolvedTrashDir = path.resolve(trashDir);

--- a/test/trash-path-bounds.test.ts
+++ b/test/trash-path-bounds.test.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { movePathToTrash } from "../src/trash.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+it("admits a descendant of an explicitly allowed filesystem root", async () => {
+  const home = await tempRoot("fs-safe-trash-root-");
+  vi.spyOn(os, "homedir").mockReturnValue(home);
+  const source = path.join(home, "source");
+  await fs.writeFile(source, "synthetic bytes");
+  const destination = await movePathToTrash(source, { allowedRoots: [path.parse(home).root] });
+  expect(path.relative(path.join(home, ".Trash"), destination).startsWith("..")).toBe(false);
+  expect(await fs.readFile(destination, "utf8")).toBe("synthetic bytes");
+  await expect(fs.lstat(source)).rejects.toMatchObject({ code: "ENOENT" });
+  await expect(movePathToTrash(home, { allowedRoots: [home] })).rejects.toThrow("outside allowed roots");
+});
+
+it("preserves a long valid basename without overflowing its reservation directory", async () => {
+  const home = await tempRoot("fs-safe-trash-long-name-");
+  vi.spyOn(os, "homedir").mockReturnValue(home);
+  const basename = "x".repeat(240);
+  const source = path.join(home, basename);
+  await fs.writeFile(source, "synthetic bytes");
+  const destination = await movePathToTrash(source, { allowedRoots: [home] });
+  expect(path.basename(destination)).toBe(basename);
+  expect(Buffer.byteLength(path.basename(path.dirname(destination)))).toBeLessThan(255);
+  expect(await fs.readFile(destination, "utf8")).toBe("synthetic bytes");
+  await expect(fs.lstat(source)).rejects.toMatchObject({ code: "ENOENT" });
+});


### PR DESCRIPTION
Trash admission rejected descendants when an explicitly allowed root already ended with a separator, such as a filesystem root. Reservation directory names also appended timestamps and randomness to the complete source basename, making valid 240-character filenames fail with ENAMETOOLONG.

Respect the existing separator at root boundaries and use a bounded reservation prefix. The file inside the reservation retains its full original basename; root targets and disallowed paths still reject.

Validation: both regression tests fail on the baseline and pass on the candidate. A successful same-filesystem Trash benchmark used an isolated synthetic home (35 measured 4 KiB moves, fixture writes excluded; macOS median 0.574 ms). Independent Codex review clean through P2. Full native Linux `pnpm check` passed (8,509 tests, 89 skipped), and `git diff --check` passed. AWS Crabbox `cbx_e7c5e5c92048` required a fresh sync after an interrupted transport; the completed test run passed.
