### PR TITLE
perf(archive): retain ZIP buffers across native reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,14 @@ jobs:
           FS_SAFE_NATIVE_MODE: require
         run: pnpm test test/file-hash-options.test.ts
 
+      - name: Test native ZIP buffer ownership and validation
+        env:
+          FS_SAFE_NATIVE_MODE: require
+        run: pnpm test test/native-zip-buffer.test.ts
+
+      - name: Prove native ZIP buffer lifetime across garbage collection
+        run: node --expose-gc scripts/native-zip-buffer-gc-proof.mjs
+
       - name: Prove sidecar contention with required native binding
         run: node scripts/sidecar-contention-proof.mjs require
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Read native ZIP entries from the retained, admitted input buffer and reuse the parsed directory, eliminating temporary disk staging and archive handoff copies while preserving validation.
+
 - Give the full documentation-build smoke test a bounded longer runtime so slow Windows runners do not hit the default unit-test deadline.
 - Add byte limits and cooperative cancellation to `sha256File`, preserving descriptor ownership and waiting for native work to stop before rejecting.
 

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -571,8 +571,12 @@ limits. It does not apply payload budgets to unrequested members. ZIP
 inputs retain the archive subpath's 256 MiB compressed-input ceiling.
 With a native binding it uses the same Rust decoders as extraction, including
 zstd and bzip2 TAR. Without native it retains the JS ZIP/TAR/gzip implementation.
-The JavaScript ZIP reader consumes the admitted buffer directly. Native decoders
-and TAR replay use a private disk snapshot of that buffer.
+Both ZIP readers consume the admitted buffer directly. The native ZIP reader
+retains the private allocation and parsed directory across worker-thread
+inspection and reading, without a disk snapshot or an extra archive-byte copy.
+Decompression still allocates its bounded output; Node receives that native
+allocation without another copy where external buffers are supported.
+TAR decoders and replay retain their private disk snapshot.
 
 Requested paths and effective member names use extraction's canonical pre-strip
 identity: backslashes become `/`, and repeated separators and `.` components

--- a/docs/native.md
+++ b/docs/native.md
@@ -59,6 +59,15 @@ whether a path, archive entry, mode, owner, or cleanup policy is acceptable.
 
 ## Archives
 
+Native ZIP entry reads retain a private, unpooled input Buffer in the async
+reader and reuse the parsed ZIP directory after TypeScript admission and
+selection. The internal binding borrows that allocation: it must never be
+mutated or detached while the reader or a read task exists. The public API only
+accepts a pathname and owns this buffer exclusively. An N-API reference keeps
+the bytes alive; a mutex serializes access to the retained ZIP cursor. Output
+decompression allocates a new vector, which N-API transfers to Node without a
+second payload copy on runtimes supporting external buffers.
+
 Rust streams ZIP and TAR payloads, including gzip, zstd, and bzip2. It first
 returns a bounded manifest. TypeScript applies the shared path, filter, strip,
 mode, and byte policies and returns an index-bound extraction plan. Rust then

--- a/native/src/archive.rs
+++ b/native/src/archive.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{Cursor, Read, Seek, SeekFrom};
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicBool, Ordering},
 };
 
