### PR TITLE
fix(path): preserve canonical traversal through root reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.
 - Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.
+- Read the checked canonical Root path after symlink/parent traversal, preserve raw components in absolute reads, and resume alias inspection when parent components cancel a missing prefix.
 - Add a method-by-method benchmark with callable API coverage checks, native/fallback reports, and separate fixture timing.
 - Keep zero-delay lock retries finite when a large backoff factor overflows, preventing synchronous waits from bypassing retry and timeout budgets.
 - Honor finite timeouts and retry delays above Node's single-timer limit by rearming bounded timers instead of expiring after approximately 1 ms.

--- a/docs/root.md
+++ b/docs/root.md
@@ -218,6 +218,11 @@ await fs.readText("config.toml");
 await fs.readText("links/current.log", { symlinks: "follow-within-root" });
 ```
 
+With `follow-within-root`, parent components after a symlink are applied to the
+symlink's resolved target. Reads use that checked canonical path, including
+after home expansion and through `readAbsolute` and `reader`; the default policy still rejects a symlink
+even when a later `..` would hide it in a purely lexical normalization.
+
 Text helpers default to UTF-8. Pass `encoding` per call to `readText`, `readJson`, `write`, `create`, or `append` when you need another encoding.
 
 ## Common patterns

--- a/src/root-context.ts
+++ b/src/root-context.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { inspectDirectoryIdentity } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { sameFileIdentity } from "./file-identity.js";
-import { expandHomePrefix } from "./home-dir.js";
 import {
   assertNoNulPathInput,
   assertNoUnsafeDeviceReadPath,
@@ -13,6 +12,7 @@ import {
   isPathInside,
 } from "./path.js";
 import { ROOT_PATH_ALIAS_POLICIES, resolveRootPath } from "./root-path.js";
+import { rawPathRelativeToCanonicalRoot } from "./root-path-existing.js";
 import { outsideWorkspaceError } from "./root-errors.js";
 import { isDriveRelativePath } from "./safe-path-segment.js";
 
@@ -50,7 +50,11 @@ export async function expandRelativePathWithHome(relativePath: string): Promise<
     }
     cachedHomePath = { raw: rawHome, real: realHome };
   }
-  return expandHomePrefix(relativePath, { home: cachedHomePath.real });
+  if (relativePath === "~") return cachedHomePath.real;
+  if (relativePath.startsWith("~/") || (path.sep === "\\" && relativePath.startsWith("~\\"))) {
+    return `${ensureTrailingSep(cachedHomePath.real)}${relativePath.slice(2)}`;
+  }
+  return relativePath;
 }
 
 export async function resolveRootContext(rootDir: string): Promise<RootContext> {
@@ -81,19 +85,34 @@ export async function resolveRootContext(rootDir: string): Promise<RootContext> 
   };
 }
 
-export function rootRelativeReadPath(root: RootContext, filePath: string): string {
+export function rootRelativeReadPath(root: RootContext, filePath: string, options: { rejectSymlinks?: boolean } = {}): string {
   const absoluteInput = path.isAbsolute(filePath);
-  const candidatePath = absoluteInput
-    ? path.resolve(filePath)
-    : path.resolve(root.rootDir, filePath);
+  if (!absoluteInput) return filePath;
+  const raw = process.platform === "win32" ? filePath.replaceAll("/", path.sep) : filePath;
+  for (const base of [root.rootDir, root.rootReal]) {
+    const prefix = ensureTrailingSep(base);
+    const matches = process.platform === "win32"
+      ? raw.slice(0, prefix.length).toLowerCase() === prefix.toLowerCase()
+      : raw.startsWith(prefix);
+    if (matches) {
+      let start = prefix.length;
+      while (raw[start] === path.sep) start += 1;
+      return raw.slice(start);
+    }
+  }
+  const candidatePath = path.resolve(filePath);
   let relativeBase = root.rootDir;
   if (
-    absoluteInput &&
     !isPathInside(root.rootDir, candidatePath) &&
     isPathInside(root.rootReal, candidatePath)
   ) {
     // A Root created through an alias has two valid in-root absolute spellings.
     relativeBase = root.rootReal;
+  }
+  if (isPathInside(relativeBase, candidatePath)) {
+    const relative = rawPathRelativeToCanonicalRoot(raw, root.rootReal, options);
+    if (relative !== undefined) return relative;
+    throw outsideWorkspaceError();
   }
   return path.relative(relativeBase, candidatePath);
 }
@@ -128,12 +147,13 @@ export async function resolvePathInRoot(
     allowFinalSymlink?: boolean;
     rejectUnsafeDeviceReads?: boolean;
     rejectSymlinks?: boolean;
+    resolveCanonical?: boolean;
   },
 ): Promise<{ rootReal: string; rootWithSep: string; resolved: string }> {
   assertValidRootRelativePath(relativePath);
   await assertRootIdentityCurrent(root);
   const expanded = await expandRelativePathWithHome(relativePath);
-  const resolved = path.resolve(root.rootWithSep, expanded);
+  let resolved = path.resolve(root.rootWithSep, expanded);
   if (!isPathInside(root.rootWithSep, resolved)) {
     throw outsideWorkspaceError();
   }
@@ -144,7 +164,7 @@ export async function resolvePathInRoot(
     ? expanded
     : `${root.rootWithSep}${expanded}`;
   try {
-    await resolveRootPath({
+    const checked = await resolveRootPath({
       absolutePath: rawAbsolutePath,
       rootPath: root.rootReal,
       rootCanonicalPath: root.rootReal,
@@ -152,6 +172,7 @@ export async function resolvePathInRoot(
       policy: options?.allowFinalSymlink ? ROOT_PATH_ALIAS_POLICIES.unlinkTarget : undefined,
       rejectSymlinks: options?.rejectSymlinks,
     });
+    if (options?.resolveCanonical) resolved = checked.canonicalPath;
   } catch (error) {
     if (error instanceof FsSafeError && error.code === "symlink") {
       throw error;

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -435,7 +435,7 @@ export class RootHandle implements Root {
   async resolve(relativePath: string): Promise<string> {
     assertValidRootDestinationPath(relativePath);
     return (
-      await resolvePathInRoot(this.context, relativePath, { allowFinalSymlink: true })
+      await resolvePathInRoot(this.context, relativePath, { allowFinalSymlink: true, resolveCanonical: true })
     ).resolved;
   }
 
@@ -698,16 +698,13 @@ export async function root(
 
 async function openFileInRoot(
   root: RootContext,
-  params: {
-    relativePath: string;
-    hardlinks?: HardlinkPolicy;
-    symlinks?: SymlinkPolicy;
-  },
+  params: RootOpenOptions & { relativePath: string },
 ): Promise<OpenResult> {
   const { rootWithSep, resolved } = await resolvePathInRoot(root, params.relativePath, {
     allowFinalSymlink: true,
     rejectUnsafeDeviceReads: true,
     rejectSymlinks: params.symlinks !== "follow-within-root",
+    resolveCanonical: true,
   });
 
   const { opened } = await openVerifiedLocalFile(resolved, {
@@ -753,7 +750,7 @@ async function readPathInRoot(
     symlinks?: SymlinkPolicy;
   },
 ): Promise<ReadResult> {
-  const relativePath = rootRelativeReadPath(root, params.filePath);
+  const relativePath = rootRelativeReadPath(root, params.filePath, { rejectSymlinks: params.symlinks !== "follow-within-root" });
   return await readFileInRoot(root, {
     relativePath,
     hardlinks: params.hardlinks,

--- a/src/root-path-existing.ts
+++ b/src/root-path-existing.ts
@@ -1,6 +1,36 @@
 import fs from "node:fs";
 import path from "node:path";
-import { isNotFoundPathError } from "./path.js";
+import { FsSafeError } from "./errors.js";
+import { isNotFoundPathError, isPathInside } from "./path.js";
+
+export function rawPathRelativeToCanonicalRoot(
+  candidate: string,
+  rootCanonicalPath: string,
+  options: { rejectSymlinks?: boolean } = {},
+): string | undefined {
+  const absolute = path.isAbsolute(candidate) ? candidate : `${process.cwd()}${path.sep}${candidate}`;
+  const raw = process.platform === "win32" ? absolute.replaceAll("/", path.sep) : absolute;
+  const filesystemRoot = path.parse(raw).root;
+  const segments = raw.slice(filesystemRoot.length).split(path.sep);
+  let prefix = filesystemRoot;
+  for (let index = 0; index < segments.length; index += 1) {
+    prefix += `${prefix.endsWith(path.sep) ? "" : path.sep}${segments[index]}`;
+    let canonical: string;
+    try {
+      if (options.rejectSymlinks && fs.lstatSync(prefix).isSymbolicLink()) {
+        throw new FsSafeError("symlink", "symlink path component not allowed");
+      }
+      canonical = fs.realpathSync.native(prefix);
+    } catch (error) {
+      if (error instanceof FsSafeError) throw error;
+      continue;
+    }
+    if (!isPathInside(rootCanonicalPath, canonical)) continue;
+    return [path.relative(rootCanonicalPath, canonical), ...segments.slice(index + 1)]
+      .filter(Boolean).join(path.sep);
+  }
+  return undefined;
+}
 
 function isFilesystemRoot(candidate: string): boolean {
   return path.parse(candidate).root === candidate;

--- a/src/root-path-existing.ts
+++ b/src/root-path-existing.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
+import { formatErrorDetail } from "./error-detail.js";
 import { isNotFoundPathError, isPathInside } from "./path.js";
 
 export function rawPathRelativeToCanonicalRoot(
@@ -23,7 +24,7 @@ export function rawPathRelativeToCanonicalRoot(
       }
       canonical = fs.realpathSync.native(prefix);
       if (isSymlink && !isPathInside(rootCanonicalPath, canonical) && !isPathInside(canonical, rootCanonicalPath)) {
-        throw new FsSafeError("outside-workspace", "symlink prefix resolves outside the root ancestry");
+        throw new FsSafeError("outside-workspace", `symlink prefix resolves outside the root ancestry: ${formatErrorDetail(candidate)}`);
       }
     } catch (error) {
       if (error instanceof FsSafeError) throw error;

--- a/src/root-path.ts
+++ b/src/root-path.ts
@@ -9,6 +9,7 @@ import {
   isPathRelativeEscape,
 } from "./path.js";
 import {
+  rawPathRelativeToCanonicalRoot,
   resolvePathViaExistingAncestor,
   resolvePathViaExistingAncestorSync,
 } from "./root-path-existing.js";
@@ -78,6 +79,14 @@ async function resolveRootPathInternal(
   const rootCanonicalPath = params.rootCanonicalPath
     ? path.resolve(params.rootCanonicalPath)
     : await resolvePathViaExistingAncestor(rootPath);
+  const reentered = rawPathRelativeToRoot(rootPath, params.absolutePath) === undefined
+    ? rawPathRelativeToCanonicalRoot(params.absolutePath, rootCanonicalPath, params) : undefined;
+  if (reentered !== undefined) {
+    return resolveRootPathLexicalAsync({
+      params: { ...params, absolutePath: `${rootPath}${path.sep}${reentered}` },
+      absolutePath, rootPath, rootCanonicalPath,
+    });
+  }
   const context = createBoundaryResolutionContext({
     resolveParams: params,
     rootPath,
@@ -120,6 +129,14 @@ function resolveRootPathSyncInternal(params: ResolveRootPathParams): ResolvedRoo
   const rootCanonicalPath = params.rootCanonicalPath
     ? path.resolve(params.rootCanonicalPath)
     : resolvePathViaExistingAncestorSync(rootPath);
+  const reentered = rawPathRelativeToRoot(rootPath, params.absolutePath) === undefined
+    ? rawPathRelativeToCanonicalRoot(params.absolutePath, rootCanonicalPath, params) : undefined;
+  if (reentered !== undefined) {
+    return resolveRootPathLexicalSync({
+      params: { ...params, absolutePath: `${rootPath}${path.sep}${reentered}` },
+      absolutePath, rootPath, rootCanonicalPath,
+    });
+  }
   const context = createBoundaryResolutionContext({
     resolveParams: params,
     rootPath,
@@ -182,6 +199,7 @@ type LexicalTraversalState = {
   canonicalCursor: string;
   lexicalCursor: string;
   preserveFinalSymlink: boolean;
+  missingDepth: number;
 };
 
 type LexicalTraversalContext = {
@@ -215,6 +233,7 @@ function createLexicalTraversalState(params: {
     canonicalCursor: params.rootCanonicalPath,
     lexicalCursor: params.rootPath,
     preserveFinalSymlink: false,
+    missingDepth: 0,
   };
 }
 
@@ -270,16 +289,6 @@ function assertLexicalCursorInsideBoundary(
   });
 }
 
-function applyMissingSuffixToCanonicalCursor(
-  context: LexicalTraversalContext,
-  missingFromIndex: number,
-): void {
-  const missingSuffix = context.state.segments.slice(missingFromIndex);
-  for (const segment of missingSuffix) {
-    advanceCanonicalCursorForSegment(context, segment);
-  }
-}
-
 function advanceCanonicalCursorForSegment(
   context: LexicalTraversalContext,
   segment: string,
@@ -305,12 +314,13 @@ function finalizeLexicalResolution(
 function handleLexicalLstatFailure(
   context: LexicalTraversalContext,
   error: unknown,
-  missingFromIndex: number,
+  segment: string,
 ): boolean {
   if (!isNotFoundPathError(error)) {
     return false;
   }
-  applyMissingSuffixToCanonicalCursor(context, missingFromIndex);
+  advanceCanonicalCursorForSegment(context, segment);
+  context.state.missingDepth = 1;
   return true;
 }
 
@@ -345,6 +355,7 @@ function applyResolvedSymlinkHop(
 function applyParentTraversalStep(context: LexicalTraversalContext): void {
   context.state.lexicalCursor = path.resolve(context.state.lexicalCursor, "..");
   advanceCanonicalCursorForSegment(context, "..");
+  if (context.state.missingDepth > 0) context.state.missingDepth -= 1;
 }
 
 type LexicalResolutionParams = {
@@ -368,11 +379,16 @@ async function resolveRootPathLexicalAsync(
       continue;
     }
     state.lexicalCursor = path.join(state.lexicalCursor, segment);
+    if (state.missingDepth > 0) {
+      advanceCanonicalCursorForSegment(context, segment);
+      state.missingDepth += 1;
+      continue;
+    }
     let stat: fs.Stats;
     try {
       stat = fs.lstatSync(state.lexicalCursor);
     } catch (error) {
-      if (handleLexicalLstatFailure(context, error, idx)) break;
+      if (handleLexicalLstatFailure(context, error, segment)) continue;
       throw error;
     }
 
@@ -414,11 +430,16 @@ function resolveRootPathLexicalSync(params: LexicalResolutionParams): ResolvedRo
       continue;
     }
     state.lexicalCursor = path.join(state.lexicalCursor, segment);
+    if (state.missingDepth > 0) {
+      advanceCanonicalCursorForSegment(context, segment);
+      state.missingDepth += 1;
+      continue;
+    }
     let stat: fs.Stats;
     try {
       stat = fs.lstatSync(state.lexicalCursor);
     } catch (error) {
-      if (handleLexicalLstatFailure(context, error, idx)) break;
+      if (handleLexicalLstatFailure(context, error, segment)) continue;
       throw error;
     }
 

--- a/test/root-canonical-read.test.ts
+++ b/test/root-canonical-read.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { root } from "../src/root.js";
+import { resolveRootPath, resolveRootPathSync } from "../src/root-path.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.unstubAllEnvs());
+
+async function fixture() {
+  const dir = await tempRoot("fs-safe-canonical-read-");
+  await fs.mkdir(path.join(dir, "deep", "dir"), { recursive: true });
+  await fs.writeFile(path.join(dir, "deep", "value"), "canonical bytes");
+  await fs.writeFile(path.join(dir, "value"), "lexical bytes");
+  await fs.symlink(path.join(dir, "deep", "dir"), path.join(dir, "link"),
+    process.platform === "win32" ? "junction" : "dir");
+  return { dir, scoped: await root(dir) };
+}
+
+it.each(["readText", "readAbsolute relative", "readAbsolute absolute", "open", "resolve"])(
+  "%s follows symlinks before resolving subsequent parent components",
+  async method => {
+    const { dir, scoped } = await fixture();
+    const relative = `link${path.sep}..${path.sep}value`;
+    const absolute = `${dir}${path.sep}${relative}`;
+    const options = { symlinks: "follow-within-root" as const };
+    const expected = "canonical bytes";
+    if (process.platform !== "win32") expect(await fs.readFile(absolute, "utf8")).toBe(expected);
+    if (method === "resolve") {
+      expect(await scoped.resolve(relative)).toBe(path.join(dir, "deep", "value"));
+    } else if (method === "open") {
+      const opened = await scoped.open(relative, options);
+      try { expect(await opened.handle.readFile("utf8")).toBe(expected); }
+      finally { await opened.handle.close(); }
+    } else if (method === "readText") {
+      expect(await scoped.readText(relative, options)).toBe(expected);
+    } else {
+      const read = await scoped.readAbsolute(method.endsWith("absolute") ? absolute : relative, options);
+      expect(read.buffer.toString("utf8")).toBe(expected);
+    }
+  },
+);
+
+it("retains symlink rejection for readAbsolute spellings containing parent components", async () => {
+  const { dir, scoped } = await fixture();
+  const relative = `link${path.sep}..${path.sep}value`;
+  for (const input of [relative, `${dir}${path.sep}${relative}`]) {
+    await expect(scoped.readAbsolute(input)).rejects.toMatchObject({ code: "symlink" });
+  }
+});
+
+it.each(["readText", "readAbsolute"] as const)("%s preserves traversal after home expansion", async method => {
+  const { dir, scoped } = await fixture();
+  vi.stubEnv("HOME", dir);
+  const relative = `~${path.sep}link${path.sep}..${path.sep}value`;
+  const result = await scoped[method](relative, { symlinks: "follow-within-root" });
+  expect(typeof result === "string" ? result : result.buffer.toString("utf8")).toBe("canonical bytes");
+  await expect(scoped[method](relative)).rejects.toMatchObject({ code: "symlink" });
+});
+
+it("preserves raw parent components through both spellings of an aliased root", async () => {
+  const { dir } = await fixture();
+  const alias = path.join(await tempRoot("fs-safe-read-root-alias-"), "alias");
+  await fs.symlink(dir, alias, process.platform === "win32" ? "junction" : "dir");
+  const scoped = await root(alias);
+  for (const spelling of [alias, dir]) {
+    const read = await scoped.readAbsolute(`${spelling}${path.sep}link${path.sep}..${path.sep}value`, {
+      symlinks: "follow-within-root",
+    });
+    expect(read.buffer.toString("utf8")).toBe("canonical bytes");
+  }
+});
+
+it("accepts redundant separators after an absolute root prefix", async () => {
+  const { dir, scoped } = await fixture();
+  const read = await scoped.readAbsolute(`${dir}${path.sep}${path.sep}value`);
+  expect(read.buffer.toString("utf8")).toBe("lexical bytes");
+});
+
+it("preserves traversal after an absolute spelling re-enters the root", async () => {
+  const { dir, scoped } = await fixture();
+  const sibling = await tempRoot("fs-safe-read-entry-prefix-");
+  expect(path.dirname(sibling)).toBe(path.dirname(dir));
+  const raw = `${sibling}${path.sep}..${path.sep}${path.basename(dir)}${path.sep}link${path.sep}..${path.sep}value`;
+  const read = await scoped.readAbsolute(raw, { symlinks: "follow-within-root" });
+  expect(read.buffer.toString("utf8")).toBe("canonical bytes");
+  await expect(scoped.readAbsolute(raw)).rejects.toMatchObject({ code: "symlink" });
+});
+
+it("retains the rejection policy for an external symlink before root re-entry", async () => {
+  const { dir, scoped } = await fixture();
+  const prefix = await tempRoot("fs-safe-external-entry-alias-");
+  await fs.symlink(path.join(dir, "deep", "dir"), path.join(prefix, "alias"),
+    process.platform === "win32" ? "junction" : "dir");
+  await fs.mkdir(path.join(dir, path.basename(dir)));
+  await fs.writeFile(path.join(dir, path.basename(dir), "value"), "external alias bytes");
+  const raw = `${prefix}${path.sep}alias${path.sep}..${path.sep}..${path.sep}${path.basename(dir)}${path.sep}value`;
+  await expect(scoped.readAbsolute(raw)).rejects.toMatchObject({ code: "symlink" });
+  const read = await scoped.readAbsolute(raw, { symlinks: "follow-within-root" });
+  expect(read.buffer.toString("utf8")).toBe("external alias bytes");
+});
+
+it.each(["async", "sync"])("%s resolution resumes inspection after a missing prefix is canceled", async mode => {
+  const { dir } = await fixture();
+  const params = { rootPath: dir, absolutePath: `${dir}${path.sep}missing${path.sep}..${path.sep}link${path.sep}..${path.sep}value`, boundaryLabel: "fixture" };
+  const resolved = mode === "async" ? await resolveRootPath(params) : resolveRootPathSync(params);
+  expect(resolved.canonicalPath).toBe(path.join(dir, "deep", "value"));
+  const outside = await tempRoot("fs-safe-canonical-outside-");
+  await fs.writeFile(path.join(outside, "secret"), "outside bytes");
+  await fs.symlink(outside, path.join(dir, "outside"), process.platform === "win32" ? "junction" : "dir");
+  const escape = { ...params, absolutePath: `${dir}${path.sep}missing${path.sep}..${path.sep}outside${path.sep}secret` };
+  if (mode === "async") await expect(resolveRootPath(escape)).rejects.toThrow("Symlink escapes");
+  else expect(() => resolveRootPathSync(escape)).toThrow("Symlink escapes");
+});
+
+it.each(["async", "sync"])("%s resolution preserves symlink parents after an outside root alias", async mode => {
+  const { dir } = await fixture();
+  const alias = path.join(await tempRoot("fs-safe-outside-read-alias-"), "alias");
+  await fs.symlink(dir, alias, process.platform === "win32" ? "junction" : "dir");
+  const raw = `${alias}${path.sep}link${path.sep}..${path.sep}value`;
+  const params = { rootPath: dir, absolutePath: raw, boundaryLabel: "fixture" };
+  const resolved = mode === "async" ? await resolveRootPath(params) : resolveRootPathSync(params);
+  expect(resolved.absolutePath).toBe(path.resolve(raw));
+  expect(resolved.canonicalPath).toBe(path.join(dir, "deep", "value"));
+  if (mode === "async") await expect(resolveRootPath({ ...params, rejectSymlinks: true })).rejects.toMatchObject({ code: "symlink" });
+  else expect(() => resolveRootPathSync({ ...params, rejectSymlinks: true })).toThrowError(expect.objectContaining({ code: "symlink" }));
+});

--- a/test/sidecar-lock-root-ancestry.test.ts
+++ b/test/sidecar-lock-root-ancestry.test.ts
@@ -40,7 +40,7 @@ it.skipIf(process.platform === "win32")("permits an unchanged canonical parent r
   const lockPath = path.join(capability.rootReal, "alias/state.lock");
   await capability.create("actual/state.lock", "{}");
   __setFsSafeTestHooksForTest({ async afterOpenedPathIdentityCheck(candidate) {
-    if (candidate !== lockPath) return;
+    if (candidate !== path.join(capability.rootReal, "actual/state.lock")) return;
     __setFsSafeTestHooksForTest();
     await fs.unlink(lockPath);
   } });


### PR DESCRIPTION
Root reads validated symlink-aware traversal but then opened the separately normalized path. With an in-root `link` targeting `deep/dir`, `link/../value` read the root's `value` instead of `deep/value`. Absolute-read and home expansion could also erase the symlink before enforcing the rejection policy. Resolution stopped inspecting entries after a missing prefix, even if later parent components returned to an existing directory.

Preserve raw components through home expansion and absolute root entry, consume the checked canonical result for Root reads and resolve, and resume component inspection after missing components are canceled. Absolute aliases retain the unnormalized tail after entering a proven canonical root; external alias hops still reject when symlinks are disallowed. The resolver retains its original absolute-path output field and bounded missing-prefix behavior.

Validation: 40 focused tests cover reads, opens, resolve, home paths, aliased roots, redundant separators, root re-entry, default symlink rejection, and missing-prefix escapes. The original seven regression cases fail on the baseline. A built-package probe now matches filesystem traversal for both Root reads and outside-root aliases. Full native Linux `pnpm check` passed (8,535 tests, 89 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; independent Codex review clean through P2; `git diff --check` passed.
