### PR TITLE
perf(archive): avoid unused snapshots for JavaScript ZIP reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Close publication descriptors when initial inspection fails, and relinquish descriptor numbers before potentially failing closes so cleanup cannot close a reused descriptor.
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
 - Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.
+- Read JavaScript ZIP members directly from the admitted in-memory archive, avoiding an unused disk snapshot while preserving byte limits, identity checks, and ZIP integrity validation.
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.
 - Read durable queue entries through the shared bounded buffer, using the admitted file size to reduce filesystem calls and chunk copies while retaining exact identity and byte-limit checks.
 - Preserve recreated temporary paths when an exit-cleanup lookup observed the original name missing; absence no longer authorizes a forced removal.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -555,8 +555,8 @@ await extractArchive({
 ## `readArchiveEntry`
 
 `readArchiveEntry(archivePath, entryPath, { maxBytes, kind? })` reads one
-regular-file entry into a bounded `Buffer` without extracting a tree. It pins
-and privately stages the archive input, rejects link, directory, and duplicate
+regular-file entry into a bounded `Buffer` without extracting a tree. It reads
+the input through an identity-checked descriptor, rejects link, directory, and duplicate
 entries, verifies ZIP CRC and declared size,
 and throws `ArchiveLimitError` if the requested entry's output exceeds
 `maxBytes`. ZIP output within that cap must match the declared uncompressed
@@ -571,6 +571,8 @@ limits. It does not apply payload budgets to unrequested members. ZIP
 inputs retain the archive subpath's 256 MiB compressed-input ceiling.
 With a native binding it uses the same Rust decoders as extraction, including
 zstd and bzip2 TAR. Without native it retains the JS ZIP/TAR/gzip implementation.
+The JavaScript ZIP reader consumes the admitted buffer directly. Native decoders
+and TAR replay use a private disk snapshot of that buffer.
 
 Requested paths and effective member names use extraction's canonical pre-strip
 identity: backslashes become `/`, and repeated separators and `.` components

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -91,11 +91,7 @@ async function readStreamBounded(
   return Buffer.concat(chunks, total);
 }
 
-async function stageArchiveInput(archivePath: string): Promise<{
-  path: string;
-  buffer: Buffer;
-  cleanup(): Promise<void>;
-}> {
+async function readArchiveInput(archivePath: string): Promise<Buffer> {
   const resolved = fsSync.realpathSync.native(archivePath);
   const before = await inspectFileIdentity(async () => {
     const stat = fsSync.lstatSync(archivePath, { bigint: true });
@@ -105,9 +101,7 @@ async function stageArchiveInput(archivePath: string): Promise<{
     return stat;
   });
   const handle = await fs.open(resolved, resolveReadOpenFlags());
-  let staged: Awaited<ReturnType<typeof tempFile>> | undefined;
   try {
-    staged = await tempFile({ prefix: "fs-safe-archive-read", fileName: "archive.bin" });
     const opened = await inspectFileIdentity(async () => {
       const stat = fsSync.fstatSync(handle.fd, { bigint: true });
       if (!stat.isFile()) throw new Error("archive changed during validation");
@@ -119,11 +113,8 @@ async function stageArchiveInput(archivePath: string): Promise<{
       return stat;
     }, opened);
 
-    const buffer = await readFileHandleBounded(handle, DEFAULT_MAX_ARCHIVE_BYTES_ZIP);
-    await fs.writeFile(staged.path, buffer, { flag: "wx", mode: 0o600 });
-    return { path: staged.path, buffer, cleanup: staged.cleanup };
+    return await readFileHandleBounded(handle, DEFAULT_MAX_ARCHIVE_BYTES_ZIP);
   } catch (error) {
-    await staged?.cleanup().catch(() => undefined);
     if (error instanceof FsSafeError && error.code === "path-mismatch") {
       throw new FsSafeError("path-mismatch", "archive changed during validation", { cause: error });
     }
@@ -204,12 +195,18 @@ export async function readArchiveEntry(
     throw new Error(`unsupported archive: ${archivePath}`);
   }
   const requestedEntry = normalizedRequestedEntry(entryPath);
-  const staged = await stageArchiveInput(archivePath);
+  const buffer = await readArchiveInput(archivePath);
+  const physicalCount = kind === "zip"
+    ? admitZipBuffer(buffer, resolveExtractLimits())
+    : undefined;
+  const native = getNativeBinding();
+  if (!native) {
+    assertPortableArchiveKind(kind);
+    if (kind === "zip") return await readZipEntry(buffer, requestedEntry, options.maxBytes);
+  }
+  const staged = await tempFile({ prefix: "fs-safe-archive-read", fileName: "archive.bin" });
   try {
-    const physicalCount = kind === "zip"
-      ? admitZipBuffer(staged.buffer, resolveExtractLimits())
-      : undefined;
-    const native = getNativeBinding();
+    await fs.writeFile(staged.path, buffer, { flag: "wx", mode: 0o600 });
     if (native) {
       try {
         const signal = new AbortController().signal;
@@ -265,10 +262,7 @@ export async function readArchiveEntry(
         throw error;
       }
     }
-    assertPortableArchiveKind(kind);
-    return kind === "zip"
-      ? await readZipEntry(staged.buffer, requestedEntry, options.maxBytes)
-      : await readTarEntry(staged.path, requestedEntry, options.maxBytes);
+    return await readTarEntry(staged.path, requestedEntry, options.maxBytes);
   } finally {
     await staged.cleanup();
   }

--- a/test/archive-read-boundaries.test.ts
+++ b/test/archive-read-boundaries.test.ts
@@ -239,12 +239,10 @@ describe("bounded archive reads", () => {
     "closes the selected archive when private staging allocation fails",
     async () => {
       const root = await tempRoot("fs-safe-archive-read-staging-failure-");
-      const archivePath = path.join(root, "fixture.zip");
+      const archivePath = path.join(root, "fixture.tar");
       const privateTmp = path.join(root, "private-tmp");
       await fs.mkdir(privateTmp, { mode: 0o700 });
-      const zip = new JSZip();
-      zip.file("value", "ok");
-      await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer" }));
+      await fs.writeFile(archivePath, tarFixture([{ path: "value", body: "ok" }]));
       await fs.writeFile(path.join(privateTmp, `fs-safe-${process.getuid!()}`), "synthetic blocker", {
         flag: "wx",
         mode: 0o600,

--- a/test/archive-zip-read-memory.test.ts
+++ b/test/archive-zip-read-memory.test.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import JSZip from "jszip";
+import { afterEach, expect, it, vi } from "vitest";
+import { readArchiveEntry } from "../src/archive-read.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import * as temp from "../src/temp-target.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => { vi.restoreAllMocks(); __resetFsSafeNativeConfigForTest(); });
+
+it("reads a fallback ZIP directly from the admitted buffer without a disk snapshot", async () => {
+  const dir = await tempRoot("fs-safe-zip-memory-");
+  const archive = path.join(dir, "input.zip");
+  const zip = new JSZip();
+  zip.file("entry", "archive bytes");
+  await fs.writeFile(archive, await zip.generateAsync({ type: "nodebuffer" }));
+  configureFsSafeNative({ mode: "off" });
+  const staging = vi.spyOn(temp, "tempFile").mockRejectedValue(new Error("temporary storage unavailable"));
+  await expect(readArchiveEntry(archive, "entry", { maxBytes: 13 })).resolves.toEqual(Buffer.from("archive bytes"));
+  expect(staging).not.toHaveBeenCalled();
+  await expect(readArchiveEntry(archive, "entry", { maxBytes: 1 })).rejects.toThrow();
+  expect(staging).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
JavaScript ZIP member reads copied the complete admitted archive to a private disk file even though JSZip consumed only the in-memory buffer. This added file creation, copying, and cleanup to every call and made those reads depend unnecessarily on temporary storage.

Read the archive through the same bounded, identity-checked descriptor and feed the admitted buffer directly to JSZip. Native decoders and TAR replay retain private disk snapshots. ZIP framing, entry limits, CRC, and size validation remain in place. Regression coverage proves fallback ZIP reads work without temporary storage; the staging-allocation failure test now exercises TAR, where staging remains required.

Three alternating Linux rounds measured 4 KiB stored ZIP reads at 1.63–1.80× faster, 1 MiB at 1.21–1.52×, and 8 MiB at 1.12–1.23× on AWS Crabbox `cbx_e7c5e5c92048` (AMD EPYC, Node 24). These warm synthetic-file timings exclude archive fixture creation.

Validation: 17 focused boundary/memory tests passed; full native Linux `pnpm check` passed (8,520 tests, 89 skipped); independent Codex review clean through P2; `git diff --check` passed.
