### PR TITLE
fix(root): reject ambiguous parent traversal before mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Speed up POSIX containment checks with trailing root separators and filename helpers while preserving traversal rejection, Unicode handling, reserved names, and collision-resistant install names.
 - Bound speculative read allocations for large or exhausted files, and accelerate synchronous bounded reads of regular files up to 16 MiB without extra chunk copies; retain one-read async performance through the default Root byte budget.
 - Read the checked canonical Root path after symlink/parent traversal, preserve raw components in absolute reads, and resume alias inspection when parent components cancel a missing prefix.
+- Reject ambiguous symlink/parent combinations in Root mutations instead of silently writing to the separately normalized target.
 - Preserve raw symlink and parent components in `openRootFile` and `openRootFileSync`, so validation cannot normalize away a rejected link or open a different in-root file.
 - Add a method-by-method benchmark with callable API coverage checks, native/fallback reports, and separate fixture timing.
 - Report the resolved target's size when Root walking follows a symlink, so size filters and returned entry metadata describe the same object.

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -38,6 +38,12 @@ await fs.mkdir("snapshots/2026/05");
 Private sibling temporary names are independent of the destination basename,
 so staging does not add a suffix to an otherwise valid long filename.
 
+Write paths reject `path-alias` when symlinks and parent components select a
+different target before and after lexical normalization, such as `link/../file`
+where `link` points into a deeper directory. This avoids silently modifying the
+wrong file. Resolve an intended alias explicitly with `Root.resolve()` before
+passing its canonical path to a mutation.
+
 A failure before the final rename leaves the destination at its previous
 contents. A successful rename publishes the complete replacement. This
 old-or-new guarantee does not apply to `append()` or `openWritable()`, which

--- a/src/pinned-operation.ts
+++ b/src/pinned-operation.ts
@@ -31,7 +31,7 @@ function validatePinnedRelativePath(relativePath: string): void {
   ) {
     throw new FsSafeError("invalid-path", "relative path must not escape root");
   }
