### PR TITLE
fix(path): preserve raw segments in guarded root file opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.
 - Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.
+- Preserve raw symlink and parent components in `openRootFile` and `openRootFileSync`, so validation cannot normalize away a rejected link or open a different in-root file.
 - Add a method-by-method benchmark with callable API coverage checks, native/fallback reports, and separate fixture timing.
 - Keep zero-delay lock retries finite when a large backoff factor overflows, preventing synchronous waits from bypassing retry and timeout budgets.
 - Honor finite timeouts and retry delays above Node's single-timer limit by rearming bounded timers instead of expiring after approximately 1 ms.

--- a/src/root-file.ts
+++ b/src/root-file.ts
@@ -67,9 +67,16 @@ export function canUseRootFileOpen(ioFs: typeof fs): boolean {
   );
 }
 
+function absoluteRootFilePath(filePath: string): string {
+  if (path.isAbsolute(filePath)) return filePath;
+  const drive = path.parse(filePath).root;
+  const base = drive ? path.resolve(drive) : process.cwd();
+  return `${base}${path.sep}${filePath.slice(drive.length)}`;
+}
+
 export function openRootFileSync(params: OpenRootFileSyncParams): RootFileOpenResult {
   const ioFs = params.ioFs ?? fs;
-  const absolutePath = path.resolve(params.absolutePath);
+  const absolutePath = absoluteRootFilePath(params.absolutePath);
   let resolved: ResolvedRootFilePath | RootFileOpenResult;
   try {
     resolved = mapResolvedRootPath(absolutePath, resolveRootPathSync({
@@ -166,7 +173,7 @@ export async function openRootFile(
   params: OpenRootFileParams,
 ): Promise<RootFileOpenResult> {
   const ioFs = params.ioFs ?? fs;
-  const absolutePath = path.resolve(params.absolutePath);
+  const absolutePath = absoluteRootFilePath(params.absolutePath);
   let resolved: ResolvedRootFilePath | RootFileOpenResult;
   try {
     resolved = mapResolvedRootPath(absolutePath, await resolveRootPath({

--- a/test/root-file-raw-path.test.ts
+++ b/test/root-file-raw-path.test.ts
@@ -1,0 +1,51 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { openRootFile, openRootFileSync } from "../src/root-file.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+
+it.each(["async", "sync"].flatMap(mode => [false, true].map(rejectSymlinks => ({ mode, rejectSymlinks }))))(
+  "$mode retains symlink/parent traversal before opening (reject=$rejectSymlinks)",
+  async ({ mode, rejectSymlinks }) => {
+    const dir = await tempRoot("fs-safe-root-file-raw-");
+    await fs.mkdir(path.join(dir, "deep", "dir"), { recursive: true });
+    await fs.writeFile(path.join(dir, "value"), "lexical bytes");
+    await fs.writeFile(path.join(dir, "deep", "value"), "canonical bytes");
+    await fs.symlink(path.join(dir, "deep", "dir"), path.join(dir, "link"),
+      process.platform === "win32" ? "junction" : "dir");
+    const params = {
+      absolutePath: `${dir}${path.sep}link${path.sep}..${path.sep}value`,
+      rootPath: dir, boundaryLabel: "fixture", rejectSymlinks,
+    };
+    const opened = mode === "async" ? await openRootFile(params) : openRootFileSync(params);
+    if (rejectSymlinks) {
+      if (opened.ok) fsSync.closeSync(opened.fd);
+      expect(opened).toMatchObject({ ok: false, reason: "validation", error: { code: "symlink" } });
+    } else {
+      expect(opened.ok).toBe(true);
+      if (!opened.ok) throw opened.error;
+      try { expect(fsSync.readFileSync(opened.fd, "utf8")).toBe("canonical bytes"); }
+      finally { fsSync.closeSync(opened.fd); }
+    }
+  },
+);
+
+it.runIf(process.platform === "win32").each(["async", "sync"])(
+  "%s preserves drive-relative inputs",
+  async mode => {
+    const dir = await tempRoot("fs-safe-root-file-drive-");
+    const target = path.join(dir, "value");
+    await fs.writeFile(target, "drive-relative bytes");
+    const drive = path.parse(target).root.slice(0, 2);
+    const driveRelative = `${drive}${path.relative(path.resolve(drive), target)}`;
+    const params = { rootPath: dir, absolutePath: driveRelative, boundaryLabel: "fixture" };
+    const opened = mode === "async" ? await openRootFile(params) : openRootFileSync(params);
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) throw opened.error;
+    try { expect(fsSync.readFileSync(opened.fd, "utf8")).toBe("drive-relative bytes"); }
+    finally { fsSync.closeSync(opened.fd); }
+  },
+);


### PR DESCRIPTION
The guarded root-file open helpers normalized their input before boundary validation. A `link/../value` spelling could therefore bypass default symlink rejection or open the lexically normalized file instead of the symlink-aware canonical target.

Anchor ordinary relative paths to the working directory and Windows drive-relative paths to the appropriate drive directory, while preserving the unresolved remainder for the shared resolver. Both async and sync opens retain the existing pinned-file checks and result shape.

Validation: four real-file regressions fail on the baseline and pass on the candidate; Windows-only cases exercise drive-relative inputs. Ten focused tests passed locally with two Windows skips. Full native Linux `pnpm check` passed (8,523 tests, 91 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; independent Codex review clean through P2; `git diff --check` passed.
