### PR TITLE
feat(root): check caller authority before filesystem mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Read native ZIP entries from the retained, admitted input buffer and reuse the parsed directory, eliminating temporary disk staging and archive handoff copies while preserving validation.
 - Add `@openclaw/fs-safe/clone` for native APFS directory clones, Btrfs subvolume preparation and snapshots, and parallel ReFS tree cloning, with exclusive destinations and cancellation that waits for native writes to settle.
 - Add async and sync positional reads that fill caller-owned buffers through short reads, stop at EOF, preserve descriptor offsets and ownership, and support cooperative async cancellation.
-- Add composed Root `assertBeforeMutation` callbacks that recheck live caller authority immediately before filesystem mutation dispatch, preserving refusal errors and owned cleanup across native and JavaScript writers.
+- Add composed Root `assertBeforeMutation` callbacks that recheck live caller authority immediately before filesystem mutation dispatch, including each buffered-write chunk and direct file removal, preserving refusal errors and owned cleanup across native and JavaScript writers.
+
 - Give the full documentation-build smoke test a bounded longer runtime so slow Windows runners do not hit the default unit-test deadline.
 - Add byte limits and cooperative cancellation to `sha256File`, preserving descriptor ownership and waiting for native work to stop before rejecting.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Read native ZIP entries from the retained, admitted input buffer and reuse the parsed directory, eliminating temporary disk staging and archive handoff copies while preserving validation.
 - Add `@openclaw/fs-safe/clone` for native APFS directory clones, Btrfs subvolume preparation and snapshots, and parallel ReFS tree cloning, with exclusive destinations and cancellation that waits for native writes to settle.
 - Add async and sync positional reads that fill caller-owned buffers through short reads, stop at EOF, preserve descriptor offsets and ownership, and support cooperative async cancellation.
-
+- Add composed Root `assertBeforeMutation` callbacks that recheck live caller authority immediately before filesystem mutation dispatch, preserving refusal errors and owned cleanup across native and JavaScript writers.
 - Give the full documentation-build smoke test a bounded longer runtime so slow Windows runners do not hit the default unit-test deadline.
 - Add byte limits and cooperative cancellation to `sha256File`, preserving descriptor ownership and waiting for native work to stop before rejecting.
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ await fs.create("notes/README.md", "seed\n"); // throws if it already exists
 
 `write()` replaces file contents by default; pass `{ overwrite: false }` or use `create()` when an existing file should be an error. `move()` defaults to no clobber because it can otherwise delete an unrelated target while also consuming the source. Pass `{ overwrite: true }` when replacing the target is intended.
 
