### PR TITLE
fix(walk): report followed target sizes consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.
 - Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.
 - Add a method-by-method benchmark with callable API coverage checks, native/fallback reports, and separate fixture timing.
+- Report the resolved target's size when Root walking follows a symlink, so size filters and returned entry metadata describe the same object.
 - Keep zero-delay lock retries finite when a large backoff factor overflows, preventing synchronous waits from bypassing retry and timeout budgets.
 - Fence move-fallback staging publication and cleanup to its initially admitted identity, preserve later substituted paths after copy failures, and reject writes that make no progress.
 - Honor finite timeouts and retry delays above Node's single-timer limit by rearming bounded timers instead of expiring after approximately 1 ms.

--- a/docs/walk.md
+++ b/docs/walk.md
@@ -76,6 +76,8 @@ accepts `maxDepth`, `maxEntries`, `symlinkPolicy: "skip" |
 one `kind: "truncated"` marker and ends; pass `limitBehavior: "throw"` for a
 typed `FsSafeError("too-large")` instead.
 
+For followed symlinks, both `kind` and `size` describe the resolved target.
+
 `entryFilter` is evaluated for each resolved file, directory, or other entry:
 
 ```ts

--- a/src/root-walk.ts
+++ b/src/root-walk.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { resolveRootPath } from "./root-path.js";
-import type { DirEntry } from "./types.js";
+import type { DirEntry, PathStat } from "./types.js";
 
 export type RootWalkSymlinkPolicy = "skip" | "follow-within-root";
 export type RootWalkLimitBehavior = "truncate" | "throw";
@@ -35,6 +35,7 @@ export type RootWalkOptions = {
 
 type RootWalkCapability = {
   rootReal: string;
+  stat(relativePath: string): Promise<PathStat>;
   list(relativePath: string, options: { withFileTypes: true }): Promise<DirEntry[]>;
 };
 
@@ -154,8 +155,9 @@ export async function* walkRoot(
         if (!resolved.exists) {
           continue;
         }
-        kind = resolved.kind === "directory" ? "directory" : resolved.kind === "file" ? "file" : "other";
-        size = entry.size;
+        const target = await root.stat(path.relative(root.rootReal, resolved.canonicalPath));
+        kind = target.isDirectory ? "directory" : target.isFile ? "file" : "other";
+        size = target.size;
       }
 
       const walkEntry: RootWalkDataEntry = { relativePath: child, kind, size };

--- a/test/root-walk-options.test.ts
+++ b/test/root-walk-options.test.ts
@@ -116,6 +116,7 @@ it("reports failed directory subtrees and continues when requested", async () =>
   ) => Promise<DirEntry[]>;
   const walkingRoot = {
     rootReal: capability.rootReal,
+    stat: capability.stat.bind(capability),
     async list(relativePath: string, options: { withFileTypes: true }): Promise<DirEntry[]> {
       if (relativePath === "broken") {
         throw Object.assign(new Error("unreadable subtree"), { code: "EACCES" });
@@ -156,6 +157,7 @@ it("observes an abort that occurs while an empty directory is being listed", asy
   const capability = await root(directory);
   const walkingRoot = {
     rootReal: capability.rootReal,
+    stat: capability.stat.bind(capability),
     async list(): Promise<DirEntry[]> {
       controller.abort();
       return [];

--- a/test/root-walk-size.test.ts
+++ b/test/root-walk-size.test.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { root } from "../src/root.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+
+it.skipIf(process.platform === "win32")("filters followed file links using the target size", async () => {
+  const dir = await tempRoot("fs-safe-walk-link-size-");
+  await fs.writeFile(path.join(dir, "target"), Buffer.alloc(4096, 120));
+  await fs.symlink("target", path.join(dir, "alias"));
+  const scoped = await root(dir);
+  const entries = [];
+  for await (const entry of scoped.walk("", {
+    symlinkPolicy: "follow-within-root",
+    entryFilter: entry => entry.relativePath === "alias" && entry.size === 4096 ? "include" : "skip",
+  })) entries.push(entry);
+  expect(entries).toEqual([{ relativePath: "alias", kind: "file", size: 4096 }]);
+});
+
+it("uses resolved directory metadata for a followed directory alias", async () => {
+  const dir = await tempRoot("fs-safe-walk-directory-size-");
+  const target = path.join(dir, "target");
+  await fs.mkdir(target);
+  await fs.symlink(target, path.join(dir, "alias"), process.platform === "win32" ? "junction" : "dir");
+  const scoped = await root(dir);
+  const expected = await scoped.stat("target");
+  const entries = [];
+  for await (const entry of scoped.walk("", { symlinkPolicy: "follow-within-root", maxDepth: 1 })) {
+    entries.push(entry);
+  }
+  expect(entries).toContainEqual({ relativePath: "alias", kind: "directory", size: expected.size });
+});


### PR DESCRIPTION
Root walking changed a followed symlink's kind to the target kind but retained the symlink's own size. Size-based filters could therefore discard a large target based on the short link text, and emitted metadata described two different objects.

Read the target metadata through the Root stat boundary and use that observation for both kind and size. Extend the internal walk capability and test doubles with the required stat method; document the metadata semantics.

Validation: file-size filtering and directory-alias regressions fail on the baseline and pass on the candidate. Full native Linux `pnpm check` passed (8,566 tests, 89 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; independent Codex review clean through P2; `git diff --check` passed.
