### PR TITLE
perf(walk): reuse entry classification and joined paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reduce directory-walk overhead by sharing synchronous entry classification and reusing each joined path, avoiding an extra promise per async entry.
 - Skip invalid delivered-marker names during durable queue batch loading, preserving malformed files while continuing to load valid pending entries.
 - Forward archive deadlines through a separate abort signal for each native pass, so completed inspection cannot mask cancellation of extraction.
 - Honor Root durability defaults and per-call overrides in the Windows JavaScript write/create fallback, and preserve unowned staging replacements when a write or sync fails.

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -72,12 +72,12 @@ function shouldStop(result: WalkDirectoryResult, options: WalkDirectoryOptions):
 
 function buildEntry(params: {
   rootDir: string;
-  dir: string;
+  fullPath: string;
   dirent: fsSync.Dirent;
   depth: number;
   kind?: WalkEntryKind;
 }): WalkDirectoryEntry {
-  const fullPath = path.join(params.dir, params.dirent.name);
+  const fullPath = params.fullPath;
   const relativePath = path.relative(params.rootDir, fullPath) || params.dirent.name;
   return {
     name: params.dirent.name,
@@ -105,22 +105,7 @@ function recordFailedDir(
   });
 }
 
-function resolveSyncKind(fullPath: string, dirent: fsSync.Dirent, symlinks: WalkSymlinkPolicy): WalkEntryKind | null {
-  const kind = kindForDirent(dirent);
-  if (kind !== "symlink") return kind;
-  if (symlinks === "skip") return null;
-  if (symlinks === "include") return "symlink";
-  try {
-    const stat = fsSync.statSync(fullPath);
-    if (stat.isDirectory()) return "directory";
-    if (stat.isFile()) return "file";
-  } catch {
-    return null;
-  }
-  return "other";
-}
-
-async function resolveAsyncKind(fullPath: string, dirent: fsSync.Dirent, symlinks: WalkSymlinkPolicy): Promise<WalkEntryKind | null> {
+function resolveKind(fullPath: string, dirent: fsSync.Dirent, symlinks: WalkSymlinkPolicy): WalkEntryKind | null {
   const kind = kindForDirent(dirent);
   if (kind !== "symlink") return kind;
   if (symlinks === "skip") return null;
@@ -176,9 +161,9 @@ export function walkDirectorySync(
       }
       result.scannedEntryCount += 1;
       const fullPath = path.join(dir, dirent.name);
-      const kind = resolveSyncKind(fullPath, dirent, symlinks);
+      const kind = resolveKind(fullPath, dirent, symlinks);
       if (!kind) continue;
-      const entry = buildEntry({ rootDir: root, dir, dirent, depth, kind });
+      const entry = buildEntry({ rootDir: root, fullPath, dirent, depth, kind });
       if (options.include?.(entry) ?? true) {
         result.entries.push(entry);
       }
@@ -238,9 +223,9 @@ export async function walkDirectory(
       }
       result.scannedEntryCount += 1;
       const fullPath = path.join(dir, dirent.name);
-      const kind = await resolveAsyncKind(fullPath, dirent, symlinks);
+      const kind = resolveKind(fullPath, dirent, symlinks);
       if (!kind) continue;
-      const entry = buildEntry({ rootDir: root, dir, dirent, depth, kind });
+      const entry = buildEntry({ rootDir: root, fullPath, dirent, depth, kind });
       if (options.include?.(entry) ?? true) {
         result.entries.push(entry);
       }


### PR DESCRIPTION
Async directory walking created and awaited a promise for every entry even though classification used only synchronous metadata. Both walkers also joined each entry path twice.

Share one classifier and reuse the joined path when building the result. Scanning budgets, depth limits, symlink handling, directory-cycle detection, filters, and failure reporting are unchanged.

Three alternating Linux rounds over a warm 5,000-file directory measured async scans at 1.34–1.87× faster and sync scans at 1.23–1.30× faster. Candidate medians were 7.00–7.06 ms async and 6.38–6.48 ms sync. Fixture creation was outside timing, and results were checked for complete inventories.

Validation: 83 focused tests passed with two platform skips; full native Linux `pnpm check` passed (8,564 tests, 89 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; independent Codex review clean through P2; `git diff --check` passed.
