### PR TITLE
fix(move): retain staging ownership through copy failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.
 - Add a method-by-method benchmark with callable API coverage checks, native/fallback reports, and separate fixture timing.
 - Keep zero-delay lock retries finite when a large backoff factor overflows, preventing synchronous waits from bypassing retry and timeout budgets.
+- Fence move-fallback staging publication and cleanup to its initially admitted identity, preserve later substituted paths after copy failures, and reject writes that make no progress.
 - Honor finite timeouts and retry delays above Node's single-timer limit by rearming bounded timers instead of expiring after approximately 1 ms.
 
 ## 0.9.0 - 2026-09-11

--- a/docs/atomic.md
+++ b/docs/atomic.md
@@ -207,6 +207,13 @@ directory mode. Staged file modes are applied through their still-open handles.
 If descriptor-bound mode application fails, the staged path is removed and the
 move fails before publication. A transient staged-path cleanup failure retains
 an identity-bound process-exit cleanup retry.
+The staging entry's initially admitted identity is checked before publication
+and cleanup; a later substituted entry is preserved. Regular files are admitted
+through their new descriptor. Node provides no creation descriptor for directories
+or symlinks, so their first identity comes from an immediate pathname observation.
+Replacement before that observation remains a best-effort detection gap: use a
+parent protected from concurrent untrusted mutation or OS isolation. A copy write
+that makes no progress rejects instead of looping indefinitely.
 On POSIX, staged directory modes are applied through no-follow directory
 descriptors; on Windows, Node cannot portably open those descriptors and no
 pathname `chmod` fallback is attempted, so directory modes remain subject to