-  for (const segment of relativePath.split("/")) {
+  for (const segment of relativePath.split(process.platform === "win32" ? /[\\/]/ : "/")) {
     if (segment === "..") {
       throw new FsSafeError("invalid-path", "relative path must not contain '..'");
     }

--- a/src/root-context.ts
+++ b/src/root-context.ts
@@ -39,6 +39,8 @@ export function assertValidRootDestinationPath(relativePath: string): void {
 }
 
 let cachedHomePath: { raw: string; real: string } | undefined;
+const POSIX_PARENT_COMPONENT = /(?:^|\/)\.\.(?:\/|$)/;
+const WINDOWS_PARENT_COMPONENT = /(?:^|[\\/])\.\.(?:[\\/]|$)/;
 
 export async function expandRelativePathWithHome(relativePath: string): Promise<string> {
   const rawHome = process.env.HOME || process.env.USERPROFILE || os.homedir();
@@ -151,6 +153,7 @@ export async function resolvePathInRoot(
     rejectUnsafeDeviceReads?: boolean;
     rejectSymlinks?: boolean;
     resolveCanonical?: boolean;
+    rejectAmbiguousParents?: boolean;
   },
 ): Promise<{ rootReal: string; rootWithSep: string; resolved: string }> {
   assertValidRootRelativePath(relativePath);
@@ -167,14 +170,23 @@ export async function resolvePathInRoot(
     ? expanded
     : `${root.rootWithSep}${expanded}`;
   try {
-    const checked = await resolveRootPath({
+    const resolution = {
       absolutePath: rawAbsolutePath,
       rootPath: root.rootReal,
       rootCanonicalPath: root.rootReal,
       boundaryLabel: "root",
       policy: options?.allowFinalSymlink ? ROOT_PATH_ALIAS_POLICIES.unlinkTarget : undefined,
       rejectSymlinks: options?.rejectSymlinks,
-    });
+    };
+    const checked = await resolveRootPath(resolution);
+    const parentComponent = process.platform === "win32" ? WINDOWS_PARENT_COMPONENT : POSIX_PARENT_COMPONENT;
+    if (options?.rejectAmbiguousParents && parentComponent.test(expanded) &&
+      path.relative(checked.canonicalPath, resolved) !== "") {
+      const normalized = await resolveRootPath({ ...resolution, absolutePath: resolved });
+      if (path.relative(checked.canonicalPath, normalized.canonicalPath) !== "") {
+        throw new FsSafeError("path-alias", "parent traversal resolves differently through a symlink");
+      }
+    }
     if (options?.resolveCanonical) resolved = checked.canonicalPath;
   } catch (error) {
     if (error instanceof FsSafeError && error.code === "symlink") {

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -825,6 +825,7 @@ async function resolveGuardedWritePathInRoot(
 ): Promise<GuardedWritePath> {
   const resolvedPath = await resolvePathInRoot(root, params.relativePath, {
     aliasErrorCode: "path-alias",
+    rejectAmbiguousParents: true,
     allowFinalSymlink: params.allowFinalSymlink,
   });
   await assertMutationNotDenied(

--- a/test/root-mutation-parent.test.ts
+++ b/test/root-mutation-parent.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { validatePinnedOperationPayload } from "../src/pinned-operation.js";
+import { configureFsSafeNative, root } from "../src/index.js";
+import { __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+afterEach(() => {
+  __resetFsSafeNativeConfigForTest();
+  Object.defineProperty(process, "platform", platform);
+});
+
+it("rejects internal Windows parent components in raw move payloads", () => {
+  Object.defineProperty(process, "platform", { value: "win32" });
+  for (const value of [String.raw`link\..\value`, String.raw`link/..\value`]) {
+    expect(() => validatePinnedOperationPayload({ from: value, to: "out" }))
+      .toThrowError(expect.objectContaining({ code: "invalid-path" }));
+    expect(() => validatePinnedOperationPayload({ from: "in", to: value }))
+      .toThrowError(expect.objectContaining({ code: "invalid-path" }));
+  }
+});
+
+it.each(["write", "create", "append", "openWritable", "copyIn", "move"] as const)(
+  "%s rejects a parent traversal whose symlink changes the target",
+  async method => {
+    const dir = await tempRoot("fs-safe-mutation-parents-");
+    await fs.mkdir(path.join(dir, "deep", "dir"), { recursive: true });
+    await fs.symlink(path.join(dir, "deep", "dir"), path.join(dir, "link"),
+      process.platform === "win32" ? "junction" : "dir");
+    const name = method === "create" ? "new" : "value";
+    if (method !== "create") {
+      await fs.writeFile(path.join(dir, name), "root original");
+      await fs.writeFile(path.join(dir, "deep", name), "deep original");
+    }
+    const source = path.join(dir, "source");
+    await fs.writeFile(source, "source bytes");
+    configureFsSafeNative({ mode: "off" });
+    const scoped = await root(dir);
+    const relative = `link${path.sep}..${path.sep}${name}`;
+    const pending = method === "openWritable"
+      ? scoped.openWritable(relative).then(async opened => { await opened.handle.close(); })
+      : method === "copyIn" ? scoped.copyIn(relative, source)
+        : method === "move" ? scoped.move(relative, "moved")
+        : scoped[method](relative, "new bytes");
+    await expect(pending).rejects.toMatchObject({ code: method === "move" ? "invalid-path" : "path-alias" });
+    if (method === "create") {
+      await expect(fs.stat(path.join(dir, name))).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.stat(path.join(dir, "deep", name))).rejects.toMatchObject({ code: "ENOENT" });
+    } else {
+      expect(await fs.readFile(path.join(dir, name), "utf8")).toBe("root original");
+      expect(await fs.readFile(path.join(dir, "deep", name), "utf8")).toBe("deep original");
+    }
+    await scoped.write(`deep${path.sep}dir${path.sep}..${path.sep}plain`, "ordinary parent");
+    expect(await fs.readFile(path.join(dir, "deep", "plain"), "utf8")).toBe("ordinary parent");
+    if (method === "move") {
+      await expect(scoped.move("source", relative)).rejects.toMatchObject({ code: "invalid-path" });
+      expect(await fs.readFile(source, "utf8")).toBe("source bytes");
+    }
+  },
+);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers writing through `link/../value` could modify a different in-root file than the raw path selects. With `link -> deep/dir`, normalization selected `root/value` even though traversal selects `root/deep/value`.

## Why This Change Was Made

Guarded writes now reject parent traversal when the raw and normalized paths resolve to different canonical targets. Ordinary parent traversal and existing symlink policy stay intact. Windows move validation also recognizes internal parent components separated by backslashes or mixed separators.

## User Impact

`write`, `create`, `append`, `openWritable`, and `copyIn` reject ambiguous targets before mutation with `path-alias`. Move payloads retain their existing prohibition on parent components, consistently across Windows separators. Documentation and the changelog describe the behavior.

## Evidence

A built-package baseline probe changed the wrong file. The candidate passes 29 focused regression/boundary tests, including preserved source/destination contents and ordinary parent traversal. `pnpm build` and `git diff --check` pass. Independent Codex autoreview reports no actionable P0–P2 findings. Full cross-platform checks run in CI; the manual Linux validation broker was unavailable.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
