### PR TITLE
feat(clone): add native APFS, Btrfs, and ReFS directory cloning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,25 @@ jobs:
       - name: Build and stage host binding
         run: pnpm native:build
 
+      - name: Test native directory cloning
+        run: pnpm test test/clone.test.ts
+
+      - name: Test native Btrfs snapshots
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y btrfs-progs
+          fixture=$(mktemp -d "$RUNNER_TEMP/fs-safe-btrfs.XXXXXX")
+          mkdir "$fixture/mount"
+          truncate -s 1G "$fixture/volume.img"
+          mkfs.btrfs -q "$fixture/volume.img"
+          sudo mount -o loop "$fixture/volume.img" "$fixture/mount"
+          trap 'sudo umount "$fixture/mount"' EXIT
+          sudo chown "$(id -u):$(id -g)" "$fixture/mount"
+          FS_SAFE_CLONE_TEST_ROOT="$fixture/mount" pnpm test test/clone.test.ts
+
       - name: Smoke method benchmarks with native binding
         run: pnpm benchmark:methods --mode require --iterations 1 --samples 1 --warmup 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `@openclaw/fs-safe/clone` for native APFS directory clones, Btrfs subvolume preparation and snapshots, and parallel ReFS tree cloning, with exclusive destinations and cancellation that waits for native writes to settle.
 - Give the full documentation-build smoke test a bounded longer runtime so slow Windows runners do not hit the default unit-test deadline.
 - Add byte limits and cooperative cancellation to `sha256File`, preserving descriptor ownership and waiting for native work to stop before rejecting.
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ contract. Low-level helpers that OpenClaw needs to compose higher-level APIs are
 | `@openclaw/fs-safe/file-lock` | async/sync sidecar locks, root-bounded sidecars, ownership verification, and stale policy |
 | `@openclaw/fs-safe/permissions` | POSIX mode and Windows ACL inspection, raw owner/ACE facts, private-directory creation, and remediation helpers |
 | `@openclaw/fs-safe/walk` | budget-bounded directory walking with symlink policy, filters, and truncation accounting; not root-bounded |
+| `@openclaw/fs-safe/clone`       | native APFS directory clones and clone metadata, Btrfs subvolume snapshots, and parallel ReFS block cloning; see [directory cloning](docs/clone.md)                                                                                                                                            |
 | `@openclaw/fs-safe/archive` | policy-driven ZIP/TAR extraction, clamp/filter policy, metadata/path-depth limits, native gzip/zstd/bzip2, and bounded entry reads |
 | `@openclaw/fs-safe/advanced` | lower-level composition helpers such as path scopes, root-file open, bounded descriptor reads, install paths, filename sanitizing, temp-file targets, sibling-temp writes, local-root readers, regular-file helpers, `pathExists`, and `withTimeout`; less stable than focused public subpaths |
 | `@openclaw/fs-safe/errors` | `FsSafeError`, closed codes/categories, causes, and operation-specific details receipts |