@@ -14,6 +14,7 @@ use crate::tar_meter::{TarMetadataMeter, TarMeterLimits, MAX_SAFE_INTEGER, MAX_M
 use crate::{NativeResult, native_error, platform, validate_portable_relative_path};
 
 #[napi(object)]
+#[derive(Clone)]
 pub struct NativeArchiveEntry {
     pub index: u32,
     pub path: String,
@@ -192,7 +193,7 @@ fn inspect_tar(
     Ok(result)
 }
 
-fn zip_kind(file: &zip::read::ZipFile<'_, File>) -> &'static str {
+fn zip_kind<R: Read>(file: &zip::read::ZipFile<'_, R>) -> &'static str {
     let mode = file.unix_mode().unwrap_or(0);
     if mode & 0o170000 == 0o120000 {
         "symlink"
@@ -219,6 +220,12 @@ fn inspect_zip(
         .len().saturating_mul(3);
     let mut archive =
         zip::ZipArchive::new(file).map_err(|error| io_error("read zip archive", error))?;
+    inspect_zip_entries(&mut archive, max_path_bytes, cancelled)
+}
+
+fn inspect_zip_entries<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>, max_path_bytes: u64, cancelled: &AtomicBool,
+) -> Result<Vec<ArchiveEntryData>> {
     let mut result = Vec::with_capacity(archive.len());
     let mut manifest_bytes = 0_u64;
     for index in 0..archive.len() {
@@ -261,10 +268,11 @@ fn limit_error(code: &'static str) -> Error {
 
 fn zip_entry_count(path: &str, max_entries: usize) -> Result<u64> {
     let mut file = File::open(path).map_err(|error| io_error("open zip archive", error))?;
-    let length = file
-        .metadata()
-        .map_err(|error| io_error("stat zip archive", error))?
-        .len();
+    zip_reader_entry_count(&mut file, max_entries)
+}
+
+fn zip_reader_entry_count<R: Read + Seek>(file: &mut R, max_entries: usize) -> Result<u64> {
+    let length = file.seek(SeekFrom::End(0)).map_err(|error| io_error("stat zip archive", error))?;
     let tail_size = length.min(65_557) as usize;
     let mut tail = vec![0_u8; tail_size];
     file.seek(SeekFrom::End(-(tail_size as i64)))
@@ -314,7 +322,7 @@ fn zip_entry_count(path: &str, max_entries: usize) -> Result<u64> {
             continue;
         }
         let parsed = count_central_directory_entries(
-            &mut file,
+            file,
             directory_offset,
             directory_size,
             max_entries,
@@ -329,8 +337,8 @@ fn zip_entry_count(path: &str, max_entries: usize) -> Result<u64> {
     ))
 }
 
-fn count_central_directory_entries(
-    file: &mut File,
+fn count_central_directory_entries<R: Read + Seek>(
+    file: &mut R,
     offset: u64,
     size: u64,
     max_entries: usize,
@@ -725,6 +733,110 @@ fn read_bounded(
     Ok(output)
 }
 
+type BufferedZip = zip::ZipArchive<Cursor<Buffer>>;
+
+#[napi]
+pub struct NativeZipBufferReader {
+    archive: Arc<Mutex<BufferedZip>>,
+    entries: Vec<NativeArchiveEntry>,
+}
+
+#[napi]
+impl NativeZipBufferReader {
+    #[napi(getter)]
+    pub fn entries(&self) -> Vec<NativeArchiveEntry> {
+        self.entries.clone()
+    }
+
+    #[napi]
+    pub fn read_entry(&self, index: u32, max_bytes: f64, signal: Option<AbortSignal>) -> Result<AsyncTask<ReadZipBufferTask>> {
+        if !max_bytes.is_finite() || !(0.0..=MAX_SAFE_INTEGER as f64).contains(&max_bytes)
+            || max_bytes.fract() != 0.0 {
+            return Err(Error::new(Status::InvalidArg, "maxBytes must be a non-negative safe integer"));
+        }
+        let cancelled = signal.as_ref().map(cancellation).unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+        Ok(AsyncTask::with_optional_signal(ReadZipBufferTask {
+            archive: Arc::clone(&self.archive), index: index as usize, max_bytes: max_bytes as u64,
+            cancelled,
+        }, signal))
+    }
+}
+
+pub struct OpenZipBufferTask {
+    buffer: Option<Buffer>,
+    max_entries: usize,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl Task for OpenZipBufferTask {
+    type Output = NativeZipBufferReader;
+    type JsValue = NativeZipBufferReader;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        check_cancelled(&self.cancelled)?;
+        let buffer = self.buffer.take().ok_or_else(|| Error::new(Status::GenericFailure, "ZIP buffer already consumed"))?;
+        let max_path_bytes = (buffer.len() as u64).saturating_mul(3);
+        let mut cursor = Cursor::new(buffer);
+        zip_reader_entry_count(&mut cursor, self.max_entries)?;
+        let mut archive = zip::ZipArchive::new(cursor).map_err(|error| io_error("read zip archive", error))?;
+        let entries = inspect_zip_entries(&mut archive, max_path_bytes, &self.cancelled)?
+            .into_iter().map(|entry| NativeArchiveEntry {
+                index: entry.index, path: entry.path, kind: entry.kind,
+                size: entry.size as f64, mode: entry.mode,
+            }).collect();
+        Ok(NativeZipBufferReader { archive: Arc::new(Mutex::new(archive)), entries })
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        check_cancelled(&self.cancelled)?;
+        Ok(output)
+    }
+}
+
+// Internal borrowing contract: the caller supplies a private, unpooled buffer
+// and never mutates/detaches it while this reader or any of its tasks is alive.
+// napi::Buffer retains the JS allocation; Cursor reads it without a byte copy.
+#[napi(js_name = "openZipBufferNative")]
+pub fn open_zip_buffer_native(buffer: Buffer, limits: NativeTarLimits, signal: Option<AbortSignal>) -> Result<AsyncTask<OpenZipBufferTask>> {
+    let limits = limits.checked()?;
+    let cancelled = signal.as_ref().map(cancellation).unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+    Ok(AsyncTask::with_optional_signal(OpenZipBufferTask { buffer: Some(buffer), max_entries: limits.max_entries, cancelled }, signal))
+}
+
+pub struct ReadZipBufferTask {
+    archive: Arc<Mutex<BufferedZip>>,
+    index: usize,
+    max_bytes: u64,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl Task for ReadZipBufferTask {
+    type Output = Vec<u8>;
+    type JsValue = Buffer;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        check_cancelled(&self.cancelled)?;
+        let mut archive = self.archive.lock().map_err(|_| Error::new(Status::GenericFailure, "ZIP reader unavailable"))?;
+        check_cancelled(&self.cancelled)?;
+        let mut entry = archive.by_index(self.index).map_err(|error| io_error("read zip entry", error))?;
+        if zip_kind(&entry) != "file" {
+            return Err(Error::new(Status::InvalidArg, "archive entry is not a file"));
+        }
+        let expected_size = entry.size();
+        let output = read_bounded(&mut entry, self.max_bytes, Arc::clone(&self.cancelled))?;
+        if output.len() as u64 != expected_size {
+            return Err(Error::new(Status::InvalidArg, "archive-header-invalid: ZIP entry size does not match declared uncompressed size"));
+        }
+        Ok(output)
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        check_cancelled(&self.cancelled)?;
+        // napi transfers the Vec allocation to a Node Buffer.
+        Ok(output.into())
+    }
+}
+
 pub struct ReadEntryTask {
     path: String,
     format: ArchiveFormat,
@@ -802,6 +914,25 @@ mod tests {
     use super::*;
 
     static TEMP_PATH_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    #[test]
+    fn buffered_zip_retains_the_input_allocation_across_reader_and_tasks() {
+        assert!(open_zip_buffer_native(Buffer::default(), native_limits(f64::NAN), None).is_err());
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        writer.start_file("payload", zip::write::SimpleFileOptions::default()).unwrap();
+        writer.write_all(b"retained bytes").unwrap();
+        let input = Buffer::from(writer.finish().unwrap().into_inner());
+        let input_pointer = input.as_ptr();
+        let mut open = OpenZipBufferTask { buffer: Some(input), max_entries: 10, cancelled: Arc::new(AtomicBool::new(false)) };
+        let reader = open.compute().unwrap();
+        let archive = Arc::clone(&reader.archive);
+        let mut task = ReadZipBufferTask { archive: Arc::clone(&archive), index: 0, max_bytes: 14, cancelled: Arc::new(AtomicBool::new(false)) };
+        drop(reader);
+        assert_eq!(task.compute().unwrap(), b"retained bytes");
+        drop(task);
+        let original = Arc::try_unwrap(archive).ok().unwrap().into_inner().unwrap().into_inner().into_inner();
+        assert_eq!(original.as_ptr(), input_pointer, "input bytes must not be copied");
+    }
 
     fn fixture_tar() -> Vec<u8> {
         let mut bytes = Vec::new();

--- a/scripts/native-zip-buffer-gc-proof.mjs
+++ b/scripts/native-zip-buffer-gc-proof.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import JSZip from "jszip";
+import { configureFsSafeNative } from "../dist/native-config.js";
+import { getNativeBinding } from "../dist/native.js";
+import { resolveTarMeterLimits } from "../dist/archive-limits.js";
+
+assert.equal(typeof globalThis.gc, "function", "run with --expose-gc");
+configureFsSafeNative({ mode: "require" });
+const native = getNativeBinding();
+const payload = Buffer.alloc(1024 * 1024, 42);
+const zip = new JSZip();
+zip.file("payload", payload);
+const fixture = await zip.generateAsync({ type: "nodebuffer", compression: "DEFLATE" });
+
+for (let round = 0; round < 3; round++) {
+  let input = Buffer.allocUnsafeSlow(fixture.length);
+  fixture.copy(input);
+  let reader = await native.openZipBufferNative(input, resolveTarMeterLimits());
+  input = undefined;
+  await new Promise(resolve => setImmediate(resolve));
+  globalThis.gc();
+  const pending = Array.from({ length: 8 }, () => reader.readEntry(0, payload.length));
+  reader = undefined;
+  globalThis.gc();
+  const results = await Promise.all(pending);
+  for (const result of results) assert.ok(result.equals(payload));
+  await new Promise(resolve => setImmediate(resolve));
+  globalThis.gc();
+}
+console.log(JSON.stringify({ proof: "native-zip-buffer-gc", reads: 24, outcome: "passed" }));

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -2,7 +2,7 @@ import { classifyArchiveParserError } from "./archive-parser-errors.js";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { Readable } from "node:stream";
-import { readFileHandleBounded } from "./bounded-read.js";
+import { readBoundedAsync } from "./bounded-read.js";
 import {
   ArchiveFormatError,
   ArchiveSecurityError,
@@ -30,7 +30,8 @@ import type { ZipEntry } from "./archive-zip-entry.js";
 import { FsSafeError } from "./errors.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
-import { getNativeBinding } from "./native.js";
+import { getNativeBinding, type NativeBinding } from "./native.js";
+import type { NativeArchiveEntry } from "./native-binding.js";
 import { admitZipBuffer } from "./archive-zip-admission.js";
 import { resolveExtractLimits, resolveTarMeterLimits } from "./archive-limits.js";
 import { tempFile } from "./temp-target.js";
@@ -113,7 +114,15 @@ async function readArchiveInput(archivePath: string): Promise<Buffer> {
       return stat;
     }, opened);
 
-    return await readFileHandleBounded(handle, DEFAULT_MAX_ARCHIVE_BYTES_ZIP);
+    // Native ZIP workers borrow this private buffer. A pooled allocation could
+    // share its ArrayBuffer with unrelated JS buffers while the worker runs.
+    return await readBoundedAsync(DEFAULT_MAX_ARCHIVE_BYTES_ZIP,
+      async (buffer, length) => (await handle.read(buffer, 0, length, null)).bytesRead,
+      { unpooled: true, observeRegularFileSize: () => {
+        const size = fsSync.fstatSync(handle.fd).size;
+        return Number.isSafeInteger(size) && size >= 0 ? size : undefined;
+      } },
+    );
   } catch (error) {
     if (error instanceof FsSafeError && error.code === "path-mismatch") {
       throw new FsSafeError("path-mismatch", "archive changed during validation", { cause: error });
@@ -182,6 +191,51 @@ async function readTarEntry(archivePath: string, entryPath: string, maxBytes: nu
   return result!;
 }
 
+function selectNativeEntry(
+  manifest: NativeArchiveEntry[], requested: string, displayPath: string, physicalCount?: number,
+): NativeArchiveEntry {
+  if (physicalCount !== undefined && manifest.length !== physicalCount) {
+    throw new ArchiveSecurityError("entry-path", "zip decoder collapsed entry names");
+  }
+  const seen = new Set<string>();
+  let selected: NativeArchiveEntry | undefined;
+  for (const entry of manifest) {
+    const normalized = canonicalEntryPath(entry.path);
+    if (seen.has(normalized)) {
+      throw new ArchiveSecurityError("entry-path", `archive contains duplicate entry path: ${formatErrorDetail(normalized)}`);
+    }
+    seen.add(normalized);
+    if (normalized === requested) {
+      if (entry.kind !== "file") throw new Error(`archive entry is not a file: ${formatErrorDetail(displayPath)}`);
+      selected = entry;
+    }
+  }
+  if (!selected) throw new Error(`archive entry not found: ${formatErrorDetail(displayPath)}`);
+  return selected;
+}
+
+function throwNativeReadError(error: unknown): never {
+  if (error instanceof Error) {
+    const mapped = classifyArchiveParserError(error.message, { cause: error });
+    if (mapped) throw mapped;
+    if (isArchiveFormatErrorMessage(error.message)) throw new ArchiveFormatError(error.message, { cause: error });
+  }
+  throw error;
+}
+
+async function readNativeZipEntry(
+  native: NativeBinding, buffer: Buffer, requested: string, displayPath: string, maxBytes: number, physicalCount: number,
+): Promise<Buffer> {
+  try {
+    const signal = new AbortController().signal;
+    const reader = await native.openZipBufferNative(buffer, resolveTarMeterLimits(), AbortSignal.any([signal]));
+    const selected = selectNativeEntry(reader.entries, requested, displayPath, physicalCount);
+    return await reader.readEntry(selected.index, maxBytes, AbortSignal.any([signal]));
+  } catch (error) {
+    throwNativeReadError(error);
+  }
+}
+
 export async function readArchiveEntry(
   archivePath: string,
   entryPath: string,
@@ -200,6 +254,9 @@ export async function readArchiveEntry(
     ? admitZipBuffer(buffer, resolveExtractLimits())
     : undefined;
   const native = getNativeBinding();
+  if (kind === "zip" && native) {
+    return await readNativeZipEntry(native, buffer, requestedEntry, entryPath, options.maxBytes, physicalCount!);
+  }
   if (!native) {
     assertPortableArchiveKind(kind);
     if (kind === "zip") return await readZipEntry(buffer, requestedEntry, options.maxBytes);
@@ -217,49 +274,17 @@ export async function readArchiveEntry(
           limits,
           signal,
         );
-        let rawEntryPath: string | undefined;
-        if (physicalCount !== undefined && manifest.length !== physicalCount) {
-          throw new ArchiveSecurityError("entry-path", "zip decoder collapsed entry names");
-        }
-        const seenPaths = new Set<string>();
-        for (const entry of manifest) {
-          const normalized = canonicalEntryPath(entry.path);
-          if (seenPaths.has(normalized)) {
-            throw new ArchiveSecurityError(
-              "entry-path",
-              `archive contains duplicate entry path: ${formatErrorDetail(normalized)}`,
-            );
-          }
-          seenPaths.add(normalized);
-          if (normalized === requestedEntry) {
-            if (entry.kind !== "file") {
-              throw new Error(
-                `archive entry is not a file: ${formatErrorDetail(entryPath)}`,
-              );
-            }
-            rawEntryPath = entry.path;
-          }
-        }
-        if (!rawEntryPath) {
-          throw new Error(`archive entry not found: ${formatErrorDetail(entryPath)}`);
-        }
+        const selected = selectNativeEntry(manifest, requestedEntry, entryPath);
         return await native.readArchiveEntryNative(
           staged.path,
           kind,
-          rawEntryPath,
+          selected.path,
           options.maxBytes,
           limits,
           signal,
         );
       } catch (error) {
-        if (error instanceof Error) {
-          const mapped = classifyArchiveParserError(error.message, { cause: error });
-          if (mapped) throw mapped;
-        }
-        if (error instanceof Error && isArchiveFormatErrorMessage(error.message)) {
-          throw new ArchiveFormatError(error.message, { cause: error });
-        }
-        throw error;
+        throwNativeReadError(error);
       }
     }
     return await readTarEntry(staged.path, requestedEntry, options.maxBytes);

--- a/src/bounded-read.ts
+++ b/src/bounded-read.ts
@@ -9,27 +9,31 @@ const MAX_INITIAL_READ_BYTES = 16 * 1024 * 1024;
 
 type ReadableFileHandle = Pick<FileHandle, "read">;
 
-function createInitialBuffer(maxBytes: number, size: number): Buffer {
+function createInitialBuffer(maxBytes: number, size: number, allocate = Buffer.allocUnsafe): Buffer {
   // A size hint can describe a huge sparse file or an already exhausted fd.
-  return Buffer.allocUnsafe(Math.min(maxBytes, size, MAX_INITIAL_READ_BYTES) + 1);
+  return allocate(Math.min(maxBytes, size, MAX_INITIAL_READ_BYTES) + 1);
 }
 
-function createScratchBuffer(maxBytes: number): Buffer {
-  return Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, maxBytes + 1));
+function createScratchBuffer(maxBytes: number, allocate = Buffer.allocUnsafe): Buffer {
+  return allocate(Math.min(READ_CHUNK_BYTES, maxBytes + 1));
 }
 
-function growReadBuffer(buffer: Buffer, maxBytes: number): Buffer {
+function growReadBuffer(buffer: Buffer, maxBytes: number, allocate = Buffer.allocUnsafe): Buffer {
   // Grow only after consuming the whole buffer, never from an unchecked size hint.
   const capacity = Math.min(maxBytes + 1, Math.max(READ_CHUNK_BYTES, buffer.length * 2));
-  const grown = Buffer.allocUnsafe(capacity);
+  const grown = allocate(capacity);
   buffer.copy(grown);
   return grown;
 }
 
-function finishReadBuffer(buffer: Buffer, total: number): Buffer {
+function finishReadBuffer(buffer: Buffer, total: number, allocate?: (size: number) => Buffer): Buffer {
   if (total === 0) return Buffer.alloc(0);
   const result = buffer.subarray(0, total);
-  return total < buffer.length / 2 ? Buffer.from(result) : result;
+  if (total >= buffer.length / 2) return result;
+  if (!allocate) return Buffer.from(result);
+  const compact = allocate(total);
+  result.copy(compact);
+  return compact;
 }
 
 function addReadBytes(
@@ -56,27 +60,30 @@ export async function readBoundedAsync(
     observeRegularFileSize?: () => number | undefined;
     initialSize?: number;
     createLimitError?: () => Error;
+    /** Keep the result outside Node's shared small-buffer allocation pool. */
+    unpooled?: boolean;
   } = {},
 ): Promise<Buffer> {
   normalizeMaxBytes(maxBytes);
   let total = 0;
   const { observeRegularFileSize, createLimitError } = options;
+  const allocate = options.unpooled ? Buffer.allocUnsafeSlow : undefined;
   const size = options.initialSize ?? observeRegularFileSize?.();
-  let buffer = size === undefined ? createScratchBuffer(maxBytes) : createInitialBuffer(maxBytes, size);
+  let buffer = size === undefined ? createScratchBuffer(maxBytes, allocate) : createInitialBuffer(maxBytes, size, allocate);
   if (size !== undefined) {
     const bytesRead = await readChunk(buffer, buffer.length);
-    if (bytesRead === 0) return finishReadBuffer(buffer, 0);
+    if (bytesRead === 0) return finishReadBuffer(buffer, 0, allocate);
     // Short reads can occur before EOF. Only use the size shortcut on this
     // initial read; virtual files can report zero or stale sizes thereafter.
     const currentSize = bytesRead < buffer.length ? observeRegularFileSize?.() : undefined;
     total = addReadBytes(total, bytesRead, maxBytes, createLimitError);
-    if (currentSize !== undefined && bytesRead >= currentSize) return finishReadBuffer(buffer, total);
+    if (currentSize !== undefined && bytesRead >= currentSize) return finishReadBuffer(buffer, total, allocate);
   }
   while (true) {
-    if (total === buffer.length) buffer = growReadBuffer(buffer, maxBytes);
+    if (total === buffer.length) buffer = growReadBuffer(buffer, maxBytes, allocate);
     const remaining = buffer.subarray(total);
     const bytesRead = await readChunk(remaining, remaining.length);
-    if (bytesRead === 0) return finishReadBuffer(buffer, total);
+    if (bytesRead === 0) return finishReadBuffer(buffer, total, allocate);
     total = addReadBytes(total, bytesRead, maxBytes, createLimitError);
   }
 }

--- a/src/native-binding.ts
+++ b/src/native-binding.ts
@@ -78,6 +78,11 @@ export interface NativeWindowsSecurityFacts {
 }
 
 export interface NativeBinding {
+  /** Internal: input remains private, unpooled and immutable until the reader is released. */
+  openZipBufferNative(buffer: Buffer, limits: TarMeterLimits, signal?: AbortSignal): Promise<{
+    readonly entries: NativeArchiveEntry[];
+    readEntry(index: number, maxBytes: number, signal?: AbortSignal): Promise<Buffer>;
+  }>;
   // POSIX-only direct-child staging; the matching Windows binary omits these methods.
   createStagedFile?(parentFd: number, basename: string): number;
   stagedFileMatches?(parentFd: number, basename: string, fileFd: number): boolean;

--- a/test/archive-read-boundaries.test.ts
+++ b/test/archive-read-boundaries.test.ts
@@ -352,14 +352,13 @@ describe("bounded archive reads", () => {
     }));
     let manifest: Array<{ index: number; path: string; kind: string; size: number; mode: number }> = [];
     let readError: Error | undefined;
-    const inspectArchiveNative = vi.fn(async () => manifest);
-    const readArchiveEntryNative = vi.fn(async () => {
+    const readEntry = vi.fn(async () => {
       if (readError) throw readError;
       return Buffer.from("value");
     });
+    const openZipBufferNative = vi.fn(async () => ({ entries: manifest, readEntry }));
     __setNativeLoaderForTest(() => ({
-      inspectArchiveNative,
-      readArchiveEntryNative,
+      openZipBufferNative,
     }) as unknown as NativeBinding);
     configureFsSafeNative({ mode: "require" });
     const regular = { index: 0, path: "value.txt", kind: "file", size: 5, mode: 0o644 };
@@ -386,14 +385,12 @@ describe("bounded archive reads", () => {
     readError = undefined;
     await expect(readArchiveEntry(archivePath, "value.txt", { maxBytes: 5 }))
       .resolves.toEqual(Buffer.from("value"));
-    expect(readArchiveEntryNative).toHaveBeenLastCalledWith(
-      expect.any(String),
-      "zip",
-      "./value.txt",
-      5,
+    expect(openZipBufferNative).toHaveBeenLastCalledWith(
+      expect.any(Buffer),
       resolveTarMeterLimits(),
       expect.any(AbortSignal),
     );
+    expect(readEntry).toHaveBeenLastCalledWith(0, 5, expect.any(AbortSignal));
   });
 
   it("requires native support for explicitly selected zstd and bzip2 TAR reads", async () => {

--- a/test/archive-read-canonical.test.ts
+++ b/test/archive-read-canonical.test.ts
@@ -32,11 +32,18 @@ for (const { mode, format } of routes) {
       configureFsSafeNative({ mode });
       if (mode === "require") {
         const native = paxNative!;
-        inspectNative = vi.fn(native.inspectArchiveNative.bind(native));
+        inspectNative = vi.fn(format === "zip" ? native.openZipBufferNative.bind(native) : native.inspectArchiveNative.bind(native));
         readNative = vi.fn(native.readArchiveEntryNative.bind(native));
         extractNative = vi.fn(native.extractArchiveNative.bind(native));
-        __setNativeLoaderForTest(() => ({ ...native, inspectArchiveNative: inspectNative,
-          readArchiveEntryNative: readNative, extractArchiveNative: extractNative }));
+        __setNativeLoaderForTest(() => ({ ...native,
+          inspectArchiveNative: format === "zip" ? native.inspectArchiveNative.bind(native) : inspectNative,
+          readArchiveEntryNative: readNative, extractArchiveNative: extractNative,
+          openZipBufferNative: async (...args) => {
+            const reader = await inspectNative(...args);
+            readNative = vi.fn(reader.readEntry.bind(reader));
+            return { entries: reader.entries, readEntry: readNative };
+          },
+        }));
       }
     });
     async function setup(name: keyof typeof tarReadArchives = "members") {
@@ -87,9 +94,13 @@ for (const { mode, format } of routes) {
       await unchanged(options.destDir);
       nativeRead(true);
       if (mode === "require") {
-        const manifest = await inspectNative.mock.results[0]!.value;
-        // Rust must receive the selected manifest spelling, not the canonical alias.
-        expect(manifest.some((entry: { path: string }) => entry.path === readNative.mock.calls[0]![2])).toBe(true);
+        const inspected = await inspectNative.mock.results[0]!.value;
+        // ZIP selects the retained manifest index; TAR retains its raw spelling.
+        if (format === "zip") {
+          expect(inspected.entries.some((entry: { index: number }) => entry.index === readNative.mock.calls[0]![0])).toBe(true);
+        } else {
+          expect(inspected.some((entry: { path: string }) => entry.path === readNative.mock.calls[0]![2])).toBe(true);
+        }
       }
     });
 

--- a/test/archive-zip-integrity.test.ts
+++ b/test/archive-zip-integrity.test.ts
@@ -70,10 +70,17 @@ for (const mode of ["off", "auto", "require"] as const) {
       if (mode !== "off") {
         // The shared loader uses native/<host artifact>, never a registry binary.
         // FS_SAFE_NATIVE_MODE=require makes a missing local build fail the suite.
-        read = vi.fn(native!.readArchiveEntryNative.bind(native));
+        read = vi.fn();
         extract = vi.fn(native!.extractArchiveNative.bind(native));
         __setNativeLoaderForTest(() => ({
-          ...native!, readArchiveEntryNative: read, extractArchiveNative: extract,
+          ...native!, extractArchiveNative: extract,
+          openZipBufferNative: async (...args) => {
+            const reader = await native!.openZipBufferNative(...args);
+            return { entries: reader.entries, readEntry: (...params) => {
+              read(...params);
+              return reader.readEntry(...params);
+            } };
+          },
         }));
       }
     });

--- a/test/native-zip-buffer.test.ts
+++ b/test/native-zip-buffer.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import JSZip from "jszip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readArchiveEntry } from "../src/archive-read.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __loadBundledNativeForTest, __resetNativeLoaderForTest, __setNativeLoaderForTest, type NativeBinding } from "../src/native.js";
+import { resolveTarMeterLimits } from "../src/archive-limits.js";
+import { readBoundedAsync } from "../src/bounded-read.js";
+import * as temp from "../src/temp-target.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+let native: NativeBinding | undefined;
+try { native = __loadBundledNativeForTest(); }
+catch (error) { if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error; }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+it.each([0, 1, 7, 64 * 1024])("keeps an unpooled bounded read private after a short read (%s bytes)", async length => {
+  const source = Buffer.alloc(length, 42);
+  let offset = 0;
+  const result = await readBoundedAsync(length, async (buffer, capacity) => {
+    const count = Math.min(capacity, source.length - offset, 3);
+    source.copy(buffer, 0, offset, offset + count);
+    offset += count;
+    return count;
+  }, { unpooled: true, initialSize: 1024 });
+  expect(result).toEqual(source);
+  expect(result.byteOffset).toBe(0);
+  expect(result.buffer.byteLength).toBeLessThanOrEqual(Math.max(length * 2, 1));
+});
+
+describe.skipIf(!native)("native buffered ZIP reads", () => {
+  it.each(["STORE", "DEFLATE"] as const)("reads %s without disk staging and keeps admitted bytes across source replacement", async compression => {
+    const dir = await tempRoot("fs-safe-native-buffer-");
+    const archivePath = path.join(dir, "input.zip");
+    const payload = Buffer.alloc(8192, 42);
+    const zip = new JSZip();
+    zip.file("payload", payload);
+    await fs.writeFile(archivePath, await zip.generateAsync({ type: "nodebuffer", compression }));
+    const open = vi.fn(async (buffer: Buffer, limits: Parameters<NativeBinding["openZipBufferNative"]>[1]) => {
+      expect(buffer.byteOffset).toBe(0);
+      expect(buffer.buffer.byteLength).toBeLessThanOrEqual(buffer.length + 1);
+      const reader = await native!.openZipBufferNative(buffer, limits);
+      await fs.writeFile(archivePath, "replaced after admission");
+      return reader;
+    });
+    __setNativeLoaderForTest(() => ({ ...native!, openZipBufferNative: open }));
+    configureFsSafeNative({ mode: "require" });
+    const staging = vi.spyOn(temp, "tempFile").mockRejectedValue(new Error("temporary storage unavailable"));
+    await expect(readArchiveEntry(archivePath, "payload", { maxBytes: payload.length })).resolves.toEqual(payload);
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(staging).not.toHaveBeenCalled();
+  });
+
+  it.each(["limit", "crc", "missing", "declared-size"])("retains %s rejection without staging", async failure => {
+    const dir = await tempRoot("fs-safe-native-buffer-errors-");
+    const archivePath = path.join(dir, "input.zip");
+    const zip = new JSZip(); zip.file("payload", "original bytes");
+    const bytes = await zip.generateAsync({ type: "nodebuffer", compression: failure === "declared-size" ? "DEFLATE" : "STORE" });
+    if (failure === "crc") bytes[30 + bytes.readUInt16LE(26) + bytes.readUInt16LE(28)]! ^= 1;
+    if (failure === "declared-size") {
+      bytes.writeUInt32LE(100, 22);
+      bytes.writeUInt32LE(100, bytes.readUInt32LE(bytes.length - 6) + 24);
+    }
+    await fs.writeFile(archivePath, bytes);
+    configureFsSafeNative({ mode: "require" });
+    const staging = vi.spyOn(temp, "tempFile").mockRejectedValue(new Error("temporary storage unavailable"));
+    const pending = readArchiveEntry(archivePath, failure === "missing" ? "absent" : "payload", {
+      maxBytes: failure === "limit" ? 1 : failure === "declared-size" ? 16 : 100,
+    });
+    if (failure === "missing") await expect(pending).rejects.toThrow("archive entry not found");
+    else if (failure === "crc") await expect(pending).rejects.toThrow(/checksum/i);
+    else await expect(pending).rejects.toMatchObject({
+      code: failure === "limit" ? "archive-entry-extracted-size-exceeds-limit" : "archive-header-invalid",
+    });
+    expect(staging).not.toHaveBeenCalled();
+  });
+
+  it("retains the archive across concurrent reads and validates direct byte budgets", async () => {
+    const zip = new JSZip(); zip.file("payload", "read repeatedly");
+    const bytes = await zip.generateAsync({ type: "nodebuffer" });
+    const owned = Buffer.allocUnsafeSlow(bytes.length); bytes.copy(owned);
+    const reader = await native!.openZipBufferNative(owned, resolveTarMeterLimits());
+    expect(reader.entries).toMatchObject([{ path: "payload", index: 0, kind: "file", size: 15 }]);
+    const results = await Promise.all(Array.from({ length: 12 }, () => reader.readEntry(0, 15)));
+    for (const result of results) expect(result.toString()).toBe("read repeatedly");
+    for (const max of [-1, NaN, Infinity, 0.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() => reader.readEntry(0, max)).toThrow();
+    }
+    await expect(reader.readEntry(0, 14)).rejects.toThrow();
+    await expect(reader.readEntry(1, 15)).rejects.toThrow();
+    const readAbort = new AbortController();
+    const reading = reader.readEntry(0, 15, readAbort.signal);
+    readAbort.abort();
+    await expect(reading).rejects.toThrow();
+    const openAbort = new AbortController();
+    const opening = native!.openZipBufferNative(owned, resolveTarMeterLimits(), openAbort.signal);
+    openAbort.abort();
+    await expect(opening).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes avoidable latency when reading a ZIP entry with the native backend. The API already holds an identity-checked, admitted archive buffer, but previously wrote those bytes to a temporary file and reopened/reparsed it for native inspection and reading. On a busy filesystem that staging work can dwarf decoding.

## Why This Change Was Made

A native reader now retains the private input allocation and parsed ZIP directory across worker-thread inspection and reading. TypeScript still admits the raw ZIP, rejects canonical collisions and non-file selections, then selects the native manifest index. Output remains bounded and checked for CRC and declared size. The input uses an unpooled allocation so unrelated small Node buffers cannot share its backing store; an N-API reference retains it and a mutex serializes cursor access. Cooperative cancellation remains available, including before result delivery.

There is no temporary ZIP copy or full-buffer handoff copy. Decompression still allocates output; N-API transfers that allocation to Node without another payload copy where external buffers are supported. TAR staging and native extraction keep their existing paths.

## User Impact

The public pathname API and its validation policy are unchanged. Native ZIP entry reads no longer require temporary storage. The native borrowing contract remains internal: the library-owned archive bytes are private and never mutated or detached while the reader/tasks exist.

## Evidence

On an isolated Linux c7a.2xlarge / AMD EPYC 9R14 / Node 24.18.1 runner, 30 interleaved reads per route of a 1 MiB stored entry measured median total latency of 0.951 ms for the new native path, 1.836 ms for the previous staged native path, and 2.910 ms for JS. That is 1.93× faster than the previous native path and 3.06× faster than JS for this workload. The comparison uses the same native binary for the old/new routes. Earlier noisy macOS numbers are not used as a general speedup claim.

Additional isolated cases, using the same interleaved protocol:

| Entry | JS median | Old native median | Buffered native median |
|---|---:|---:|---:|
| 64 B stored | 0.422 ms | 0.572 ms | 0.268 ms |
| 1 MiB stored | 2.910 ms | 1.836 ms | 0.951 ms |
| 1 MiB deflated | 3.182 ms | 1.195 ms | 0.867 ms |
| 16 MiB deflated | 54.818 ms | 15.645 ms | 14.451 ms |

Full `pnpm check` passed on AWS Crabbox `cbx_cd53fd29233d`: 8,666 tests passed, 91 skipped; all 72 Rust tests passed. A pointer-identity test verifies the input allocation is retained without copying; a forced-GC proof verifies 24 queued reads after JS releases its input/reader references. Focused regressions cover unavailable temporary storage, source replacement after admission, concurrent reads, cancellation, byte limits, CRC, malformed declared sizes, canonical selection and existing error mapping. Independent Codex review is clean. Cross-platform CI includes the native ownership and GC proofs.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included
