### PR TITLE
fix(root): verify opened identities during mode inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Honor Root durability defaults and per-call overrides in the Windows JavaScript write/create fallback, and preserve unowned staging replacements when a write or sync fails.
 - Preserve Linux native directory-only open flags so non-directories are rejected by the kernel before FIFO blocking or truncation, while removing the redundant post-open stat.
 - Close publication descriptors when initial inspection fails, and relinquish descriptor numbers before potentially failing closes so cleanup cannot close a reused descriptor.
+- Require a verified descriptor identity before inheriting an existing write target's mode, including bounded reinspection of transient unknown Windows identities.
 - Expand leading home-directory prefixes before resolving parent segments, so `~/../file` resolves against the home directory's parent; keep tildes elsewhere in a relative path literal.
 - Shorten only the home directory and its descendants in error messages, preserving sibling paths that share the same string prefix.
 - Accelerate ZIP integrity checks with Node's native CRC32 on Node 22.2 and newer, retaining checksum validation and compatibility with earlier Node 22 versions.

--- a/src/root-write-mode.ts
+++ b/src/root-write-mode.ts
@@ -1,7 +1,6 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { FsSafeError } from "./errors.js";
-import { sameFileIdentity } from "./file-identity.js";
 import { isNotFoundPathError, isPathInside } from "./path.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { hardlinkedPathNotAllowedError, outsideWorkspaceError } from "./root-errors.js";
@@ -24,9 +23,7 @@ export async function inheritWriteTargetMode(params: {
     const handle = await fs.open(params.targetPath, resolveReadOpenFlags());
     try {
       // Bind admission to the inode whose metadata is inherited.
-      if (!sameFileIdentity(fsSync.fstatSync(handle.fd, { bigint: true }), existing)) {
-        throw new FsSafeError("path-mismatch", "write target changed during mode inheritance");
-      }
+      await inspectFileIdentity(() => fsSync.fstatSync(handle.fd, { bigint: true }), existing);
     } finally {
       await handle.close().catch(() => undefined);
     }

--- a/test/write-mode-identity.test.ts
+++ b/test/write-mode-identity.test.ts
@@ -13,6 +13,7 @@ it.each([false, true])("verifies unknown Windows opened identity before inheriti
   const dir = await tempRoot("fs-safe-write-mode-identity-");
   const targetPath = path.join(dir, "target");
   await fs.writeFile(targetPath, "existing bytes", { mode: 0o600 });
+  const expectedMode = (await fs.stat(targetPath)).mode & 0o777;
   Object.defineProperty(process, "platform", { value: "win32" });
   let opened: fs.FileHandle | undefined;
   const open = fs.open.bind(fs), fstat = fsSync.fstatSync.bind(fsSync);
@@ -30,7 +31,7 @@ it.each([false, true])("verifies unknown Windows opened identity before inheriti
     return Object.assign(Object.create(stat), { dev: 0n, ino: 0n });
   });
   const mode = inheritWriteTargetMode({ targetPath, rootWithSep: dir + path.sep });
-  if (recovers) await expect(mode).resolves.toBe(0o600);
+  if (recovers) await expect(mode).resolves.toBe(expectedMode);
   else await expect(mode).rejects.toMatchObject({ code: "path-mismatch" });
   expect(inspections).toBe(2);
   expect(opened?.fd).toBe(-1);

--- a/test/write-mode-identity.test.ts
+++ b/test/write-mode-identity.test.ts
@@ -1,0 +1,38 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { inheritWriteTargetMode } from "../src/root-write-mode.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => { vi.restoreAllMocks(); Object.defineProperty(process, "platform", platform); });
+
+it.each([false, true])("verifies unknown Windows opened identity before inheriting mode (recovers=%s)", async recovers => {
+  const dir = await tempRoot("fs-safe-write-mode-identity-");
+  const targetPath = path.join(dir, "target");
+  await fs.writeFile(targetPath, "existing bytes", { mode: 0o600 });
+  Object.defineProperty(process, "platform", { value: "win32" });
+  let opened: fs.FileHandle | undefined;
+  const open = fs.open.bind(fs), fstat = fsSync.fstatSync.bind(fsSync);
+  vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+    const handle = await open(...args);
+    if (args[0] === targetPath) opened = handle;
+    return handle;
+  });
+  let inspections = 0;
+  vi.spyOn(fsSync, "fstatSync").mockImplementation((...args) => {
+    const stat = fstat(...args);
+    if (args[0] !== opened?.fd) return stat;
+    inspections += 1;
+    if (recovers && inspections > 1) return stat;
+    return Object.assign(Object.create(stat), { dev: 0n, ino: 0n });
+  });
+  const mode = inheritWriteTargetMode({ targetPath, rootWithSep: dir + path.sep });
+  if (recovers) await expect(mode).resolves.toBe(0o600);
+  else await expect(mode).rejects.toMatchObject({ code: "path-mismatch" });
+  expect(inspections).toBe(2);
+  expect(opened?.fd).toBe(-1);
+  expect(await fs.readFile(targetPath, "utf8")).toBe("existing bytes");
+});


### PR DESCRIPTION
Write-mode inheritance required a known pathname identity but compared the subsequently opened descriptor with a permissive Windows identity helper. An unknown descriptor identity could therefore satisfy read-open admission without proving it referred to the previously inspected target.

Use the shared exact identity verifier for that descriptor, with bounded retry for transient Windows unknowns and fail-closed rejection if verification remains impossible. The descriptor is still closed in every case.

Validation: both Windows-identity regressions fail on the baseline and pass on the candidate; all 18 focused inheritance tests pass. Full native Linux `pnpm check` passed (8,571 tests, 91 skipped) on AWS Crabbox `cbx_e7c5e5c92048`; independent Codex review clean through P2; `git diff --check` passed.
