### PR TITLE
fix(permissions): treat principal names as own dictionary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Resolve Windows ACL principal names such as `constructor` and `__proto__` as real dictionary keys, without skipping SID lookup or dropping translated entries.
 - Skip invalid delivered-marker names during durable queue batch loading, preserving malformed files while continuing to load valid pending entries.
 - Forward archive deadlines through a separate abort signal for each native pass, so completed inspection cannot mask cancellation of extraction.
 - Honor Root durability defaults and per-call overrides in the Windows JavaScript write/create fallback, and preserve unowned staging replacements when a write or sync fails.

--- a/src/windows-owner.ts
+++ b/src/windows-owner.ts
@@ -66,7 +66,7 @@ function windowsPrincipalQueryCommand(principals: string[]): string {
 
 function parsePrincipalSidRows(value: unknown): Record<string, string> {
   const rows = Array.isArray(value) ? value : value ? [value] : [];
-  const result: Record<string, string> = {};
+  const result: Record<string, string> = Object.create(null);
   for (const row of rows) {
     if (!row || typeof row !== "object") {
       continue;
@@ -90,7 +90,9 @@ export async function resolveWindowsPrincipalSids(params: {
   const known = Object.fromEntries(
     Object.entries(params.known ?? {}).map(([name, sid]) => [name.toLowerCase(), normalizeSid(sid)]),
   );
-  const unresolved = principals.filter((principal) => !known[principal.toLowerCase()]);
+  const unresolved = principals.filter((principal) =>
+    !Object.hasOwn(known, principal.toLowerCase()) || !known[principal.toLowerCase()],
+  );
   if (unresolved.length === 0) {
     return known;
   }
@@ -106,7 +108,9 @@ export async function resolveWindowsPrincipalSids(params: {
     encodePowerShellCommand(windowsPrincipalQueryCommand(unresolved)),
   ]);
   const resolved = { ...known, ...parsePrincipalSidRows(JSON.parse(stdout.trim())) };
-  if (principals.some((principal) => !resolved[principal.toLowerCase()])) {
+  if (principals.some((principal) =>
+    !Object.hasOwn(resolved, principal.toLowerCase()) || !resolved[principal.toLowerCase()],
+  )) {
     throw new Error("Windows ACL principal translation returned incomplete SID data");
   }
   return resolved;

--- a/test/windows-principal-map.test.ts
+++ b/test/windows-principal-map.test.ts
@@ -1,0 +1,42 @@
+import { expect, it, vi } from "vitest";
+import { inspectWindowsOwner, resolveWindowsPrincipalSids } from "../src/windows-owner.js";
+
+const env = { SystemRoot: String.raw`C:\Windows` };
+const sid = "S-1-5-21-1-2-3-1000";
+
+it("resolves principals named like inherited object properties", async () => {
+  const exec = vi.fn(async () => ({ stdout: JSON.stringify([
+    { name: "constructor", sid }, { name: "__proto__", sid },
+  ]), stderr: "" }));
+  const resolved = await resolveWindowsPrincipalSids({ principals: ["constructor", "__proto__"], env, exec });
+  expect(exec).toHaveBeenCalledTimes(1);
+  for (const name of ["constructor", "__proto__"]) {
+    expect(Object.hasOwn(resolved, name)).toBe(true);
+    expect(resolved[name]).toBe(sid.toLowerCase());
+  }
+});
+
+it("accepts explicit known SID entries for prototype-shaped names", async () => {
+  const known = Object.fromEntries(["constructor", "__proto__"].map(name => [name, sid]));
+  const exec = vi.fn(async () => { throw new Error("unexpected lookup"); });
+  const resolved = await resolveWindowsPrincipalSids({ principals: Object.keys(known), known, env, exec });
+  expect(exec).not.toHaveBeenCalled();
+  expect(resolved.__proto__).toBe(sid.toLowerCase());
+  expect(resolved.constructor).toBe(sid.toLowerCase());
+});
+
+it("rejects missing translated entries even when their name is inherited", async () => {
+  const exec = vi.fn(async () => ({ stdout: JSON.stringify([{ name: "constructor", sid }]), stderr: "" }));
+  await expect(resolveWindowsPrincipalSids({ principals: ["constructor", "__proto__"], env, exec }))
+    .rejects.toThrow("incomplete SID data");
+});
+
+it("preserves prototype-shaped names in owner-query SID rows", async () => {
+  const result = await inspectWindowsOwner({ targetPath: String.raw`C:\fixture`, env,
+    exec: async () => ({ stdout: JSON.stringify({ ownerSid: sid, currentUserSid: sid,
+      principalSids: [{ name: "__proto__", sid }] }), stderr: "" }),
+  });
+  expect(result.trusted).toBe(true);
+  expect(Object.hasOwn(result.principalSids!, "__proto__")).toBe(true);
+  expect(result.principalSids!.__proto__).toBe(sid.toLowerCase());
+});


### PR DESCRIPTION
Windows SID lookup treated inherited object properties as resolved principals. Names such as `constructor` could skip translation, while assigning a translated `__proto__` entry to a plain object dropped it.

Use own-property membership checks and a null-prototype row dictionary so every requested principal must have an actual SID entry. Preserve explicit known mappings and reject incomplete translations.

Validation: three regressions fail on the baseline and all four mapping tests pass on the candidate, covering lookup, explicit known keys, incomplete replies, and owner-query rows. Full native Linux `pnpm check` passed (8,568 tests, 89 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; independent Codex review clean through P2; `git diff --check` passed.
