### PR TITLE
test(docs): bound the full-site build smoke runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Give the full documentation-build smoke test a bounded longer runtime so slow Windows runners do not hit the default unit-test deadline.
+
 - Report failed parent-directory checks after JavaScript fallback moves and removals, including moved source parents, instead of silently reporting success.
 
 - Resolve Windows ACL principal names such as `constructor` and `__proto__` as real dictionary keys, without skipping SID lookup or dropping translated entries.

--- a/test/docs-site-navigation.test.ts
+++ b/test/docs-site-navigation.test.ts
@@ -103,7 +103,7 @@ describe("docs site navigation", () => {
 
   it("builds the real docs with sidebar, section, and pager links for repaired pages and staging", () => {
     const { root, output } = siteFixture();
-    const result = spawnSync(process.execPath, [builder], { cwd: root, encoding: "utf8" });
+    const result = spawnSync(process.execPath, [builder], { cwd: root, encoding: "utf8", timeout: 20_000 });
     expect(result.error).toBeUndefined();
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain("built docs site:");
@@ -124,5 +124,5 @@ describe("docs site navigation", () => {
       expect(html).toContain(`<a class="page-nav-next" href="${next}.html">`);
       expect(html).not.toContain('href="pinned-open.html"');
     }
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the full documentation-build smoke test intermittently failed on Windows by exceeding Vitest's five-second unit-test deadline. The failure recurred during the method audit, including the Node 22 check for #289, while the library regressions passed.

## Why This Change Was Made

Give this full-site test 30 seconds for fixture copying, the build, and output assertions, and cap its synchronous builder subprocess at 20 seconds. All navigation and output assertions remain intact; a stalled builder still fails within a bounded runtime.

## User Impact

CI tolerates a slow full docs build without changing the library or its published API. Other unit-test deadlines are unchanged.

## Evidence

The failing CI log reports only the real-docs navigation test timing out at 5,000 ms. The focused navigation suite passes all 12 tests with the revised budgets. Independent Codex autoreview and full cross-platform CI validate the candidate.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
