### PR TITLE
perf(archive): reuse the strict TAR metadata decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
 - Shorten only the home directory and its descendants in error messages, preserving sibling paths that share the same string prefix.
 - Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.
+- Reuse the strict UTF-8 decoder while streaming TAR metadata through WebAssembly, reducing per-member allocation without changing filename validation or BOM handling.
 - Read JavaScript ZIP members directly from the admitted in-memory archive, avoiding an unused disk snapshot while preserving byte limits, identity checks, and ZIP integrity validation.
 - Batch JavaScript SHA-256 reads for larger files in bounded buffers up to 256 KiB, reducing asynchronous filesystem calls while preserving descriptor ownership and offsets.
 - Read durable queue entries through the shared bounded buffer, using the admitted file size to reduce filesystem calls and chunk copies while retaining exact identity and byte-limit checks.

--- a/src/archive-tar-wasm.ts
+++ b/src/archive-tar-wasm.ts
@@ -38,6 +38,8 @@ const types = new Map([
   [54, "FIFO"], [55, "ContiguousFile"], [68, "GNUDumpDir"],
 ]);
 
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+
 function parserError(message: string): Error {
   const mapped = classifyArchiveParserError(message);
   if (mapped) return mapped;
@@ -66,7 +68,7 @@ export class TarParserStream extends Transform {
   }
   private text(): string {
     const abi = this.abi!;
-    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(this.bytes(abi.text_ptr(), abi.text_len()));
+    return utf8Decoder.decode(this.bytes(abi.text_ptr(), abi.text_len()));
   }
   override _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
     try {


### PR DESCRIPTION
The WebAssembly TAR bridge constructed a new UTF-8 decoder for every member name and parser error. Reuse one decoder for these synchronous, non-streaming calls, retaining fatal UTF-8 validation and BOM preservation.

Three alternating Linux rounds over 10,000 Unicode member names measured a modest 2.6–5.0% throughput improvement: inspection medians fell from 32.51–33.74 ms to 31.64–32.13 ms. The benchmark used the same WASM asset for both versions and excluded fixture creation.

Validation: 288 focused ABI, framing, and canonical-entry tests passed with 422 platform cases skipped locally; full native Linux `pnpm check` passed (8,569 tests, 91 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; independent Codex review clean through P2; `git diff --check` passed.
