### PR TITLE
feat(durability): bound and cancel file hashing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,11 @@ jobs:
       - name: Test native mode off
         run: node scripts/native-mode-smoke.mjs off
 
+      - name: Test bounded hashing with required native binding
+        env:
+          FS_SAFE_NATIVE_MODE: require
+        run: pnpm test test/file-hash-options.test.ts
+
       - name: Prove sidecar contention with required native binding
         run: node scripts/sidecar-contention-proof.mjs require
 
@@ -205,6 +210,7 @@ jobs:
             node scripts/native-mode-smoke.mjs auto
             node scripts/native-mode-smoke.mjs require
             node scripts/native-mode-smoke.mjs off
+            FS_SAFE_NATIVE_MODE=require pnpm test test/file-hash-options.test.ts
             node scripts/sidecar-contention-proof.mjs require
             FS_SAFE_NATIVE_MODE=require pnpm test test/root-create-only-preflight.test.ts test/sidecar-lock-root-admission.test.ts test/sidecar-lock-root-ancestry.test.ts test/sidecar-lock-root-budget.test.ts test/sidecar-lock-root-resolver.test.ts test/sidecar-lock-root-unlink.test.ts test/sidecar-lock-unlink-siblings.test.ts test/file-lock-sync-stale.test.ts test/file-lock-sync-release.test.ts
             FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm test test/native-owned-tree.test.ts test/native-write-containment.test.ts test/native-staging-regression.test.ts test/staged-file.test.ts test/staged-file-failures.test.ts test/native-archive-equivalence.test.ts test/native-publish-equivalence.test.ts test/archive-unified.test.ts test/archive-wasm-abi.test.ts test/archive-pax.test.ts test/archive-pax-security.test.ts test/archive-pax-compressed.test.ts test/archive-tar-strip.test.ts test/archive-tar-framing.test.ts test/archive-tar-framing-compressed.test.ts test/archive-gzip-integrity.test.ts test/archive-gzip-container.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add byte limits and cooperative cancellation to `sha256File`, preserving descriptor ownership and waiting for native work to stop before rejecting.
+
 - Report failed parent-directory checks after JavaScript fallback moves and removals, including moved source parents, instead of silently reporting success.
 
 - Resolve Windows ACL principal names such as `constructor` and `__proto__` as real dictionary keys, without skipping SID lookup or dropping translated entries.

