### PR TITLE
fix(root): pin exact directory identities before yielding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.
 - Read durable queue entries through the shared bounded buffer, using the admitted file size to reduce filesystem calls and chunk copies while retaining exact identity and byte-limit checks.
 - Preserve recreated temporary paths when an exit-cleanup lookup observed the original name missing; absence no longer authorizes a forced removal.
+- Pin Root directory identities as bigint values, reject indistinguishable numeric inode replacements, and fail closed after bounded retries when Windows root identity remains unknown.
 
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.
 - Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.

--- a/docs/root.md
+++ b/docs/root.md
@@ -37,6 +37,8 @@ type DenyMutationPolicy = {
 
 `root()` resolves the directory through the real filesystem. A symlinked input becomes the canonical path; a non-existent root throws `FsSafeError` with code `not-found`, and malformed or non-directory roots throw `invalid-path`.
 
+The root directory is pinned with exact bigint device/inode identities. A changed root rejects subsequent operations; an unknown Windows identity that remains unverifiable after bounded reinspection rejects construction with `path-mismatch`.
+
 `defaults` apply to every method on the returned handle. Per-call options on individual methods override the defaults for that call only, except `denyMutations`: root and per-call deny entries are merged so a call cannot clear a root-level deny.
 
 Every `maxBytes` value must be a non-negative safe integer or positive `Infinity`. Zero is an active zero-byte cap; `Infinity` explicitly disables the cap. An omitted or explicitly `undefined` per-call value preserves the configured Root default instead of clearing it.

--- a/src/root-context.ts
+++ b/src/root-context.ts
@@ -15,6 +15,7 @@ import {
 import { ROOT_PATH_ALIAS_POLICIES, resolveRootPath } from "./root-path.js";
 import { outsideWorkspaceError } from "./root-errors.js";
 import { isDriveRelativePath } from "./safe-path-segment.js";
+import { inspectFileIdentity } from "./strict-file-identity.js";
 
 export type RootContext = {
   rootDir: string;
@@ -55,14 +56,16 @@ export async function expandRelativePathWithHome(relativePath: string): Promise<
 
 export async function resolveRootContext(rootDir: string): Promise<RootContext> {
   assertNoNulPathInput(rootDir, "root dir contains a NUL byte");
+  const lexicalRoot = path.resolve(rootDir);
   let rootReal: string;
-  let rootIdentity: { dev: number; ino: number };
+  let rootIdentity: { dev: bigint; ino: bigint };
   try {
     rootReal = fs.realpathSync.native(rootDir);
-    const rootStat = fs.statSync(rootReal);
-    if (!rootStat.isDirectory()) {
-      throw new FsSafeError("invalid-path", "root dir is not a directory");
-    }
+    const rootStat = await inspectFileIdentity(() => {
+      const stat = fs.statSync(rootReal, { bigint: true });
+      if (!stat.isDirectory()) throw new FsSafeError("invalid-path", "root dir is not a directory");
+      return stat;
+    });
     rootIdentity = { dev: rootStat.dev, ino: rootStat.ino };
   } catch (err) {
     if (err instanceof FsSafeError) {
@@ -74,7 +77,7 @@ export async function resolveRootContext(rootDir: string): Promise<RootContext> 
     throw err;
   }
   return {
-    rootDir: path.resolve(rootDir),
+    rootDir: lexicalRoot,
     rootIdentity,
     rootReal,
     rootWithSep: ensureTrailingSep(rootReal),

--- a/test/root-context-identity.test.ts
+++ b/test/root-context-identity.test.ts
@@ -1,0 +1,75 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { root } from "../src/root.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => { vi.restoreAllMocks(); Object.defineProperty(process, "platform", platform); });
+
+it("pins a relative root spelling before an asynchronous working-directory change", async () => {
+  const before = await tempRoot("fs-safe-root-cwd-before-");
+  const after = await tempRoot("fs-safe-root-cwd-after-");
+  await fs.writeFile(path.join(before, "value"), "before");
+  await fs.writeFile(path.join(after, "value"), "after");
+  const previous = process.cwd();
+  try {
+    process.chdir(before);
+    const pending = root(".");
+    queueMicrotask(() => process.chdir(after));
+    const scoped = await pending;
+    expect(scoped.rootDir).toBe(before);
+    expect(scoped.rootReal).toBe(before);
+    await expect(scoped.readAbsolute(path.join(after, "value"))).rejects.toMatchObject({ code: "outside-workspace" });
+  } finally { process.chdir(previous); }
+});
+
+it("rejects a replacement root whose inode has the same numeric projection", async () => {
+  const base = await tempRoot("fs-safe-root-identity-");
+  const dir = path.join(base, "root");
+  await fs.mkdir(dir);
+  await fs.writeFile(path.join(dir, "value"), "original");
+  let changed = false;
+  const first = 9007199254740992n, second = first + 1n;
+  expect(Number(first)).toBe(Number(second));
+  for (const method of ["statSync", "lstatSync"] as const) {
+    const original = fsSync[method].bind(fsSync);
+    vi.spyOn(fsSync, method).mockImplementation((...args) => {
+      const stat = original(...args);
+      if (String(args[0]) !== dir) return stat;
+      const ino = changed ? second : first;
+      return Object.assign(Object.create(stat), { ino: typeof stat.ino === "bigint" ? ino : Number(ino) });
+    });
+  }
+  const scoped = await root(dir);
+  await fs.rename(dir, path.join(base, "original"));
+  await fs.mkdir(dir);
+  await fs.writeFile(path.join(dir, "value"), "replacement");
+  changed = true;
+  await expect(scoped.readText("value")).rejects.toMatchObject({ code: "path-mismatch" });
+});
+
+it.each([false, true])("bounds unknown Windows root identity observations (recovers=%s)", async recovers => {
+  const dir = await tempRoot("fs-safe-root-unknown-");
+  await fs.writeFile(path.join(dir, "value"), "original");
+  Object.defineProperty(process, "platform", { value: "win32" });
+  const stat = fsSync.statSync.bind(fsSync);
+  let attempts = 0;
+  vi.spyOn(fsSync, "statSync").mockImplementation((...args) => {
+    const current = stat(...args);
+    if (String(args[0]) !== dir) return current;
+    attempts += 1;
+    if (recovers && attempts > 1) return current;
+    return Object.assign(Object.create(current), {
+      dev: typeof current.dev === "bigint" ? 0n : 0,
+      ino: typeof current.ino === "bigint" ? 0n : 0,
+    });
+  });
+  if (recovers) {
+    const scoped = await root(dir);
+    expect(await scoped.readText("value")).toBe("original");
+  } else await expect(root(dir)).rejects.toMatchObject({ code: "path-mismatch" });
+  expect(attempts).toBe(2);
+});

--- a/test/root-windows-write-durability.test.ts
+++ b/test/root-windows-write-durability.test.ts
@@ -79,16 +79,19 @@ it.each(operations.flatMap(operation => settings.map(setting => ({ operation, ..
 );
 
 it.each(["write", "replace", "create"] as const)("%s reports file sync failure and cleans only the owned new file with a large parent inode", async operation => {
-  const { dir, scoped, target } = await fixture();
+  const { dir, target } = await fixture();
   if (operation === "replace") await fs.writeFile(target, "original");
-  const lstat = fsSync.lstatSync.bind(fsSync);
-  vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
-    const stat = lstat(...args);
-    if (String(args[0]) === dir && typeof stat.ino === "bigint") {
-      return Object.assign(Object.create(stat), { ino: 9007199254740993n });
-    }
-    return stat;
-  });
+  for (const method of ["statSync", "lstatSync"] as const) {
+    const original = fsSync[method].bind(fsSync);
+    vi.spyOn(fsSync, method).mockImplementation((...args) => {
+      const stat = original(...args);
+      if (String(args[0]) === dir && typeof stat.ino === "bigint") {
+        return Object.assign(Object.create(stat), { ino: 9007199254740993n });
+      }
+      return stat;
+    });
+  }
+  const scoped = await root(dir);
   const error = Object.assign(new Error("sync failed"), { code: "EIO" });
   const open = fs.open.bind(fs);
   vi.spyOn(fs, "open").mockImplementation(async (...args) => {

--- a/test/sidecar-lock-root-ancestry.test.ts
+++ b/test/sidecar-lock-root-ancestry.test.ts
@@ -78,12 +78,13 @@ it.each(["numeric", "unknown", "changed", "EACCES", "EIO"])("rejects %s canonica
 
 it.each(["EACCES", "EIO"])("does not treat initial directory %s as missing-parent evidence", async (code) => {
   const capability = await root(await tempRoot("sidecar-parent-denial-"));
-  const lockPath = path.join(capability.rootReal, "state.lock");
-  await capability.create("state.lock", "{}");
+  const parent = path.join(capability.rootReal, "parent");
+  const lockPath = path.join(parent, "state.lock");
+  await capability.create("parent/state.lock", "{}");
   const failure = Object.assign(new Error("directory failure"), { code });
   const lstat = fsSync.lstatSync.bind(fsSync), open = vi.spyOn(capability, "open");
   vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
-    if (String(args[0]) === capability.rootReal && typeof args[1] === "object" && args[1]?.bigint) throw failure;
+    if (String(args[0]) === parent && typeof args[1] === "object" && args[1]?.bigint) throw failure;
     return lstat(...args);
   });
   await expect(readSidecarLockSnapshot(lockPath, { lockRoot: capability, discardObservation: "unlinked" })).rejects.toBe(failure);


### PR DESCRIPTION
Root construction retained numeric device/inode values even though later operations could check exact bigint identities. Distinct large directory inode values could round to the same number and allow a replaced root to pass validation. Unknown Windows identities were also admitted without a bounded recheck.

Capture an exact bigint root receipt through the existing identity verifier. Retain the absolute lexical root before the new asynchronous inspection so a concurrent working-directory change cannot separate the lexical root from its canonical identity. Existing root type and not-found errors remain intact.

Validation: regression tests cover an actual directory replacement with colliding numeric inode projections, unknown Windows identity recovery/rejection, and working-directory changes during construction. Fifty-one focused tests passed; full native Linux `pnpm check` passed (8,568 tests, 89 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; independent Codex review clean through P2; `git diff --check` passed.