--- a/src/guarded-mutation.ts
+++ b/src/guarded-mutation.ts
@@ -110,6 +110,7 @@ export function guardedRenameSync(params: {
 
 export async function guardedRm(params: {
   target: string;
+  assertBeforeMutation?: () => void;
   recursive?: boolean;
   force?: boolean;
   verifyAfter?: boolean;
@@ -118,6 +119,7 @@ export async function guardedRm(params: {
   await withAsyncDirectoryGuards(
     [guard],
     async () => {
+      params.assertBeforeMutation?.();
       await fs.rm(params.target, {
         ...(params.recursive !== undefined ? { recursive: params.recursive } : {}),
         ...(params.force !== undefined ? { force: params.force } : {}),
@@ -129,6 +131,7 @@ export async function guardedRm(params: {
 
 export function guardedRmSync(params: {
   target: string;
+  assertBeforeMutation?: () => void;
   recursive?: boolean;
   force?: boolean;
   verifyAfter?: boolean;
@@ -136,11 +139,13 @@ export function guardedRmSync(params: {
   const guard = createSyncDirectoryGuard(path.dirname(params.target));
   withSyncDirectoryGuards(
     [guard],
-    () =>
+    () => {
+      params.assertBeforeMutation?.();
       fsSync.rmSync(params.target, {
         ...(params.recursive !== undefined ? { recursive: params.recursive } : {}),
         ...(params.force !== undefined ? { force: params.force } : {}),
-      }),
+      });
+    },
     { verifyAfter: params.verifyAfter },
   );
 }

--- a/src/move-path-stage.ts
+++ b/src/move-path-stage.ts
@@ -1,0 +1,52 @@
+import fsSync, { type BigIntStats } from "node:fs";
+import path from "node:path";
+import { createAsyncDirectoryGuard } from "./directory-guard.js";
+import { FsSafeError } from "./errors.js";
+import { guardedRm, guardedRmSync } from "./guarded-mutation.js";
+import { sameFileIdentityForCleanup } from "./file-identity.js";
+import { registerTempPathForExit, type TempPathRegistration } from "./temp-cleanup.js";
+
+export async function createMoveStageOwner(staged: string) {
+  const parent = await createAsyncDirectoryGuard(path.dirname(staged), { bigint: true });
+  let identity: BigIntStats | undefined;
+  let unregister: TempPathRegistration | undefined;
+  const changed = () => new FsSafeError("path-mismatch", "move staging path changed before publication");
+  const assertParent = (): void => {
+    const current = fsSync.lstatSync(parent.dir, { bigint: true });
+    if (!current.isDirectory() || current.isSymbolicLink() ||
+      !sameFileIdentityForCleanup(current, parent.stat) ||
+      fsSync.realpathSync.native(parent.dir) !== parent.realPath) throw changed();
+  };
+  const assertCurrent = (): void => {
+    assertParent();
+    if (!identity || !sameFileIdentityForCleanup(fsSync.lstatSync(staged, { bigint: true }), identity)) {
+      throw changed();
+    }
+  };
+  return {
+    record(created: BigIntStats): void {
+      if (!sameFileIdentityForCleanup(created, created)) throw changed();
+      identity = created;
+      unregister = registerTempPathForExit(staged, {
+        identity,
+        cleanupSync: () => {
+          guardedRmSync({ target: staged, recursive: created.isDirectory(), assertBeforeMutation: assertCurrent });
+        },
+      });
+    },
+    assertCurrent,
+    published(): void { unregister?.(); },
+    async cleanup(): Promise<void> {
+      if (!identity) return;
+      try {
+        await guardedRm({ target: staged, recursive: identity.isDirectory(), assertBeforeMutation: assertCurrent });
+        unregister?.();
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT" || error instanceof FsSafeError) {
+          unregister?.();
+        }
+        // Retry only the original receipt after transient cleanup I/O failures.
+      }
+    },
+  };
+}

--- a/src/move-path.ts
+++ b/src/move-path.ts
@@ -3,6 +3,7 @@ import fsSync, { constants as fsConstants } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createAsyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { guardedRename } from "./guarded-mutation.js";
 import {
@@ -16,7 +17,8 @@ import {
   type EntryIdentity,
 } from "./move-path-cleanup.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
-import { registerTempPathForExit } from "./temp-cleanup.js";
+import { cleanupPinnedFilePath } from "./replace-file-temp-owner.js";
+import { createMoveStageOwner } from "./move-path-stage.js";
 
 export type MovePathPublicationReceipt = Readonly<{
   path: string;
@@ -151,6 +153,7 @@ async function writeAll(handle: FileHandle, buffer: Buffer, bytesRead: number): 
   let offset = 0;
   while (offset < bytesRead) {
     const { bytesWritten } = await handle.write(buffer, offset, bytesRead - offset);
+    if (bytesWritten <= 0) throw new FsSafeError("helper-failed", "move copy made no progress");
     offset += bytesWritten;
   }
 }
@@ -161,8 +164,8 @@ async function copyRegularFilePinned(params: {
   mode: number;
   rejectHardlinks: boolean;
   to: string;
+  onCreated?: (identity: fsSync.BigIntStats) => void;
 }): Promise<EntryIdentity> {
-  let destinationCreated = false;
   let openedIdentity: EntryIdentity;
   let sourceHandle: FileHandle;
   try {
@@ -197,13 +200,16 @@ async function copyRegularFilePinned(params: {
     }
     await assertSourceStillMatches(params.from, openedIdentity);
 
+    const parentGuard = await createAsyncDirectoryGuard(path.dirname(params.to), { bigint: true });
     const destinationHandle = await fs.open(
       params.to,
       fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
       modeBits(params.mode) || 0o666,
     );
-    destinationCreated = true;
+    let destinationIdentity: fsSync.BigIntStats | undefined;
     try {
+      destinationIdentity = fsSync.fstatSync(destinationHandle.fd, { bigint: true });
+      params.onCreated?.(destinationIdentity);
       const scratch = Buffer.allocUnsafe(64 * 1024);
       while (true) {
         const { bytesRead } = await sourceHandle.read(scratch, 0, scratch.length, null);
@@ -222,14 +228,14 @@ async function copyRegularFilePinned(params: {
         throw sourceChangedError(params.from);
       }
       await destinationHandle.chmod(modeBits(params.mode));
+    } catch (error) {
+      await cleanupPinnedFilePath({
+        pathname: params.to, handle: destinationHandle, identity: destinationIdentity, parentGuard,
+      });
+      throw error;
     } finally {
       await destinationHandle.close();
     }
-  } catch (error) {
-    if (destinationCreated) {
-      await fs.rm(params.to, { force: true }).catch(() => undefined);
-    }
-    throw error;
   } finally {
     await sourceHandle.close();
   }
@@ -242,6 +248,7 @@ async function copyEntryWithManifest(
   options: {
     sourceHardlinks: "allow" | "reject";
     budget?: { discovered: number };
+    onCreated?: (identity: fsSync.BigIntStats) => void;
   },
   expectedIdentity?: EntryIdentity,
 ): Promise<CopiedEntryManifest> {
@@ -256,6 +263,7 @@ async function copyEntryWithManifest(
     const targetType =
       process.platform === "win32" && fsSync.statSync(from).isDirectory() ? "junction" : undefined;
     await fs.symlink(target, to, targetType);
+    options.onCreated?.(fsSync.lstatSync(to, { bigint: true }));
     // readlink() is path-based; verify the symlink we copied is still the one
     // we inspected before letting the staged destination become visible.
     await assertSourceStillMatches(from, identity);
@@ -264,6 +272,7 @@ async function copyEntryWithManifest(
 
   if (sourceStat.isDirectory()) {
     await fs.mkdir(to, { mode: modeBits(sourceStat.mode) || 0o755 });
+    options.onCreated?.(fsSync.lstatSync(to, { bigint: true }));
     const children: Array<{ name: string; manifest: CopiedEntryManifest }> = [];
     const childNames: string[] = [];
     const directory = await fs.opendir(from);
@@ -276,7 +285,9 @@ async function copyEntryWithManifest(
     for (const child of childNames) {
       children.push({
         name: child,
-        manifest: await copyEntryWithManifest(path.join(from, child), path.join(to, child), options),
+        manifest: await copyEntryWithManifest(path.join(from, child), path.join(to, child), {
+          sourceHardlinks: options.sourceHardlinks, budget: options.budget,
+        }),
       });
     }
     // Directory traversal is path-based in Node. Treat a changed parent as a
@@ -301,6 +312,7 @@ async function copyEntryWithManifest(
     mode: sourceStat.mode,
     rejectHardlinks: options.sourceHardlinks === "reject",
     to,
+    onCreated: options.onCreated,
   });
   return { ...copiedIdentity, kind: "leaf" };
 }
@@ -381,27 +393,27 @@ export async function movePathWithCopyFallback(
   const sourceIdentity = await assertCopyDestinationOutsideSource(sourcePath, targetPath);
   const targetDir = path.dirname(targetPath);
   const staged = path.join(targetDir, `.fs-safe-move-${process.pid}-${randomUUID()}.tmp`);
-  const unregisterStaged = registerTempPathForExit(staged, { recursive: true });
+  const stage = await createMoveStageOwner(staged);
   try {
     const manifest = await copyEntryWithManifest(
       sourcePath,
       staged,
       {
         sourceHardlinks: rejectHardlinks ? "reject" : "allow",
+        onCreated: stage.record,
         ...(rejectHardlinks ? { budget: { discovered: 1 } } : {}),
       },
       sourceIdentity,
     );
     const cleanupState = createCleanupCopiedEntryState(sourcePath, manifest);
-    unregisterStaged.setIdentity(fsSync.lstatSync(staged, { bigint: true }));
     await assertCopyDestinationOutsideSource(sourcePath, targetPath, manifest);
     await guardedRename({
       from: staged,
       to: targetPath,
-      assertBeforeRename,
+      assertBeforeRename: () => { assertBeforeRename(); stage.assertCurrent(); },
       onSourceInspected,
       onRenamed: () => {
-        unregisterStaged();
+        stage.published();
         onRenamed();
       },
     });
@@ -416,20 +428,7 @@ export async function movePathWithCopyFallback(
     }
   } finally {
     if (!destinationPublished) {
-      try {
-        const stagedIdentity = fsSync.lstatSync(staged, { bigint: true });
-        if (!stagedIdentity.isSymbolicLink()) unregisterStaged.setIdentity(stagedIdentity);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-          unregisterStaged();
-        }
-      }
-      try {
-        await fs.rm(staged, { recursive: true, force: true });
-        unregisterStaged();
-      } catch {
-        // Keep the identity-bound exit cleanup registered for a later retry.
-      }
+      await stage.cleanup();
     }
   }
 }

--- a/test/move-stage-ownership.test.ts
+++ b/test/move-stage-ownership.test.ts
@@ -1,0 +1,109 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { movePathWithCopyFallback } from "../src/move-path.js";
+import { __cleanupRegisteredTempPathForTest } from "../src/temp-cleanup.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+async function fixture(kind: "file" | "directory" = "file") {
+  const dir = await tempRoot("fs-safe-move-stage-owner-");
+  const source = path.join(dir, "source"), target = path.join(dir, "target");
+  if (kind === "directory") {
+    await fs.mkdir(source);
+    await fs.writeFile(path.join(source, "child"), "source bytes");
+  } else await fs.writeFile(source, "source bytes");
+  const rename = fs.rename.bind(fs);
+  vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+    if (from === source && to === target) throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
+    await rename(from, to);
+  });
+  return { dir, source, target, moved: path.join(dir, "displaced") };
+}
+
+it.each(["file", "directory"] as const)("preserves a replaced %s stage after a copy failure", async kind => {
+  const { dir, source, target, moved } = await fixture(kind);
+  let stage!: string;
+  const error = Object.assign(new Error("copy failed"), { code: "EIO" });
+  const substitute = async () => {
+    await fs.rename(stage, moved);
+    if (kind === "directory") {
+      await fs.mkdir(stage);
+      await fs.writeFile(path.join(stage, "sentinel"), "unowned bytes");
+    } else await fs.writeFile(stage, "unowned bytes");
+    throw error;
+  };
+  if (kind === "file") {
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      if (path.basename(String(args[0])).startsWith(".fs-safe-move-")) {
+        stage = String(args[0]);
+        vi.spyOn(handle, "write").mockImplementation(substitute);
+      }
+      return handle;
+    });
+  } else {
+    const mkdir = fs.mkdir.bind(fs), opendir = fs.opendir.bind(fs);
+    vi.spyOn(fs, "mkdir").mockImplementation(async (...args) => {
+      const result = await mkdir(...args);
+      if (path.basename(String(args[0])).startsWith(".fs-safe-move-")) stage = String(args[0]);
+      return result;
+    });
+    vi.spyOn(fs, "opendir").mockImplementation(async (...args) => {
+      if (args[0] === source) return await substitute();
+      return await opendir(...args);
+    });
+  }
+  await expect(movePathWithCopyFallback({ from: source, to: target })).rejects.toBe(error);
+  __cleanupRegisteredTempPathForTest(stage);
+  expect(await fs.readFile(kind === "file" ? stage : path.join(stage, "sentinel"), "utf8"))
+    .toBe("unowned bytes");
+  expect(await fs.readFile(kind === "file" ? source : path.join(source, "child"), "utf8"))
+    .toBe("source bytes");
+  await expect(fs.lstat(target)).rejects.toMatchObject({ code: "ENOENT" });
+  expect((await fs.readdir(dir)).includes("displaced")).toBe(true);
+});
+
+it("rejects a substituted stage immediately before publication", async () => {
+  const { dir, source, target, moved } = await fixture();
+  let stage!: string;
+  await expect(movePathWithCopyFallback({
+    from: source, to: target,
+    assertBeforeRename() {
+      const name = fsSync.readdirSync(dir).find(entry => entry.startsWith(".fs-safe-move-"));
+      if (!name) return;
+      stage = path.join(dir, name);
+      fsSync.renameSync(stage, moved);
+      fsSync.writeFileSync(stage, "unowned bytes");
+    },
+  })).rejects.toMatchObject({ code: "path-mismatch" });
+  expect(await fs.readFile(source, "utf8")).toBe("source bytes");
+  expect(await fs.readFile(stage, "utf8")).toBe("unowned bytes");
+  expect(await fs.readFile(moved, "utf8")).toBe("source bytes");
+  await expect(fs.lstat(target)).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+it("rejects a zero-progress copy without retrying the write", async () => {
+  const { dir, source, target } = await fixture();
+  const open = fs.open.bind(fs);
+  let writes = 0;
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (path.basename(String(args[0])).startsWith(".fs-safe-move-")) {
+      vi.spyOn(handle, "write").mockImplementation(async () => {
+        if (++writes > 1) throw new Error("unexpected repeated write");
+        return { bytesWritten: 0, buffer: Buffer.alloc(0) };
+      });
+    }
+    return handle;
+  });
+  await expect(movePathWithCopyFallback({ from: source, to: target })).rejects.toMatchObject({
+    code: "helper-failed", message: "move copy made no progress",
+  });
+  expect(writes).toBe(1);
+  expect(await fs.readdir(dir)).toEqual(["source"]);
+});


### PR DESCRIPTION
Move copy fallback could adopt the current staging pathname during error cleanup and remove a replacement it did not create. A real-file probe reproduced loss of an unrelated replacement after an injected copy-write failure. The copy write loop also retried forever when a write reported zero progress.

Retain the staging entry's initially admitted identity and original parent guard through copy, publication, and cleanup. Regular-file admission uses the newly opened descriptor; failed leaf cleanup keeps that descriptor until its ownership checks finish. Check the stage again after the caller's pre-rename assertion, preserve substituted paths, and retain the original guarded exit-cleanup receipt only for transient failures. Reject a zero-progress write.

Node directory/symlink creation has no returned descriptor, so initial admission still uses a pathname observation. The docs explicitly retain that existing best-effort gap and the need for a protected parent or OS isolation against hostile concurrent mutation. This change does not claim atomic creation ownership for those entries.

Validation: four focused regressions cover file/directory substitution, a swap immediately before publication, and zero-progress writes. The move suite passed 85 tests with two platform skips. The real-file candidate preserves the replacement deleted by the baseline. Full native Linux `pnpm check` passed (8,521 tests, 89 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; independent Codex review clean through P2; `git diff --check` passed.
