### PR TITLE
fix(root): report failed post-mutation parent checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Report failed parent-directory checks after JavaScript fallback moves and removals, including moved source parents, instead of silently reporting success.
+
 - Resolve Windows ACL principal names such as `constructor` and `__proto__` as real dictionary keys, without skipping SID lookup or dropping translated entries.
 - Reduce directory-walk overhead by sharing synchronous entry classification and reusing each joined path, avoiding an extra promise per async entry.
 - Skip invalid delivered-marker names during durable queue batch loading, preserving malformed files while continuing to load valid pending entries.

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -203,9 +203,16 @@ await fs.move("incoming/foo.txt", "archive/foo.txt", { overwrite: true });
 
 Both `from` and `to` are bounded; `..` in either is rejected.
 
+The JavaScript fallback checks both parent directories before and after the
+rename. A failed post-operation check rejects even though the rename may
+already have completed; rejection does not imply rollback.
+
 ### `fs.remove(rel)`
 
 Unlink a file or `rmdir` an empty directory. Non-empty directories throw `not-empty`. For atomic directory replacement, use [`replaceDirectoryAtomic`](atomic.md#replacedirectoryatomic).
+
+The JavaScript fallback reports failed parent-directory checks after removal.
+The entry may already have been removed when this verification rejects.
 
 ```ts
 await fs.remove("logs/yesterday.log");

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -1400,7 +1400,7 @@ async function removePathFallback(resolved: { resolved: string }): Promise<void>
   } catch (error) {
     throw normalizeRemovePathError(error);
   }
-  await assertAsyncDirectoryGuard(guard).catch(() => undefined);
+  await assertAsyncDirectoryGuard(guard).catch(error => { throw normalizeRemoveGuardError(error); });
 }
 
 async function mkdirPathFallback(resolved: { rootReal: string; resolved: string }): Promise<void> {
@@ -1566,7 +1566,12 @@ async function movePathFallback(
     }
     throw error;
   }
-  await assertAsyncDirectoryGuard(targetParentGuard).catch(() => undefined);
+  try {
+    await assertAsyncDirectoryGuard(sourceParentGuard);
+    await assertAsyncDirectoryGuard(targetParentGuard);
+  } catch (error) {
+    throw normalizePinnedPathError(error);
+  }
 }
 
 async function writeFileFallback(

--- a/test/root-post-mutation-guard.test.ts
+++ b/test/root-post-mutation-guard.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { configureFsSafeNative, root } from "../src/index.js";
+import { __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetFsSafeNativeConfigForTest();
+});
+
+it.each(["remove", "move-source", "move-target"].flatMap(operation =>
+  [false, true].map(missing => ({ operation, missing }))))(
+  "$operation reports a changed parent after the mutation (missing=$missing)",
+  async ({ operation, missing }) => {
+    const dir = await tempRoot("fs-safe-post-mutation-");
+    const sourceDir = path.join(dir, "source");
+    const targetDir = path.join(dir, "target");
+    await fs.mkdir(sourceDir);
+    await fs.mkdir(targetDir);
+    await fs.writeFile(path.join(sourceDir, "value"), "original");
+    configureFsSafeNative({ mode: "off" });
+    const scoped = await root(dir);
+    const rename = fs.rename.bind(fs);
+    const movedParent = path.join(dir, "moved-parent");
+    const replaceParent = async (parent: string) => {
+      await rename(parent, movedParent);
+      if (!missing) await fs.mkdir(parent);
+    };
+    if (operation === "remove") {
+      const remove = fs.rm.bind(fs);
+      vi.spyOn(fs, "rm").mockImplementationOnce(async (file, options) => {
+        await remove(file, options);
+        await replaceParent(sourceDir);
+      });
+      await expect(scoped.remove("source/value")).rejects.toMatchObject({
+        code: missing ? "not-found" : "path-mismatch",
+        message: expect.not.stringContaining(dir),
+      });
+      await expect(fs.stat(path.join(movedParent, "value"))).rejects.toMatchObject({ code: "ENOENT" });
+    } else {
+      vi.spyOn(fs, "rename").mockImplementationOnce(async (from, to) => {
+        await rename(from, to);
+        await replaceParent(operation === "move-source" ? sourceDir : targetDir);
+      });
+      await expect(scoped.move("source/value", "target/value")).rejects.toMatchObject({
+        code: missing ? "path-alias" : "path-mismatch",
+        message: expect.not.stringContaining(dir),
+      });
+      expect(await fs.readFile(path.join(operation === "move-target" ? movedParent : targetDir, "value"), "utf8"))
+        .toBe("original");
+    }
+  },
+);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where consumers using fallback `move` or `remove` received success even when the parent-directory check detected a concurrent replacement after the mutation. Moves also failed to check the source parent after renaming.

## Why This Change Was Made

Propagate post-operation parent-check failures, verify both move parents, and normalize filesystem probe errors through the existing library error helpers. These checks detect observed changes; they do not make Node pathname mutations atomic or roll back completed operations.

## User Impact

A changed or missing parent now causes rejection instead of silent success. The destination may already have been renamed or the source removed when verification rejects, as documented in the writing guide.

## Evidence

Three baseline regression cases returned success after parent replacement. The candidate passes 42 focused tests across post-mutation guards, platform fallback behavior, and directory errors. New tests cover both replacement and disappearance, preserve proof of completed side effects, and check bounded error messages. Build and diff whitespace checks pass. Independent Codex autoreview reports no actionable P0–P2 findings; full checks run in CI.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