--- a/benchmarks/clone.mjs
+++ b/benchmarks/clone.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { cloneTree, probeTreeClone } from "../dist/clone.js";
+
+const [sourceArgument, parentArgument, samplesArgument = "3"] = process.argv.slice(2);
+assert(
+  sourceArgument && parentArgument,
+  "Usage: node benchmarks/clone.mjs SOURCE DESTINATION_PARENT [SAMPLES]",
+);
+const samples = Number(samplesArgument);
+assert(
+  Number.isSafeInteger(samples) && samples >= 1 && samples <= 20,
+  "SAMPLES must be between 1 and 20",
+);
+const source = await fs.realpath(sourceArgument);
+const parent = await fs.realpath(parentArgument);
+const relative = path.relative(source, parent);
+assert(
+  relative &&
+    (path.isAbsolute(relative) || relative === ".." || relative.startsWith(`..${path.sep}`)),
+  "Destination parent must be outside the source tree",
+);
+const backend = probeTreeClone(parent);
+assert(backend, "Destination parent has no native tree-clone support");
+const output = await fs.mkdtemp(path.join(parent, "fs-safe-clone-benchmark-"));
+console.log(`Retaining benchmark outputs at ${output}`);
+
+async function inventory(directory, prefix = "") {
+  const entries = [];
+  for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const filename = path.join(directory, entry.name);
+    if (entry.isSymbolicLink()) {
+      entries.push([relativePath, "symlink", await fs.readlink(filename)]);
+    } else if (entry.isDirectory()) {
+      entries.push([relativePath, "directory"]);
+      entries.push(...(await inventory(filename, relativePath)));
+    } else {
+      assert(entry.isFile(), `Unsupported fixture entry: ${relativePath}`);
+      const hash = createHash("sha256");
+      for await (const chunk of createReadStream(filename)) hash.update(chunk);
+      entries.push([relativePath, "file", (await fs.stat(filename)).size, hash.digest("hex")]);
+    }
+  }
+  return entries.sort((left, right) => (left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0));
+}
+
+const expected = await inventory(source);
+const results = [];
+for (let sample = 0; sample < samples; sample++) {
+  // Alternate ordering so every 16-worker measurement is not always warmer.
+  for (const concurrency of sample % 2 ? [16, 1] : [1, 16]) {
+    const destination = path.join(output, `workers-${concurrency}-sample-${sample + 1}`);
+    const started = performance.now();
+    await cloneTree(source, destination, { concurrency });
+    const seconds = (performance.now() - started) / 1000;
+    assert.deepEqual(
+      await inventory(destination),
+      expected,
+      "Clone paths, file bytes, or symlinks differ",
+    );
+    const result = {
+      concurrency,
+      sample: sample + 1,
+      seconds,
+      rssBytes: process.memoryUsage().rss,
+      destination,
+    };
+    results.push(result);
+    console.log(JSON.stringify(result));
+  }
+}
+assert.deepEqual(await inventory(source), expected, "Source changed during benchmark");
+const medians = [1, 16].map((concurrency) => {
+  const times = results
+    .filter((result) => result.concurrency === concurrency)
+    .map((result) => result.seconds)
+    .sort((a, b) => a - b);
+  const middle = Math.floor(times.length / 2);
+  return {
+    concurrency,
+    seconds: times.length % 2 ? times[middle] : (times[middle - 1] + times[middle]) / 2,
+  };
+});
+const report = {
+  backend,
+  source,
+  output,
+  samples,
+  entries: expected.length,
+  medians,
+  results,
+  allPathsAndBytesMatch: true,
+};
+await fs.writeFile(path.join(output, "results.json"), `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify({ backend, medians, allPathsAndBytesMatch: true }));

--- a/benchmarks/lifecycle.mjs
+++ b/benchmarks/lifecycle.mjs
@@ -4,6 +4,39 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 
 export async function registerLifecycle({ api: a, workspace: w, native, binding, register: add, contract, onCleanup }) {
+  const cloneBackend = a.probeTreeClone(w);
+  add("probeTreeClone", () => a.probeTreeClone(w), {
+    sync: true,
+    verify: (backend) => assert.equal(backend, cloneBackend),
+  });
+  const cloneSource = path.join(w, "clone-source");
+  const cloneTarget = path.join(w, "clone-target");
+  const clonePreparation = path.join(w, "clone-preparation");
+  const cloneSkip = !cloneBackend
+    ? "Native directory cloning requires APFS, Btrfs, or ReFS."
+    : undefined;
+  if (cloneBackend) {
+    await a.createCloneSource(cloneSource);
+    fs.writeFileSync(path.join(cloneSource, "payload"), "clone benchmark");
+  }
+  add("createCloneSource", () => a.createCloneSource(clonePreparation), {
+    skip: cloneSkip,
+    verify: () => assert(fs.statSync(clonePreparation).isDirectory()),
+    after: () => fs.rmSync(clonePreparation, { recursive: true, force: true }),
+  });
+  add("cloneTree", () => a.cloneTree(cloneSource, cloneTarget), {
+    skip: cloneSkip,
+    verify: () =>
+      assert.equal(fs.readFileSync(path.join(cloneTarget, "payload"), "utf8"), "clone benchmark"),
+    after: () => fs.rmSync(cloneTarget, { recursive: true, force: true }),
+  });
+  add("readCloneFileMetadata", () => a.readCloneFileMetadata([path.join(w, "input.json")]), {
+    skip: !native ? "Native metadata reader unavailable." : undefined,
+    verify: (entries) => {
+      assert.equal(entries.length, 1);
+      if (cloneBackend === "apfs") assert.equal(entries[0]?.type, 1);
+    },
+  });
   if (binding) {
     const directory = path.join(w, "native-directory");
     fs.mkdirSync(directory);

--- a/docs/clone.md
+++ b/docs/clone.md
@@ -1,0 +1,58 @@
+# Native directory cloning
+
+`@openclaw/fs-safe/clone` materializes independent directory trees using filesystem copy-on-write primitives. It requires a native binding and a supported filesystem; it never substitutes an ordinary byte copy when cloning is unavailable.
+
+```ts
+import { cloneTree, createCloneSource, probeTreeClone } from "@openclaw/fs-safe/clone";
+
+const parent = "/srv/worktrees";
+const backend = probeTreeClone(parent);
+if (backend) {
+  const template = `${parent}/template`;
+  await createCloneSource(template);
+  // Populate this caller-owned template, then keep its contents unchanged.
+  await cloneTree(template, `${parent}/checkout`, { signal: AbortSignal.timeout(60_000) });
+}
+```
+
+## Filesystems
+
+| Backend | Operation                                                  | Source preparation                                                                                                          |
+| ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `apfs`  | One native directory clone                                 | `createCloneSource` creates an empty directory.                                                                             |
+| `btrfs` | One native writable subvolume snapshot                     | `createCloneSource` creates a subvolume; an ordinary directory is not a snapshot source. No `btrfs` executable is required. |
+| `refs`  | Native directory traversal with parallel file block clones | `createCloneSource` creates an empty directory on ReFS, including Dev Drive volumes.                                        |
+
+Source and destination must be on a filesystem that supports cloning between them. The source repository used to populate a template can live elsewhere. ReFS shares file data rather than the whole directory metadata tree, so creating many small files still has a cost.
+
+Btrfs preserves native subvolume snapshot semantics: nested subvolume contents are not included. Prepare source-only templates without nested subvolumes. This API does not recursively snapshot a hierarchy of subvolumes.
+
+## API
+
+`TreeCloneBackend` is the `"apfs" | "btrfs" | "refs"` union returned by the probe. `CloneTreeOptions` contains the optional `signal` and `concurrency` arguments.
+
+`probeTreeClone(parentPath)` synchronously inspects an existing directory and returns `"apfs"`, `"btrfs"`, `"refs"`, or `undefined`. It creates no probe artifacts. An unavailable native binding produces `undefined` in automatic mode; the package's explicit native `require` mode still reports a missing binding as an error.
+
+`createCloneSource(destination, { signal? })` creates an empty cloneable source. Its parent must already exist and the destination must be absent.
+
+`cloneTree(source, destination, { signal?, concurrency? })` clones a directory into an absent destination. Existing destinations are never merged or overwritten. The destination must be outside the source tree. ReFS uses 16 workers by default; `concurrency` accepts integers from 1 through 32. APFS and Btrfs use their bulk operation and do not need worker parallelism.
+
+Clones preserve file contents, empty directories, timestamps, executable modes where supported, and literal symbolic links. Editing a clone does not modify its source. Unsupported filesystem operations fail; callers may choose their own copy or checkout fallback after the failed operation has settled.
+
+The ReFS backend rejects files with alternate data streams and unsupported reparse-point types instead of silently losing their contents. Symbolic links and junctions are preserved.
+
+`readCloneFileMetadata(files)` asynchronously reads APFS data-stream identities and file metadata in one native batch. Results correspond to input order; missing or unsupported entries return `undefined`. The returned `CloneFileMetadata` includes clone ID, device/inode, size, mode, ownership, and timestamps. These are point-in-time observations, not authorization or proof that later reads remain unchanged. Consumers such as Git index adapters must validate their own content and timestamp invariants. The reader does not follow leaf symbolic links.
+
+## Ownership and cancellation
+
+These are low-level operations on caller-owned absolute paths, not Root-relative methods. The source and destination parent must be real directories. The library pins their descriptors and verifies their identities; it does not establish the caller's authorization to use them. Keep the source immutable for the operation, including writes through other aliases, and keep the destination namespace under the caller's control. Literal symlinks in the cloned contents are preserved rather than followed or sanitized.
+
+An already aborted signal prevents dispatch. In-flight cancellation stops cancellable traversal and waits for admitted native writes to finish before rejecting. APFS and Btrfs bulk operations cannot be interrupted once dispatched. An aborted or failed call can therefore leave a destination, including a complete bulk clone. It remains caller-owned; after settlement, the caller decides whether to retain or remove it. Do not start cleanup by racing the cloning promise against an abort promise.
+
+Completion is not a crash-durability guarantee. The API is suitable for reconstructible templates and checkouts; it does not sync every file or replace application-level publication and recovery rules.
+
+## Platform tests and benchmarks
+
+After building the host native binding, run `pnpm test test/clone.test.ts`. APFS tests can use the normal macOS temporary directory. For Btrfs or ReFS, set `FS_SAFE_CLONE_TEST_ROOT` to an existing writable directory on that filesystem. The test creates and cleans only its own temporary children. An explicitly configured unsupported directory fails the test rather than silently skipping platform proof.
+
+Run `node benchmarks/clone.mjs SOURCE DESTINATION_PARENT` after `pnpm build` to compare one and 16 workers on the same immutable source. It records copying time separately from fixture preparation and full file-hash verification, and retains its uniquely named output directory for inspection. Prepare Btrfs sources with `createCloneSource` first.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -132,7 +132,7 @@ type FsSafeErrorCode =
 | `symlink` | Path component is a symlink, policy is `reject`. | Caller followed a symlink they shouldn't have, or `symlinks: "reject"` is set. |
 | `timeout` | An operation with a wall-clock budget overran. | Secure file read or timed operation exceeded `timeoutMs`. |
 | `too-large` | A read or bounded walk exceeded its configured budget. | Caller gave a too-permissive file or traversal limit. |
-| `unsupported-platform` | Reserved compatibility code for a platform-specific operation. | No current public helper emits this `FsSafeError` code. Platform-specific APIs currently return a typed unsupported result or use `helper-unavailable`; keep the union member when exhaustively switching across supported package versions. |
+| `unsupported-platform` | The destination filesystem cannot perform the requested operation. | `createCloneSource` and `cloneTree` emit this code when the native probe finds no supported cloning backend. Callers can select their own checkout or copy fallback after the operation settles. |
 
 Secret writes reject invalid `mode` / `dirMode` values with `invalid-path` before directory creation. Existing secret directories with a mode different from the requested `dirMode` report `insecure-permissions` without chmod; a created directory whose descriptor ownership no longer matches its initializing effective user reports `not-owned`.
 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -35,6 +35,7 @@ windows-sys = { version = "0.61.2", features = [
   "Win32_Security_Authorization",
   "Win32_Storage_FileSystem",
   "Win32_System_IO",
+  "Win32_System_Ioctl",
   "Win32_System_LibraryLoader",
   "Win32_System_Threading",
 ] }

--- a/native/src/clone_metadata.rs
+++ b/native/src/clone_metadata.rs
@@ -20,7 +20,7 @@ fn metadata(path: &str) -> Option<Buffer> {
     let status = unsafe {
         libc::getattrlist(
             path.as_ptr(),
-            &mut attributes,
+            (&mut attributes as *mut libc::attrlist).cast(),
             result.as_mut_ptr().cast(),
             result.len(),
             0x21,

--- a/native/src/clone_metadata.rs
+++ b/native/src/clone_metadata.rs
@@ -1,0 +1,51 @@
+use napi::bindgen_prelude::{AsyncTask, Buffer, Task};
+use napi::{Env, Result};
+use napi_derive::napi;
+
+pub struct CloneMetadataTask {
+    paths: Vec<String>,
+}
+
+#[cfg(target_os = "macos")]
+fn metadata(path: &str) -> Option<Buffer> {
+    let path = std::ffi::CString::new(path).ok()?;
+    let mut attributes: libc::attrlist = unsafe { std::mem::zeroed() };
+    attributes.bitmapcount = 5;
+    attributes.commonattr = 0x8203_8c0a;
+    attributes.fileattr = 0x200;
+    attributes.forkattr = 0x100;
+    let mut result = [0u8; 100];
+    // Darwin packs getattrlist results at four-byte boundaries. Keep the kernel
+    // snapshot intact; the TypeScript decoder checks every returned attribute.
+    let status = unsafe {
+        libc::getattrlist(
+            path.as_ptr(),
+            &mut attributes,
+            result.as_mut_ptr().cast(),
+            result.len(),
+            0x21,
+        )
+    };
+    (status == 0).then(|| result.to_vec().into())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn metadata(_path: &str) -> Option<Buffer> {
+    None
+}
+
+impl Task for CloneMetadataTask {
+    type Output = Vec<Option<Buffer>>;
+    type JsValue = Vec<Option<Buffer>>;
+    fn compute(&mut self) -> Result<Self::Output> {
+        Ok(self.paths.iter().map(|path| metadata(path)).collect())
+    }
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output)
+    }
+}
+
+#[napi(js_name = "readCloneFileMetadata")]
+pub fn read_clone_file_metadata(paths: Vec<String>) -> AsyncTask<CloneMetadataTask> {
+    AsyncTask::new(CloneMetadataTask { paths })
+}

--- a/native/src/clone_tree.rs
+++ b/native/src/clone_tree.rs
@@ -1,0 +1,93 @@
+use crate::{NativeResult, into_napi, native_error, validate_relative_path};
+use napi::bindgen_prelude::{AbortSignal, AsyncTask, Task};
+use napi::{Env, Error, JsError, Result, Status};
+use napi_derive::napi;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+#[cfg(unix)]
+use crate::clone_unix as backend;
+#[cfg(windows)]
+use crate::clone_windows as backend;
+
+fn basename(name: &str) -> NativeResult<()> {
+    validate_relative_path(name, false)?;
+    if name.contains('/') || name.contains('\\') || name.contains(':') {
+        return Err(native_error(
+            "EINVAL",
+            "clone destination must be a direct-child basename",
+        ));
+    }
+    Ok(())
+}
+
+#[napi(js_name = "probeTreeClone")]
+pub fn probe_tree_clone(env: Env, parent_fd: i32) -> Result<Option<String>> {
+    into_napi(env, backend::probe(parent_fd))
+}
+
+pub struct CloneTreeTask {
+    source_fd: Option<i32>,
+    parent_fd: i32,
+    basename: String,
+    concurrency: usize,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl Task for CloneTreeTask {
+    type Output = NativeResult<()>;
+    type JsValue = ();
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        if self.cancelled.load(Ordering::Relaxed) {
+            return Ok(Err(native_error("ABORT_ERR", "tree clone aborted")));
+        }
+        Ok(match self.source_fd {
+            Some(source) => backend::clone_tree(
+                source,
+                self.parent_fd,
+                &self.basename,
+                &self.cancelled,
+                self.concurrency,
+            ),
+            None => backend::create_source(self.parent_fd, &self.basename),
+        })
+    }
+
+    fn resolve(&mut self, env: Env, output: Self::Output) -> Result<()> {
+        output.map_err(|error| Error::from(JsError::from(error).into_unknown(env)))
+    }
+}
+
+#[napi(js_name = "cloneTree")]
+pub fn clone_tree(
+    source_fd: Option<i32>,
+    parent_fd: i32,
+    name: String,
+    concurrency: u32,
+    signal: Option<AbortSignal>,
+) -> Result<AsyncTask<CloneTreeTask>> {
+    basename(&name).map_err(|error| Error::new(Status::InvalidArg, error.reason))?;
+    if !(1..=32).contains(&concurrency) {
+        return Err(Error::new(
+            Status::InvalidArg,
+            "clone concurrency must be between 1 and 32",
+        ));
+    }
+    let cancelled = Arc::new(AtomicBool::new(false));
+    if let Some(signal) = &signal {
+        let flag = Arc::clone(&cancelled);
+        signal.on_abort(move || flag.store(true, Ordering::Relaxed));
+    }
+    // Do not give AsyncTask the signal: early rejection would close the borrowed
+    // descriptors while native workers still use them. JS waits for settlement.
+    Ok(AsyncTask::new(CloneTreeTask {
+        source_fd,
+        parent_fd,
+        basename: name,
+        concurrency: concurrency as usize,
+        cancelled,
+    }))
+}

--- a/native/src/clone_unix.rs
+++ b/native/src/clone_unix.rs
@@ -1,0 +1,156 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::unix::{borrowed, os_error, validate_child_basename};
+use crate::{NativeResult, native_error};
+
+pub fn probe(parent_fd: i32) -> NativeResult<Option<String>> {
+    let stats = rustix::fs::fstatfs(borrowed(parent_fd))
+        .map_err(|error| os_error(error, "inspect clone filesystem"))?;
+    #[cfg(target_os = "linux")]
+    let supported = (stats.f_type as u64 == 0x9123_683e).then_some("btrfs");
+    #[cfg(target_os = "macos")]
+    let supported = stats.f_fstypename[..5]
+        .iter()
+        .map(|&value| value as u8)
+        .eq(b"apfs\0".iter().copied())
+        .then_some("apfs");
+    Ok(supported.map(str::to_owned))
+}
+
+fn require_supported(parent_fd: i32) -> NativeResult<()> {
+    if probe(parent_fd)?.is_none() {
+        return Err(native_error(
+            "ENOTSUP",
+            "directory cloning is unavailable on this filesystem",
+        ));
+    }
+    Ok(())
+}
+
+fn check_cancelled(cancelled: &AtomicBool) -> NativeResult<()> {
+    if cancelled.load(Ordering::Relaxed) {
+        return Err(native_error("Cancelled", "directory cloning aborted"));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[repr(C)]
+struct BtrfsVolumeArgs {
+    fd: i64,
+    name: [u8; 4088],
+}
+
+#[cfg(target_os = "linux")]
+const _: () = assert!(std::mem::size_of::<BtrfsVolumeArgs>() == 4096);
+
+#[cfg(target_os = "linux")]
+fn btrfs_mutation<const OPCODE: rustix::ioctl::Opcode>(
+    parent_fd: i32,
+    basename: &str,
+    source_fd: i32,
+) -> NativeResult<()> {
+    validate_child_basename(basename)?;
+    let mut args = BtrfsVolumeArgs {
+        fd: i64::from(source_fd),
+        name: [0; 4088],
+    };
+    if basename.len() >= args.name.len() {
+        return Err(native_error(
+            "ENAMETOOLONG",
+            "clone destination basename is too long",
+        ));
+    }
+    args.name[..basename.len()].copy_from_slice(basename.as_bytes());
+    // Linux uapi/linux/btrfs.h: SNAP_CREATE and SUBVOL_CREATE take the same
+    // 4096-byte btrfs_ioctl_vol_args. The kernel creates one exclusive child.
+    unsafe {
+        rustix::ioctl::ioctl(
+            borrowed(parent_fd),
+            rustix::ioctl::Setter::<OPCODE, BtrfsVolumeArgs>::new(args),
+        )
+    }
+    .map_err(|error| os_error(error, "create Btrfs clone directory"))
+}
+
+pub fn create_source(parent_fd: i32, basename: &str) -> NativeResult<()> {
+    validate_child_basename(basename)?;
+    require_supported(parent_fd)?;
+    #[cfg(target_os = "linux")]
+    {
+        const CREATE: rustix::ioctl::Opcode =
+            rustix::ioctl::opcode::write::<BtrfsVolumeArgs>(0x94, 14);
+        btrfs_mutation::<CREATE>(parent_fd, basename, 0)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        rustix::fs::mkdirat(
+            borrowed(parent_fd),
+            basename,
+            rustix::fs::Mode::from_bits_retain(0o700),
+        )
+        .map_err(|error| os_error(error, "create clone source directory"))
+    }
+}
+
+pub fn clone_tree(
+    source_fd: i32,
+    parent_fd: i32,
+    basename: &str,
+    cancelled: &AtomicBool,
+    _concurrency: usize,
+) -> NativeResult<()> {
+    validate_child_basename(basename)?;
+    check_cancelled(cancelled)?;
+    require_supported(parent_fd)?;
+    require_supported(source_fd)?;
+    let source = rustix::fs::fstat(borrowed(source_fd))
+        .map_err(|error| os_error(error, "inspect clone source"))?;
+    if !rustix::fs::FileType::from_raw_mode(source.st_mode).is_dir() {
+        return Err(native_error("ENOTDIR", "clone source must be a directory"));
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // Btrfs assigns inode 256 to subvolume roots. Snapshotting an ordinary
+        // directory must fail rather than silently changing the operation.
+        if source.st_ino != 256 {
+            return Err(native_error(
+                "ENOTSUP",
+                "Btrfs directory cloning requires a subvolume source",
+            ));
+        }
+        const SNAPSHOT: rustix::ioctl::Opcode =
+            rustix::ioctl::opcode::write::<BtrfsVolumeArgs>(0x94, 1);
+        check_cancelled(cancelled)?;
+        btrfs_mutation::<SNAPSHOT>(parent_fd, basename, source_fd)?;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let name = std::ffi::CString::new(basename)
+            .map_err(|_| native_error("EINVAL", "clone destination contains a NUL byte"))?;
+        // sys/clonefile.h: preserve literal symlinks and source ACLs. Both
+        // descriptors remain pinned by the caller until this operation settles.
+        const CLONE_NOFOLLOW: u32 = 0x0001;
+        const CLONE_ACL: u32 = 0x0004;
+        check_cancelled(cancelled)?;
+        if unsafe {
+            libc::fclonefileat(
+                source_fd,
+                parent_fd,
+                name.as_ptr(),
+                CLONE_NOFOLLOW | CLONE_ACL,
+            )
+        } != 0
+        {
+            let error = rustix::io::Errno::from_raw_os_error(
+                std::io::Error::last_os_error()
+                    .raw_os_error()
+                    .unwrap_or(libc::EIO),
+            );
+            return Err(os_error(error, "clone APFS directory"));
+        }
+    }
+    // These bulk operations cannot be interrupted once dispatched. Report
+    // cancellation only after their writes settle; recovery may then proceed.
+    check_cancelled(cancelled)
+}

--- a/native/src/clone_windows.rs
+++ b/native/src/clone_windows.rs
@@ -1,0 +1,751 @@
+use std::ffi::c_void;
+use std::mem::{size_of, size_of_val};
+use std::ptr::{null, null_mut};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
+
+use windows_sys::Win32::Foundation::{
+    DUPLICATE_SAME_ACCESS, DuplicateHandle, ERROR_HANDLE_EOF, ERROR_MORE_DATA, GetLastError, HANDLE,
+};
+use windows_sys::Win32::Storage::FileSystem::{
+    BY_HANDLE_FILE_INFORMATION, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_NORMAL,
+    FILE_ATTRIBUTE_REPARSE_POINT, FILE_BASIC_INFO, FILE_END_OF_FILE_INFO, FILE_GENERIC_READ,
+    FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_STREAM_INFO, FileBasicInfo,
+    FileEndOfFileInfo, FileStreamInfo, GetFileInformationByHandle, GetFileInformationByHandleEx,
+    GetVolumeInformationByHandleW, SetFileInformationByHandle,
+};
+use windows_sys::Win32::System::IO::DeviceIoControl;
+use windows_sys::Win32::System::Ioctl::{
+    DUPLICATE_EXTENTS_DATA, FSCTL_DUPLICATE_EXTENTS_TO_FILE, FSCTL_GET_INTEGRITY_INFORMATION,
+    FSCTL_GET_INTEGRITY_INFORMATION_BUFFER, FSCTL_GET_REPARSE_POINT,
+    FSCTL_SET_INTEGRITY_INFORMATION, FSCTL_SET_INTEGRITY_INFORMATION_BUFFER,
+    FSCTL_SET_REPARSE_POINT, FSCTL_SET_SPARSE,
+};
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+use crate::windows::{
+    OwnedHandle, ReparsePolicy, handle_identity, handle_is_reparse, list_directory_entries,
+    mark_handle_for_deletion, nt_open_relative_with_policy, nt_open_relative_with_sharing,
+    remove_directory_handle, root_handle, win_error,
+};
+use crate::{NativeResult, native_error};
+
+const DELETE_ACCESS: u32 = 0x0001_0000;
+const FILE_OPEN: u32 = 1;
+const FILE_CREATE: u32 = 2;
+const FILE_DIRECTORY_FILE: u32 = 1;
+const FILE_NO_INTERMEDIATE_BUFFERING: u32 = 8;
+const FILE_SUPPORTS_BLOCK_REFCOUNTING: u32 = 0x0800_0000;
+const IO_REPARSE_TAG_MOUNT_POINT: u32 = 0xa000_0003;
+const IO_REPARSE_TAG_SYMLINK: u32 = 0xa000_000c;
+
+// Windows permits concurrent handle-relative opens. Each directory is enumerated by
+// exactly one producer; workers only use these handles as pinned parent capabilities.
+struct Directory(OwnedHandle);
+unsafe impl Send for Directory {}
+unsafe impl Sync for Directory {}
+
+struct FileJob {
+    source_parent: Arc<Directory>,
+    target_parent: Arc<Directory>,
+    name: String,
+    attributes: u32,
+    file_id: u64,
+    volume: u32,
+}
+
+fn check_cancelled(cancelled: &AtomicBool) -> NativeResult<()> {
+    if cancelled.load(Ordering::Acquire) {
+        Err(native_error("ABORT_ERR", "directory clone was cancelled"))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_basename(name: &str) -> NativeResult<()> {
+    crate::validate_relative_path(name, false)?;
+    if name.contains(['/', '\\', ':']) {
+        return Err(native_error("EINVAL", "clone requires a direct child name"));
+    }
+    Ok(())
+}
+
+fn is_refs(handle: HANDLE) -> NativeResult<bool> {
+    let mut filesystem = [0_u16; 32];
+    let mut flags = 0;
+    if unsafe {
+        GetVolumeInformationByHandleW(
+            handle,
+            null_mut(),
+            0,
+            null_mut(),
+            null_mut(),
+            &mut flags,
+            filesystem.as_mut_ptr(),
+            filesystem.len() as u32,
+        )
+    } == 0
+    {
+        return Err(win_error(unsafe { GetLastError() }, "inspect clone volume"));
+    }
+    let end = filesystem
+        .iter()
+        .position(|unit| *unit == 0)
+        .unwrap_or(filesystem.len());
+    Ok(
+        String::from_utf16_lossy(&filesystem[..end]).eq_ignore_ascii_case("ReFS")
+            && flags & FILE_SUPPORTS_BLOCK_REFCOUNTING != 0,
+    )
+}
+
+pub(crate) fn probe(parent_fd: i32) -> NativeResult<Option<String>> {
+    Ok(is_refs(root_handle(parent_fd)?)?.then(|| "refs".to_owned()))
+}
+
+fn create_directory(parent: HANDLE, name: &str) -> NativeResult<Arc<Directory>> {
+    validate_basename(name)?;
+    let directory = nt_open_relative_with_policy(
+        parent,
+        name,
+        FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE_ACCESS,
+        FILE_CREATE,
+        FILE_DIRECTORY_FILE,
+        ReparsePolicy::Reject,
+    )?;
+    Ok(Arc::new(Directory(directory)))
+}
+
+pub(crate) fn create_source(parent_fd: i32, basename: &str) -> NativeResult<()> {
+    let parent = root_handle(parent_fd)?;
+    if !is_refs(parent)? {
+        return Err(native_error("ENOTSUP", "directory cloning requires ReFS"));
+    }
+    create_directory(parent, basename)?;
+    Ok(())
+}
+
+fn file_information(handle: HANDLE) -> NativeResult<BY_HANDLE_FILE_INFORMATION> {
+    let mut info = BY_HANDLE_FILE_INFORMATION::default();
+    if unsafe { GetFileInformationByHandle(handle, &mut info) } == 0 {
+        return Err(win_error(unsafe { GetLastError() }, "inspect clone source"));
+    }
+    Ok(info)
+}
+
+fn metadata(handle: HANDLE) -> NativeResult<FILE_BASIC_INFO> {
+    let mut info = FILE_BASIC_INFO::default();
+    if unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileBasicInfo,
+            (&mut info as *mut FILE_BASIC_INFO).cast(),
+            size_of::<FILE_BASIC_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(win_error(unsafe { GetLastError() }, "read clone metadata"));
+    }
+    Ok(info)
+}
+
+fn reject_named_streams(handle: HANDLE) -> NativeResult<()> {
+    // The unnamed stream fits easily; a larger response necessarily contains a
+    // named stream. Refuse it instead of silently discarding application data.
+    let mut storage = [0_u64; 64];
+    if unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileStreamInfo,
+            storage.as_mut_ptr().cast(),
+            size_of_val(&storage) as u32,
+        )
+    } == 0
+    {
+        let error = unsafe { GetLastError() };
+        if error == ERROR_HANDLE_EOF {
+            return Ok(());
+        }
+        if error == ERROR_MORE_DATA {
+            return Err(native_error(
+                "ENOTSUP",
+                "clone does not support named data streams",
+            ));
+        }
+        return Err(win_error(error, "inspect clone data streams"));
+    }
+    let info = unsafe { &*storage.as_ptr().cast::<FILE_STREAM_INFO>() };
+    if info.StreamNameLength == 0 && info.NextEntryOffset == 0 {
+        return Ok(());
+    }
+    let name = [
+        b':' as u16,
+        b':' as u16,
+        b'$' as u16,
+        b'D' as u16,
+        b'A' as u16,
+        b'T' as u16,
+        b'A' as u16,
+    ];
+    let name_offset = std::mem::offset_of!(FILE_STREAM_INFO, StreamName);
+    if info.NextEntryOffset != 0 || info.StreamNameLength as usize != name.len() * 2 {
+        return Err(native_error(
+            "ENOTSUP",
+            "clone does not support named data streams",
+        ));
+    }
+    let actual = unsafe {
+        std::slice::from_raw_parts(
+            storage.as_ptr().cast::<u8>().add(name_offset).cast::<u16>(),
+            name.len(),
+        )
+    };
+    if actual != name {
+        return Err(native_error(
+            "ENOTSUP",
+            "clone does not support named data streams",
+        ));
+    }
+    Ok(())
+}
+
+fn set_metadata(handle: HANDLE, mut info: FILE_BASIC_INFO) -> NativeResult<()> {
+    // Sparse, integrity and reparse attributes belong to their respective FSCTLs.
+    info.FileAttributes &= 0x3127;
+    if info.FileAttributes == 0 {
+        info.FileAttributes = FILE_ATTRIBUTE_NORMAL;
+    }
+    info.ChangeTime = 0;
+    if unsafe {
+        SetFileInformationByHandle(
+            handle,
+            FileBasicInfo,
+            (&info as *const FILE_BASIC_INFO).cast(),
+            size_of::<FILE_BASIC_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(win_error(
+            unsafe { GetLastError() },
+            "preserve clone metadata",
+        ));
+    }
+    Ok(())
+}
+
+fn control(
+    handle: HANDLE,
+    code: u32,
+    input: *const c_void,
+    input_size: u32,
+    output: *mut c_void,
+    output_size: u32,
+) -> NativeResult<u32> {
+    let mut returned = 0;
+    // All callers pass initialized buffers whose lifetimes cover this synchronous call.
+    if unsafe {
+        DeviceIoControl(
+            handle,
+            code,
+            input,
+            input_size,
+            output,
+            output_size,
+            &mut returned,
+            null_mut(),
+        )
+    } == 0
+    {
+        return Err(win_error(
+            unsafe { GetLastError() },
+            &format!("clone control {code:#x}"),
+        ));
+    }
+    Ok(returned)
+}
+
+fn open_source(job: &FileJob) -> NativeResult<(OwnedHandle, BY_HANDLE_FILE_INFORMATION)> {
+    let is_reparse = job.attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0;
+    let is_directory = job.attributes & FILE_ATTRIBUTE_DIRECTORY != 0;
+    // Denying write sharing rejects existing writers and excludes new writers
+    // until the extent clone settles; timestamps alone cannot establish stability.
+    let source = nt_open_relative_with_sharing(
+        job.source_parent.0.0,
+        &job.name,
+        FILE_GENERIC_READ,
+        FILE_OPEN,
+        if !is_reparse && !is_directory {
+            FILE_NO_INTERMEDIATE_BUFFERING
+        } else {
+            0
+        },
+        ReparsePolicy::AllowLeaf,
+        FILE_SHARE_READ | FILE_SHARE_DELETE,
+    )?;
+    let information = file_information(source.0)?;
+    let identity = (
+        information.dwVolumeSerialNumber,
+        ((information.nFileIndexHigh as u64) << 32) | information.nFileIndexLow as u64,
+        information.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY != 0,
+    );
+    if identity != (job.volume, job.file_id, is_directory)
+        || (information.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0) != is_reparse
+    {
+        return Err(native_error(
+            "path-mismatch",
+            "clone source changed while opening",
+        ));
+    }
+    Ok((source, information))
+}
+
+fn clone_reparse(source: HANDLE, target: HANDLE) -> NativeResult<()> {
+    let mut data = [0_u8; 16 * 1024];
+    let count = control(
+        source,
+        FSCTL_GET_REPARSE_POINT,
+        null(),
+        0,
+        data.as_mut_ptr().cast(),
+        data.len() as u32,
+    )?;
+    if count < 8 || count as usize > data.len() {
+        return Err(native_error("EIO", "invalid clone reparse data"));
+    }
+    let tag = u32::from_le_bytes(data[..4].try_into().unwrap());
+    if !matches!(tag, IO_REPARSE_TAG_SYMLINK | IO_REPARSE_TAG_MOUNT_POINT) {
+        return Err(native_error(
+            "ENOTSUP",
+            "clone supports only symlink and junction reparse points",
+        ));
+    }
+    control(
+        target,
+        FSCTL_SET_REPARSE_POINT,
+        data.as_ptr().cast(),
+        count,
+        null_mut(),
+        0,
+    )?;
+    Ok(())
+}
+
+fn clone_file(job: FileJob, cancelled: &AtomicBool) -> NativeResult<()> {
+    check_cancelled(cancelled)?;
+    let (source, information) = open_source(&job)?;
+    reject_named_streams(source.0)?;
+    let before = metadata(source.0)?;
+    let reparse = information.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0;
+    let target = nt_open_relative_with_policy(
+        job.target_parent.0.0,
+        &job.name,
+        FILE_GENERIC_READ | FILE_GENERIC_WRITE | DELETE_ACCESS,
+        FILE_CREATE,
+        if information.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY != 0 {
+            FILE_DIRECTORY_FILE
+        } else {
+            0
+        },
+        ReparsePolicy::Reject,
+    )?;
+    if reparse {
+        clone_reparse(source.0, target.0)?;
+    } else {
+        let mut integrity = FSCTL_GET_INTEGRITY_INFORMATION_BUFFER::default();
+        control(
+            source.0,
+            FSCTL_GET_INTEGRITY_INFORMATION,
+            null(),
+            0,
+            (&mut integrity as *mut FSCTL_GET_INTEGRITY_INFORMATION_BUFFER).cast(),
+            size_of::<FSCTL_GET_INTEGRITY_INFORMATION_BUFFER>() as u32,
+        )?;
+        let settings = FSCTL_SET_INTEGRITY_INFORMATION_BUFFER {
+            ChecksumAlgorithm: integrity.ChecksumAlgorithm,
+            Reserved: 0,
+            Flags: integrity.Flags,
+        };
+        control(
+            target.0,
+            FSCTL_SET_INTEGRITY_INFORMATION,
+            (&settings as *const FSCTL_SET_INTEGRITY_INFORMATION_BUFFER).cast(),
+            size_of::<FSCTL_SET_INTEGRITY_INFORMATION_BUFFER>() as u32,
+            null_mut(),
+            0,
+        )?;
+        control(target.0, FSCTL_SET_SPARSE, null(), 0, null_mut(), 0)?;
+        let size = ((information.nFileSizeHigh as u64) << 32) | information.nFileSizeLow as u64;
+        let cluster = u64::from(integrity.ClusterSizeInBytes);
+        if !cluster.is_power_of_two() || cluster > 0x8000_0000 {
+            return Err(native_error("EIO", "invalid ReFS clone cluster size"));
+        }
+        let rounded = size
+            .checked_add(cluster - 1)
+            .map(|value| value / cluster * cluster)
+            .filter(|value| *value <= i64::MAX as u64)
+            .ok_or_else(|| native_error("EFBIG", "clone size exceeds Windows range"))?;
+        let eof = FILE_END_OF_FILE_INFO {
+            EndOfFile: size as i64,
+        };
+        if unsafe {
+            SetFileInformationByHandle(
+                target.0,
+                FileEndOfFileInfo,
+                (&eof as *const FILE_END_OF_FILE_INFO).cast(),
+                size_of::<FILE_END_OF_FILE_INFO>() as u32,
+            )
+        } == 0
+        {
+            return Err(win_error(
+                unsafe { GetLastError() },
+                "set clone file length",
+            ));
+        }
+        // ReFS permits the final partial cluster beyond EOF while retaining the exact
+        // logical file size. Each request remains below the API's 4 GiB limit.
+        let mut offset = 0;
+        while offset < size {
+            check_cancelled(cancelled)?;
+            let length = (rounded - offset).min(0x8000_0000);
+            let request = DUPLICATE_EXTENTS_DATA {
+                FileHandle: source.0,
+                SourceFileOffset: offset as i64,
+                TargetFileOffset: offset as i64,
+                ByteCount: length as i64,
+            };
+            control(
+                target.0,
+                FSCTL_DUPLICATE_EXTENTS_TO_FILE,
+                (&request as *const DUPLICATE_EXTENTS_DATA).cast(),
+                size_of::<DUPLICATE_EXTENTS_DATA>() as u32,
+                null_mut(),
+                0,
+            )?;
+            offset += length;
+        }
+    }
+    let after = metadata(source.0)?;
+    let final_information = file_information(source.0)?;
+    if before.LastWriteTime != after.LastWriteTime
+        || before.ChangeTime != after.ChangeTime
+        || information.nFileSizeHigh != final_information.nFileSizeHigh
+        || information.nFileSizeLow != final_information.nFileSizeLow
+    {
+        return Err(native_error(
+            "path-mismatch",
+            "clone source changed while cloning",
+        ));
+    }
+    set_metadata(target.0, before)
+}
+
+fn copy_tree(
+    source: Arc<Directory>,
+    target: Arc<Directory>,
+    cancelled: &AtomicBool,
+    concurrency: usize,
+) -> NativeResult<()> {
+    let concurrency = concurrency.clamp(1, 32);
+    let (sender, receiver) = mpsc::sync_channel::<FileJob>(concurrency * 4);
+    let receiver = Mutex::new(receiver);
+    let failed = AtomicBool::new(false);
+    let first_error = Mutex::new(None);
+    let mut directories = Vec::new();
+    std::thread::scope(|scope| -> NativeResult<()> {
+        let mut workers = Vec::new();
+        for _ in 0..concurrency {
+            workers.push(scope.spawn(|| {
+                loop {
+                    let job = receiver.lock().unwrap().recv();
+                    let Ok(job) = job else {
+                        break;
+                    };
+                    if failed.load(Ordering::Acquire) {
+                        continue;
+                    }
+                    if let Err(error) = clone_file(job, cancelled) {
+                        failed.store(true, Ordering::Release);
+                        first_error.lock().unwrap().get_or_insert(error);
+                    }
+                }
+            }));
+        }
+        let traversal: NativeResult<()> = (|| {
+            let mut pending = vec![(source, target)];
+            while let Some((source, target)) = pending.pop() {
+                check_cancelled(cancelled)?;
+                if failed.load(Ordering::Acquire) {
+                    break;
+                }
+                let info = metadata(source.0.0)?;
+                reject_named_streams(source.0.0)?;
+                let volume = handle_identity(source.0.0)?.0;
+                for (name, attributes, file_id) in list_directory_entries(source.0.0)? {
+                    check_cancelled(cancelled)?;
+                    if failed.load(Ordering::Acquire) {
+                        break;
+                    }
+                    validate_basename(&name)?;
+                    let job = FileJob {
+                        source_parent: source.clone(),
+                        target_parent: target.clone(),
+                        name,
+                        attributes,
+                        file_id,
+                        volume,
+                    };
+                    if attributes & FILE_ATTRIBUTE_DIRECTORY != 0
+                        && attributes & FILE_ATTRIBUTE_REPARSE_POINT == 0
+                    {
+                        let child = Arc::new(Directory(open_source(&job)?.0));
+                        let destination = create_directory(target.0.0, &job.name)?;
+                        pending.push((child, destination));
+                    } else {
+                        sender
+                            .send(job)
+                            .map_err(|_| native_error("EIO", "clone worker queue closed"))?;
+                    }
+                }
+                directories.push((target, info));
+            }
+            Ok(())
+        })();
+        if traversal.is_err() {
+            failed.store(true, Ordering::Release);
+        }
+        drop(sender);
+        // All writes must settle before cancellation or error becomes visible to JS.
+        for worker in workers {
+            worker
+                .join()
+                .map_err(|_| native_error("EIO", "clone worker panicked"))?;
+        }
+        traversal?;
+        if let Some(error) = first_error.lock().unwrap().take() {
+            return Err(error);
+        }
+        check_cancelled(cancelled)?;
+        for (directory, info) in directories.into_iter().rev() {
+            check_cancelled(cancelled)?;
+            set_metadata(directory.0.0, info)?;
+        }
+        Ok(())
+    })
+}
+
+pub(crate) fn clone_tree(
+    source_fd: i32,
+    parent_fd: i32,
+    basename: &str,
+    cancelled: &AtomicBool,
+    concurrency: usize,
+) -> NativeResult<()> {
+    validate_basename(basename)?;
+    check_cancelled(cancelled)?;
+    let source_handle = root_handle(source_fd)?;
+    let parent_handle = root_handle(parent_fd)?;
+    let source_identity = handle_identity(source_handle)?;
+    let parent_identity = handle_identity(parent_handle)?;
+    if !source_identity.2
+        || !parent_identity.2
+        || handle_is_reparse(source_handle)?
+        || handle_is_reparse(parent_handle)?
+    {
+        return Err(native_error(
+            "ENOTDIR",
+            "clone requires pinned ordinary directories",
+        ));
+    }
+    if source_identity.0 != parent_identity.0 {
+        return Err(native_error("EXDEV", "ReFS clone requires the same volume"));
+    }
+    if !is_refs(parent_handle)? {
+        return Err(native_error("ENOTSUP", "directory cloning requires ReFS"));
+    }
+    // The facade gives this operation its own pinned directory descriptor. Duplicate
+    // its ownership for the worker scope without re-resolving any source pathname.
+    let process = unsafe { GetCurrentProcess() };
+    let mut source = null_mut();
+    if unsafe {
+        DuplicateHandle(
+            process,
+            source_handle,
+            process,
+            &mut source,
+            0,
+            0,
+            DUPLICATE_SAME_ACCESS,
+        )
+    } == 0
+    {
+        return Err(win_error(
+            unsafe { GetLastError() },
+            "duplicate pinned clone source",
+        ));
+    }
+    let source = Arc::new(Directory(OwnedHandle(source)));
+    let target = create_directory(parent_handle, basename)?;
+    if let Err(error) = copy_tree(source, target.clone(), cancelled, concurrency) {
+        let cleanup =
+            remove_directory_handle(target.0.0).and_then(|()| mark_handle_for_deletion(target.0.0));
+        return match cleanup {
+            Ok(()) => Err(error),
+            Err(cleanup) => Err(native_error(
+                error.status,
+                format!("{}; remove partial clone: {}", error.reason, cleanup.reason),
+            )),
+        };
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File, OpenOptions};
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use windows_sys::Win32::Storage::FileSystem::{FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_WRITE};
+    use windows_sys::Win32::System::Ioctl::FSCTL_GET_RETRIEVAL_POINTERS;
+
+    fn directory(path: &Path) -> File {
+        OpenOptions::new()
+            .read(true)
+            .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+            .open(path)
+            .unwrap()
+    }
+
+    fn descriptor(file: &File) -> i32 {
+        // Unit tests run without Node/libuv. The shared Windows resolver accepts
+        // direct HANDLEs, as it does for other native Windows boundary tests.
+        i32::try_from(file.as_raw_handle() as isize).unwrap()
+    }
+
+    fn marker(path: &Path, offset: u64) -> [u8; 16] {
+        let mut file = File::open(path).unwrap();
+        file.seek(SeekFrom::Start(offset)).unwrap();
+        let mut bytes = [0_u8; 16];
+        file.read_exact(&mut bytes).unwrap();
+        bytes
+    }
+
+    fn first_extent(file: &File) -> i64 {
+        let vcn = 0_i64;
+        let mut output = [0_u64; 64];
+        let bytes = control(
+            file.as_raw_handle(),
+            FSCTL_GET_RETRIEVAL_POINTERS,
+            (&vcn as *const i64).cast(),
+            size_of::<i64>() as u32,
+            output.as_mut_ptr().cast(),
+            size_of_val(&output) as u32,
+        )
+        .unwrap();
+        assert!(bytes >= 32);
+        // RETRIEVAL_POINTERS_BUFFER: count/padding, starting VCN, next VCN, LCN.
+        let lcn = output[3] as i64;
+        assert!(lcn >= 0, "the leading marker must have an allocated extent");
+        lcn
+    }
+
+    #[test]
+    fn refs_tree_clones_large_sparse_files_and_rejects_lossy_sources() {
+        let explicit = std::env::var_os("FS_SAFE_CLONE_TEST_ROOT");
+        let base =
+            fs::canonicalize(explicit.clone().map_or_else(std::env::temp_dir, Into::into)).unwrap();
+        let base_handle = directory(&base);
+        if !is_refs(base_handle.as_raw_handle()).unwrap() {
+            assert!(explicit.is_none(), "FS_SAFE_CLONE_TEST_ROOT requires ReFS");
+            eprintln!("ReFS unavailable; set FS_SAFE_CLONE_TEST_ROOT to exercise the sparse clone");
+            return;
+        }
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = base.join(format!(
+            "fs-safe-refs-native-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir(&root).unwrap();
+        let owned = fs::canonicalize(&root).unwrap();
+        assert_eq!(owned.parent(), Some(base.as_path()));
+        {
+            let parent = directory(&root);
+            let parent_fd = descriptor(&parent);
+            create_source(parent_fd, "source").unwrap();
+            let source_path = root.join("source");
+            let source = directory(&source_path);
+            let source_fd = descriptor(&source);
+            let source_file = source_path.join("large");
+            let size = 0x8000_0000_u64 + 4097;
+            let offsets = [0, 0x8000_0000 - 16, size - 16];
+            {
+                let mut file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create_new(true)
+                    .open(&source_file)
+                    .unwrap();
+                control(
+                    file.as_raw_handle(),
+                    FSCTL_SET_SPARSE,
+                    null(),
+                    0,
+                    null_mut(),
+                    0,
+                )
+                .unwrap();
+                file.set_len(size).unwrap();
+                for (index, offset) in offsets.into_iter().enumerate() {
+                    file.seek(SeekFrom::Start(offset)).unwrap();
+                    file.write_all(&[17 + index as u8; 16]).unwrap();
+                }
+            }
+            let cancelled = AtomicBool::new(false);
+            clone_tree(source_fd, parent_fd, "copy", &cancelled, 8).unwrap();
+            let copied = root.join("copy/large");
+            assert_eq!(fs::metadata(&copied).unwrap().len(), size);
+            assert_eq!(
+                fs::metadata(&copied).unwrap().modified().unwrap(),
+                fs::metadata(&source_file).unwrap().modified().unwrap()
+            );
+            for offset in offsets {
+                assert_eq!(marker(&copied, offset), marker(&source_file, offset));
+            }
+            assert_eq!(
+                first_extent(&File::open(&copied).unwrap()),
+                first_extent(&File::open(&source_file).unwrap())
+            );
+            {
+                let mut file = OpenOptions::new().write(true).open(&copied).unwrap();
+                file.seek(SeekFrom::Start(size - 16)).unwrap();
+                file.write_all(&[99; 16]).unwrap();
+            }
+            assert_eq!(marker(&source_file, size - 16), [19; 16]);
+            assert_eq!(marker(&copied, size - 16), [99; 16]);
+            {
+                let _writer = OpenOptions::new().write(true).open(&source_file).unwrap();
+                let error =
+                    clone_tree(source_fd, parent_fd, "writer-copy", &cancelled, 8).unwrap_err();
+                assert!(error.reason.contains("Windows error 32"), "{error}");
+            }
+            assert!(!root.join("writer-copy").exists());
+            let named = source_path.join("large:metadata");
+            fs::write(&named, b"named stream data").unwrap();
+            let error = clone_tree(source_fd, parent_fd, "ads-copy", &cancelled, 8).unwrap_err();
+            assert_eq!(error.status, "ENOTSUP");
+            assert!(!root.join("ads-copy").exists());
+            assert_eq!(fs::read(&named).unwrap(), b"named stream data");
+            assert_eq!(marker(&source_file, size - 16), [19; 16]);
+        }
+        // Only this test's exclusively created, still-identical directory is disposable.
+        assert_eq!(fs::canonicalize(&root).unwrap(), owned);
+        assert_eq!(owned.parent(), Some(base.as_path()));
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -6,6 +6,12 @@ use napi_derive::napi;
 mod archive;
 mod archive_gzip;
 mod fast_file;
+mod clone_tree;
+mod clone_metadata;
+#[cfg(unix)]
+mod clone_unix;
+#[cfg(windows)]
+mod clone_windows;
 mod owned_tree;
 #[cfg(unix)]
 mod staged_file;

--- a/native/src/windows.rs
+++ b/native/src/windows.rs
@@ -136,7 +136,7 @@ unsafe extern "C" fn ignore_invalid_parameter(
 ) {
 }
 
-struct OwnedHandle(HANDLE);
+pub(crate) struct OwnedHandle(pub(crate) HANDLE);
 
 impl Drop for OwnedHandle {
     fn drop(&mut self) {
@@ -155,7 +155,7 @@ impl OwnedHandle {
     }
 }
 
-fn root_handle(fd: i32) -> NativeResult<HANDLE> {
+pub(crate) fn root_handle(fd: i32) -> NativeResult<HANDLE> {
     let direct = fd as usize as HANDLE;
     // Node/libuv may expose a Windows HANDLE directly rather than a UCRT fd.
     // Probe that representation first with a non-destructive handle query.
@@ -229,7 +229,7 @@ fn wide_relative(path: &str) -> NativeResult<Vec<u16>> {
     Ok(wide)
 }
 
-fn win_error(code: u32, operation: &str) -> napi::Error<String> {
+pub(crate) fn win_error(code: u32, operation: &str) -> napi::Error<String> {
     let typed = match code {
         ERROR_FILE_EXISTS | ERROR_ALREADY_EXISTS => "EEXIST",
         ERROR_FILE_NOT_FOUND | ERROR_PATH_NOT_FOUND => "ENOENT",
@@ -250,7 +250,7 @@ fn nt_error(status: i32, operation: &str) -> napi::Error<String> {
     win_error(unsafe { RtlNtStatusToDosError(status) }, operation)
 }
 
-fn handle_is_reparse(handle: HANDLE) -> NativeResult<bool> {
+pub(crate) fn handle_is_reparse(handle: HANDLE) -> NativeResult<bool> {
     // SAFETY: info is a valid output buffer for the supplied class.
     let mut info: FILE_ATTRIBUTE_TAG_INFO = unsafe { zeroed() };
     let ok = unsafe {
@@ -278,7 +278,7 @@ fn assert_not_reparse(handle: HANDLE) -> NativeResult<()> {
     Ok(())
 }
 
-enum ReparsePolicy {
+pub(crate) enum ReparsePolicy {
     Reject,
     AllowLeaf,
 }
@@ -300,13 +300,28 @@ fn nt_open_relative(
     )
 }
 
-fn nt_open_relative_with_policy(
+pub(crate) fn nt_open_relative_with_policy(
     root: HANDLE,
     path: &str,
     desired_access: u32,
     disposition: u32,
     options: u32,
     reparse_policy: ReparsePolicy,
+) -> NativeResult<OwnedHandle> {
+    nt_open_relative_with_sharing(
+        root, path, desired_access, disposition, options, reparse_policy,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+    )
+}
+
+pub(crate) fn nt_open_relative_with_sharing(
+    root: HANDLE,
+    path: &str,
+    desired_access: u32,
+    disposition: u32,
+    options: u32,
+    reparse_policy: ReparsePolicy,
+    share_access: u32,
 ) -> NativeResult<OwnedHandle> {
     if matches!(reparse_policy, ReparsePolicy::AllowLeaf) {
         crate::validate_relative_path(path, false)?;
@@ -343,7 +358,7 @@ fn nt_open_relative_with_policy(
             &mut io,
             null(),
             0,
-            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            share_access,
             disposition,
             // FILE_OPEN_REPARSE_POINT opens the final entry itself without reparsing.
             options | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT,
@@ -619,7 +634,7 @@ pub fn rename_replace(
     )
 }
 
-fn handle_identity(handle: HANDLE) -> NativeResult<(u32, u64, bool)> {
+pub(crate) fn handle_identity(handle: HANDLE) -> NativeResult<(u32, u64, bool)> {
     // SAFETY: info is a valid output buffer for this API.
     let mut info: BY_HANDLE_FILE_INFORMATION = unsafe { zeroed() };
     if unsafe { GetFileInformationByHandle(handle, &mut info) } == 0 {
@@ -651,7 +666,7 @@ fn same_handle_identity(left: HANDLE, right: HANDLE) -> NativeResult<bool> {
     Ok(left.2 && right.2 && left.0 == right.0 && left.1 == right.1)
 }
 
-fn list_directory_entries(directory: HANDLE) -> NativeResult<Vec<(String, u32, u64)>> {
+pub(crate) fn list_directory_entries(directory: HANDLE) -> NativeResult<Vec<(String, u32, u64)>> {
     let mut entries = Vec::new();
     let mut restart = true;
     loop {
@@ -721,7 +736,7 @@ fn list_directory_entries(directory: HANDLE) -> NativeResult<Vec<(String, u32, u
     Ok(entries)
 }
 
-fn mark_handle_for_deletion(handle: HANDLE) -> NativeResult<()> {
+pub(crate) fn mark_handle_for_deletion(handle: HANDLE) -> NativeResult<()> {
     let info = FILE_DISPOSITION_INFO_EX {
         Flags: FILE_DISPOSITION_FLAG_DELETE
             | FILE_DISPOSITION_FLAG_POSIX_SEMANTICS
@@ -783,7 +798,7 @@ fn remove_directory_handle_with_hook(
     Ok(())
 }
 
-fn remove_directory_handle(directory: HANDLE) -> NativeResult<()> {
+pub(crate) fn remove_directory_handle(directory: HANDLE) -> NativeResult<()> {
     remove_directory_handle_with_hook(directory, &mut |_| {})
 }
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
       "types": "./dist/root.d.ts",
       "default": "./dist/root.js"
     },
+    "./clone": {
+      "types": "./dist/clone.d.ts",
+      "default": "./dist/clone.js"
+    },
     "./config": {
       "types": "./dist/config.d.ts",
       "default": "./dist/config.js"

--- a/scripts/docs-site-navigation.mjs
+++ b/scripts/docs-site-navigation.mjs
@@ -6,7 +6,7 @@ export const sections = [
   ["Root API", ["root.md", "reading.md", "writing.md", "walk.md", "path-scope.md"]],
   ["Atomic & temp", ["atomic.md", "staged-file.md", "durability.md", "output.md", "json.md", "temp.md", "archive.md"]],
   ["Stores", ["store.md", "json-store.md", "file-store.md", "private-file-store.md"]],
-  ["Specialized", ["secret-file.md", "secure-file.md", "permissions.md", "regular-file.md", "sidecar-lock.md", "local-roots.md"]],
+  ["Specialized", ["clone.md", "secret-file.md", "secure-file.md", "permissions.md", "regular-file.md", "sidecar-lock.md", "local-roots.md"]],
   ["Path & filename", ["path.md", "filename.md", "install-path.md"]],
   ["Reference", ["errors.md", "types.md", "public-api.md", "testing.md", "timing.md", "advanced.md", "test-hooks.md", "migrating-to-0.5.md", "migrating-to-0.6.md", "contributing.md"]],
 ];

--- a/src/clone-metadata.ts
+++ b/src/clone-metadata.ts
@@ -1,0 +1,52 @@
+import { assertAbsolutePathInput } from "./absolute-path.js";
+import { requireNativeBinding } from "./native.js";
+
+export type CloneFileMetadata = {
+  dev: number;
+  type: number;
+  mtimeSec: number;
+  mtimeNs: number;
+  ctimeSec: number;
+  ctimeNs: number;
+  uid: number;
+  gid: number;
+  mode: number;
+  ino: bigint;
+  size: bigint;
+  cloneId: bigint;
+};
+
+/** Batched APFS metadata snapshots; absent on unsupported files or filesystems.
+ * These are point-in-time facts, not authorization or a guarantee against later edits.
+ */
+export async function readCloneFileMetadata(
+  files: readonly string[],
+): Promise<(CloneFileMetadata | undefined)[]> {
+  const paths = files.map(assertAbsolutePathInput);
+  const results = await requireNativeBinding().readCloneFileMetadata(paths);
+  return results.map((result) => {
+    if (
+      !result ||
+      result.length !== 100 ||
+      result.readUInt32LE(0) !== 100 ||
+      result.readUInt32LE(4) !== 0x82038c0a ||
+      result.readUInt32LE(16) !== 0x200 ||
+      result.readUInt32LE(20) !== 0x100
+    )
+      return undefined;
+    return {
+      dev: result.readUInt32LE(24),
+      type: result.readUInt32LE(28),
+      mtimeSec: Number(result.readBigInt64LE(32)),
+      mtimeNs: Number(result.readBigInt64LE(40)),
+      ctimeSec: Number(result.readBigInt64LE(48)),
+      ctimeNs: Number(result.readBigInt64LE(56)),
+      uid: result.readUInt32LE(64),
+      gid: result.readUInt32LE(68),
+      mode: result.readUInt32LE(72),
+      ino: result.readBigUInt64LE(76),
+      size: result.readBigUInt64LE(84),
+      cloneId: result.readBigUInt64LE(92),
+    };
+  });
+}

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import path from "node:path";
+import { assertAbsolutePathInput } from "./absolute-path.js";
+import { FsSafeError } from "./errors.js";
+import { getNativeBinding, requireNativeBinding } from "./native.js";
+import { assertStagedDirectoryCurrent, openStagedDirectory } from "./staged-directory.js";
+export { readCloneFileMetadata, type CloneFileMetadata } from "./clone-metadata.js";
+
+export type TreeCloneBackend = "apfs" | "btrfs" | "refs";
+export type CloneTreeOptions = { signal?: AbortSignal; concurrency?: number };
+
+/** Inspect an existing real directory without creating probe files. */
+export function probeTreeClone(parentPath: string): TreeCloneBackend | undefined {
+  const native = getNativeBinding();
+  if (!native) return undefined;
+  const parent = openStagedDirectory(assertAbsolutePathInput(parentPath));
+  try {
+    return native.probeTreeClone(parent.fd) ?? undefined;
+  } finally {
+    fs.closeSync(parent.fd);
+  }
+}
+
+/** Create an empty clone source: a Btrfs subvolume or an ordinary APFS/ReFS directory. */
+export async function createCloneSource(
+  destination: string,
+  options: Pick<CloneTreeOptions, "signal"> = {},
+): Promise<void> {
+  await clone(undefined, destination, options);
+}
+
+/** Clone an immutable, caller-owned tree into an absent destination, without byte-copy fallback. */
+export async function cloneTree(
+  source: string,
+  destination: string,
+  options: CloneTreeOptions = {},
+): Promise<void> {
+  await clone(source, destination, options);
+}
+
+async function clone(
+  source: string | undefined,
+  destination: string,
+  options: CloneTreeOptions,
+): Promise<void> {
+  options.signal?.throwIfAborted();
+  const concurrency = options.concurrency ?? 16;
+  if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 32) {
+    throw new FsSafeError("invalid-path", "clone concurrency must be an integer between 1 and 32");
+  }
+  const native = requireNativeBinding();
+  const target = assertAbsolutePathInput(destination);
+  const name = path.basename(target);
+  if (!name) throw new FsSafeError("invalid-path", "clone destination must name a child directory");
+  const parent = openStagedDirectory(path.dirname(target));
+  let original: ReturnType<typeof openStagedDirectory> | undefined;
+  try {
+    if (!native.probeTreeClone(parent.fd)) {
+      throw new FsSafeError(
+        "unsupported-platform",
+        "destination filesystem does not support tree cloning",
+      );
+    }
+    if (source !== undefined) {
+      original = openStagedDirectory(assertAbsolutePathInput(source));
+      const relative = path.relative(
+        original.receipt.realPath,
+        path.join(parent.receipt.realPath, name),
+      );
+      if (
+        relative === "" ||
+        (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`))
+      ) {
+        throw new FsSafeError("invalid-path", "clone destination must be outside the source tree");
+      }
+      assertStagedDirectoryCurrent(original.receipt);
+    }
+    assertStagedDirectoryCurrent(parent.receipt);
+    options.signal?.throwIfAborted();
+    // napi-rs uses the supplied signal's onabort property. Give it a private
+    // signal so caller handlers and other admitted native operations stay intact.
+    const cancellation = options.signal ? new AbortController() : undefined;
+    const abort = () => cancellation?.abort();
+    options.signal?.addEventListener("abort", abort, { once: true });
+    try {
+      await native.cloneTree(
+        original?.fd ?? null,
+        parent.fd,
+        name,
+        concurrency,
+        cancellation?.signal,
+      );
+    } catch (error) {
+      options.signal?.throwIfAborted();
+      throw error;
+    } finally {
+      options.signal?.removeEventListener("abort", abort);
+    }
+    options.signal?.throwIfAborted();
+    assertStagedDirectoryCurrent(parent.receipt);
+    if (original) assertStagedDirectoryCurrent(original.receipt);
+  } finally {
+    try {
+      if (original) fs.closeSync(original.fd);
+    } finally {
+      fs.closeSync(parent.fd);
+    }
+  }
+}

