### PR TITLE
fix(write): retain exact parent identity for failure cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 - Honor finite timeouts and retry delays above Node's single-timer limit by rearming bounded timers instead of expiring after approximately 1 ms.
 - Allow explicitly authorized filesystem-root descendants in Trash moves and keep reservation-directory names bounded for long source filenames.
 
+- Retain exact parent-directory identities in JavaScript fallback writes so failure cleanup removes owned partial files even when Windows directory indexes exceed numeric precision.
+
 ## 0.9.0 - 2026-09-11
 
 **Highlights:** Faster bulk extraction and configurable durability, with Windows filesystem fixes and reliable mixed-version lock cleanup.

--- a/docs/writing.md
+++ b/docs/writing.md
@@ -54,6 +54,10 @@ Post-publication verification can still reject after a complete replacement has
 been committed. Rejection does not promise that a successful rename was rolled
 back; the published file or a raced replacement may remain at the destination.
 
+Failed-write cleanup compares exact parent and file identities, including large
+Windows file indexes. Replaced paths and paths whose ownership cannot be verified
+are preserved.
+
 ## Denying mutations
 
 All mutation verbs accept `denyMutations?: DenyMutationPolicy`, either as a root default or per-call option:

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -157,7 +157,6 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
   const exactRoot = typeof params.rootIdentity?.dev === "bigint" && typeof params.rootIdentity.ino === "bigint"
     ? { dev: params.rootIdentity.dev, ino: params.rootIdentity.ino } : undefined;
   if (exactRoot) await inspectDirectoryIdentity(params.rootPath, exactRoot);
-  const guardOptions = { bigint: exactRoot !== undefined };
   let parentPath = params.relativeParentPath
     ? path.join(params.rootPath, ...params.relativeParentPath.split("/"))
     : params.rootPath;
@@ -174,8 +173,8 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
     });
   }
   const parentGuard = params.mkdir
-    ? await createAsyncDirectoryGuard(parentPath, guardOptions)
-    : await createNearestExistingDirectoryGuard(params.rootPath, parentPath, guardOptions);
+    ? await createAsyncDirectoryGuard(parentPath, { bigint: true })
+    : await createNearestExistingDirectoryGuard(params.rootPath, parentPath, { bigint: true });
   const targetPath = path.join(parentPath, params.basename);
   if (params.overwrite === false) {
     const handle = await withAsyncDirectoryGuards(

--- a/test/pinned-write-cleanup-authority.test.ts
+++ b/test/pinned-write-cleanup-authority.test.ts
@@ -1,11 +1,19 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAsyncDirectoryGuard } from "../src/directory-guard.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { runPinnedWriteHelper } from "../src/pinned-write.js";
 import { cleanupPinnedFilePath } from "../src/replace-file-temp-owner.js";
 import { useRealTempDirs } from "./helpers/vitest.js";
 
 const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetFsSafeNativeConfigForTest();
+});
 
 describe("pinned failure cleanup authority", () => {
   it.each(["owned", "replacement", "stale-parent", "missing-identity"])(
@@ -45,4 +53,36 @@ describe("pinned failure cleanup authority", () => {
       }
     },
   );
+});
+
+describe.each([false, true])("pinned write cleanup with mkdir=%s", (mkdir) => {
+  it.each([false, true])("cleans failed writes under a large parent identity with overwrite=%s", async (overwrite) => {
+    const directory = await tempRoot("fs-safe-pinned-cleanup-large-parent-");
+    const target = path.join(directory, "value");
+    if (overwrite) await fs.writeFile(target, "prior content");
+    const parentInode = 9007199254740993n;
+    const lstat = fsSync.lstatSync.bind(fsSync);
+    // Real I/O and retained descriptors; only the parent's identity representation
+    // models an NTFS file index that loses bits in a numeric Stats result.
+    vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+      const stat = lstat(...args);
+      if (String(args[0]) === directory) {
+        stat.ino = typeof stat.ino === "bigint" ? parentInode : Number(parentInode);
+      }
+      return stat;
+    });
+    configureFsSafeNative({ mode: "off" });
+    await expect(runPinnedWriteHelper({
+      rootPath: directory,
+      relativeParentPath: "",
+      basename: "value",
+      mkdir,
+      mode: 0o600,
+      maxBytes: 3,
+      overwrite,
+      input: { kind: "stream", stream: Readable.from([Buffer.from("12"), Buffer.from("34")]) },
+    })).rejects.toMatchObject({ code: "too-large" });
+    expect(await fs.readdir(directory)).toEqual(overwrite ? ["value"] : []);
+    if (overwrite) expect(await fs.readFile(target, "utf8")).toBe("prior content");
+  });
 });


### PR DESCRIPTION
A failed JavaScript fallback write can leave its partial file or staging file behind when the parent directory's inode exceeds JavaScript's safe integer range. The writer previously captured a numeric parent guard unless the caller supplied a bigint root identity; cleanup then correctly refused to delete using that rounded identity.

Capture the parent guard as bigint at both creation paths. This fixes the producer of the incomplete cleanup authority while retaining the existing checks that preserve replaced paths, unknown identities, and the original write error. Public return values and optional root-identity validation remain unchanged. Production code shrinks by one line.

Four regressions cover create-only and overwrite failures with both parent-guard constructors. They use real files and descriptors, modeling only a parent inode whose numeric representation loses bits; all four fail on base c578547 and pass with this fix. The existing replacement and missing-authority cases remain covered. Focused validation passes 55 tests across six files with a freshly built native binding and an independent dependency install; independent review is clean through P2. The [full CI matrix](https://github.com/openclaw/fs-safe/actions/runs/34720204763) passes, including Windows native checks and packed package consumers. A broad local run was interrupted after existing archive tests hit their timeouts under heavy host contention; no local full-suite pass is claimed, and no timeouts or assertions were weakened. Full-suite validation is supplied by CI. [Coverage](https://github.com/openclaw/fs-safe/actions/runs/34720205157) also passes on Linux, macOS, and Windows, including the original streamed-write cleanup test.

Discovered while investigating the unrelated Windows coverage cleanup failure in #290. This fixes a deterministically reproduced existing precision defect; the original CI log did not record the runner's inode value, so it does not prove that every possible retained-output failure has the same cause.