--- a/docs/durability.md
+++ b/docs/durability.md
@@ -199,7 +199,7 @@ import { sha256File } from "@openclaw/fs-safe/durability";
 const snapshot = await open(stagedArchive, "r");
 try {
   const before = await snapshot.stat();
-  const hash = await sha256File(snapshot);
+  const hash = await sha256File(snapshot, { maxBytes: before.size });
   if (hash.bytes !== before.size || hash.digest !== manifest.sha256) {
     throw new Error("staged backup does not match its manifest");
   }
@@ -209,6 +209,21 @@ try {
 ```
 
 The result is `{ bytes, digest }`, where `digest` is lowercase hexadecimal.
+The optional `Sha256FileOptions` argument supports `maxBytes` and `signal`.
+`maxBytes` accepts a non-negative safe integer (including zero), or
+`Infinity` for no limit, which is also the default. Oversized files reject with
+`FsSafeError("too-large")`; reads stay bounded to at most `maxBytes + 1` bytes,
+even if the file grows after its initial size check. Hashing never silently
+truncates to the limit.
+
+Pass `signal` to cancel. A pre-aborted signal rejects before file I/O or native
+loading. In-flight cancellation is cooperative between reads and rejects with
+the signal's original reason only after the pending read or native task stops.
+Callers may close their handle after awaiting rejection; do not close it while
+the operation is pending. A signal can be shared by successive or concurrent
+hashes. Neither mode provides a snapshot of concurrently modified contents;
+callers requiring stable content must also fence identity and metadata.
+
 The handle overload never closes the caller's descriptor and uses positioned
 reads, so it does not alter the descriptor's current offset. The path overload
 rejects symbolic links and non-regular files, compares lossless bigint identities
@@ -226,7 +241,7 @@ descriptor inspection rather than waiting for a writer.
 When the optional binding is active, hashing runs as an async native task and
 does not occupy the JavaScript event loop with digest updates. With native mode
 `off`, or in `auto` when no binding loads, the fallback performs asynchronous
-positioned reads in 64 KiB chunks but updates Node's `Hash` on the JavaScript
+positioned reads in chunks of up to 256 KiB but updates Node's `Hash` on the JavaScript
 thread. Both paths stream constant-size buffers rather than loading the file
 into memory. Native mode `require` keeps its usual fail-closed loader semantics.
 

--- a/native/src/fast_file.rs
+++ b/native/src/fast_file.rs
@@ -1,8 +1,12 @@
-use napi::bindgen_prelude::{AsyncTask, Task};
-use napi::{Env, Error, Result, Status};
+use napi::bindgen_prelude::{AbortSignal, AsyncTask, Task};
+use napi::{Env, Error, JsError, Result, Status};
 use napi_derive::napi;
 use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use crate::{into_napi, platform};
 
@@ -88,21 +92,58 @@ pub fn copy_file_range_exclusive(
 
 pub struct HashTask {
     fd: i32,
+    max_bytes: u64,
+    cancelled: Arc<AtomicBool>,
 }
 
 impl Task for HashTask {
-    type Output = (u64, String);
+    type Output = crate::NativeResult<(u64, String)>;
     type JsValue = FileHash;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        let reader = platform::open_independent_reader(self.fd)
-            .map_err(|error| Error::new(Status::GenericFailure, error.reason))?;
+        Ok(self.hash())
+    }
+
+    fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        let (bytes, digest) =
+            output.map_err(|error| Error::from(JsError::from(error).into_unknown(env)))?;
+        Ok(FileHash {
+            bytes: bytes as f64,
+            digest,
+        })
+    }
+}
+
+impl HashTask {
+    fn check_cancelled(&self) -> crate::NativeResult<()> {
+        if self.cancelled.load(Ordering::Relaxed) {
+            return Err(crate::native_error(
+                "Cancelled",
+                "SHA-256 operation aborted",
+            ));
+        }
+        Ok(())
+    }
+
+    fn hash(&self) -> crate::NativeResult<(u64, String)> {
+        self.check_cancelled()?;
+        let reader = platform::open_independent_reader(self.fd)?;
         let mut hasher = Sha256::new();
         let mut buffer = [0_u8; 64 * 1024];
         let mut bytes = 0_u64;
         loop {
-            let read = platform::read_at(&reader, &mut buffer, bytes)
-                .map_err(|error| Error::new(Status::GenericFailure, error.reason))?;
+            self.check_cancelled()?;
+            let length = (self.max_bytes - bytes)
+                .saturating_add(1)
+                .min(buffer.len() as u64) as usize;
+            let read = platform::read_at(&reader, &mut buffer[..length], bytes)?;
+            self.check_cancelled()?;
+            if read as u64 > self.max_bytes - bytes {
+                return Err(crate::native_error(
+                    "too-large",
+                    "SHA-256 input exceeds maxBytes",
+                ));
+            }
             if read == 0 {
                 break;
             }
@@ -115,16 +156,41 @@ impl Task for HashTask {
         }
         Ok((bytes, digest))
     }
-
-    fn resolve(&mut self, _env: Env, (bytes, digest): Self::Output) -> Result<Self::JsValue> {
-        Ok(FileHash {
-            bytes: bytes as f64,
-            digest,
-        })
-    }
 }
 
 #[napi(js_name = "sha256File")]
-pub fn sha256_file(fd: i32) -> AsyncTask<HashTask> {
-    AsyncTask::new(HashTask { fd })
+pub fn sha256_file(
+    fd: i32,
+    max_bytes: Option<f64>,
+    signal: Option<AbortSignal>,
+) -> Result<AsyncTask<HashTask>> {
+    let max_bytes = match max_bytes {
+        Some(value)
+            if value.is_finite()
+                && (0.0..=9_007_199_254_740_991.0).contains(&value)
+                && value.fract() == 0.0 =>
+        {
+            value as u64
+        }
+        Some(_) => {
+            return Err(Error::new(
+                Status::InvalidArg,
+                "maxBytes must be a non-negative safe integer",
+            ));
+        }
+        None => u64::MAX,
+    };
+    let cancelled = Arc::new(AtomicBool::new(false));
+    if let Some(signal) = &signal {
+        let callback = Arc::clone(&cancelled);
+        signal.on_abort(move || callback.store(true, Ordering::Relaxed));
+    }
+    Ok(AsyncTask::with_optional_signal(
+        HashTask {
+            fd,
+            max_bytes,
+            cancelled,
+        },
+        signal,
+    ))
 }

--- a/scripts/consumer-install-smoke.mjs
+++ b/scripts/consumer-install-smoke.mjs
@@ -59,7 +59,11 @@ const hashScript = `
     await assert.rejects(sha256File('fixture.txt'), {code:'helper-unavailable'});
     console.log('helper-unavailable');
   } else {
-    const result=await sha256File('fixture.txt');
+    const result=await sha256File('fixture.txt', {maxBytes:3, signal:new AbortController().signal});
+    assert.equal(result.bytes,3);
+    await assert.rejects(sha256File('fixture.txt', {maxBytes:2}), {code:'too-large'});
+    const reason=new Error('cancelled consumer hash');
+    await assert.rejects(sha256File('fixture.txt', {signal:AbortSignal.abort(reason)}), error=>error===reason);
     assert.equal(result.digest,'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
     console.log(result.digest);
   }

--- a/src/durability.ts
+++ b/src/durability.ts
@@ -25,5 +25,6 @@ export {
 export {
   sha256File,
   type Sha256FileInput,
+  type Sha256FileOptions,
   type Sha256FileResult,
 } from "./file-hash.js";

--- a/src/file-hash.ts
+++ b/src/file-hash.ts
@@ -2,12 +2,18 @@ import { createHash } from "node:crypto";
 import fsSync from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
+import { normalizeMaxBytes } from "./byte-budget.js";
 import { FsSafeError } from "./errors.js";
 import { getNativeBinding, type NativeBinding } from "./native.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
 
 export type Sha256FileInput = string | FileHandle;
+
+export type Sha256FileOptions = {
+  maxBytes?: number;
+  signal?: AbortSignal;
+};
 
 export type Sha256FileResult = {
   bytes: number;
@@ -17,13 +23,38 @@ export type Sha256FileResult = {
 export async function hashFileHandle(
   handle: FileHandle,
   native: NativeBinding | undefined = getNativeBinding(),
+  { maxBytes = Infinity, signal }: Sha256FileOptions = {},
 ): Promise<Sha256FileResult> {
+  signal?.throwIfAborted();
   const stat = fsSync.fstatSync(handle.fd);
   if (!stat.isFile()) {
     throw new FsSafeError("not-file", "SHA-256 input is not a regular file");
   }
+  if (stat.size > maxBytes) {
+    throw new FsSafeError("too-large", `SHA-256 input exceeds ${maxBytes} bytes`);
+  }
   if (native) {
-    return await native.sha256File(handle.fd);
+    // A completed N-API task can mask later aborts on the same signal.
+    const nativeSignal = signal ? AbortSignal.any([signal]) : undefined;
+    try {
+      const result = await native.sha256File(
+        handle.fd,
+        Number.isFinite(maxBytes) ? maxBytes : undefined,
+        nativeSignal,
+      );
+      signal?.throwIfAborted();
+      return result;
+    } catch (error) {
+      // N-API settles only after compute stops; never race descriptor cleanup.
+      signal?.throwIfAborted();
+      if ((error as NodeJS.ErrnoException | null)?.code === "too-large") {
+        throw new FsSafeError("too-large", `SHA-256 input exceeds ${maxBytes} bytes`, { cause: error });
+      }
+      throw error;
+    } finally {
+      // Node retains composite signals while N-API's abort listener is attached.
+      if (nativeSignal) nativeSignal.onabort = null;
+    }
   }
 
   const hash = createHash("sha256");
@@ -32,7 +63,13 @@ export async function hashFileHandle(
   );
   let position = 0;
   while (true) {
-    const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+    signal?.throwIfAborted();
+    const length = Math.min(buffer.length, maxBytes - position + 1);
+    const { bytesRead } = await handle.read(buffer, 0, length, position);
+    signal?.throwIfAborted();
+    if (bytesRead > maxBytes - position) {
+      throw new FsSafeError("too-large", `SHA-256 input exceeds ${maxBytes} bytes`);
+    }
     if (bytesRead === 0) {
       return { bytes: position, digest: hash.digest("hex") };
     }
@@ -41,7 +78,10 @@ export async function hashFileHandle(
   }
 }
 
-async function hashPath(filePath: string): Promise<Sha256FileResult> {
+async function hashPath(
+  filePath: string,
+  options: Sha256FileOptions,
+): Promise<Sha256FileResult> {
   const before = await inspectFileIdentity(async () => {
     const stat = fsSync.lstatSync(filePath, { bigint: true });
     if (stat.isSymbolicLink()) {
@@ -55,6 +95,7 @@ async function hashPath(filePath: string): Promise<Sha256FileResult> {
 
   let handle: FileHandle;
   try {
+    options.signal?.throwIfAborted();
     handle = await fs.open(filePath, resolveReadOpenFlags());
   } catch (error) {
     if ((error as NodeJS.ErrnoException | null)?.code === "ELOOP") {
@@ -66,6 +107,7 @@ async function hashPath(filePath: string): Promise<Sha256FileResult> {
   }
 
   try {
+    options.signal?.throwIfAborted();
     const opened = await inspectFileIdentity(async () => {
       const stat = fsSync.fstatSync(handle.fd, { bigint: true });
       if (!stat.isFile()) {
@@ -80,12 +122,19 @@ async function hashPath(filePath: string): Promise<Sha256FileResult> {
       }
       return stat;
     }, opened);
-    return await hashFileHandle(handle);
+    return await hashFileHandle(handle, getNativeBinding(), options);
   } finally {
     await handle.close().catch(() => undefined);
   }
 }
 
-export async function sha256File(input: Sha256FileInput): Promise<Sha256FileResult> {
-  return typeof input === "string" ? await hashPath(input) : await hashFileHandle(input);
+export async function sha256File(
+  input: Sha256FileInput,
+  options: Sha256FileOptions = {},
+): Promise<Sha256FileResult> {
+  options.signal?.throwIfAborted();
+  const normalized = { maxBytes: normalizeMaxBytes(options.maxBytes), signal: options.signal };
+  return typeof input === "string"
+    ? await hashPath(input, normalized)
+    : await hashFileHandle(input, getNativeBinding(), normalized);
 }

--- a/src/native-binding.ts
+++ b/src/native-binding.ts
@@ -144,5 +144,5 @@ export interface NativeBinding {
     targetRootFd: number,
     targetRelPath: string,
   ): void;
-  sha256File(fd: number): Promise<NativeFileHash>;
+  sha256File(fd: number, maxBytes?: number, signal?: AbortSignal): Promise<NativeFileHash>;
 }

--- a/test/file-hash-identity.test.ts
+++ b/test/file-hash-identity.test.ts
@@ -63,7 +63,7 @@ function assertTrace(
     const fd = subject.close.mock.calls[0]![0];
     expect(subject.descriptors).toEqual(Array(counts.descriptor).fill(fd));
     expect(subject.handles[0]!.fd).toBe(-1);
-    if (hashing === "mock-native") expect(subject.nativeHash).toHaveBeenCalledWith(fd);
+    if (hashing === "mock-native") expect(subject.nativeHash.mock.calls[0]?.[0]).toBe(fd);
     for (const call of subject.read.mock.calls) expect(call).toEqual([fd]);
   }
   for (const observation of subject.observations) {

--- a/test/file-hash-options.test.ts
+++ b/test/file-hash-options.test.ts
@@ -1,0 +1,277 @@
+import { createHash } from "node:crypto";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sha256File } from "../src/durability.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import {
+  __loadBundledNativeForTest,
+  __resetNativeLoaderForTest,
+  __setNativeLoaderForTest,
+  type NativeBinding,
+} from "../src/native.js";
+import { useTempDirs } from "./helpers/vitest.js";
+
+let native: NativeBinding | undefined;
+try {
+  native = __loadBundledNativeForTest();
+} catch (error) {
+  if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error;
+}
+
+const { tempRoot } = useTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+async function fixture(contents: string | Buffer): Promise<string> {
+  const directory = await tempRoot("fs-safe-hash-options-");
+  const file = path.join(directory, "payload");
+  await fs.writeFile(file, contents);
+  return file;
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+for (const mode of ["off", "require"] as const) {
+  describe.runIf(mode === "off" || Boolean(native))(`bounded SHA-256 (${mode})`, () => {
+    beforeEach(() => {
+      configureFsSafeNative({ mode });
+      if (mode === "require") __setNativeLoaderForTest(() => native!);
+    });
+
+    it.each([undefined, Infinity, 6])("hashes the complete file with limit %s", async (maxBytes) => {
+      const file = await fixture("abcdef");
+      const handle = await fs.open(file, "r");
+      const expected = {
+        bytes: 6,
+        digest: createHash("sha256").update("abcdef").digest("hex"),
+      };
+      try {
+        await handle.read(Buffer.alloc(2), 0, 2, null);
+        await expect(sha256File(handle, { maxBytes })).resolves.toEqual(expected);
+        await expect(sha256File(file, { maxBytes })).resolves.toEqual(expected);
+        const next = Buffer.alloc(1);
+        await handle.read(next, 0, 1, null);
+        expect(next.toString()).toBe("c");
+      } finally {
+        await handle.close();
+      }
+    });
+
+    it("accepts an empty file at zero and rejects a nonempty file without consuming its offset", async () => {
+      const file = await fixture("");
+      await expect(sha256File(file, { maxBytes: 0 })).resolves.toEqual({
+        bytes: 0,
+        digest: createHash("sha256").digest("hex"),
+      });
+      await fs.writeFile(file, "abcdef");
+      const handle = await fs.open(file, "r");
+      try {
+        await handle.read(Buffer.alloc(2), 0, 2, null);
+        for (const maxBytes of [0, 5]) {
+          await expect(sha256File(file, { maxBytes })).rejects.toMatchObject({ code: "too-large" });
+          await expect(sha256File(handle, { maxBytes })).rejects.toMatchObject({ code: "too-large" });
+        }
+        const next = Buffer.alloc(1);
+        await handle.read(next, 0, 1, null);
+        expect(next.toString()).toBe("c");
+      } finally {
+        await handle.close();
+      }
+    });
+  });
+}
+
+it.each([-1, -Infinity, NaN, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+  "rejects invalid limit %s before I/O or native loading",
+  async (maxBytes) => {
+    const file = await fixture("abc");
+    const handle = await fs.open(file, "r");
+    const loader = vi.fn(() => { throw new Error("unexpected native loading"); });
+    configureFsSafeNative({ mode: "require" });
+    __setNativeLoaderForTest(loader);
+    const open = vi.spyOn(fs, "open");
+    const lstat = vi.spyOn(fsSync, "lstatSync");
+    const fstat = vi.spyOn(fsSync, "fstatSync");
+    const read = vi.spyOn(handle, "read");
+    try {
+      await expect(sha256File(file, { maxBytes })).rejects.toBeInstanceOf(RangeError);
+      await expect(sha256File(handle, { maxBytes })).rejects.toBeInstanceOf(RangeError);
+      expect(open).not.toHaveBeenCalled();
+      expect(lstat).not.toHaveBeenCalled();
+      expect(fstat).not.toHaveBeenCalled();
+      expect(read).not.toHaveBeenCalled();
+      expect(loader).not.toHaveBeenCalled();
+    } finally {
+      await handle.close();
+    }
+  },
+);
+
+it("preserves a pre-aborted reason without I/O or native loading", async () => {
+  const file = await fixture("abc");
+  const handle = await fs.open(file, "r");
+  const reason = { cancellation: "caller-owned reason" };
+  const signal = AbortSignal.abort(reason);
+  const loader = vi.fn(() => { throw new Error("unexpected native loading"); });
+  configureFsSafeNative({ mode: "require" });
+  __setNativeLoaderForTest(loader);
+  const open = vi.spyOn(fs, "open");
+  const lstat = vi.spyOn(fsSync, "lstatSync");
+  const fstat = vi.spyOn(fsSync, "fstatSync");
+  const read = vi.spyOn(handle, "read");
+  try {
+    await expect(sha256File(file, { signal })).rejects.toBe(reason);
+    await expect(sha256File(handle, { signal })).rejects.toBe(reason);
+    expect(open).not.toHaveBeenCalled();
+    expect(lstat).not.toHaveBeenCalled();
+    expect(fstat).not.toHaveBeenCalled();
+    expect(read).not.toHaveBeenCalled();
+    expect(loader).not.toHaveBeenCalled();
+  } finally {
+    await handle.close();
+  }
+});
+
+it.each([0, 3, 256 * 1024])("reads at most limit + 1 bytes when a file grows past %s", async (maxBytes) => {
+  const file = await fixture(Buffer.alloc(maxBytes, 0x61));
+  const handle = await fs.open(file, "r");
+  configureFsSafeNative({ mode: "off" });
+  const realRead = handle.read.bind(handle);
+  let bytes = 0;
+  let reads = 0;
+  vi.spyOn(handle, "read").mockImplementation(async (...args) => {
+    if (reads++ === 0) await fs.appendFile(file, Buffer.alloc(64 * 1024, 0x62));
+    const result = await realRead(...args);
+    bytes += result.bytesRead;
+    return result;
+  });
+  try {
+    await expect(sha256File(handle, { maxBytes })).rejects.toMatchObject({ code: "too-large" });
+    expect(bytes).toBe(maxBytes + 1);
+  } finally {
+    await handle.close();
+  }
+});
+
+it.each(["path", "handle"] as const)("joins a pending fallback read before rejecting an aborted %s hash", async (input) => {
+  const file = await fixture("abcdef");
+  configureFsSafeNative({ mode: "off" });
+  const handle = await fs.open(file, "r");
+  await handle.read(Buffer.alloc(2), 0, 2, null);
+  const entered = deferred();
+  const release = deferred();
+  const controller = new AbortController();
+  const reason = new Error("hash cancelled during read");
+  const realRead = handle.read.bind(handle);
+  const read = vi.spyOn(handle, "read").mockImplementationOnce(async (...args) => {
+    entered.resolve();
+    await release.promise;
+    return await realRead(...args);
+  });
+  const close = vi.spyOn(handle, "close");
+  if (input === "path") vi.spyOn(fs, "open").mockResolvedValueOnce(handle);
+  let settled = false;
+  const operation = sha256File(input === "path" ? file : handle, { signal: controller.signal })
+    .then((result) => { settled = true; return result; }, (error: unknown) => { settled = true; return error; });
+  try {
+    await Promise.race([entered.promise, operation.then(() => { throw new Error("read was not entered"); })]);
+    controller.abort(reason);
+    await new Promise<void>((resolve) => { setImmediate(resolve); });
+    expect(settled).toBe(false);
+    expect(close).not.toHaveBeenCalled();
+    release.resolve();
+    expect(await operation).toBe(reason);
+    expect(read).toHaveBeenCalledTimes(1);
+    if (input === "path") {
+      expect(handle.fd).toBe(-1);
+      expect(close).toHaveBeenCalledOnce();
+    } else {
+      const next = Buffer.alloc(1);
+      await realRead(next, 0, 1, null);
+      expect(next.toString()).toBe("c");
+      expect(close).not.toHaveBeenCalled();
+    }
+  } finally {
+    release.resolve();
+    await operation;
+    if (handle.fd !== -1) await handle.close();
+  }
+});
+
+it.runIf(Boolean(native))("rejects growth after admission in the native hasher", async () => {
+  const file = await fixture("abc");
+  const handle = await fs.open(file, "r");
+  configureFsSafeNative({ mode: "require" });
+  let entered = false;
+  __setNativeLoaderForTest(() => ({
+    ...native!,
+    sha256File(...args) {
+      entered = true;
+      fsSync.appendFileSync(file, Buffer.alloc(64 * 1024, 0x62));
+      return native!.sha256File(...args);
+    },
+  }));
+  try {
+    await expect(sha256File(handle, { maxBytes: 3 })).rejects.toMatchObject({ code: "too-large" });
+    expect(entered).toBe(true);
+  } finally {
+    await handle.close();
+  }
+});
+
+it.runIf(Boolean(native))("cancels concurrent native hashes after an earlier hash completed on the same parent signal", async () => {
+  configureFsSafeNative({ mode: "require" });
+  const file = await fixture("abcdef");
+  const handle = await fs.open(file, "r");
+  const controller = new AbortController();
+  const onAbort = vi.fn();
+  controller.signal.onabort = onAbort;
+  const reason = new Error("native hashes cancelled");
+  const entered = deferred();
+  let calls = 0;
+  let pending = 0;
+  const forwardedSignals: AbortSignal[] = [];
+  __setNativeLoaderForTest(() => ({
+    ...native!,
+    sha256File(...args) {
+      calls++;
+      pending++;
+      if (args[2]) forwardedSignals.push(args[2]);
+      const operation = native!.sha256File(...args).finally(() => { pending--; });
+      if (calls === 3) entered.resolve();
+      return operation;
+    },
+  }));
+  const operations: Array<Promise<unknown>> = [];
+  try {
+    await handle.read(Buffer.alloc(2), 0, 2, null);
+    await expect(sha256File(handle, { signal: controller.signal })).resolves.toMatchObject({ bytes: 6 });
+    expect(forwardedSignals[0]!.onabort).toBeNull();
+    await fs.truncate(file, 256 * 1024 * 1024);
+    for (let index = 0; index < 2; index++) {
+      operations.push(sha256File(handle, { signal: controller.signal }).catch((error: unknown) => error));
+    }
+    await Promise.race([entered.promise, Promise.all(operations).then(() => { throw new Error("native hashes were not entered"); })]);
+    controller.abort(reason);
+    for (const error of await Promise.all(operations)) expect(error).toBe(reason);
+    expect(pending).toBe(0);
+    for (const signal of forwardedSignals) expect(signal.onabort).toBeNull();
+    expect(onAbort).toHaveBeenCalledOnce();
+    const next = Buffer.alloc(1);
+    await handle.read(next, 0, 1, null);
+    expect(next.toString()).toBe("c");
+  } finally {
+    controller.abort(reason);
+    await Promise.allSettled(operations);
+    await handle.close();
+  }
+});

--- a/test/public-api.json
+++ b/test/public-api.json
@@ -549,6 +549,7 @@
         "PublishFileExclusiveStrategy",
         "PublishFileExclusiveSyncFailurePolicy",
         "Sha256FileInput",
+        "Sha256FileOptions",
         "Sha256FileResult"
       ],
       "errorCodes": {}


### PR DESCRIPTION
`sha256File` can now stop at a byte budget or respond to cancellation, allowing workspace and backup readers to use the native hasher while retaining their existing resource limits. Previously the helper always read to EOF and could not be cancelled.

The optional `maxBytes` and `signal` arguments work in both native and JavaScript modes. Oversized inputs reject with `FsSafeError("too-large")`, including files that grow after admission, and reads consume at most the limit plus one byte. Cancellation preserves the caller's reason and waits for the pending read/native task to stop before settling, so callers can safely close their handles afterward. Existing pathname identity checks, descriptor ownership, and positioned offsets remain intact.

Each native operation receives a fresh abort signal so completed operations cannot hide later cancellation. The native handler is detached after settlement to avoid retaining completed operations under a long-lived parent signal. Existing calls and native-loading defaults are unchanged. The public type export, docs, and changelog are updated together.

Validation: 148 focused hashing/identity/docs tests and the full local `pnpm check` pass (8,611 tests). The new option tests fail against the original implementation. Rust tests and clippy pass, as do fresh packed npm/pnpm consumer installs in native, fallback, and missing-binding modes. A real GC probe retains 0/100 completed native signals after cleanup (100/100 before the fix); a 4 GiB sparse-file probe joins native cancellation in 1.25 ms after abort. Independent review is clean through P2. The final rebase combined changelog entries only; the reviewed implementation and test blobs are unchanged. [Final-commit CI](https://github.com/openclaw/fs-safe/actions/runs/34719323310) provides cross-platform validation.

The separate Windows coverage workflow failed an existing create-only streamed-write cleanup assertion. This is outside the hashing call graph: `runPinnedWriteHelper` in fallback mode calls the unchanged pinned-write cleanup owner. Four deterministic regressions reproduce the same retained-output symptom on base `c578547` when the parent inode is above `Number.MAX_SAFE_INTEGER`; the cleanup correctly refuses the rounded numeric parent receipt. The repair in [#292](https://github.com/openclaw/fs-safe/pull/292) records the parent identity as bigint at admission. All jobs in the final-commit `ci` workflow, including Windows full checks, native checks, and packed consumers, passed. This coverage failure is recorded rather than retried away.

Warm-cache hash measurements on macOS arm64 / Node 26.8.2, four readers, 16 rotated measured rounds with every digest and byte count checked:

| Fixture | Node 64 KiB positioned loop | Bounded + cancellable native | Bounded + cancellable fallback |
| --- | ---: | ---: | ---: |
| 512 × 4 KiB | 21.37 ms | 19.27 ms | 23.69 ms |
| 64 × 512 KiB | 17.14 ms | 6.83 ms | 16.31 ms |
| 8 × 8 MiB | 30.38 ms | 9.87 ms | 26.57 ms |

The new controls add about 3 microseconds per file versus unbounded native hashing in the small-file case, around 2% in the 512 KiB case, and no resolved overhead in the 8 MiB case. These are hash-loop measurements including open/close, excluding inventory, identity fences, transport, and model calls; they do not establish end-to-end session latency. Native loading remains opt-in according to the consumer's existing policy.