+Mutating methods accept `assertBeforeMutation: () => void` for live lease or
+cancellation checks immediately before filesystem dispatch. Root defaults and
+per-call checks compose; cleanup and already-dispatched work still settle.
+See [live mutation authority](docs/root.md#live-mutation-authority) for the exact
+scope, including raw writable handles and lock bookkeeping.
+
 Use `ensureRoot()` when a computed relative directory target resolves to the root itself (`""` or `"."`) and you want the operation to be accepted. `root()` still requires the trusted root directory to already exist.
 
 ## Reading

--- a/docs/root.md
+++ b/docs/root.md
@@ -18,6 +18,7 @@ const fs = await root("/srv/workspace", {
 function root(rootDir: string, defaults?: RootDefaults): Promise<Root>;
 
 type RootDefaults = {
+  assertBeforeMutation?: () => void; // synchronous caller authority check at mutation dispatch
   durable?: boolean;               // fsync write/create/writeJson/createJson/append/copyIn; default true
   hardlinks?: "reject" | "allow";  // refuse files with nlink > 1 on read; defaults to "reject"
   denyMutations?: DenyMutationPolicy; // absolute paths/prefixes mutation methods may not change
@@ -39,7 +40,7 @@ type DenyMutationPolicy = {
 
 The root directory is pinned with exact bigint device/inode identities. A changed root rejects subsequent operations; an unknown Windows identity that remains unverifiable after bounded reinspection rejects construction with `path-mismatch`.
 
-`defaults` apply to every method on the returned handle. Per-call options on individual methods override the defaults for that call only, except `denyMutations`: root and per-call deny entries are merged so a call cannot clear a root-level deny.
+`defaults` apply to every method on the returned handle. Per-call options on individual methods override the defaults for that call only, except `denyMutations` and `assertBeforeMutation`: deny entries are merged, and the root assertion runs before the per-call assertion. A call cannot clear either root-level restriction.
 
 Every `maxBytes` value must be a non-negative safe integer or positive `Infinity`. Zero is an active zero-byte cap; `Infinity` explicitly disables the cap. An omitted or explicitly `undefined` per-call value preserves the configured Root default instead of clearing it.
 
@@ -132,6 +133,47 @@ derive portable destination names from host files must sanitize or map that
 basename first.
 
 `openWritable` opens a writable file with options `mode?: number` and `writeMode?: "replace" | "append" | "update"`. `replace` truncates existing files and is the default; `update` keeps existing contents. Use it for streaming output. Prefer `await using` for cleanup.
+
+### Live mutation authority
+
+All mutation methods accept `assertBeforeMutation?: () => void`. Use it when a
+lease, operation owner, or cancellation state can expire while filesystem
+preparation is awaiting I/O:
+
+```ts
+const controller = new AbortController();
+await fs.write("config.json", "{}\n", {
+  assertBeforeMutation: () => controller.signal.throwIfAborted(),
+});
+```
+
+The callback runs synchronously after awaited preparation, immediately before
+each Root-owned mutation is dispatched: parent creation, file creation and
+content writes (including private staging and streamed chunks), publication,
+truncation, append, move, and removal. Native calls that perform multiple
+filesystem steps are one dispatch. No asynchronous wait separates the check
+from that dispatch. A thrown value rejects the operation unchanged; an async
+or thenable-returning callback rejects with `TypeError` before that mutation.
+Synchronous return values are ignored. Callbacks can run multiple times and
+must inspect current authority each time.
+
+Already dispatched I/O cannot be revoked. Identity-checked cleanup, final
+permissions, and durability finish under the existing operation owner even
+after authority expires. Sidecar lock acquisition, recovery, and release for
+`renameIdentity: "verify-content-with-lock"` are lock bookkeeping outside this
+callback; content mutations still recheck after the lock is acquired. An
+operation may leave already-created parent directories when a later check
+rejects. A no-op such as `ensureRoot()` on the existing root does not require a
+callback invocation. This is a dispatch fence, not a filesystem transaction or
+a replacement for root confinement.
+
+If cleanup also fails or cannot prove ownership of an entry, the existing
+structured cleanup error takes precedence and retains the authority refusal
+as its cause.
+
+For `openWritable()`, the callback covers the library's parent creation,
+exclusive creation, and truncation. The returned raw `FileHandle` belongs to
+the caller, which must check authority before its own later writes.
 
 All mutation methods accept `denyMutations?: { paths?: string[]; prefixes?: string[] }`. Entries must be absolute paths. `paths` blocks those exact paths; `prefixes` blocks those paths and their descendants. fs-safe preserves path strings exactly and canonicalizes through existing ancestors before comparing, so a symlinked ancestor to a denied location is still denied. Denied mutations throw `FsSafeError` with code `denied-path`. Use this for caller-specific sensitive paths, not as a replacement for the root boundary, symlink, or hardlink checks.
 

--- a/docs/root.md
+++ b/docs/root.md
@@ -150,8 +150,10 @@ await fs.write("config.json", "{}\n", {
 The callback runs synchronously after awaited preparation, immediately before
 each Root-owned mutation is dispatched: parent creation, file creation and
 content writes (including private staging and streamed chunks), publication,
-truncation, append, move, and removal. Native calls that perform multiple
-filesystem steps are one dispatch. No asynchronous wait separates the check
+truncation, append, move, and removal. Buffered writes use bounded chunks and
+recheck before every partial-write submission; file removal submits a direct
+unlink request. Native calls that perform multiple filesystem steps are one
+dispatch. No asynchronous wait separates the check
 from that dispatch. A thrown value rejects the operation unchanged; an async
 or thenable-returning callback rejects with `TypeError` before that mutation.
 Synchronous return values are ignored. Callbacks can run multiple times and

--- a/src/guarded-mkdir.ts
+++ b/src/guarded-mkdir.ts
@@ -34,6 +34,7 @@ export async function mkdirPathComponentsWithGuards(params: {
   rootReal: string;
   targetPath: string;
   beforeComponent?: (componentPath: string) => Promise<void> | void;
+  assertBeforeMutation?: () => void;
   mode?: number;
   rejectSymlinks?: boolean;
 }): Promise<string> {
@@ -50,6 +51,7 @@ export async function mkdirPathComponentsWithGuards(params: {
     const parentGuard = await createAsyncDirectoryGuard(current);
     await assertAsyncDirectoryGuard(parentGuard);
     await params.beforeComponent?.(next);
+    params.assertBeforeMutation?.();
     try {
       await fs.mkdir(next, { mode: params.mode });
     } catch (error) {

--- a/src/mutation-authority.ts
+++ b/src/mutation-authority.ts
@@ -1,0 +1,40 @@
+import { FsSafeError } from "./errors.js";
+
+export class MutationAuthorityError extends FsSafeError {
+  constructor(readonly rejection: unknown) {
+    super("denied-path", "mutation authority rejected the operation", { cause: rejection });
+  }
+}
+
+function assertSynchronous(returned: unknown): void {
+  if (
+    returned !== null &&
+    (typeof returned === "object" || typeof returned === "function") &&
+    typeof (returned as { then?: unknown }).then === "function"
+  ) {
+    // TypeScript permits async functions for () => void. Do not admit their work.
+    void Promise.resolve(returned).catch(() => undefined);
+    throw new TypeError("assertBeforeMutation must be synchronous");
+  }
+}
+
+export function composeMutationAssertions(
+  defaultAssertion?: () => void,
+  callAssertion?: () => void,
+): (() => void) | undefined {
+  if (!defaultAssertion && !callAssertion) return undefined;
+  return () => {
+    try {
+      assertSynchronous(defaultAssertion?.());
+      assertSynchronous(callAssertion?.());
+    } catch (error) {
+      throw new MutationAuthorityError(error);
+    }
+  };
+}
+
+export function rethrowMutationAuthorityError(error: unknown): never {
+  if (error instanceof MutationAuthorityError) throw error.rejection;
+  // Cleanup failures and indeterminate publication receipts must retain their context.
+  throw error;
+}

--- a/src/native-operations.ts
+++ b/src/native-operations.ts
@@ -6,6 +6,7 @@ import { FsSafeError } from "./errors.js";
 import { sameFileIdentityForCleanup } from "./file-identity.js";
 import { getNativeBinding, type NativeBinding } from "./native.js";
 import type { PinnedWriteInput } from "./pinned-write.js";
+import { writeAllToFile } from "./write-file-handle.js";
 
 export type NativeFileHandle = {
   readonly fd: number;
@@ -42,19 +43,18 @@ export async function writeNativeInput(
   assertBeforeMutation?: () => void,
 ): Promise<void> {
   let bytes = 0;
-  const write = (data: Buffer) => {
+  const write = async (data: Buffer) => {
     bytes += data.byteLength;
     if (maxBytes !== undefined && bytes > maxBytes) {
       throw new FsSafeError("too-large", `file exceeds limit of ${maxBytes} bytes (got at least ${bytes})`);
     }
-    assertBeforeMutation?.();
-    writeNativeFd(fd, data);
+    await writeAllToFile(fd, data, { assertBeforeMutation });
   };
   if (input.kind === "buffer") {
-    write(typeof input.data === "string" ? Buffer.from(input.data, input.encoding ?? "utf8") : input.data);
+    await write(typeof input.data === "string" ? Buffer.from(input.data, input.encoding ?? "utf8") : input.data);
   } else {
     for await (const chunk of input.stream) {
-      write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+      await write(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
     }
   }
 }

--- a/src/native-operations.ts
+++ b/src/native-operations.ts
@@ -39,6 +39,7 @@ export async function writeNativeInput(
   fd: number,
   input: PinnedWriteInput,
   maxBytes?: number,
+  assertBeforeMutation?: () => void,
 ): Promise<void> {
   let bytes = 0;
   const write = (data: Buffer) => {
@@ -46,6 +47,7 @@ export async function writeNativeInput(
     if (maxBytes !== undefined && bytes > maxBytes) {
       throw new FsSafeError("too-large", `file exceeds limit of ${maxBytes} bytes (got at least ${bytes})`);
     }
+    assertBeforeMutation?.();
     writeNativeFd(fd, data);
   };
   if (input.kind === "buffer") {

--- a/src/native-pinned-write-windows.ts
+++ b/src/native-pinned-write-windows.ts
@@ -46,6 +46,7 @@ export async function runPinnedWriteWindows(
   let completed = false;
   try {
     tempName = `.fs-safe-${randomUUID()}.tmp`;
+    params.assertBeforeMutation?.();
     tempFd = binding.openBeneath(
       parentFd,
       tempName,
@@ -59,8 +60,9 @@ export async function runPinnedWriteWindows(
     // can remove owner access. Keep the unpublished inode private and
     // reopenable until the published name has been identity-fenced.
     fsSync.fchmodSync(tempFd, 0o600);
-    await writeNativeInput(tempFd, params.input, params.maxBytes);
+    await writeNativeInput(tempFd, params.input, params.maxBytes, params.assertBeforeMutation);
     if (params.sync !== false) syncFileBestEffortSync(tempFd);
+    params.assertBeforeMutation?.();
     if (params.overwrite === false) {
       binding.renameNoReplace(parentFd, tempName, parentFd, params.basename);
     } else {

--- a/src/native-pinned-write.ts
+++ b/src/native-pinned-write.ts
@@ -48,6 +48,7 @@ export async function runPinnedWriteNative(binding: NativeBinding, params: Pinne
       throw new FsSafeError("path-mismatch", "root path changed during native write");
     }
     if (params.mkdir) {
+      params.assertBeforeMutation?.();
       binding.mkdirBeneath(root.fd, params.relativeParentPath, 0o777);
     }
     parentFd = binding.openBeneath(

--- a/src/native-staged-file.ts
+++ b/src/native-staged-file.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import type { AnyAsyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
+import { MutationAuthorityError } from "./mutation-authority.js";
 import type { FileIdentityStat } from "./file-identity.js";
 import type { NativeBinding } from "./native-binding.js";
 import { writeNativeInput } from "./native-operations.js";
@@ -70,6 +71,7 @@ class NativeStagedFile implements StagedFile {
   readonly #portableNames: boolean;
   readonly #publishedMode: number;
   readonly #sync: boolean;
+  readonly #assertBeforeMutation?: () => void;
   readonly #name = `.fs-safe-${randomUUID()}.tmp`;
   #state: State = { status: "open", publication: NOT_PUBLISHED };
   #receipt?: StagedFileReceipt;
@@ -81,6 +83,7 @@ class NativeStagedFile implements StagedFile {
     portableNames: boolean,
     publishedMode: number,
     sync: boolean,
+    assertBeforeMutation?: () => void,
   ) {
     this.#binding = binding;
     this.#parentFd = parentFd;
@@ -88,6 +91,7 @@ class NativeStagedFile implements StagedFile {
     this.#portableNames = portableNames;
     this.#publishedMode = publishedMode;
     this.#sync = sync;
+    this.#assertBeforeMutation = assertBeforeMutation;
   }
 
   // Takes ownership of parentFd, including all construction and preparation failures.
@@ -101,10 +105,11 @@ class NativeStagedFile implements StagedFile {
     // Public staging uses portable names; existing POSIX writes accept literal names.
     portableNames = true,
     sync = true,
+    assertBeforeMutation?: () => void,
   ): Promise<NativeStagedFile> {
     let staged: NativeStagedFile;
     try {
-      staged = new NativeStagedFile(binding, parentFd, directory, portableNames, mode, sync);
+      staged = new NativeStagedFile(binding, parentFd, directory, portableNames, mode, sync, assertBeforeMutation);
     } catch (error) {
       try {
         fs.closeSync(parentFd);
@@ -127,7 +132,7 @@ class NativeStagedFile implements StagedFile {
     // This owner never escapes. Only the internal verifier borrows its fd;
     // public descriptor methods remain await-free and cannot race disposal.
     await using staged = await NativeStagedFile.create(
-      binding, parentFd, directory, params.input, params.mode, params.maxBytes, false, params.sync,
+      binding, parentFd, directory, params.input, params.mode, params.maxBytes, false, params.sync, params.assertBeforeMutation,
     );
     const published = await staged.publish(params.basename, { overwrite: params.overwrite !== false });
     const identity = published.staged.identity;
@@ -185,10 +190,11 @@ class NativeStagedFile implements StagedFile {
       // The exclusive open performs no fallible post-open checks. Store its fd
       // before every subsequent operation, including the first metadata read.
       const state = this.#open();
+      this.#assertBeforeMutation?.();
       state.fileFd = this.#binding.createStagedFile(this.#parentFd, this.#name);
       const fd = state.fileFd;
       fs.fchmodSync(fd, 0o600);
-      await writeNativeInput(fd, input, maxBytes);
+      await writeNativeInput(fd, input, maxBytes, this.#assertBeforeMutation);
       if (this.#sync) syncFileBestEffortSync(fd);
       const stat = fs.fstatSync(fd, { bigint: true });
       this.#receipt = Object.freeze({
@@ -237,6 +243,7 @@ class NativeStagedFile implements StagedFile {
         throw new FsSafeError("invalid-path", "publication needs a distinct basename and explicit overwrite policy");
       }
       this.#assertCurrent();
+      this.#assertBeforeMutation?.();
       try {
         if (overwrite) {
           this.#binding.renameReplace(this.#parentFd, this.#name, this.#parentFd, basename);
@@ -275,6 +282,7 @@ class NativeStagedFile implements StagedFile {
       assertStagedDirectoryCurrent(this.#directory);
       return receipt;
     } catch (error) {
+      if (error instanceof MutationAuthorityError) throw error;
       // Closure rejects further use, not the recorded outcome of an earlier publication.
       const publication = this.#state.status === "closed"
         ? this.#state.receipt.publication

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -20,6 +20,7 @@ import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { cleanupPinnedFilePath } from "./replace-file-temp-owner.js";
 import { withSidecarLock } from "./sidecar-lock.js";
 import { getFsSafeTestHooks } from "./test-hooks.js";
+import { writeAllToFile } from "./write-file-handle.js";
 
 export type PinnedWriteInput =
   | { kind: "buffer"; data: string | Buffer; encoding?: BufferEncoding }
@@ -63,19 +64,7 @@ async function writeStreamToHandle(
     const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array);
     bytes += buffer.byteLength;
     assertWithinMaxBytes(bytes, maxBytes);
-    let offset = 0;
-    while (offset < buffer.byteLength) {
-      assertBeforeMutation?.();
-      const { bytesWritten } = await handle.write(
-        buffer,
-        offset,
-        buffer.byteLength - offset,
-      );
-      if (bytesWritten <= 0) {
-        throw new FsSafeError("helper-failed", "fallback stream write made no progress");
-      }
-      offset += bytesWritten;
-    }
+    await writeAllToFile(handle, buffer, { assertBeforeMutation });
   }
 }
 
@@ -209,12 +198,9 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
           byteLength(params.input.data, params.input.encoding),
           params.maxBytes,
         );
-        params.assertBeforeMutation?.();
-        if (typeof params.input.data === "string") {
-          await handle.writeFile(params.input.data, params.input.encoding ?? "utf8");
-        } else {
-          await handle.writeFile(params.input.data);
-        }
+        await writeAllToFile(handle, params.input.data, {
+          encoding: params.input.encoding, assertBeforeMutation: params.assertBeforeMutation,
+        });
       } else {
         await writeStreamToHandle(params.input.stream, handle, params.maxBytes, params.assertBeforeMutation);
       }
@@ -262,12 +248,9 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
         byteLength(params.input.data, params.input.encoding),
         params.maxBytes,
       );
-      params.assertBeforeMutation?.();
-      if (typeof params.input.data === "string") {
-        await handle.writeFile(params.input.data, params.input.encoding ?? "utf8");
-      } else {
-        await handle.writeFile(params.input.data);
-      }
+      await writeAllToFile(handle, params.input.data, {
+        encoding: params.input.encoding, assertBeforeMutation: params.assertBeforeMutation,
+      });
     } else {
       await writeStreamToHandle(params.input.stream, handle, params.maxBytes, params.assertBeforeMutation);
     }

--- a/src/pinned-write.ts
+++ b/src/pinned-write.ts
@@ -56,6 +56,7 @@ async function writeStreamToHandle(
   stream: Readable,
   handle: FileHandle,
   maxBytes: number | undefined,
+  assertBeforeMutation?: () => void,
 ): Promise<void> {
   let bytes = 0;
   for await (const chunk of stream) {
@@ -64,6 +65,7 @@ async function writeStreamToHandle(
     assertWithinMaxBytes(bytes, maxBytes);
     let offset = 0;
     while (offset < buffer.byteLength) {
+      assertBeforeMutation?.();
       const { bytesWritten } = await handle.write(
         buffer,
         offset,
@@ -89,6 +91,7 @@ export type PinnedWriteParams = {
   mode: number;
   sync?: boolean;
   overwrite?: boolean;
+  assertBeforeMutation?: () => void;
   maxBytes?: number;
   input: PinnedWriteInput;
   rootIdentity?: FileIdentityStat;
@@ -168,6 +171,7 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
     parentPath = await mkdirPathComponentsWithGuards({
       rootReal: params.rootPath,
       targetPath: parentPath,
+      assertBeforeMutation: params.assertBeforeMutation,
       beforeComponent: async (componentPath) =>
         await getFsSafeTestHooks()?.beforeRootFallbackMutation?.("mkdir", componentPath),
     });
@@ -179,12 +183,14 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
   if (params.overwrite === false) {
     const handle = await withAsyncDirectoryGuards(
       [parentGuard],
-      async () =>
-        await fs.open(
+      async () => {
+        params.assertBeforeMutation?.();
+        return await fs.open(
           targetPath,
           fsSync.constants.O_WRONLY | fsSync.constants.O_CREAT | fsSync.constants.O_EXCL,
           params.mode,
-        ),
+        );
+      },
       {
         onPostGuardFailure: async (openedHandle) => {
           // The parent failed verification, so targetPath may now resolve
@@ -203,13 +209,14 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
           byteLength(params.input.data, params.input.encoding),
           params.maxBytes,
         );
+        params.assertBeforeMutation?.();
         if (typeof params.input.data === "string") {
           await handle.writeFile(params.input.data, params.input.encoding ?? "utf8");
         } else {
           await handle.writeFile(params.input.data);
         }
       } else {
-        await writeStreamToHandle(params.input.stream, handle, params.maxBytes);
+        await writeStreamToHandle(params.input.stream, handle, params.maxBytes, params.assertBeforeMutation);
       }
       // Content writes may clear set-ID bits; finalize them through the owned fd.
       await handle.chmod(params.mode);
@@ -246,6 +253,7 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
   let readHandle: FileHandle | undefined;
   let renamed = false;
   try {
+    params.assertBeforeMutation?.();
     handle = await fs.open(tempPath, tempFlags, params.mode);
     let verificationIdentity = fsSync.fstatSync(handle.fd, { bigint: true });
     tempIdentity = verificationIdentity;
@@ -254,13 +262,14 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
         byteLength(params.input.data, params.input.encoding),
         params.maxBytes,
       );
+      params.assertBeforeMutation?.();
       if (typeof params.input.data === "string") {
         await handle.writeFile(params.input.data, params.input.encoding ?? "utf8");
       } else {
         await handle.writeFile(params.input.data);
       }
     } else {
-      await writeStreamToHandle(params.input.stream, handle, params.maxBytes);
+      await writeStreamToHandle(params.input.stream, handle, params.maxBytes, params.assertBeforeMutation);
     }
     tempStat = fsSync.fstatSync(handle.fd);
     const tempPathStat = fsSync.lstatSync(tempPath);
@@ -272,6 +281,7 @@ async function runPinnedWriteFallback(params: PinnedWriteParams): Promise<FileId
     if (params.sync !== false) await syncFileBestEffort(handle);
     let verifiedIdentity: FileIdentityStat = expectedTempStat;
     await withAsyncDirectoryGuards([parentGuard], async () => {
+      params.assertBeforeMutation?.();
       await fs.rename(tempPath, targetPath);
       renamed = true;
       await getFsSafeTestHooks()?.afterPinnedWriteFallbackRename?.(targetPath);

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -76,6 +76,23 @@ import { inheritWriteTargetMode } from "./root-write-mode.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
 import { onCopyPublication, type CopyPublicationOptions } from "./copy-publication.js";
 
+import {
+  mergeReadOptions, readDefaults,
+  type HardlinkPolicy, type RootAppendOptions, type RootCopyOptions,
+  type RootCreateJsonOptions, type RootCreateOptions, type RootDefaults,
+  type RootMkdirOptions, type RootMoveOptions, type RootOpenOptions,
+  type RootOpenWritableOptions, type RootReadOptions, type RootRemoveOptions,
+  type RootWriteJsonOptions, type RootWriteOptions, type SymlinkPolicy,
+} from "./root-options.js";
+import { composeMutationAssertions, rethrowMutationAuthorityError } from "./mutation-authority.js";
+export type {
+  HardlinkPolicy, RootAppendOptions, RootCopyOptions, RootCreateJsonOptions,
+  RootCreateOptions, RootDefaults, RootMkdirOptions, RootMoveOptions,
+  RootOpenOptions, RootOpenWritableOptions, RootOptions, RootReadOptions,
+  RootRemoveOptions, RootWriteJsonOptions, RootWriteOptions, SymlinkPolicy, WritableOpenMode,
+} from "./root-options.js";
+export { DEFAULT_ROOT_MAX_BYTES } from "./root-options.js";
+
 export type { DenyMutationPolicy } from "./deny-mutations.js";
 export type { RenameIdentityPolicy } from "./pinned-write.js";
 export { resolveOpenedFileRealPathForHandle } from "./opened-realpath.js";
@@ -87,69 +104,6 @@ export type OpenResult = {
   stat: Stats;
   [Symbol.asyncDispose](): Promise<void>;
 };
-
-export type RootOptions = {
-  rootDir: string;
-  defaults?: RootDefaults;
-};
-
-export type SymlinkPolicy = "reject" | "follow-within-root";
-export type HardlinkPolicy = "reject" | "allow";
-export type WritableOpenMode = "replace" | "append" | "update";
-
-export type RootDefaults = {
-  durable?: boolean;
-  hardlinks?: HardlinkPolicy;
-  maxBytes?: number;
-  mkdir?: boolean;
-  mode?: number;
-  denyMutations?: DenyMutationPolicy;
-  nonBlockingRead?: boolean;
-  renameIdentity?: RenameIdentityPolicy;
-  symlinks?: SymlinkPolicy;
-};
-
-export type RootReadOptions = Pick<
-  RootDefaults,
-  "hardlinks" | "maxBytes" | "nonBlockingRead" | "symlinks"
->;
-
-export type RootOpenOptions = Omit<RootReadOptions, "maxBytes">;
-
-export type RootWriteOptions = Pick<RootDefaults, "denyMutations" | "durable" | "mkdir" | "mode" | "renameIdentity"> & {
-  encoding?: BufferEncoding;
-  overwrite?: boolean;
-};
-
-export type RootOpenWritableOptions = Pick<RootDefaults, "denyMutations" | "mkdir" | "mode"> & {
-  writeMode?: WritableOpenMode;
-};
-
-export type RootCopyOptions = Pick<RootDefaults, "denyMutations" | "durable" | "maxBytes" | "mkdir" | "mode"> & {
-  sourceHardlinks?: HardlinkPolicy;
-};
-
-export type RootWriteJsonOptions = RootWriteOptions & {
-  replacer?: Parameters<typeof JSON.stringify>[1];
-  space?: Parameters<typeof JSON.stringify>[2];
-  trailingNewline?: boolean;
-};
-
-export type RootCreateOptions = Omit<RootWriteOptions, "overwrite">;
-export type RootCreateJsonOptions = Omit<RootWriteJsonOptions, "overwrite">;
-
-export type RootAppendOptions = RootWriteOptions & {
-  prependNewlineIfNeeded?: boolean;
-};
-
-export type RootMoveOptions = Pick<RootDefaults, "denyMutations"> & {
-  overwrite?: boolean;
-};
-
-export type RootRemoveOptions = Pick<RootDefaults, "denyMutations">;
-export type RootMkdirOptions = Pick<RootDefaults, "denyMutations">;
-
-type RootReadParams = Omit<RootReadOptions, "nonBlockingRead">;
 
 function logWarn(message: string): void {
   if (process.env.FS_SAFE_DEBUG_WARNINGS === "1") {
@@ -177,8 +131,6 @@ const OPEN_APPEND_CREATE_FLAGS =
   fsConstants.O_CREAT |
   fsConstants.O_EXCL |
   (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
-
-export const DEFAULT_ROOT_MAX_BYTES = 16 * 1024 * 1024;
 
 function pathStatFromStats(stat: Stats): PathStat {
   return {
@@ -423,9 +375,10 @@ export class RootHandle implements Root {
     };
   }
 
-  private mutationOptions<T extends { denyMutations?: DenyMutationPolicy }>(options: T): T {
+  private mutationOptions<T extends { denyMutations?: DenyMutationPolicy; assertBeforeMutation?: () => void }>(options: T): T {
     return {
       ...options,
+      assertBeforeMutation: composeMutationAssertions(this.defaults.assertBeforeMutation, options.assertBeforeMutation),
       denyMutations: mergeDenyMutationPolicies(
         this.defaults.denyMutations,
         options.denyMutations,
@@ -506,7 +459,7 @@ export class RootHandle implements Root {
       ...this.mutationOptions(options),
       append: writeMode === "append",
       truncateExisting: writeMode === "replace",
-    });
+    }).catch(rethrowMutationAuthorityError);
   }
 
   async append(relativePath: string, data: string | Buffer, options: RootAppendOptions = {}): Promise<void> {
@@ -518,7 +471,7 @@ export class RootHandle implements Root {
       mode: this.defaults.mode,
       ...this.mutationOptions(options),
       durable: options.durable ?? this.defaults.durable ?? true,
-    });
+    }).catch(rethrowMutationAuthorityError);
   }
 
   async remove(relativePath: string, options: RootRemoveOptions = {}): Promise<void> {
@@ -526,7 +479,7 @@ export class RootHandle implements Root {
     await removePathInRoot(this.context, {
       relativePath,
       ...this.mutationOptions(options),
-    });
+    }).catch(rethrowMutationAuthorityError);
   }
 
   async mkdir(relativePath: string, options: RootMkdirOptions = {}): Promise<void> {
@@ -534,7 +487,7 @@ export class RootHandle implements Root {
     await mkdirPathInRoot(this.context, {
       relativePath,
       ...this.mutationOptions(options),
-    });
+    }).catch(rethrowMutationAuthorityError);
   }
 
   async ensureRoot(options: RootMkdirOptions = {}): Promise<void> {
@@ -542,7 +495,7 @@ export class RootHandle implements Root {
       relativePath: "",
       allowRoot: true,
       ...this.mutationOptions(options),
-    });
+    }).catch(rethrowMutationAuthorityError);
   }
 
   async write(
@@ -559,7 +512,7 @@ export class RootHandle implements Root {
       renameIdentity: this.defaults.renameIdentity,
       ...this.mutationOptions(options),
       durable: options.durable ?? this.defaults.durable ?? true,
-    });
+    }).catch(rethrowMutationAuthorityError);
   }
 
   async create(
@@ -576,7 +529,7 @@ export class RootHandle implements Root {
       ...this.mutationOptions(options),
       durable: options.durable ?? this.defaults.durable ?? true,
       overwrite: false,
-    });
+    }).catch(rethrowMutationAuthorityError);
   }
 
   async writeJson(
@@ -615,7 +568,7 @@ export class RootHandle implements Root {
       ...copyOptions,
       durable: options.durable ?? this.defaults.durable ?? true,
       verifyPublished: (options as CopyPublicationOptions)[onCopyPublication],
-    });
+    }).catch(rethrowMutationAuthorityError);
   }
 
   async exists(relativePath: string): Promise<boolean> {
@@ -655,7 +608,7 @@ export class RootHandle implements Root {
     assertValidRootRelativePath(fromRelative);
     assertValidRootDestinationPath(toRelative);
     validatePinnedOperationPayload({ from: fromRelative, to: toRelative });
-    const { denyMutations } = this.mutationOptions(options);
+    const { denyMutations, assertBeforeMutation } = this.mutationOptions(options);
     await assertMoveMutationAllowed(this.context, {
       fromRelative,
       toRelative,
@@ -664,31 +617,16 @@ export class RootHandle implements Root {
     await movePathFallback(this.context, {
       fromRelative,
       denyMutations,
+      assertBeforeMutation,
       overwrite: options.overwrite ?? false,
       toRelative,
-    });
+    }).catch(rethrowMutationAuthorityError);
   }
   walk(relativePath: string, options: RootWalkOptions): AsyncIterableIterator<RootWalkEntry> {
     assertValidRootRelativePath(relativePath);
     return walkRoot(this, relativePath, options);
   }
 }
-function readDefaults(defaults: RootDefaults): RootReadParams {
-  return {
-    hardlinks: defaults.hardlinks,
-    maxBytes: normalizeMaxBytes(defaults.maxBytes, { defaultValue: DEFAULT_ROOT_MAX_BYTES }),
-    symlinks: defaults.symlinks,
-  };
-}
-
-function mergeReadOptions(defaults: RootDefaults, options: RootReadOptions): RootReadParams {
-  const merged = readDefaults(defaults);
-  if (options.hardlinks !== undefined) merged.hardlinks = options.hardlinks;
-  merged.maxBytes = normalizeMaxBytes(options.maxBytes, { defaultValue: merged.maxBytes });
-  if (options.symlinks !== undefined) merged.symlinks = options.symlinks;
-  return merged;
-}
-
 export async function root(
   rootDir: string,
   defaults: RootDefaults = {},
@@ -801,10 +739,11 @@ function rootWriteQueueKey(root: RootContext, relativePath: string): string {
 
 type PinnedWriteTarget = { rootReal: string; targetPath: string; relativeParentPath: string; basename: string; mode: number };
 
-async function prepareRootWriteTarget(rootReal: string, targetPath: string): Promise<string> {
+async function prepareRootWriteTarget(rootReal: string, targetPath: string, assertBeforeMutation?: () => void): Promise<string> {
   const parentPath = await mkdirPathComponentsWithGuards({
     rootReal,
     targetPath: path.dirname(targetPath),
+    assertBeforeMutation,
   });
   // Continue through the guarded walk's real parent instead of re-entering
   // the original path through a symlinked component.
@@ -856,6 +795,7 @@ async function openWritableFileInRoot(
     mkdir?: boolean;
     mode?: number;
     denyMutations?: DenyMutationPolicy;
+    assertBeforeMutation?: () => void;
     truncateExisting?: boolean;
     append?: boolean;
   },
@@ -866,7 +806,7 @@ async function openWritableFileInRoot(
   });
   let ioPath = params.mkdir === false
     ? resolved
-    : await prepareRootWriteTarget(rootReal, resolved);
+    : await prepareRootWriteTarget(rootReal, resolved, params.assertBeforeMutation);
   try {
     const resolvedRealPath = fsSync.realpathSync.native(ioPath);
     if (!isPathInside(rootWithSep, resolvedRealPath)) {
@@ -898,6 +838,7 @@ async function openWritableFileInRoot(
       if (!isNotFoundPathError(err)) {
         throw err;
       }
+      params.assertBeforeMutation?.();
       handle = await fs.open(ioPath, createFlags, mode);
       createdForWrite = true;
     }
@@ -961,6 +902,7 @@ async function openWritableFileInRoot(
     // Truncate only after boundary and identity checks complete. This avoids
     // irreversible side effects if a symlink target changes before validation.
     if (params.append !== true && params.truncateExisting !== false && !createdForWrite) {
+      params.assertBeforeMutation?.();
       await handle.truncate(0);
     }
     return {
@@ -992,6 +934,7 @@ async function appendFileInRoot(
     mkdir?: boolean;
     mode?: number;
     denyMutations?: DenyMutationPolicy;
+    assertBeforeMutation?: () => void;
     prependNewlineIfNeeded?: boolean;
   },
 ): Promise<void> {
@@ -1000,9 +943,20 @@ async function appendFileInRoot(
     mkdir: params.mkdir,
     mode: params.mode,
     denyMutations: params.denyMutations,
+    assertBeforeMutation: params.assertBeforeMutation,
     truncateExisting: false,
     append: true,
   });
+  let dispatched = false;
+  // Reverse disposal order closes the handle before path cleanup and retains both failures.
+  await using cleanup = {
+    async [Symbol.asyncDispose]() {
+      if (!dispatched && target.createdForWrite) {
+        await removePathIfIdentityUnchanged(target.realPath, target.stat);
+      }
+    },
+  };
+  await using handle = target.handle;
   try {
     let prefix = "";
     if (
@@ -1019,6 +973,8 @@ async function appendFileInRoot(
       }
     }
 
+    params.assertBeforeMutation?.();
+    dispatched = true;
     if (typeof params.data === "string") {
       await target.handle.appendFile(`${prefix}${params.data}`, params.encoding ?? "utf8");
     } else {
@@ -1030,14 +986,14 @@ async function appendFileInRoot(
     if (params.durable !== false && target.createdForWrite) {
       await syncDirectoryBestEffort(path.dirname(target.realPath));
     }
-  } finally {
-    await target.handle.close().catch(() => {});
+  } catch (error) {
+    rethrowMutationAuthorityError(error);
   }
 }
 
 async function removePathInRoot(
   root: RootContext,
-  params: { relativePath: string; denyMutations?: DenyMutationPolicy },
+  params: RootRemoveOptions & { relativePath: string },
 ): Promise<void> {
   validatePinnedOperationPayload({ relativePath: params.relativePath });
   const resolved = await resolvePinnedPathInRoot(root, {
@@ -1046,7 +1002,7 @@ async function removePathInRoot(
     remove: true,
   });
   try {
-    await removePathFallback(resolved);
+    await removePathFallback(resolved, params.assertBeforeMutation);
   } catch (error) {
     throw normalizePinnedPathError(error);
   }
@@ -1058,12 +1014,13 @@ async function mkdirPathInRoot(
     relativePath: string;
     allowRoot?: boolean;
     denyMutations?: DenyMutationPolicy;
+    assertBeforeMutation?: () => void;
   },
 ): Promise<void> {
   validatePinnedOperationPayload({ relativePath: params.relativePath });
   const resolved = await resolvePinnedPathInRoot(root, params);
   try {
-    await mkdirPathFallback(resolved);
+    await mkdirPathFallback(resolved, params.assertBeforeMutation);
   } catch (error) {
     throw normalizePinnedPathError(error);
   }
@@ -1115,6 +1072,7 @@ async function commitPinnedWriteInRoot(
       overwrite: params.overwrite,
       input: { kind: "buffer", data: params.data, encoding: params.encoding },
       rootIdentity: root.rootIdentity,
+      assertBeforeMutation: params.assertBeforeMutation,
       verifyPublished: async (fd, expectedIdentity, parentGuard) => {
         verifyingPublication = true;
         try {
@@ -1155,6 +1113,7 @@ async function copyFileInRoot(
     mkdir?: boolean;
     mode?: number;
     denyMutations?: DenyMutationPolicy;
+    assertBeforeMutation?: () => void;
     sourceHardlinks?: HardlinkPolicy;
     durable?: boolean;
     verifyPublished?: CopyPublicationOptions[typeof onCopyPublication];
@@ -1197,6 +1156,7 @@ async function copyFileInRoot(
             verifyPublished: params.verifyPublished,
             input: { kind: "stream", stream: source.handle.createReadStream() },
             rootIdentity: root.rootIdentity,
+            assertBeforeMutation: params.assertBeforeMutation,
           });
         } catch (error) {
           throw normalizePinnedWriteError(error);
@@ -1394,19 +1354,21 @@ async function prepareRemoveGuard(targetPath: string) {
   }
 }
 
-async function removePathFallback(resolved: { resolved: string }): Promise<void> {
+async function removePathFallback(resolved: { resolved: string }, assertBeforeMutation?: () => void): Promise<void> {
   const guard = await prepareRemoveGuard(resolved.resolved);
   try {
-    await (fsSync.lstatSync(resolved.resolved).isDirectory() ? fs.rmdir(resolved.resolved) : fs.rm(resolved.resolved));
+    const isDirectory = fsSync.lstatSync(resolved.resolved).isDirectory();
+    assertBeforeMutation?.();
+    await (isDirectory ? fs.rmdir(resolved.resolved) : fs.rm(resolved.resolved));
   } catch (error) {
     throw normalizeRemovePathError(error);
   }
   await assertAsyncDirectoryGuard(guard).catch(error => { throw normalizeRemoveGuardError(error); });
 }
 
-async function mkdirPathFallback(resolved: { rootReal: string; resolved: string }): Promise<void> {
+async function mkdirPathFallback(resolved: { rootReal: string; resolved: string }, assertBeforeMutation?: () => void): Promise<void> {
   await mkdirPathComponentsWithGuards({
-    rootReal: resolved.rootReal, targetPath: resolved.resolved,
+    rootReal: resolved.rootReal, targetPath: resolved.resolved, assertBeforeMutation,
     beforeComponent: async (componentPath) => await getFsSafeTestHooks()?.beforeRootFallbackMutation?.("mkdir", componentPath),
   });
 }
@@ -1484,6 +1446,7 @@ async function movePathFallback(
   params: {
     fromRelative: string;
     denyMutations?: DenyMutationPolicy;
+    assertBeforeMutation?: () => void;
     toRelative: string;
     overwrite: boolean;
   },
@@ -1554,6 +1517,7 @@ async function movePathFallback(
   await getFsSafeTestHooks()?.beforeRootFallbackMutation?.("move", target.resolved);
   await assertAsyncDirectoryGuard(sourceParentGuard);
   await assertAsyncDirectoryGuard(targetParentGuard);
+  params.assertBeforeMutation?.();
   try {
     await fs.rename(source.resolved, target.resolved);
   } catch (error) {
@@ -1590,6 +1554,7 @@ async function writeFileFallback(
     // Private, writable placeholder: Windows cannot rename over a read-only file.
     mode: 0o600,
     denyMutations: params.denyMutations,
+    assertBeforeMutation: params.assertBeforeMutation,
     truncateExisting: false,
   });
   const destinationPath = target.realPath;
@@ -1607,9 +1572,11 @@ async function writeFileFallback(
   try {
     if (target.createdForWrite) placeholderIdentity = fsSync.fstatSync(target.handle.fd, { bigint: true });
     tempPath = buildAtomicWriteTempPath(destinationPath);
+    params.assertBeforeMutation?.();
     writtenHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, 0o600);
     writtenIdentity = fsSync.fstatSync(writtenHandle.fd, { bigint: true });
     unregisterTempPath = registerTempPathForExit(tempPath, { identity: writtenIdentity, singleLinkFile: true });
+    params.assertBeforeMutation?.();
     await writtenHandle.writeFile(params.data, params.encoding ?? "utf8");
     if (params.durable !== false) await writtenHandle.sync();
     const commitTempPath = tempPath;
@@ -1627,6 +1594,7 @@ async function writeFileFallback(
       }
       // Windows cannot replace a destination while its old handle remains open.
       await target.handle.close();
+      params.assertBeforeMutation?.();
       await fs.rename(commitTempPath, destinationPath);
       tempPath = null;
       published = true;
@@ -1683,7 +1651,7 @@ async function writeMissingFileFallback(
   });
   const targetPath = params.mkdir === false
     ? resolved
-    : await prepareRootWriteTarget(rootReal, resolved);
+    : await prepareRootWriteTarget(rootReal, resolved, params.assertBeforeMutation);
   const parentGuard = await createAsyncDirectoryGuard(path.dirname(targetPath), { bigint: true });
   let created = false;
   let createdIdentity: BigIntStats | undefined;
@@ -1693,11 +1661,13 @@ async function writeMissingFileFallback(
     const { handle, writtenStat } = await withAsyncDirectoryGuards(
       [parentGuard],
       async () => {
+        params.assertBeforeMutation?.();
         const handle = await fs.open(targetPath, OPEN_WRITE_CREATE_FLAGS, params.mode ?? 0o600).catch((error) => recordExclusiveCreateFailure(error, targetPath));
         writtenHandle = handle;
         created = true;
         const writtenStat = fsSync.fstatSync(handle.fd, { bigint: true });
         createdIdentity = writtenStat;
+        params.assertBeforeMutation?.();
         await handle.writeFile(params.data, params.encoding ?? "utf8");
         if (params.durable !== false) await handle.sync();
         return { handle, writtenStat };

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -75,6 +75,7 @@ import { verifyAtomicWriteResult } from "./root-write-verification.js";
 import { inheritWriteTargetMode } from "./root-write-mode.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
 import { onCopyPublication, type CopyPublicationOptions } from "./copy-publication.js";
+import { writeAllToFile } from "./write-file-handle.js";
 
 import {
   mergeReadOptions, readDefaults,
@@ -973,15 +974,14 @@ async function appendFileInRoot(
       }
     }
 
-    params.assertBeforeMutation?.();
+    const payload = typeof params.data === "string" ? `${prefix}${params.data}`
+      : prefix.length > 0 ? Buffer.concat([Buffer.from(prefix, "utf8"), params.data]) : params.data;
+    await writeAllToFile(target.handle, payload, {
+      encoding: params.encoding,
+      assertBeforeMutation: () => { params.assertBeforeMutation?.(); dispatched = true; },
+    });
+    // A successful empty append still creates the file, as Node's appendFile does.
     dispatched = true;
-    if (typeof params.data === "string") {
-      await target.handle.appendFile(`${prefix}${params.data}`, params.encoding ?? "utf8");
-    } else {
-      const payload =
-        prefix.length > 0 ? Buffer.concat([Buffer.from(prefix, "utf8"), params.data]) : params.data;
-      await target.handle.appendFile(payload);
-    }
     if (params.durable !== false) await target.handle.sync();
     if (params.durable !== false && target.createdForWrite) {
       await syncDirectoryBestEffort(path.dirname(target.realPath));
@@ -1194,12 +1194,10 @@ async function removePathIfIdentityUnchanged(
   identity: FileIdentityStat,
 ): Promise<void> {
   const parentGuard = await createAsyncDirectoryGuard(path.dirname(targetPath));
-  const current = fsSync.lstatSync(targetPath);
-  if (current.isSymbolicLink() || !sameFileIdentityForCleanup(current, identity)) {
-    return;
-  }
   await withAsyncDirectoryGuards([parentGuard], async () => {
-    await fs.rm(targetPath);
+    const current = fsSync.lstatSync(targetPath);
+    if (current.isSymbolicLink() || !sameFileIdentityForCleanup(current, identity)) return;
+    await fs.unlink(targetPath);
   });
 }
 
@@ -1359,7 +1357,7 @@ async function removePathFallback(resolved: { resolved: string }, assertBeforeMu
   try {
     const isDirectory = fsSync.lstatSync(resolved.resolved).isDirectory();
     assertBeforeMutation?.();
-    await (isDirectory ? fs.rmdir(resolved.resolved) : fs.rm(resolved.resolved));
+    await (isDirectory ? fs.rmdir(resolved.resolved) : fs.unlink(resolved.resolved));
   } catch (error) {
     throw normalizeRemovePathError(error);
   }
@@ -1576,8 +1574,9 @@ async function writeFileFallback(
     writtenHandle = await fs.open(tempPath, OPEN_WRITE_CREATE_FLAGS, 0o600);
     writtenIdentity = fsSync.fstatSync(writtenHandle.fd, { bigint: true });
     unregisterTempPath = registerTempPathForExit(tempPath, { identity: writtenIdentity, singleLinkFile: true });
-    params.assertBeforeMutation?.();
-    await writtenHandle.writeFile(params.data, params.encoding ?? "utf8");
+    await writeAllToFile(writtenHandle, params.data, {
+      encoding: params.encoding, assertBeforeMutation: params.assertBeforeMutation,
+    });
     if (params.durable !== false) await writtenHandle.sync();
     const commitTempPath = tempPath;
     const commitHandle = writtenHandle;
@@ -1667,8 +1666,9 @@ async function writeMissingFileFallback(
         created = true;
         const writtenStat = fsSync.fstatSync(handle.fd, { bigint: true });
         createdIdentity = writtenStat;
-        params.assertBeforeMutation?.();
-        await handle.writeFile(params.data, params.encoding ?? "utf8");
+        await writeAllToFile(handle, params.data, {
+          encoding: params.encoding, assertBeforeMutation: params.assertBeforeMutation,
+        });
         if (params.durable !== false) await handle.sync();
         return { handle, writtenStat };
       },

--- a/src/root-options.ts
+++ b/src/root-options.ts
@@ -1,0 +1,86 @@
+import { normalizeMaxBytes } from "./byte-budget.js";
+import type { DenyMutationPolicy } from "./deny-mutations.js";
+import type { RenameIdentityPolicy } from "./pinned-write.js";
+
+export const DEFAULT_ROOT_MAX_BYTES = 16 * 1024 * 1024;
+
+export type RootOptions = {
+  rootDir: string;
+  defaults?: RootDefaults;
+};
+
+export type SymlinkPolicy = "reject" | "follow-within-root";
+export type HardlinkPolicy = "reject" | "allow";
+export type WritableOpenMode = "replace" | "append" | "update";
+
+export type RootDefaults = {
+  assertBeforeMutation?: () => void;
+  durable?: boolean;
+  hardlinks?: HardlinkPolicy;
+  maxBytes?: number;
+  mkdir?: boolean;
+  mode?: number;
+  denyMutations?: DenyMutationPolicy;
+  nonBlockingRead?: boolean;
+  renameIdentity?: RenameIdentityPolicy;
+  symlinks?: SymlinkPolicy;
+};
+
+export type RootReadOptions = Pick<
+  RootDefaults,
+  "hardlinks" | "maxBytes" | "nonBlockingRead" | "symlinks"
+>;
+
+export type RootOpenOptions = Omit<RootReadOptions, "maxBytes">;
+
+export type RootWriteOptions = Pick<RootDefaults, "assertBeforeMutation" | "denyMutations" | "durable" | "mkdir" | "mode" | "renameIdentity"> & {
+  encoding?: BufferEncoding;
+  overwrite?: boolean;
+};
+
+export type RootOpenWritableOptions = Pick<RootDefaults, "assertBeforeMutation" | "denyMutations" | "mkdir" | "mode"> & {
+  writeMode?: WritableOpenMode;
+};
+
+export type RootCopyOptions = Pick<RootDefaults, "assertBeforeMutation" | "denyMutations" | "durable" | "maxBytes" | "mkdir" | "mode"> & {
+  sourceHardlinks?: HardlinkPolicy;
+};
+
+export type RootWriteJsonOptions = RootWriteOptions & {
+  replacer?: Parameters<typeof JSON.stringify>[1];
+  space?: Parameters<typeof JSON.stringify>[2];
+  trailingNewline?: boolean;
+};
+
+export type RootCreateOptions = Omit<RootWriteOptions, "overwrite">;
+export type RootCreateJsonOptions = Omit<RootWriteJsonOptions, "overwrite">;
+
+export type RootAppendOptions = RootWriteOptions & {
+  prependNewlineIfNeeded?: boolean;
+};
+
+export type RootMoveOptions = Pick<RootDefaults, "assertBeforeMutation" | "denyMutations"> & {
+  overwrite?: boolean;
+};
+
+export type RootRemoveOptions = Pick<RootDefaults, "assertBeforeMutation" | "denyMutations">;
+export type RootMkdirOptions = Pick<RootDefaults, "assertBeforeMutation" | "denyMutations">;
+
+export type RootReadParams = Omit<RootReadOptions, "nonBlockingRead">;
+
+export function readDefaults(defaults: RootDefaults): RootReadParams {
+  return {
+    hardlinks: defaults.hardlinks,
+    maxBytes: normalizeMaxBytes(defaults.maxBytes, { defaultValue: DEFAULT_ROOT_MAX_BYTES }),
+    symlinks: defaults.symlinks,
+  };
+}
+
+export function mergeReadOptions(defaults: RootDefaults, options: RootReadOptions): RootReadParams {
+  const merged = readDefaults(defaults);
+  if (options.hardlinks !== undefined) merged.hardlinks = options.hardlinks;
+  merged.maxBytes = normalizeMaxBytes(options.maxBytes, { defaultValue: merged.maxBytes });
+  if (options.symlinks !== undefined) merged.symlinks = options.symlinks;
+  return merged;
+}
+

--- a/src/root-options.ts
+++ b/src/root-options.ts
@@ -83,4 +83,3 @@ export function mergeReadOptions(defaults: RootDefaults, options: RootReadOption
   if (options.symlinks !== undefined) merged.symlinks = options.symlinks;
   return merged;
 }
-

--- a/src/write-file-handle.ts
+++ b/src/write-file-handle.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import { FsSafeError } from "./errors.js";
+
+const WRITE_CHUNK_BYTES = 512 * 1024;
+
+export async function writeAllToFile(
+  target: FileHandle | number,
+  data: string | Uint8Array,
+  options: { encoding?: BufferEncoding; assertBeforeMutation?: () => void } = {},
+): Promise<void> {
+  const buffer = typeof data === "string" ? Buffer.from(data, options.encoding ?? "utf8") : data;
+  let offset = 0;
+  while (offset < buffer.byteLength) {
+    const length = Math.min(WRITE_CHUNK_BYTES, buffer.byteLength - offset);
+    options.assertBeforeMutation?.();
+    const written = typeof target === "number"
+      ? await new Promise<number>((resolve, reject) => {
+        fs.write(target, buffer, offset, length, null, (error, bytesWritten) => {
+          if (error) reject(error);
+          else resolve(bytesWritten);
+        });
+      })
+      : (await target.write(buffer, offset, length, null)).bytesWritten;
+    if (written <= 0) {
+      throw new FsSafeError("helper-failed", "file write made no progress");
+    }
+    offset += written;
+  }
+}

--- a/test/clawpatch-regression.test.ts
+++ b/test/clawpatch-regression.test.ts
@@ -438,7 +438,7 @@ describe("clawpatch regression coverage", () => {
     vi.spyOn(fs, "open").mockImplementation(async (...args) => {
       const handle = await realOpen(...args);
       if (path.basename(String(args[0])) === "created.txt") {
-        vi.spyOn(handle, "writeFile").mockRejectedValueOnce(
+        vi.spyOn(handle, "write").mockRejectedValueOnce(
           Object.assign(new Error("test write failure"), { code: "EIO" }),
         );
       }

--- a/test/pinned-write-file-mode.test.ts
+++ b/test/pinned-write-file-mode.test.ts
@@ -26,16 +26,11 @@ describe.skipIf(process.platform === "win32")("fallback final file mode", () => 
         const handle = await open(...args);
         if (!(await handle.stat()).isFile()) return handle;
         const chmod = handle.chmod.bind(handle);
-        const writeFile = handle.writeFile.bind(handle);
         const write = handle.write.bind(handle);
         const sync = handle.sync.bind(handle);
         vi.spyOn(handle, "chmod").mockImplementation(async (mode) => {
           events.push("chmod");
           await chmod(mode);
-        });
-        vi.spyOn(handle, "writeFile").mockImplementation(async (...args) => {
-          events.push("write");
-          await writeFile(...args);
         });
         vi.spyOn(handle, "write").mockImplementation((async (...args: Parameters<typeof handle.write>) => {
           events.push("write");

--- a/test/root-create-publication.test.ts
+++ b/test/root-create-publication.test.ts
@@ -51,15 +51,13 @@ describe("create-only publication outcomes", () => {
         const handle = await open(...args);
         if (!(await handle.stat()).isFile()) return handle;
         if (String(args[0]) !== target) return handle;
-        const writeFile = handle.writeFile.bind(handle);
-        vi.spyOn(handle, "writeFile").mockImplementation(async (...writeArgs) => {
-          if (outcome === "write-error") {
-            await writeFile("partial");
+        if (outcome === "write-error") {
+          const write = handle.write.bind(handle);
+          vi.spyOn(handle, "write").mockImplementation(async () => {
+            await write("partial");
             throw failure;
-          }
-          await writeFile(...writeArgs);
-          if (outcome === "competing-create") return; // target already exists; never reached
-        });
+          });
+        }
         return handle;
       });
       if (outcome === "competing-create") await fs.writeFile(target, "winner", { mode: 0o600 });
@@ -94,14 +92,10 @@ describe("create-only publication visibility", () => {
     vi.spyOn(fs, "open").mockImplementation(async (...args) => {
       const handle = await open(...args);
       if (String(args[0]) !== target || !(await handle.stat()).isFile()) return handle;
-      const writeFile = handle.writeFile.bind(handle);
-      vi.spyOn(handle, "writeFile").mockImplementation(async (...writeArgs) => {
-        visibleBeforeWrite = await fs.lstat(target).then(
-          (stat) => stat.isFile() && stat.size === 0,
-          () => false,
-        );
-        await writeFile(...writeArgs);
-      });
+      visibleBeforeWrite = await fs.lstat(target).then(
+        (stat) => stat.isFile() && stat.size === 0,
+        () => false,
+      );
       return handle;
     });
 
@@ -121,12 +115,12 @@ describe("create-only publication visibility", () => {
       const target = path.join(capability.rootReal, "target");
       const content = operation.endsWith("Json") ? '{"value":"complete"}' : "complete";
       let visibleBeforeWrite: boolean | undefined;
-      const writeSync = fsSync.writeSync.bind(fsSync);
-      vi.spyOn(fsSync, "writeSync").mockImplementation((fd, buffer, ...rest) => {
+      const write = fsSync.write.bind(fsSync);
+      vi.spyOn(fsSync, "write").mockImplementation((fd, buffer, ...writeArgs) => {
         if (visibleBeforeWrite === undefined && fsSync.fstatSync(fd).isFile()) {
           visibleBeforeWrite = fsSync.existsSync(target);
         }
-        return writeSync(fd, buffer, ...rest as []);
+        return write(fd, buffer, ...writeArgs);
       });
 
       await runOperation(capability, operation, content);

--- a/test/root-mutation-authority.test.ts
+++ b/test/root-mutation-authority.test.ts
@@ -1,0 +1,232 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { root } from "../src/root.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __loadBundledNativeForTest, __resetNativeLoaderForTest } from "../src/native.js";
+import { __setFsSafeTestHooksForTest } from "../src/test-hooks.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+let nativeAvailable = false;
+try {
+  __loadBundledNativeForTest();
+  nativeAvailable = true;
+} catch (error) {
+  if (process.env.FS_SAFE_NATIVE_MODE === "require") throw error;
+}
+afterEach(() => {
+  vi.restoreAllMocks();
+  __setFsSafeTestHooksForTest();
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+  Object.defineProperty(process, "platform", platform);
+});
+
+const routes = [
+  { name: "fallback", mode: "off", windows: false },
+  { name: "Windows fallback", mode: "off", windows: true },
+  ...(nativeAvailable ? [{ name: "native", mode: "require", windows: false } as const] : []),
+] as const;
+
+async function fixture() {
+  const directory = await tempRoot("fs-safe-root-authority-");
+  await fs.writeFile(path.join(directory, "source"), "replacement");
+  await fs.writeFile(path.join(directory, "target"), "original");
+  return { directory, scoped: await root(directory) };
+}
+
+describe.each(routes)("Root mutation authority: $name", ({ mode, windows }) => {
+  function configure() {
+    configureFsSafeNative({ mode });
+    if (windows) Object.defineProperty(process, "platform", { value: "win32" });
+  }
+
+  it.each(["write", "create", "copyIn"] as const)(
+    "%s refuses publication after preparation loses authority and cleans its own files",
+    async (operation) => {
+      const { directory, scoped } = await fixture();
+      if (operation === "copyIn") await fs.writeFile(path.join(directory, "source"), Buffer.alloc(256 * 1024, 1));
+      configure();
+      const target = operation === "create" ? "created" : "target";
+      const expired = Object.assign(new Error("owner expired"), { code: "EEXIST" });
+      let active = true;
+      let writes = 0;
+      const open = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+        const handle = await open(...args);
+        const writeFile = handle.writeFile.bind(handle);
+        vi.spyOn(handle, "writeFile").mockImplementation(async (...writeArgs) => {
+          await writeFile(...writeArgs);
+          active = false;
+        });
+        // Exclusive creation is visible before content is written. Its owner must
+        // remove that empty file when authority expired during the open itself.
+        if (operation === "create" && mode === "off" && String(args[0]) === path.join(directory, target)) {
+          active = false;
+        }
+        const write = handle.write.bind(handle);
+        vi.spyOn(handle, "write").mockImplementation((async (...writeArgs: Parameters<typeof handle.write>) => {
+          const result = await write(...writeArgs);
+          writes++;
+          active = false;
+          return result;
+        }) as typeof handle.write);
+        return handle;
+      });
+      const writeSync = fsSync.writeSync.bind(fsSync);
+      vi.spyOn(fsSync, "writeSync").mockImplementation(((...args: Parameters<typeof fsSync.writeSync>) => {
+        const result = writeSync(...args);
+        writes++;
+        active = false;
+        return result;
+      }) as typeof fsSync.writeSync);
+      const assertBeforeMutation = () => { if (!active) throw expired; };
+      const pending = operation === "copyIn"
+        ? scoped.copyIn(target, path.join(directory, "source"), { assertBeforeMutation })
+        : scoped[operation](target, "replacement", { assertBeforeMutation });
+      await expect(pending).rejects.toBe(expired);
+      expect(active).toBe(false);
+      if (operation === "copyIn") expect(writes).toBe(1);
+      expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("original");
+      expect((await fs.readdir(directory)).sort()).toEqual(["source", "target"]);
+    },
+  );
+});
+
+it.each(["mkdir", "remove", "move"] as const)(
+  "%s rechecks authority after awaited directory preparation",
+  async (operation) => {
+    const { directory, scoped } = await fixture();
+    configureFsSafeNative({ mode: "off" });
+    const expired = Object.assign(new Error("owner expired"), { code: "ENOENT" });
+    let active = true;
+    __setFsSafeTestHooksForTest({
+      beforeRootFallbackMutation: async (kind) => { if (kind === operation) active = false; },
+    });
+    const options = { assertBeforeMutation: () => { if (!active) throw expired; } };
+    await expect(operation === "move"
+      ? scoped.move("source", "target", { ...options, overwrite: true })
+      : scoped[operation](operation === "mkdir" ? "new/nested" : "target", options)).rejects.toBe(expired);
+    expect(active).toBe(false);
+    expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("original");
+    expect((await fs.readdir(directory)).sort()).toEqual(["source", "target"]);
+  },
+);
+
+it.each([
+  { method: "append", existing: true, closeFails: false },
+  { method: "append", existing: false, closeFails: false },
+  { method: "append", existing: true, closeFails: true },
+  { method: "append", existing: false, closeFails: true },
+  { method: "openWritable", existing: true, closeFails: false },
+] as const)("$method refuses mutation after opening (existing=$existing, closeFails=$closeFails)", async ({ method, existing, closeFails }) => {
+  const { directory, scoped } = await fixture();
+  configureFsSafeNative({ mode: "off" });
+  const relative = existing ? "target" : "new";
+  const expired = new Error("owner expired");
+  const closeFailure = new Error("descriptor close failed");
+  let active = true;
+  const open = fs.open.bind(fs);
+  vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+    const handle = await open(...args);
+    if (String(args[0]) === path.join(directory, relative)) {
+      active = false;
+      if (closeFails) {
+        const close = handle.close.bind(handle);
+        vi.spyOn(handle, "close").mockImplementation(async () => {
+          await close();
+          throw closeFailure;
+        });
+      }
+    }
+    return handle;
+  });
+  const options = { assertBeforeMutation: () => { if (!active) throw expired; } };
+  const pending = method === "append"
+    ? scoped.append(relative, "replacement", options)
+    : scoped.openWritable(relative, options);
+  if (closeFails) {
+    await expect(pending).rejects.toMatchObject({ error: closeFailure, suppressed: expired });
+  } else {
+    await expect(pending).rejects.toBe(expired);
+  }
+  expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("original");
+  expect((await fs.readdir(directory)).sort()).toEqual(["source", "target"]);
+});
+
+it("composes root and call authority without overriding the root check", async () => {
+  const { directory } = await fixture();
+  configureFsSafeNative({ mode: "off" });
+  const expired = new Error("root authority expired");
+  let active = true;
+  const calls: string[] = [];
+  const scoped = await root(directory, {
+    assertBeforeMutation: () => { calls.push("root"); if (!active) throw expired; },
+  });
+  const options = { assertBeforeMutation: () => calls.push("call") };
+  await scoped.create("created", "ok", options);
+  expect(calls.length).toBeGreaterThan(0);
+  expect(calls.every((value, index) => value === (index % 2 === 0 ? "root" : "call"))).toBe(true);
+  active = false;
+  await expect(scoped.remove("created", options)).rejects.toBe(expired);
+  expect(await fs.readFile(path.join(directory, "created"), "utf8")).toBe("ok");
+});
+
+it.each(["default", "call"])("rejects asynchronous %s authority before mutation", async (owner) => {
+  const { directory } = await fixture();
+  configureFsSafeNative({ mode: "off" });
+  const options = { assertBeforeMutation: async () => { throw new Error("asynchronous refusal"); } };
+  const scoped = await root(directory, owner === "default" ? options : {});
+  await expect(scoped.remove("target", owner === "call" ? options : {})).rejects.toThrow("must be synchronous");
+  expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("original");
+});
+
+it("settles final permissions and durability after an admitted publication", async () => {
+  const { directory, scoped } = await fixture();
+  configureFsSafeNative({ mode: "off" });
+  const rename = fs.rename.bind(fs);
+  let active = true;
+  vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+    await rename(...args);
+    active = false;
+  });
+  await scoped.write("target", "replacement", {
+    mode: 0o400,
+    assertBeforeMutation: () => { if (!active) throw new Error("owner expired after publication"); },
+  });
+  expect(active).toBe(false);
+  expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("replacement");
+  if (process.platform !== "win32") expect((await fs.stat(path.join(directory, "target"))).mode & 0o777).toBe(0o400);
+});
+
+it.skipIf(!nativeAvailable || process.platform === "win32")("preserves native cleanup ownership evidence when authority expires after a stage replacement", async () => {
+  const { directory, scoped } = await fixture();
+  await fs.writeFile(path.join(directory, "source"), Buffer.alloc(256 * 1024, 1));
+  configureFsSafeNative({ mode: "require" });
+  let active = true;
+  let temporaryName: string | undefined;
+  const expired = new Error("owner expired");
+  const writeSync = fsSync.writeSync.bind(fsSync);
+  vi.spyOn(fsSync, "writeSync").mockImplementation(((...args: Parameters<typeof fsSync.writeSync>) => {
+    const result = writeSync(...args);
+    if (active) {
+      temporaryName = fsSync.readdirSync(directory).find((name) => name.startsWith(".fs-safe-"));
+      expect(temporaryName).toBeDefined();
+      fsSync.renameSync(path.join(directory, temporaryName!), path.join(directory, "saved-stage"));
+      fsSync.writeFileSync(path.join(directory, temporaryName!), "replacement-owned-by-another-operation");
+      active = false;
+    }
+    return result;
+  }) as typeof fsSync.writeSync);
+  await expect(scoped.copyIn("target", path.join(directory, "source"), {
+    assertBeforeMutation: () => { if (!active) throw expired; },
+  })).rejects.toMatchObject({
+    details: { phase: "prepare", cleanup: { status: "preserved", resources: "closed" } },
+    cause: { cause: expired },
+  });
+  expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("original");
+  expect(await fs.readFile(path.join(directory, temporaryName!), "utf8")).toBe("replacement-owned-by-another-operation");
+});

--- a/test/root-mutation-authority.test.ts
+++ b/test/root-mutation-authority.test.ts
@@ -53,47 +53,56 @@ describe.each(routes)("Root mutation authority: $name", ({ mode, windows }) => {
       const target = operation === "create" ? "created" : "target";
       const expired = Object.assign(new Error("owner expired"), { code: "EEXIST" });
       let active = true;
-      let writes = 0;
-      const open = fs.open.bind(fs);
-      vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
-        const handle = await open(...args);
-        const writeFile = handle.writeFile.bind(handle);
-        vi.spyOn(handle, "writeFile").mockImplementation(async (...writeArgs) => {
-          await writeFile(...writeArgs);
-          active = false;
-        });
-        // Exclusive creation is visible before content is written. Its owner must
-        // remove that empty file when authority expired during the open itself.
-        if (operation === "create" && mode === "off" && String(args[0]) === path.join(directory, target)) {
-          active = false;
-        }
-        const write = handle.write.bind(handle);
-        vi.spyOn(handle, "write").mockImplementation((async (...writeArgs: Parameters<typeof handle.write>) => {
-          const result = await write(...writeArgs);
-          writes++;
-          active = false;
-          return result;
-        }) as typeof handle.write);
-        return handle;
-      });
-      const writeSync = fsSync.writeSync.bind(fsSync);
-      vi.spyOn(fsSync, "writeSync").mockImplementation(((...args: Parameters<typeof fsSync.writeSync>) => {
-        const result = writeSync(...args);
-        writes++;
-        active = false;
-        return result;
-      }) as typeof fsSync.writeSync);
-      const assertBeforeMutation = () => { if (!active) throw expired; };
+      const assertBeforeMutation = () => {
+        const createdTarget = operation === "create" && mode === "off" && fsSync.existsSync(path.join(directory, target));
+        const preparedStage = fsSync.readdirSync(directory).some((name) =>
+          name !== "source" && name !== "target" && fsSync.lstatSync(path.join(directory, name)).size > 0);
+        if (createdTarget || preparedStage) active = false;
+        if (!active) throw expired;
+      };
       const pending = operation === "copyIn"
         ? scoped.copyIn(target, path.join(directory, "source"), { assertBeforeMutation })
         : scoped[operation](target, "replacement", { assertBeforeMutation });
       await expect(pending).rejects.toBe(expired);
       expect(active).toBe(false);
-      if (operation === "copyIn") expect(writes).toBe(1);
       expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("original");
       expect((await fs.readdir(directory)).sort()).toEqual(["source", "target"]);
     },
   );
+
+  it.each(["short", "stalled"] as const)("preserves bytes and cleanup through %s writes", async (behavior) => {
+    const { directory, scoped } = await fixture();
+    configure();
+    let writes = 0;
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args: Parameters<typeof fs.open>) => {
+      const handle = await open(...args);
+      const write = handle.write.bind(handle);
+      vi.spyOn(handle, "write").mockImplementation((async (buffer, offset, length, position) => {
+        writes++;
+        return behavior === "stalled" ? { bytesWritten: 0, buffer }
+          : await write(buffer, offset, Math.min(length, 3), position);
+      }) as typeof handle.write);
+      return handle;
+    });
+    const write = fsSync.write.bind(fsSync);
+    vi.spyOn(fsSync, "write").mockImplementation(((fd, buffer, offset, length, position, callback) => {
+      writes++;
+      if (behavior === "stalled") callback(null, 0, buffer);
+      else write(fd, buffer, offset, Math.min(length, 3), position, callback);
+    }) as typeof fsSync.write);
+    const content = "é:🙂";
+    const pending = scoped.write("target", content, { encoding: "utf16le" });
+    if (behavior === "stalled") {
+      await expect(pending).rejects.toMatchObject({ code: "helper-failed" });
+      expect(await fs.readFile(path.join(directory, "target"), "utf8")).toBe("original");
+    } else {
+      await pending;
+      expect(await fs.readFile(path.join(directory, "target"))).toEqual(Buffer.from(content, "utf16le"));
+    }
+    expect(writes).toBeGreaterThan(0);
+    expect((await fs.readdir(directory)).sort()).toEqual(["source", "target"]);
+  });
 });
 
 it.each(["mkdir", "remove", "move"] as const)(
@@ -209,20 +218,17 @@ it.skipIf(!nativeAvailable || process.platform === "win32")("preserves native cl
   let active = true;
   let temporaryName: string | undefined;
   const expired = new Error("owner expired");
-  const writeSync = fsSync.writeSync.bind(fsSync);
-  vi.spyOn(fsSync, "writeSync").mockImplementation(((...args: Parameters<typeof fsSync.writeSync>) => {
-    const result = writeSync(...args);
-    if (active) {
-      temporaryName = fsSync.readdirSync(directory).find((name) => name.startsWith(".fs-safe-"));
-      expect(temporaryName).toBeDefined();
-      fsSync.renameSync(path.join(directory, temporaryName!), path.join(directory, "saved-stage"));
-      fsSync.writeFileSync(path.join(directory, temporaryName!), "replacement-owned-by-another-operation");
-      active = false;
-    }
-    return result;
-  }) as typeof fsSync.writeSync);
   await expect(scoped.copyIn("target", path.join(directory, "source"), {
-    assertBeforeMutation: () => { if (!active) throw expired; },
+    assertBeforeMutation: () => {
+      temporaryName = fsSync.readdirSync(directory).find((name) =>
+        name !== "source" && name !== "target" && fsSync.lstatSync(path.join(directory, name)).size > 0);
+      if (active && temporaryName) {
+        fsSync.renameSync(path.join(directory, temporaryName), path.join(directory, "saved-stage"));
+        fsSync.writeFileSync(path.join(directory, temporaryName), "replacement-owned-by-another-operation");
+        active = false;
+      }
+      if (!active) throw expired;
+    },
   })).rejects.toMatchObject({
     details: { phase: "prepare", cleanup: { status: "preserved", resources: "closed" } },
     cause: { cause: expired },

--- a/test/root-mutation-dispatch.test.ts
+++ b/test/root-mutation-dispatch.test.ts
@@ -1,0 +1,142 @@
+import { createHook } from "node:async_hooks";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { root } from "../src/root.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetFsSafeNativeConfigForTest();
+});
+
+it("does not remove a file after asynchronous Node removal preparation loses authority", async () => {
+  const directory = await tempRoot("fs-safe-remove-dispatch-");
+  const target = path.join(directory, "target");
+  await fs.writeFile(target, "keep while unauthorized");
+  configureFsSafeNative({ mode: "off" });
+  const scoped = await root(directory);
+  const expired = new Error("removal owner expired during Node preparation");
+  let armed = false;
+  let revoked = false;
+  const preparations = new Set<number>();
+  // Node's rm() validates/lstats through callback requests before unlink. Observe
+  // their real completion, without replacing either fs.rm() or its filesystem work.
+  const hook = createHook({
+    init(id, type) {
+      if (armed && type === "FSREQCALLBACK") preparations.add(id);
+    },
+    after(id) {
+      if (preparations.has(id)) revoked = true;
+    },
+  });
+  hook.enable();
+  let failure: unknown;
+  try {
+    await scoped.remove("target", {
+      assertBeforeMutation: () => {
+        if (revoked) throw expired;
+        armed = true;
+      },
+    });
+  } catch (error) {
+    failure = error;
+  } finally {
+    hook.disable();
+  }
+  if (revoked) {
+    expect(failure).toBe(expired);
+    expect(await fs.readFile(target, "utf8")).toBe("keep while unauthorized");
+  } else {
+    // Direct unlink submission has no intervening asynchronous preparation.
+    expect(failure).toBeUndefined();
+    await expect(fs.lstat(target)).rejects.toMatchObject({ code: "ENOENT" });
+  }
+});
+
+it("stops a large append when authority expires after its first filesystem write", async () => {
+  const directory = await tempRoot("fs-safe-append-dispatch-");
+  const target = path.join(directory, "target");
+  const initial = Buffer.from("original");
+  const payload = Buffer.alloc(1024 * 1024, 0xe9);
+  await fs.writeFile(target, initial);
+  configureFsSafeNative({ mode: "off" });
+  const scoped = await root(directory);
+  const expired = new Error("append owner expired after the first write");
+  let armed = false;
+  let firstWrite: number | undefined;
+  let revoked = false;
+  // The first admitted request is the actual append write. Revocation happens
+  // at its completion, before Node or fs-safe can submit a subsequent chunk.
+  const hook = createHook({
+    init(id, type) {
+      if (armed && firstWrite === undefined && type === "FSREQPROMISE") firstWrite = id;
+    },
+    after(id) {
+      if (id === firstWrite) revoked = true;
+    },
+  });
+  hook.enable();
+  let failure: unknown;
+  try {
+    await scoped.append("target", payload.toString("latin1"), {
+      mkdir: false,
+      encoding: "latin1",
+      prependNewlineIfNeeded: true,
+      assertBeforeMutation: () => {
+        if (revoked) throw expired;
+        armed = true;
+      },
+    });
+  } catch (error) {
+    failure = error;
+  } finally {
+    hook.disable();
+  }
+  expect(revoked).toBe(true);
+  expect(failure).toBe(expired);
+  const actual = await fs.readFile(target);
+  const expected = Buffer.concat([initial, Buffer.from("\n"), payload]);
+  expect(actual.length).toBeGreaterThan(initial.length);
+  expect(actual.length).toBeLessThan(expected.length);
+  expect(actual).toEqual(expected.subarray(0, actual.length));
+});
+
+it("rechecks empty append cleanup identity after its awaited parent guard", async () => {
+  const directory = await tempRoot("fs-safe-append-cleanup-dispatch-");
+  const target = path.join(directory, "new");
+  configureFsSafeNative({ mode: "off" });
+  const scoped = await root(directory);
+  const expired = new Error("append owner expired");
+  let refused = false;
+  let observedLeaf = false;
+  let replaced = false;
+  const lstat = fsSync.lstatSync.bind(fsSync);
+  vi.spyOn(fsSync, "lstatSync").mockImplementation(((...args: Parameters<typeof fsSync.lstatSync>) => {
+    const stat = lstat(...args);
+    if (refused && String(args[0]) === target) observedLeaf = true;
+    if (refused && observedLeaf && !replaced && String(args[0]) === directory && fsSync.existsSync(target)) {
+      fsSync.renameSync(target, path.join(directory, "saved"));
+      fsSync.writeFileSync(target, "replacement");
+      replaced = true;
+    }
+    return stat;
+  }) as typeof fsSync.lstatSync);
+  await expect(scoped.append("new", "content", {
+    assertBeforeMutation: () => {
+      if (fsSync.existsSync(target)) { refused = true; throw expired; }
+    },
+  })).rejects.toBe(expired);
+  if (replaced) expect(await fs.readFile(target, "utf8")).toBe("replacement");
+  else await expect(fs.lstat(target)).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+it("keeps the file created by a successful empty append", async () => {
+  const directory = await tempRoot("fs-safe-empty-append-");
+  const scoped = await root(directory);
+  await scoped.append("empty", "");
+  expect(await fs.readFile(path.join(directory, "empty"))).toEqual(Buffer.alloc(0));
+});

--- a/test/root-post-mutation-guard.test.ts
+++ b/test/root-post-mutation-guard.test.ts
@@ -30,9 +30,9 @@ it.each(["remove", "move-source", "move-target"].flatMap(operation =>
       if (!missing) await fs.mkdir(parent);
     };
     if (operation === "remove") {
-      const remove = fs.rm.bind(fs);
-      vi.spyOn(fs, "rm").mockImplementationOnce(async (file, options) => {
-        await remove(file, options);
+      const unlink = fs.unlink.bind(fs);
+      vi.spyOn(fs, "unlink").mockImplementationOnce(async (file) => {
+        await unlink(file);
         await replaceParent(sourceDir);
       });
       await expect(scoped.remove("source/value")).rejects.toMatchObject({

--- a/test/root-windows-write-durability.test.ts
+++ b/test/root-windows-write-durability.test.ts
@@ -43,8 +43,8 @@ it.each(operations.flatMap(operation => settings.map(setting => ({ operation, ..
     vi.spyOn(fs, "open").mockImplementation(async (...args) => {
       const handle = await open(...args);
       if (String(args[0]) === target) destinationHandles.push(handle);
-      const write = handle.writeFile.bind(handle);
-      vi.spyOn(handle, "writeFile").mockImplementation(async (...writeArgs) => {
+      const write = handle.write.bind(handle);
+      vi.spyOn(handle, "write").mockImplementation(async (...writeArgs) => {
         events.push("write");
         return await write(...writeArgs);
       });
@@ -126,7 +126,12 @@ it.each(["write failure", "sync failure", "successful sync"] as const)(
         if (fault !== "successful sync") throw error;
       };
       if (fault === "write failure") {
-        vi.spyOn(handle, "writeFile").mockImplementation(swap);
+        const write = handle.write.bind(handle);
+        vi.spyOn(handle, "write").mockImplementation(async (...writeArgs) => {
+          const result = await write(...writeArgs);
+          await swap();
+          return result;
+        });
       } else {
         vi.spyOn(handle, "sync").mockImplementation(swap);
       }

--- a/test/sidecar-lock-root-create-denial.test.ts
+++ b/test/sidecar-lock-root-create-denial.test.ts
@@ -245,7 +245,7 @@ describe("Root exclusive-create denial (synthetic Windows/errno; real files)", (
       const handle = await realOpen(...args);
       if (args[0] === lockPath && exclusive(args[1])) {
         attempts += 1;
-        if (operation === "write") vi.spyOn(handle, "writeFile").mockRejectedValue(error);
+        if (operation === "write") vi.spyOn(handle, "write").mockRejectedValue(error);
         else {
           const realStat = fs.fstatSync.bind(fs);
           vi.spyOn(fs, "fstatSync").mockImplementation((fd, options) => {

--- a/test/staged-file-failures.test.ts
+++ b/test/staged-file-failures.test.ts
@@ -35,7 +35,7 @@ describe.runIf(native)("staged ownership failure boundaries", () => {
     const moved = `${directory}-moved`;
     const failure = Object.assign(new Error(`injected ${operation}`), { code: "EIO" });
     const method = {
-      fstat: "fstatSync", chmod: "fchmodSync", write: "writeSync", sync: "fsyncSync",
+      fstat: "fstatSync", chmod: "fchmodSync", write: "write", sync: "fsyncSync",
     }[operation] as "fstatSync";
     const original = fsSync[method];
     let createdFd: number | undefined;
@@ -194,7 +194,7 @@ describe.runIf(native)("staged ownership failure boundaries", () => {
         throw unlinkFailure;
       },
     }));
-    vi.spyOn(fsSync, "writeSync").mockImplementation(() => {
+    vi.spyOn(fsSync, "write").mockImplementation(() => {
       throw writeFailure;
     });
     const error = await stageFileInDirectory({ directory, content: "x" }).catch((value: unknown) => value);


### PR DESCRIPTION
## What Problem This Solves

Filesystem writes, moves, and removals can outlive a caller's lease or permission check while waiting for asynchronous preparation.

## Why This Change Was Made

Adds an optional synchronous `assertBeforeMutation` callback to Root defaults and mutation options. Root and per-call assertions compose, and checks run immediately before each library-owned mutation dispatch across native and JavaScript paths. Refusals preserve the caller's error; already-admitted work, descriptor disposal, and identity-owned cleanup still settle.

## User Impact

Consumers can carry revocable authority through Root operations, including configuration publication and workspace file changes. The callback cannot revoke an already-dispatched syscall or guard later writes through a returned raw FileHandle. Existing defaults remain unchanged.

Closes #251.

## Evidence

- Revoked-authority regression fails on the original implementation and preserves the target after the fix.
- 259 focused tests passed, including Root behavior and error normalization; native, JavaScript, and simulated Windows cases are covered.
- All 32 authority and dispatch tests pass against the rebuilt native binding and current package.
- Build, documentation, package, boundary, and file-size checks passed; independent review found no actionable P0-P2 findings.
- The broad local run was not completed. Focused mutation, error-contract, and native suites pass; exact-head cross-platform CI supplies the full-suite landing gate.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included

### Actual filesystem dispatch proof

Root removal now submits `unlink` directly, and buffered writes share a bounded writer that checks authority before every write submission, including short writes. This avoids the internal async preparation in Node's `rm` and the later chunks in `writeFile`/`appendFile`. The [Node write loop](https://github.com/nodejs/node/blob/848430679556aed0bd073f2bc263331ad84fa119/lib/internal/fs/promises.js#L478) and [removal preparation](https://github.com/nodejs/node/blob/848430679556aed0bd073f2bc263331ad84fa119/lib/internal/fs/promises.js#L807) explain the boundary.

A standalone built-package consumer used real filesystem operations and async-hooks observation, with no filesystem-operation mocks:

```json
{
  "observations": [
    {
      "case": "allowed-write",
      "bytes": 1048576,
      "exactBytes": true
    },
    {
      "case": "reassigned-owner-removal",
      "rejected": true,
      "targetPreserved": true
    },
    {
      "case": "allowed-removal-dispatch",
      "deferredPreparation": false,
      "targetRemoved": true
    },
    {
      "case": "append-owner-reassigned-after-first-write",
      "requestedBytes": 1048576,
      "appendedBytes": 524288,
      "rejected": true,
      "originalPrefixPreserved": true,
      "noLaterChunkWritten": true
    }
  ],
  "syntheticFixtureRemoved": true
}
```

The regressions fail on the previous PR head. Owned cleanup also rechecks the final file identity after awaited parent guards, preserving a replacement file.

### Removal semantics and Windows validation

The maintainer decision is to retain one direct `unlink` path for Root file removals. Missing targets still report `not-found`; a target disappearing after admission can now report `not-found` instead of being silently absorbed by Node's `rm` recovery. This intentionally avoids a second asynchronous pathname traversal. Ordinary Windows read-only files remain removable through [libuv's handle-based unlink implementation](https://github.com/nodejs/node/blob/v22.0.0/deps/uv/src/win/fs.c#L1073), without adding pathname-based chmod recovery.

The exact-head Node 22 Windows job had one 5,000 ms store-overlap timeout. That path exercises `Root.write`, but identical production and test bytes passed it in 2,330 ms on the earlier run; its private-mode sibling also slowed from 1,518 to 3,041 ms. Node 24 Windows, native Windows, and Node 22 Windows coverage passed. One exact failed-job rerun was requested without changing source, assertions, or timeouts.

The targeted rerun passed. Final head `cd3a12d232f6c8a8c854a9d85726840942f2c032` is green in [CI](https://github.com/openclaw/fs-safe/actions/runs/34732561026) (15 jobs), [cross-platform coverage](https://github.com/openclaw/fs-safe/actions/runs/34732561014), and [CodeQL](https://github.com/openclaw/fs-safe/actions/runs/34732560991).