--- a/src/native-binding.ts
+++ b/src/native-binding.ts
@@ -78,10 +78,23 @@ export interface NativeWindowsSecurityFacts {
 }
 
 export interface NativeBinding {
+  readCloneFileMetadata(paths: string[]): Promise<(Buffer | null)[]>;
+  probeTreeClone(parentFd: number): "apfs" | "btrfs" | "refs" | null;
+  cloneTree(
+    sourceFd: number | null,
+    parentFd: number,
+    basename: string,
+    concurrency: number,
+    signal?: AbortSignal,
+  ): Promise<void>;
   // POSIX-only direct-child staging; the matching Windows binary omits these methods.
   createStagedFile?(parentFd: number, basename: string): number;
   stagedFileMatches?(parentFd: number, basename: string, fileFd: number): boolean;
-  removeStagedFile?(parentFd: number, basename: string, fileFd: number): "removed" | "name-absent" | "preserved";
+  removeStagedFile?(
+    parentFd: number,
+    basename: string,
+    fileFd: number,
+  ): "removed" | "name-absent" | "preserved";
   cloneFileExclusive(sourceFd: number, targetRootFd: number, targetRelPath: string): number;
   copyFileRangeExclusive(
     sourceFd: number,

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -1,0 +1,301 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, assert, describe, expect, it, type TestContext } from "vitest";
+import {
+  cloneTree,
+  createCloneSource,
+  probeTreeClone,
+  readCloneFileMetadata,
+} from "../src/clone.js";
+import { configureFsSafeNative } from "../src/config.js";
+import {
+  __resetNativeLoaderForTest,
+  __setNativeLoaderForTest,
+  getNativeBinding,
+} from "../src/native.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempDirs, tempRoot } = useRealTempDirs();
+afterEach(() => {
+  configureFsSafeNative({ mode: "auto" });
+  __resetNativeLoaderForTest();
+});
+
+async function cloneFixture(context: TestContext) {
+  const explicitParent = process.env.FS_SAFE_CLONE_TEST_ROOT;
+  const parent = await fs.realpath(explicitParent ?? os.tmpdir());
+  const backend = probeTreeClone(parent);
+  if (!backend) {
+    if (explicitParent) throw new Error("FS_SAFE_CLONE_TEST_ROOT requires native clone support");
+    context.skip("native APFS, Btrfs, or ReFS volume unavailable");
+    throw new Error("unreachable");
+  }
+  const directory = await fs.mkdtemp(path.join(parent, "fs-safe-clone-"));
+  tempDirs.push(directory);
+  const source = path.join(directory, "source");
+  const destination = path.join(directory, "destination-é space");
+  await createCloneSource(source);
+  return { directory, source, destination, backend };
+}
+
+describe("native directory cloning", () => {
+  it("does not create probe artifacts or silently copy when native support is disabled", async () => {
+    const directory = await tempRoot("fs-safe-clone-disabled-");
+    const source = path.join(directory, "source");
+    const destination = path.join(directory, "destination");
+    await fs.mkdir(source);
+    await fs.writeFile(path.join(source, "payload"), "original");
+    configureFsSafeNative({ mode: "off" });
+    expect(probeTreeClone(directory)).toBeUndefined();
+    await expect(createCloneSource(destination)).rejects.toThrow();
+    await expect(cloneTree(source, destination)).rejects.toThrow();
+    expect(await fs.readdir(directory)).toEqual(["source"]);
+    expect(await fs.readFile(path.join(source, "payload"), "utf8")).toBe("original");
+  });
+
+  it("honors an already aborted signal without creating a source or clone", async () => {
+    const directory = await tempRoot("fs-safe-clone-aborted-");
+    const source = path.join(directory, "source");
+    const destination = path.join(directory, "destination");
+    await fs.mkdir(source);
+    const signal = AbortSignal.abort(new Error("caller canceled cloning"));
+    await expect(createCloneSource(destination, { signal })).rejects.toThrow("caller canceled");
+    await expect(cloneTree(source, destination, { signal })).rejects.toThrow("caller canceled");
+    expect(await fs.readdir(directory)).toEqual(["source"]);
+  });
+
+  it("keeps unsupported filesystems on the caller's fallback path", async (context) => {
+    const directory = await tempRoot("fs-safe-clone-unsupported-");
+    if (!getNativeBinding() || probeTreeClone(directory)) {
+      context.skip("requires native binding and an unsupported temporary filesystem");
+      return;
+    }
+    const source = path.join(directory, "source");
+    const destination = path.join(directory, "destination");
+    await fs.mkdir(source);
+    await fs.writeFile(path.join(source, "payload"), "original");
+    await expect(cloneTree(source, destination)).rejects.toThrow();
+    await expect(createCloneSource(destination)).rejects.toThrow();
+    expect(await fs.readdir(directory)).toEqual(["source"]);
+  });
+
+  it.each([0, -1, 1.5, 33, NaN, Infinity])(
+    "rejects invalid concurrency %s before creating a destination",
+    async (concurrency) => {
+      const directory = await tempRoot("fs-safe-clone-options-");
+      const source = path.join(directory, "source");
+      const destination = path.join(directory, "destination");
+      await fs.mkdir(source);
+      await expect(cloneTree(source, destination, { concurrency })).rejects.toThrow();
+      expect(await fs.readdir(directory)).toEqual(["source"]);
+    },
+  );
+
+  it("joins admitted native writes and retains their descriptors before rejecting cancellation", async (context) => {
+    const binding = getNativeBinding();
+    if (!binding) {
+      context.skip("native binding unavailable");
+      return;
+    }
+    const directory = await tempRoot("fs-safe-clone-settlement-");
+    const source = path.join(directory, "source");
+    const destination = path.join(directory, "destination");
+    await fs.mkdir(source);
+    const entered = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    __setNativeLoaderForTest(() => ({
+      ...binding,
+      probeTreeClone: () => "apfs",
+      async cloneTree(sourceFd, parentFd) {
+        entered.resolve();
+        await release.promise;
+        expect(sourceFd).not.toBeNull();
+        expect(fsSync.fstatSync(sourceFd!).isDirectory()).toBe(true);
+        expect(fsSync.fstatSync(parentFd).isDirectory()).toBe(true);
+        await fs.mkdir(destination);
+        await fs.writeFile(path.join(destination, "complete"), "settled");
+      },
+    }));
+    const controller = new AbortController();
+    let settled = false;
+    const pending = cloneTree(source, destination, { signal: controller.signal }).then(
+      () => {
+        settled = true;
+        return undefined;
+      },
+      (error: unknown) => {
+        settled = true;
+        return error;
+      },
+    );
+    const reason = new Error("cancel while native work is running");
+    try {
+      await Promise.race([
+        entered.promise,
+        pending.then((error) => {
+          throw error;
+        }),
+      ]);
+      controller.abort(reason);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+      release.resolve();
+      expect(await pending).toBe(reason);
+      expect(await fs.readFile(path.join(destination, "complete"), "utf8")).toBe("settled");
+    } finally {
+      release.resolve();
+      await pending;
+    }
+  });
+
+  it.for([1, 8])(
+    "preserves tree data and metadata with concurrency %s and independent writes",
+    async (concurrency, context) => {
+      const { source, destination } = await cloneFixture(context);
+      await fs.mkdir(path.join(source, "nested"));
+      await fs.mkdir(path.join(source, "empty-directory"));
+      const contents = new Map([
+        ["empty", Buffer.alloc(0)],
+        ["short", Buffer.from("unaligned payload")],
+        ["日本語-🦀", Buffer.alloc(4097, 0x37)],
+        [path.join("nested", ".payload"), Buffer.alloc(1024 * 1024, 0x5a)],
+      ]);
+      for (const [name, bytes] of contents) {
+        await fs.writeFile(path.join(source, name), bytes);
+        await fs.utimes(path.join(source, name), 1_600_000_000, 1_600_000_000);
+      }
+      const original = path.join(source, "nested", ".payload");
+      const cloned = path.join(destination, "nested", ".payload");
+      if (process.platform !== "win32") {
+        await fs.chmod(original, 0o751);
+        await fs.chmod(path.join(source, "nested"), 0o750);
+      }
+      const controller = new AbortController();
+      let callerAborts = 0;
+      controller.signal.onabort = () => {
+        callerAborts++;
+      };
+      await cloneTree(source, destination, { concurrency, signal: controller.signal });
+      controller.abort();
+      expect(callerAborts).toBe(1);
+      for (const [name, bytes] of contents) {
+        expect(await fs.readFile(path.join(destination, name))).toEqual(bytes);
+        expect((await fs.stat(path.join(destination, name))).mtimeMs).toBe(1_600_000_000_000);
+      }
+      expect(await fs.readdir(path.join(destination, "empty-directory"))).toEqual([]);
+      if (process.platform !== "win32") {
+        expect((await fs.stat(cloned)).mode & 0o777).toBe(0o751);
+        expect((await fs.stat(path.join(destination, "nested"))).mode & 0o777).toBe(0o750);
+      }
+      await fs.writeFile(cloned, "independent edit");
+      expect(await fs.readFile(original)).toEqual(contents.get(path.join("nested", ".payload")));
+      await expect(cloneTree(source, destination)).rejects.toThrow();
+      await expect(createCloneSource(destination)).rejects.toThrow();
+      expect(await fs.readFile(cloned, "utf8")).toBe("independent edit");
+      expect(await fs.readdir(destination)).not.toContain("source");
+    },
+  );
+
+  it("preserves literal symlinks and refuses a symlink as the clone source", async (context) => {
+    const { directory, source, destination } = await cloneFixture(context);
+    await fs.writeFile(path.join(source, "payload"), "original");
+    try {
+      await fs.symlink("payload", path.join(source, "link"), "file");
+    } catch (error) {
+      if (
+        process.platform === "win32" &&
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "EPERM"
+      ) {
+        context.skip("Windows symlink creation requires Developer Mode or privilege");
+      }
+      throw error;
+    }
+    await fs.symlink("missing-target", path.join(source, "dangling"), "file");
+    await cloneTree(source, destination);
+    expect(await fs.readlink(path.join(destination, "link"))).toBe("payload");
+    expect(await fs.readlink(path.join(destination, "dangling"))).toBe("missing-target");
+    await fs.writeFile(path.join(destination, "payload"), "clone edit");
+    expect(await fs.readFile(path.join(destination, "link"), "utf8")).toBe("clone edit");
+    expect(await fs.readFile(path.join(source, "payload"), "utf8")).toBe("original");
+    const alias = path.join(directory, "source-alias");
+    await fs.symlink(source, alias, process.platform === "win32" ? "junction" : "dir");
+    await expect(cloneTree(alias, path.join(directory, "alias-clone"))).rejects.toThrow();
+    await expect(fs.access(path.join(directory, "alias-clone"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("requires a Btrfs subvolume source instead of copying an ordinary directory", async (context) => {
+    const { directory, destination, backend } = await cloneFixture(context);
+    if (backend !== "btrfs") context.skip("Btrfs-specific source requirement");
+    const ordinary = path.join(directory, "ordinary");
+    await fs.mkdir(ordinary);
+    await fs.writeFile(path.join(ordinary, "payload"), "original");
+    await expect(cloneTree(ordinary, destination)).rejects.toThrow();
+    await expect(fs.access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await fs.readFile(path.join(ordinary, "payload"), "utf8")).toBe("original");
+  });
+
+  it("rejects ReFS alternate streams without reporting a lossy clone as success", async (context) => {
+    const { source, destination, backend } = await cloneFixture(context);
+    if (backend !== "refs") context.skip("ReFS-specific stream preservation");
+    const original = path.join(source, "payload");
+    await fs.writeFile(original, "main data");
+    await fs.writeFile(`${original}:metadata`, "named stream data");
+    await expect(cloneTree(source, destination)).rejects.toThrow();
+    expect(await fs.readFile(original, "utf8")).toBe("main data");
+    expect(await fs.readFile(`${original}:metadata`, "utf8")).toBe("named stream data");
+    await expect(fs.access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects cloning a tree into itself or its descendants", async (context) => {
+    const { source } = await cloneFixture(context);
+    await fs.writeFile(path.join(source, "payload"), "original");
+    await expect(cloneTree(source, source)).rejects.toThrow();
+    await expect(cloneTree(source, path.join(source, "child"))).rejects.toThrow();
+    expect(await fs.readdir(source)).toEqual(["payload"]);
+  });
+
+  it("reports APFS clone provenance and stops matching after an independent edit", async (context) => {
+    const { source, destination, backend } = await cloneFixture(context);
+    if (backend !== "apfs") context.skip("APFS clone provenance");
+    const original = path.join(source, "payload");
+    const cloned = path.join(destination, "payload");
+    await fs.writeFile(original, Buffer.alloc(1024 * 1024, 0x5a));
+    await fs.symlink("payload", path.join(source, "link"));
+    await cloneTree(source, destination);
+    const [originalMetadata, clonedMetadata, linkMetadata, missingMetadata] =
+      await readCloneFileMetadata([
+        original,
+        cloned,
+        path.join(destination, "link"),
+        path.join(destination, "missing"),
+      ]);
+    assert(originalMetadata);
+    assert(clonedMetadata);
+    expect(originalMetadata.cloneId).not.toBe(0n);
+    expect(clonedMetadata.cloneId).toBe(originalMetadata.cloneId);
+    expect(clonedMetadata.ino).not.toBe(originalMetadata.ino);
+    const stat = await fs.lstat(cloned, { bigint: true });
+    expect(clonedMetadata.ino).toBe(stat.ino);
+    expect(clonedMetadata.size).toBe(stat.size);
+    expect(BigInt(clonedMetadata.mtimeSec) * 1_000_000_000n + BigInt(clonedMetadata.mtimeNs)).toBe(
+      stat.mtimeNs,
+    );
+    expect(BigInt(clonedMetadata.ctimeSec) * 1_000_000_000n + BigInt(clonedMetadata.ctimeNs)).toBe(
+      stat.ctimeNs,
+    );
+    expect(linkMetadata?.type).not.toBe(1);
+    expect(missingMetadata).toBeUndefined();
+    await fs.writeFile(cloned, "independent edit");
+    const [afterSource, afterClone] = await readCloneFileMetadata([original, cloned]);
+    assert(afterSource);
+    assert(afterClone);
+    expect(afterClone.cloneId).not.toBe(afterSource.cloneId);
+    expect(await fs.readFile(original)).toEqual(Buffer.alloc(1024 * 1024, 0x5a));
+  });
+});

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -156,11 +156,12 @@ describe("native directory cloning", () => {
       const { source, destination } = await cloneFixture(context);
       await fs.mkdir(path.join(source, "nested"));
       await fs.mkdir(path.join(source, "empty-directory"));
+      const payload = Buffer.alloc(1024 * 1024, 0x5a);
       const contents = new Map([
         ["empty", Buffer.alloc(0)],
         ["short", Buffer.from("unaligned payload")],
         ["日本語-🦀", Buffer.alloc(4097, 0x37)],
-        [path.join("nested", ".payload"), Buffer.alloc(1024 * 1024, 0x5a)],
+        [path.join("nested", ".payload"), payload],
       ]);
       for (const [name, bytes] of contents) {
         await fs.writeFile(path.join(source, name), bytes);
@@ -181,7 +182,7 @@ describe("native directory cloning", () => {
       controller.abort();
       expect(callerAborts).toBe(1);
       for (const [name, bytes] of contents) {
-        expect(await fs.readFile(path.join(destination, name))).toEqual(bytes);
+        expect((await fs.readFile(path.join(destination, name))).equals(bytes), name).toBe(true);
         expect((await fs.stat(path.join(destination, name))).mtimeMs).toBe(1_600_000_000_000);
       }
       expect(await fs.readdir(path.join(destination, "empty-directory"))).toEqual([]);
@@ -190,7 +191,7 @@ describe("native directory cloning", () => {
         expect((await fs.stat(path.join(destination, "nested"))).mode & 0o777).toBe(0o750);
       }
       await fs.writeFile(cloned, "independent edit");
-      expect(await fs.readFile(original)).toEqual(contents.get(path.join("nested", ".payload")));
+      expect((await fs.readFile(original)).equals(payload)).toBe(true);
       await expect(cloneTree(source, destination)).rejects.toThrow();
       await expect(createCloneSource(destination)).rejects.toThrow();
       expect(await fs.readFile(cloned, "utf8")).toBe("independent edit");
@@ -296,6 +297,6 @@ describe("native directory cloning", () => {
     assert(afterSource);
     assert(afterClone);
     expect(afterClone.cloneId).not.toBe(afterSource.cloneId);
-    expect(await fs.readFile(original)).toEqual(Buffer.alloc(1024 * 1024, 0x5a));
+    expect((await fs.readFile(original)).equals(Buffer.alloc(1024 * 1024, 0x5a))).toBe(true);
   });
 });

--- a/test/documentation-contract.test.ts
+++ b/test/documentation-contract.test.ts
@@ -198,9 +198,4 @@ describe("documentation contract", () => {
     }
   });
 
-  it("does not claim a current producer for the reserved unsupported-platform code", () => {
-    expect(readRepoFile("docs/errors.md")).toContain(
-      "No current public helper emits this `FsSafeError` code",
-    );
-  });
 });

--- a/test/public-api.json
+++ b/test/public-api.json
@@ -134,6 +134,20 @@
       ],
       "errorCodes": {}
     },
+    "./clone": {
+      "runtime": [
+        "cloneTree",
+        "createCloneSource",
+        "probeTreeClone",
+        "readCloneFileMetadata"
+      ],
+      "types": [
+        "CloneFileMetadata",
+        "CloneTreeOptions",
+        "TreeCloneBackend"
+      ],
+      "errorCodes": {}
+    },
     "./config": {
       "runtime": [
         "configureFsSafeLocks",


### PR DESCRIPTION
## What Problem This Solves

Consumers currently need separate native implementations to create copy-on-write directory trees on APFS, Btrfs, and ReFS. OpenClaw duplicates this platform code and makes per-file foreign-function calls on Windows.

## Why This Change Was Made

Adds `@openclaw/fs-safe/clone` with `cloneTree`, `createCloneSource`, and a filesystem probe. APFS uses one native directory clone, Btrfs uses a subvolume snapshot without a subprocess, and ReFS uses a bounded native worker pool with 16 workers by default. A batched APFS metadata reader supports consumers that validate clone provenance.

The API requires immutable caller-owned sources and controlled destination namespaces. It pins directory descriptors, refuses overwrites and unsupported filesystems, preserves independent file data, and waits for admitted work before rejecting cancellation. ReFS rejects named streams and unsupported reparse types instead of silently dropping them. There is no byte-copy fallback or per-file durability sync.

## User Impact

Applications can request a directory clone through one portable call and choose their own fallback. Btrfs sources must be subvolumes without nested subvolumes. APFS/Btrfs bulk operations may leave a complete destination after cancellation; recovery remains with the caller.

On a Windows ReFS Dev Drive, repeated raw cloning of 41,723 files had medians of 5.78 seconds with 8 workers and 4.26 seconds with 16 workers. Initial copies at every tested concurrency matched all file hashes. These are copy-only measurements, with observed timing variability; full worktree creation also incurs Git preparation costs.

## Evidence

- Independent autoreview: scoped clean at P0–P2.
- ReFS public API tests: 14 passed, 3 platform/privilege skips.
- Native ReFS regression passed with a 2 GiB + 4097 byte sparse file: shared physical extent, exact size/timestamps, independent writes, held-writer rejection, alternate-stream rejection, and cleanup.
- Build, package/tarball contract check, docs examples, docs site, and 21 documentation tests passed.
- Local full `pnpm check`: 7,476 passed, 36 failed, 1,228 skipped. The new API documentation omission was fixed and its tests passed afterward. Remaining failures are Windows symlink setup permissions and an existing test-hook mock issue; both categories were reproduced on unchanged main. Package validation was run separately and passed.
- All checks passed at `f62a5a6c4662801d6517650c46b6ff244e5e3532`: [CI](https://github.com/openclaw/fs-safe/actions/runs/34727885285), [coverage](https://github.com/openclaw/fs-safe/actions/runs/34727885286), CodeQL, and benchmarks. Native CI executes Linux glibc/musl, macOS arm64, and Windows x64; the other release architectures are not execution claims here.
- An earlier macOS Node 22 fallback job hit an unchanged archive test's 75 ms wall-clock assertion; one diagnostic rerun passed. New clone payload assertions used an unnecessarily expensive recursive Buffer comparison under coverage; exact `Buffer.equals` comparisons fixed that cost without changing payload coverage or timeouts. Final CI and coverage passed without retries.
- OpenClaw integration against the built candidate: final restored-binding check passed all 15 backend/ReFS tests, including physical extent sharing and create/restore/template invalidation/cleanup.
- OpenClaw Linux consumer validation: core typecheck and 78 tests across seven suites passed. Candidate declarations and subprocess imports used task-only aliases because this API is not published yet; these results do not claim a released dependency install. Windows service proof uses the real candidate native binding.

### Captured APFS and Btrfs public-facade execution

The committed `test/clone.test.ts` imports `cloneTree` and `createCloneSource` from `src/clone.ts` and calls them against real filesystem fixtures. Data/metadata preservation, independent writes, source admission, and APFS clone provenance use the actual native binding. The separately named descriptor-lifetime test substitutes the native method and is not claimed as native cancellation proof.

Captured at the final head:

```text
macOS APFS: pnpm test test/clone.test.ts
test/clone.test.ts (17 tests | 3 skipped) 66ms
Test Files 1 passed (1)
Tests 14 passed | 3 skipped (17)

Linux Btrfs loopback fixture:
FS_SAFE_CLONE_TEST_ROOT="$fixture/mount" pnpm test test/clone.test.ts
test/clone.test.ts (17 tests | 2 skipped) 87ms
Test Files 1 passed (1)
Tests 15 passed | 2 skipped (17)
```

[APFS invocation/output](https://github.com/openclaw/fs-safe/actions/runs/34727885285/job/103645192957) and [Btrfs fixture setup/invocation/output](https://github.com/openclaw/fs-safe/actions/runs/34727885285/job/103645192988). Platform-specific tests skip on the other filesystems; Btrfs's ordinary-directory rejection executes on the mounted Btrfs fixture.

### Captured ReFS public-API clone and native cancellation

fs-safe PR #293, checked out at f62a5a6c4662801d6517650c46b6ff244e5e3532. The built Windows clone API and native implementation are unchanged from the validated build. Run on the local ReFS Dev Drive with Node.js v26.8.2. No mocks or binding substitutions; no dependency operations or production edits.

The script waits up to 10 seconds for a real destination file matching source bytes while another source file is still absent, then aborts. It awaits rejection, verifies the partial destination is absent, immediately reuses that same path, compares every path and file hash, verifies independent writes, and checks that output metadata stays unchanged after a 1-second quiet interval.

Invocation (from the OpenClaw task workspace; paths contain no user identity):

```powershell
node .local/fs-safe-public-proof.mjs 'D:\openclaw-refs-benchmark-jYp0ys\.templates\52f29ef5-5c83-40cc-9c0d-a55eb5c63e9b' 'D:\'
```

Captured output (exit 0):

```text
API: built dist/clone.js; native ReFS binding; no mocks
Source: 41723 files, 566784361 bytes, 1977 directories
Cancellation: matching package.json observed at 32.4 ms while another source file was absent
Cancellation: exact caller reason returned at 38.6 ms; partial destination absent
Immediate same-path reuse: success in 5.516 s
Successful clone: all 41723 relative file paths and SHA-256 hashes match; all directories match
Independent write: clone package.json changed; source bytes unchanged
Post-settlement observation: file paths, lengths, modification times and directories unchanged after 1000 ms
Retained task-owned output: D:\fs-safe-public-proof-8Ih2zp
```

Proof script:

```js
import fs from "node:fs";
import path from "node:path";
import assert from "node:assert/strict";
import { createHash } from "node:crypto";
import { setTimeout as delay } from "node:timers/promises";
import { cloneTree, probeTreeClone } from "./fs-safe-clone/dist/clone.js";

const source = path.resolve(process.argv[2]);
const volume = path.resolve(process.argv[3]);
assert.equal(probeTreeClone(volume), "refs");

function inventory(root, hashes = true) {
  const files = new Map();
  const directories = [];
  let bytes = 0;
  function visit(relative) {
    for (const entry of fs.readdirSync(path.join(root, relative), { withFileTypes: true })) {
      const name = path.join(relative, entry.name);
      const pathname = path.join(root, name);
      if (entry.isDirectory()) {
        directories.push(name);
        visit(name);
      } else {
        assert.ok(entry.isFile(), `unexpected corpus entry type: ${name}`);
        const stat = fs.statSync(pathname, { bigint: true });
        files.set(name, hashes
          ? createHash("sha256").update(fs.readFileSync(pathname)).digest("hex")
          : `${stat.size}:${stat.mtimeNs}`);
        bytes += Number(stat.size);
      }
    }
  }
  visit("");
  return { files, directories: directories.sort(), bytes };
}

console.log("API: built dist/clone.js; native ReFS binding; no mocks");
const baseline = inventory(source);
console.log(`Source: ${baseline.files.size} files, ${baseline.bytes} bytes, ${baseline.directories.length} directories`);
const root = fs.mkdtempSync(path.join(volume, "fs-safe-public-proof-"));
const destination = path.join(root, "copy");
const controller = new AbortController();
const reason = new Error("proof: cancel after native destination file activity");
let settled = false;
const start = performance.now();
const pending = cloneTree(source, destination, { concurrency: 16, signal: controller.signal }).then(
  () => ({ status: "fulfilled" }),
  (error) => ({ status: "rejected", error }),
).finally(() => { settled = true; });
const deadline = performance.now() + 10_000;
const observedRelative = "package.json";
const observedSource = fs.readFileSync(path.join(source, observedRelative));
let missingBeforeAbort;
while (!settled && performance.now() < deadline) {
  const observedPath = path.join(destination, observedRelative);
  if (fs.existsSync(observedPath) && fs.readFileSync(observedPath).equals(observedSource)) {
    missingBeforeAbort = [...baseline.files.keys()].find((name) => !fs.existsSync(path.join(destination, name)));
    if (missingBeforeAbort !== undefined) break;
  }
  await delay(2);
}
if (settled || missingBeforeAbort === undefined) {
  if (!settled) controller.abort(new Error("proof observation deadline expired"));
  await pending;
  throw new Error("Did not observe native file activity before settlement; no cancellation proof recorded");
}
const observedMs = performance.now() - start;
controller.abort(reason);
const outcome = await pending;
assert.equal(outcome.status, "rejected");
assert.equal(outcome.error, reason);
assert.equal(fs.existsSync(destination), false);
console.log(`Cancellation: matching ${observedRelative} observed at ${observedMs.toFixed(1)} ms while another source file was absent`);
console.log(`Cancellation: exact caller reason returned at ${(performance.now() - start).toFixed(1)} ms; partial destination absent`);

// Reuse immediately after rejection, with no sleep or cleanup between the calls.
const reuseStart = performance.now();
await cloneTree(source, destination, { concurrency: 16 });
console.log(`Immediate same-path reuse: success in ${((performance.now() - reuseStart) / 1000).toFixed(3)} s`);
const copied = inventory(destination);
assert.deepEqual(copied.files, baseline.files);
assert.deepEqual(copied.directories, baseline.directories);
assert.equal(copied.bytes, baseline.bytes);
console.log(`Successful clone: all ${copied.files.size} relative file paths and SHA-256 hashes match; all directories match`);

fs.writeFileSync(path.join(destination, observedRelative), "proof-owned clone edit\n");
assert.deepEqual(fs.readFileSync(path.join(source, observedRelative)), observedSource);
assert.equal(fs.readFileSync(path.join(destination, observedRelative), "utf8"), "proof-owned clone edit\n");
console.log("Independent write: clone package.json changed; source bytes unchanged");
const beforeQuiet = inventory(destination, false);
await delay(1000);
assert.deepEqual(inventory(destination, false), beforeQuiet);
assert.deepEqual(fs.readdirSync(root), ["copy"]);
console.log("Post-settlement observation: file paths, lengths, modification times and directories unchanged after 1000 ms");
console.log(`Retained task-owned output: ${root}`);
```


Implementation references: [Microsoft CopyOnWrite](https://github.com/microsoft/CopyOnWrite/blob/main/lib/Windows/WindowsCopyOnWriteFilesystem.cs), [MSBuild Artifacts](https://github.com/microsoft/MSBuildSdks/blob/main/src/Artifacts/Tasks/Robocopy.cs), [Apple clonefile contract](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/man/man2/clonefile.2), and [Btrfs subvolume semantics](https://btrfs.readthedocs.io/en/latest/btrfs-subvolume.html). No source code was copied from those projects.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
