### PR TITLE
perf(walk): bound metadata work and stream filesystem order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add async and sync positional reads that fill caller-owned buffers through short reads, stop at EOF, preserve descriptor offsets and ownership, and support cooperative async cancellation.
 - Add composed Root `assertBeforeMutation` callbacks that recheck live caller authority immediately before filesystem mutation dispatch, including each buffered-write chunk and direct file removal, preserving refusal errors and owned cleanup across native and JavaScript writers.
 - Add `follow-parents-within-root` reads and opt-in `mutationSymlinks` policies, following contained directory aliases while rejecting final symlinks at absolute root entry, open, and publication boundaries.
+- Read Root walk metadata only for examined entries, and add `order: "filesystem"` for streamed directory enumeration with bounded lookahead, cancellation, and guarded cleanup; preserve sorted traversal by default.
 
 - Give the full documentation-build smoke test a bounded longer runtime so slow Windows runners do not hit the default unit-test deadline.
 - Add byte limits and cooperative cancellation to `sha256File`, preserving descriptor ownership and waiting for native work to stop before rejecting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add async and sync positional reads that fill caller-owned buffers through short reads, stop at EOF, preserve descriptor offsets and ownership, and support cooperative async cancellation.
 - Add composed Root `assertBeforeMutation` callbacks that recheck live caller authority immediately before filesystem mutation dispatch, including each buffered-write chunk and direct file removal, preserving refusal errors and owned cleanup across native and JavaScript writers.
 - Add `follow-parents-within-root` reads and opt-in `mutationSymlinks` policies, following contained directory aliases while rejecting final symlinks at absolute root entry, open, and publication boundaries.
-- Read Root walk metadata only for examined entries, and add `order: "filesystem"` for streamed directory enumeration with bounded lookahead, cancellation, and guarded cleanup; preserve sorted traversal by default and retain both operation and close failures during disposal.
+- Bound Root walk metadata batches by the global entry budget, stopping at directories and symlinks before descent, and add `order: "filesystem"` for single-entry streaming with bounded lookahead; preserve sorted traversal and fast unbounded snapshots, share equivalent root/directory checks, and retain both operation and close failures during disposal.
 
 - Give the full documentation-build smoke test a bounded longer runtime so slow Windows runners do not hit the default unit-test deadline.
 - Add byte limits and cooperative cancellation to `sha256File`, preserving descriptor ownership and waiting for native work to stop before rejecting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add async and sync positional reads that fill caller-owned buffers through short reads, stop at EOF, preserve descriptor offsets and ownership, and support cooperative async cancellation.
 - Add composed Root `assertBeforeMutation` callbacks that recheck live caller authority immediately before filesystem mutation dispatch, including each buffered-write chunk and direct file removal, preserving refusal errors and owned cleanup across native and JavaScript writers.
 - Add `follow-parents-within-root` reads and opt-in `mutationSymlinks` policies, following contained directory aliases while rejecting final symlinks at absolute root entry, open, and publication boundaries.
-- Read Root walk metadata only for examined entries, and add `order: "filesystem"` for streamed directory enumeration with bounded lookahead, cancellation, and guarded cleanup; preserve sorted traversal by default.
+- Read Root walk metadata only for examined entries, and add `order: "filesystem"` for streamed directory enumeration with bounded lookahead, cancellation, and guarded cleanup; preserve sorted traversal by default and retain both operation and close failures during disposal.
 
 - Give the full documentation-build smoke test a bounded longer runtime so slow Windows runners do not hit the default unit-test deadline.
 - Add byte limits and cooperative cancellation to `sha256File`, preserving descriptor ownership and waiting for native work to stop before rejecting.

--- a/docs/root.md
+++ b/docs/root.md
@@ -64,7 +64,9 @@ fs.walk(rel, options)          // root-bounded AsyncIterable<{ relativePath, kin
 
 `walk()` is the incremental, root-bounded recursive scan. It supports entry and
 depth budgets, cancellation, and `symlinkPolicy: "skip" |
-"follow-within-root"`. It defers child metadata until an entry is reached.
+"follow-within-root"`. With an entry budget, sorted walks prepare small metadata
+batches within the remaining budget; unbounded sorted walks reuse the full
+directory snapshot.
 The default `order: "sorted"` enumerates and sorts each directory's names;
 `order: "filesystem"` streams names in filesystem order for bounded work in
 wide directories. Budget exhaustion yields a `"truncated"` marker by

--- a/docs/root.md
+++ b/docs/root.md
@@ -64,7 +64,10 @@ fs.walk(rel, options)          // root-bounded AsyncIterable<{ relativePath, kin
 
 `walk()` is the incremental, root-bounded recursive scan. It supports entry and
 depth budgets, cancellation, and `symlinkPolicy: "skip" |
-"follow-within-root"`. Budget exhaustion yields a `"truncated"` marker by
+"follow-within-root"`. It defers child metadata until an entry is reached.
+The default `order: "sorted"` enumerates and sorts each directory's names;
+`order: "filesystem"` streams names in filesystem order for bounded work in
+wide directories. Budget exhaustion yields a `"truncated"` marker by
 default or throws `FsSafeError("too-large")` with `limitBehavior: "throw"`.
 Use `entryFilter(entry)` to return `"include"`, `"skip"`, or
 `"skip-subtree"`. `"skip"` omits the current entry but still descends into a

--- a/docs/walk.md
+++ b/docs/walk.md
@@ -108,6 +108,10 @@ and truncation rules. Cancellation is checked between asynchronous reads; it
 does not interrupt a filesystem operation already in progress or the sorted
 mode's name sorting.
 
+If a thrown walk failure and directory close both fail, disposal throws a
+`SuppressedError` with the close failure in `error` and the original failure in
+`suppressed`, preserving both causes.
+
 `entryFilter` is evaluated for each resolved file, directory, or other entry:
 
 ```ts

--- a/docs/walk.md
+++ b/docs/walk.md
@@ -80,10 +80,19 @@ For followed symlinks, both `kind` and `size` describe the resolved target.
 
 The default `order: "sorted"` visits each directory's names in lexicographic
 order before descending depth first. It reads and sorts all names in each
-visited directory, but reads child metadata only when the entry is reached
-within the budget. `maxEntries: 0`, truncation, and early iterator
-termination never trigger metadata reads for the unused suffix. Filtering
-still requires the current entry's metadata and consumes its budget.
+visited directory. With `maxEntries`, it prepares small metadata batches capped
+by the remaining global entry budget. Every batch stops at the first directory
+or symlink, so recursive descent cannot spend a budget already used by later
+siblings. An early `break` may leave metadata from the current batch unused;
+the total still stays within `maxEntries`. Filtering requires metadata and
+consumes the entry budget, including entries skipped by the filter.
+
+Without `maxEntries`, sorted walks reuse a full directory metadata snapshot
+from the `Root.list()` owner. This preserves the existing fast complete-scan
+behavior and its snapshot semantics: changes made after a directory is listed
+do not alter its already-captured entries. Supply an entry budget or use
+filesystem order when metadata work must remain incremental. Sorted entries
+describe the observations captured in their directory snapshot or batch.
 
 Use `order: "filesystem"` when a wide directory must not be fully enumerated:
 
@@ -100,13 +109,15 @@ for await (const entry of capability.walk("", {
 This order follows the filesystem's directory stream and is not deterministic.
 It reads one entry at a time, including one name of lookahead to distinguish an
 exactly exhausted budget from truncation. The lookahead does not request full
-entry metadata from fs-safe. If a filesystem does not supply directory-entry
+entry metadata from fs-safe, and an early `break` does not prefetch later child
+metadata. If a filesystem does not supply directory-entry
 types, Node may classify that one extra entry with a synchronous `lstat`.
 Handles close on completion, truncation, cancellation, errors, or an
 early `break`. Both orders keep the same depth-first traversal, entry filtering,
-and truncation rules. Cancellation is checked between asynchronous reads; it
-does not interrupt a filesystem operation already in progress or the sorted
-mode's name sorting.
+and truncation rules. Cancellation is checked between entries, with event-loop
+handoffs between budgeted sorted batches. Root and directory checks and admitted
+child metadata reads are synchronous; no mode can interrupt a filesystem
+syscall already in progress or the sorted mode's name sorting.
 
 If a thrown walk failure and directory close both fail, disposal throws a
 `SuppressedError` with the close failure in `error` and the original failure in
@@ -146,8 +157,10 @@ Every examined directory entry consumes `maxEntries` before filtering, so
 further descent.
 
 The pure-Node path validates every directory through the Root boundary, pins
-its exact identity, and rechecks it and the Root identity around deferred child
-metadata reads. It tracks canonical directories to stop symlink cycles.
+its exact identity, and rechecks it and the Root identity around each metadata
+batch or individual filesystem-order observation. Sorted batches contain no
+await or caller code between their before/after checks. It tracks canonical
+directories to stop symlink cycles.
 Neither mode holds a descriptor for every path component, so it is not a process sandbox against a hostile peer that
 can continuously swap and restore directories. Each individual lookup retains
 the documented Node `Root` boundary checks.

--- a/docs/walk.md
+++ b/docs/walk.md
@@ -72,11 +72,41 @@ Unreadable directories are skipped rather than throwing, but every skipped direc
 `Root.walk(rel, options)` is the root-bounded counterpart to these standalone
 inventory helpers. It yields `{ relativePath, kind, size }` incrementally and
 accepts `maxDepth`, `maxEntries`, `symlinkPolicy: "skip" |
-"follow-within-root"`, and an `AbortSignal`. The default budget behavior yields
+"follow-within-root"`, `order: "sorted" | "filesystem"`, and an `AbortSignal`. The default budget behavior yields
 one `kind: "truncated"` marker and ends; pass `limitBehavior: "throw"` for a
 typed `FsSafeError("too-large")` instead.
 
 For followed symlinks, both `kind` and `size` describe the resolved target.
+
+The default `order: "sorted"` visits each directory's names in lexicographic
+order before descending depth first. It reads and sorts all names in each
+visited directory, but reads child metadata only when the entry is reached
+within the budget. `maxEntries: 0`, truncation, and early iterator
+termination never trigger metadata reads for the unused suffix. Filtering
+still requires the current entry's metadata and consumes its budget.
+
+Use `order: "filesystem"` when a wide directory must not be fully enumerated:
+
+```ts
+for await (const entry of capability.walk("", {
+  order: "filesystem",
+  maxEntries: 128,
+  symlinkPolicy: "skip",
+})) {
+  consume(entry);
+}
+```
+
+This order follows the filesystem's directory stream and is not deterministic.
+It reads one entry at a time, including one name of lookahead to distinguish an
+exactly exhausted budget from truncation. The lookahead does not request full
+entry metadata from fs-safe. If a filesystem does not supply directory-entry
+types, Node may classify that one extra entry with a synchronous `lstat`.
+Handles close on completion, truncation, cancellation, errors, or an
+early `break`. Both orders keep the same depth-first traversal, entry filtering,
+and truncation rules. Cancellation is checked between asynchronous reads; it
+does not interrupt a filesystem operation already in progress or the sorted
+mode's name sorting.
 
 `entryFilter` is evaluated for each resolved file, directory, or other entry:
 
@@ -111,10 +141,10 @@ Every examined directory entry consumes `maxEntries` before filtering, so
 `"truncated"` markers describe already-reached state and do not authorize
 further descent.
 
-The pure-Node path validates every directory canonically inside the root,
-revalidates each listing through the normal `Root.list()` boundary, and tracks
-canonical directories to stop symlink cycles. It does not hold a descriptor
-for the entire tree, so it is not a process sandbox against a hostile peer that
+The pure-Node path validates every directory through the Root boundary, pins
+its exact identity, and rechecks it and the Root identity around deferred child
+metadata reads. It tracks canonical directories to stop symlink cycles.
+Neither mode holds a descriptor for every path component, so it is not a process sandbox against a hostile peer that
 can continuously swap and restore directories. Each individual lookup retains
 the documented Node `Root` boundary checks.
 

--- a/src/root-context.ts
+++ b/src/root-context.ts
@@ -12,7 +12,7 @@ import {
   isPathInside,
 } from "./path.js";
 import { ROOT_PATH_ALIAS_POLICIES, resolveRootPath } from "./root-path.js";
-import { outsideWorkspaceError } from "./root-errors.js";
+import { outsideWorkspaceError, rootPathChangedError } from "./root-errors.js";
 import { isDriveRelativePath } from "./safe-path-segment.js";
 import { inspectFileIdentity } from "./strict-file-identity.js";
 
@@ -116,16 +116,14 @@ export async function assertRootIdentityCurrent(root: RootContext): Promise<void
     }
     current = fs.lstatSync(root.rootReal);
   } catch (error) {
-    throw new FsSafeError("path-mismatch", "root path changed during operation", {
-      cause: error instanceof Error ? error : undefined,
-    });
+    throw rootPathChangedError(error instanceof Error ? error : undefined);
   }
   if (
     current.isSymbolicLink() ||
     !current.isDirectory() ||
     !sameFileIdentity(current, root.rootIdentity)
   ) {
-    throw new FsSafeError("path-mismatch", "root path changed during operation");
+    throw rootPathChangedError();
   }
 }
 

--- a/src/root-directory-list.ts
+++ b/src/root-directory-list.ts
@@ -56,7 +56,7 @@ export async function listDirectoryPath(
 export type RootDirectoryListing = {
   next(): Promise<string | undefined>;
   readEntry(name: string): Promise<DirEntry>;
-  close(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
 };
 
 export async function listDirectoryForWalk(
@@ -93,7 +93,7 @@ export async function listDirectoryForWalk(
     await assertCurrent();
     names?.sort();
   } catch (error) {
-    await close();
+    await using cleanup = { [Symbol.asyncDispose]: close };
     normalizeDirectoryError(error);
   }
   return {
@@ -116,6 +116,6 @@ export async function listDirectoryForWalk(
         normalizeDirectoryError(error);
       }
     },
-    close,
+    [Symbol.asyncDispose]: close,
   };
 }

--- a/src/root-directory-list.ts
+++ b/src/root-directory-list.ts
@@ -127,8 +127,13 @@ export async function listDirectoryForWalk(
     await assertCurrent();
     names?.sort();
   } catch (error) {
-    await using cleanup = { [Symbol.asyncDispose]: close };
-    throw normalizeDirectoryError(error);
+    const operationError = normalizeDirectoryError(error);
+    try {
+      await close();
+    } catch (closeError) {
+      throw createSuppressedError(closeError, operationError, "directory setup and close both failed");
+    }
+    throw operationError;
   }
 
   const prepareBatch = async (sortedNames: readonly string[]) => {

--- a/src/root-directory-list.ts
+++ b/src/root-directory-list.ts
@@ -2,11 +2,16 @@ import type { Dir, Stats } from "node:fs";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard } from "./directory-guard.js";
 import { FsSafeError } from "./errors.js";
 import { isNotFoundPathError, isPathInside } from "./path.js";
 import { assertRootIdentityCurrent, type RootContext } from "./root-context.js";
+import { rootPathChangedError } from "./root-errors.js";
+import { createSuppressedError } from "./suppressed-error.js";
 import type { DirEntry, PathStat } from "./types.js";
+
+const METADATA_BATCH_SIZE = 32;
 
 export function pathStatFromStats(stat: Stats): PathStat {
   return {
@@ -24,15 +29,17 @@ export function pathStatFromStats(stat: Stats): PathStat {
   };
 }
 
-function normalizeDirectoryError(error: unknown): never {
+function normalizeDirectoryError(error: unknown): unknown {
   if (isNotFoundPathError(error)) {
-    throw new FsSafeError("not-found", "directory not found", {
+    return new FsSafeError("not-found", "directory not found", {
       cause: error instanceof Error ? error : undefined,
     });
   }
-  throw error;
+  return error;
 }
 
+export function listDirectoryPath(root: RootContext, directory: string, withFileTypes: true): Promise<DirEntry[]>;
+export function listDirectoryPath(root: RootContext, directory: string, withFileTypes: boolean): Promise<string[] | DirEntry[]>;
 export async function listDirectoryPath(
   root: RootContext,
   directory: string,
@@ -49,34 +56,59 @@ export async function listDirectoryPath(
     await assertRootIdentityCurrent(root);
     return entries;
   } catch (error) {
-    normalizeDirectoryError(error);
+    throw normalizeDirectoryError(error);
   }
 }
 
 export type RootDirectoryListing = {
-  next(): Promise<string | undefined>;
-  readEntry(name: string): Promise<DirEntry>;
+  next(): Promise<{ kind: "entry"; entry: DirEntry } | { kind: "limit"; name: string } | undefined>;
   [Symbol.asyncDispose](): Promise<void>;
+};
+
+export type RootDirectoryListingOptions = {
+  order: "sorted" | "filesystem";
+  signal?: AbortSignal;
+  snapshot: boolean;
+  admitEntry(): boolean;
 };
 
 export async function listDirectoryForWalk(
   root: RootContext,
   directory: string,
-  options: { order: "sorted" | "filesystem"; signal?: AbortSignal },
+  options: RootDirectoryListingOptions,
 ): Promise<RootDirectoryListing> {
-  const guard = await createAsyncDirectoryGuard(directory, { bigint: true }).catch(normalizeDirectoryError);
+  const guard = await createAsyncDirectoryGuard(directory, { bigint: true }).catch((error) => {
+    throw normalizeDirectoryError(error);
+  });
   if (!isPathInside(root.rootReal, guard.realPath)) {
     throw new FsSafeError("outside-workspace", "directory is outside workspace root");
   }
+  const guardPinsRoot = guard.dir === root.rootReal &&
+    guard.stat.dev === root.rootIdentity.dev && guard.stat.ino === root.rootIdentity.ino;
   const assertCurrent = async () => {
     options.signal?.throwIfAborted();
-    await assertRootIdentityCurrent(root);
-    await assertAsyncDirectoryGuard(guard);
+    if (guardPinsRoot) {
+      // One exact receipt proves both identities without dropping the canonical-path check.
+      try {
+        await assertAsyncDirectoryGuard(guard);
+      } catch (error) {
+        throw rootPathChangedError(error instanceof Error ? error : undefined);
+      }
+    } else {
+      await assertRootIdentityCurrent(root);
+      await assertAsyncDirectoryGuard(guard);
+    }
     options.signal?.throwIfAborted();
   };
   let handle: Dir | undefined;
   let names: string[] | undefined;
+  let snapshot: DirEntry[] | undefined;
   let index = 0;
+  let prepared: DirEntry[] = [];
+  let preparedIndex = 0;
+  let pendingFailure: { error: unknown } | undefined;
+  let pendingLimit: string | undefined;
+  let preparedBatch = false;
   const close = async () => {
     const owned = handle;
     handle = undefined;
@@ -87,6 +119,8 @@ export async function listDirectoryForWalk(
     if (options.order === "filesystem") {
       // A one-entry buffer keeps the truncation lookahead independent of width.
       handle = await fs.opendir(guard.realPath, { bufferSize: 1 });
+    } else if (options.snapshot) {
+      snapshot = await listDirectoryPath(root, guard.realPath, true);
     } else {
       names = await fs.readdir(guard.realPath);
     }
@@ -94,26 +128,78 @@ export async function listDirectoryForWalk(
     names?.sort();
   } catch (error) {
     await using cleanup = { [Symbol.asyncDispose]: close };
-    normalizeDirectoryError(error);
+    throw normalizeDirectoryError(error);
   }
+
+  const prepareBatch = async (sortedNames: readonly string[]) => {
+    let name = sortedNames[index++];
+    if (name === undefined) return;
+    if (!options.admitEntry()) {
+      pendingLimit = name;
+      return;
+    }
+    if (preparedBatch) await yieldToEventLoop();
+    await assertCurrent();
+    preparedBatch = true;
+    prepared = [];
+    preparedIndex = 0;
+    while (true) {
+      try {
+        const entry = { name, ...pathStatFromStats(fsSync.lstatSync(path.join(guard.realPath, name))) };
+        prepared.push(entry);
+        // No later sibling can be observed before a possible recursive descent.
+        if (entry.isDirectory || entry.isSymbolicLink || prepared.length >= METADATA_BATCH_SIZE) break;
+      } catch (error) {
+        pendingFailure = { error: normalizeDirectoryError(error) };
+        break;
+      }
+      name = sortedNames[index++];
+      if (name === undefined) break;
+      if (!options.admitEntry()) {
+        pendingLimit = name;
+        break;
+      }
+    }
+    try {
+      await assertCurrent();
+    } catch (error) {
+      if (pendingFailure) {
+        throw createSuppressedError(error, pendingFailure.error, "directory observation and identity checks both failed");
+      }
+      throw error;
+    }
+  };
+
   return {
     async next() {
-      options.signal?.throwIfAborted();
-      if (names) return names[index++];
-      await assertCurrent();
-      const entry = await handle!.read();
-      await assertCurrent();
-      return entry?.name;
-    },
-    async readEntry(name) {
       try {
-        // Iteration yields to the caller, so pathname metadata needs a fresh fence.
+        options.signal?.throwIfAborted();
+        if (snapshot) {
+          const entry = snapshot[index++];
+          if (!entry) return;
+          return options.admitEntry() ? { kind: "entry", entry } : { kind: "limit", name: entry.name };
+        }
+        if (names) {
+          if (preparedIndex >= prepared.length && !pendingFailure && pendingLimit === undefined) {
+            await prepareBatch(names);
+          }
+          const entry = prepared[preparedIndex++];
+          if (entry) return { kind: "entry", entry };
+          if (pendingFailure) throw pendingFailure.error;
+          if (pendingLimit !== undefined) return { kind: "limit", name: pendingLimit };
+          return;
+        }
         await assertCurrent();
-        const stat = await fs.lstat(path.join(guard.realPath, name));
+        const name = (await handle!.read())?.name;
         await assertCurrent();
-        return { name, ...pathStatFromStats(stat) };
+        if (name === undefined) return;
+        if (!options.admitEntry()) return { kind: "limit", name };
+        // The stream's post-read fence is also the pre-stat fence in this owned operation.
+        const stat = fsSync.lstatSync(path.join(guard.realPath, name));
+        await assertCurrent();
+        return { kind: "entry", entry: { name, ...pathStatFromStats(stat) } };
       } catch (error) {
-        normalizeDirectoryError(error);
+        throw normalizeDirectoryError(error);
       }
     },
     [Symbol.asyncDispose]: close,

--- a/src/root-directory-list.ts
+++ b/src/root-directory-list.ts
@@ -1,0 +1,121 @@
+import type { Dir, Stats } from "node:fs";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { assertAsyncDirectoryGuard, createAsyncDirectoryGuard } from "./directory-guard.js";
+import { FsSafeError } from "./errors.js";
+import { isNotFoundPathError, isPathInside } from "./path.js";
+import { assertRootIdentityCurrent, type RootContext } from "./root-context.js";
+import type { DirEntry, PathStat } from "./types.js";
+
+export function pathStatFromStats(stat: Stats): PathStat {
+  return {
+    dev: Number(stat.dev),
+    gid: Number(stat.gid),
+    ino: Number(stat.ino),
+    isDirectory: stat.isDirectory(),
+    isFile: stat.isFile(),
+    isSymbolicLink: stat.isSymbolicLink(),
+    mode: stat.mode,
+    mtimeMs: stat.mtimeMs,
+    nlink: stat.nlink,
+    size: stat.size,
+    uid: stat.uid,
+  };
+}
+
+function normalizeDirectoryError(error: unknown): never {
+  if (isNotFoundPathError(error)) {
+    throw new FsSafeError("not-found", "directory not found", {
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+  throw error;
+}
+
+export async function listDirectoryPath(
+  root: RootContext,
+  directory: string,
+  withFileTypes: boolean,
+): Promise<string[] | DirEntry[]> {
+  try {
+    const names = (await fs.readdir(directory)).sort();
+    const entries = withFileTypes
+      ? names.map(name => ({
+        name,
+        ...pathStatFromStats(fsSync.lstatSync(path.join(directory, name))),
+      }))
+      : names;
+    await assertRootIdentityCurrent(root);
+    return entries;
+  } catch (error) {
+    normalizeDirectoryError(error);
+  }
+}
+
+export type RootDirectoryListing = {
+  next(): Promise<string | undefined>;
+  readEntry(name: string): Promise<DirEntry>;
+  close(): Promise<void>;
+};
+
+export async function listDirectoryForWalk(
+  root: RootContext,
+  directory: string,
+  options: { order: "sorted" | "filesystem"; signal?: AbortSignal },
+): Promise<RootDirectoryListing> {
+  const guard = await createAsyncDirectoryGuard(directory, { bigint: true }).catch(normalizeDirectoryError);
+  if (!isPathInside(root.rootReal, guard.realPath)) {
+    throw new FsSafeError("outside-workspace", "directory is outside workspace root");
+  }
+  const assertCurrent = async () => {
+    options.signal?.throwIfAborted();
+    await assertRootIdentityCurrent(root);
+    await assertAsyncDirectoryGuard(guard);
+    options.signal?.throwIfAborted();
+  };
+  let handle: Dir | undefined;
+  let names: string[] | undefined;
+  let index = 0;
+  const close = async () => {
+    const owned = handle;
+    handle = undefined;
+    await owned?.close();
+  };
+  try {
+    await assertCurrent();
+    if (options.order === "filesystem") {
+      // A one-entry buffer keeps the truncation lookahead independent of width.
+      handle = await fs.opendir(guard.realPath, { bufferSize: 1 });
+    } else {
+      names = await fs.readdir(guard.realPath);
+    }
+    await assertCurrent();
+    names?.sort();
+  } catch (error) {
+    await close();
+    normalizeDirectoryError(error);
+  }
+  return {
+    async next() {
+      options.signal?.throwIfAborted();
+      if (names) return names[index++];
+      await assertCurrent();
+      const entry = await handle!.read();
+      await assertCurrent();
+      return entry?.name;
+    },
+    async readEntry(name) {
+      try {
+        // Iteration yields to the caller, so pathname metadata needs a fresh fence.
+        await assertCurrent();
+        const stat = await fs.lstat(path.join(guard.realPath, name));
+        await assertCurrent();
+        return { name, ...pathStatFromStats(stat) };
+      } catch (error) {
+        normalizeDirectoryError(error);
+      }
+    },
+    close,
+  };
+}

--- a/src/root-errors.ts
+++ b/src/root-errors.ts
@@ -13,6 +13,10 @@ export function outsideWorkspaceError(): FsSafeError {
   return new FsSafeError("outside-workspace", "file is outside workspace root");
 }
 
+export function rootPathChangedError(cause?: Error): FsSafeError {
+  return new FsSafeError("path-mismatch", "root path changed during operation", { cause });
+}
+
 export function directoryComponentNotDirectoryError(cause?: unknown): FsSafeError {
   return cause === undefined
     ? new FsSafeError("not-file", "directory component must be a directory")

--- a/src/root-impl.ts
+++ b/src/root-impl.ts
@@ -44,6 +44,7 @@ import { cleanupPinnedFilePath } from "./replace-file-temp-owner.js";
 import { resolveReadOpenFlags } from "./read-open-flags.js";
 import { isNonRegularWriteOpenError, resolveNonblockingWriteFlag } from "./write-open-flags.js";
 import { resolveRootPath } from "./root-path.js";
+import { listDirectoryForWalk, listDirectoryPath, pathStatFromStats } from "./root-directory-list.js";
 import {
   assertRootIdentityCurrent,
   assertValidRootDestinationPath,
@@ -134,22 +135,6 @@ const OPEN_APPEND_CREATE_FLAGS =
   fsConstants.O_CREAT |
   fsConstants.O_EXCL |
   (SUPPORTS_NOFOLLOW ? fsConstants.O_NOFOLLOW : 0);
-
-function pathStatFromStats(stat: Stats): PathStat {
-  return {
-    dev: Number(stat.dev),
-    gid: Number(stat.gid),
-    ino: Number(stat.ino),
-    isDirectory: stat.isDirectory(),
-    isFile: stat.isFile(),
-    isSymbolicLink: stat.isSymbolicLink(),
-    mode: stat.mode,
-    mtimeMs: stat.mtimeMs,
-    nlink: stat.nlink,
-    size: stat.size,
-    uid: stat.uid,
-  };
-}
 
 function openResult(params: {
   handle: FileHandle;
@@ -629,7 +614,15 @@ export class RootHandle implements Root {
   }
   walk(relativePath: string, options: RootWalkOptions): AsyncIterableIterator<RootWalkEntry> {
     assertValidRootRelativePath(relativePath);
-    return walkRoot(this, relativePath, options);
+    return walkRoot({
+      rootReal: this.rootReal,
+      stat: relative => this.stat(relative),
+      list: async (relative, listingOptions) => {
+        validatePinnedOperationPayload({ relativePath: relative });
+        const resolved = await resolvePinnedPathInRoot(this.context, { relativePath: relative, allowRoot: true });
+        return await listDirectoryForWalk(this.context, resolved.resolved, listingOptions);
+      },
+    }, relativePath, options);
   }
 }
 export async function root(
@@ -1415,30 +1408,7 @@ async function listPathFallback(
   withFileTypes: boolean,
 ): Promise<string[] | DirEntry[]> {
   const resolved = await resolvePinnedPathInRoot(root, { relativePath, allowRoot: true });
-  try {
-    const names = await fs.readdir(resolved.resolved);
-    const sortedNames = names.toSorted();
-    if (!withFileTypes) {
-      await assertRootIdentityCurrent(root);
-      return sortedNames;
-    }
-    const entries: DirEntry[] = [];
-    for (const name of sortedNames) {
-      entries.push({
-        name,
-        ...pathStatFromStats(fsSync.lstatSync(path.join(resolved.resolved, name))),
-      });
-    }
-    await assertRootIdentityCurrent(root);
-    return entries;
-  } catch (error) {
-    if (isNotFoundPathError(error)) {
-      throw new FsSafeError("not-found", "directory not found", {
-        cause: error instanceof Error ? error : undefined,
-      });
-    }
-    throw error;
-  }
+  return await listDirectoryPath(root, resolved.resolved, withFileTypes);
 }
 
 async function assertMoveMutationAllowed(

--- a/src/root-walk.ts
+++ b/src/root-walk.ts
@@ -3,6 +3,7 @@ import { FsSafeError } from "./errors.js";
 import { resolveRootPath } from "./root-path.js";
 import type { RootDirectoryListing, RootDirectoryListingOptions } from "./root-directory-list.js";
 import type { DirEntry, PathStat } from "./types.js";
+import { createSuppressedError } from "./suppressed-error.js";
 
 export type RootWalkSymlinkPolicy = "skip" | "follow-within-root";
 export type RootWalkLimitBehavior = "truncate" | "throw";
@@ -151,8 +152,10 @@ export async function* walkRoot(
       yield onDirectoryError(directory, error);
       return;
     }
-    {
-      await using ownedListing = listing;
+    // A thrown undefined still needs to be retained if closing also fails.
+    let failed = false;
+    let operationError: unknown;
+    try {
       while (true) {
         let next: Awaited<ReturnType<RootDirectoryListing["next"]>>;
         try {
@@ -212,6 +215,19 @@ export async function* walkRoot(
         }
         yield* visit(child, depth + 1);
         if (truncated) return;
+      }
+    } catch (error) {
+      failed = true;
+      operationError = error;
+      throw error;
+    } finally {
+      try {
+        await listing[Symbol.asyncDispose]();
+      } catch (closeError) {
+        if (failed) {
+          throw createSuppressedError(closeError, operationError, "directory walk and close both failed");
+        }
+        throw closeError;
       }
     }
   }

--- a/src/root-walk.ts
+++ b/src/root-walk.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { resolveRootPath } from "./root-path.js";
-import type { RootDirectoryListing } from "./root-directory-list.js";
+import type { RootDirectoryListing, RootDirectoryListingOptions } from "./root-directory-list.js";
 import type { DirEntry, PathStat } from "./types.js";
 
 export type RootWalkSymlinkPolicy = "skip" | "follow-within-root";
@@ -40,7 +40,7 @@ type RootWalkCapability = {
   stat(relativePath: string): Promise<PathStat>;
   list(
     relativePath: string,
-    options: { order: "sorted" | "filesystem"; signal?: AbortSignal },
+    options: RootDirectoryListingOptions,
   ): Promise<RootDirectoryListing>;
 };
 
@@ -94,6 +94,12 @@ export async function* walkRoot(
   let examined = 0;
   let truncated = false;
 
+  const admitEntry = () => {
+    if (examined >= maxEntries) return false;
+    examined += 1;
+    return true;
+  };
+
   const onLimit = (atPath: string): RootWalkEntry => {
     if ((options.limitBehavior ?? "truncate") === "throw") {
       throw new FsSafeError("too-large", `root walk budget exceeded at ${atPath || "."}`);
@@ -138,6 +144,8 @@ export async function* walkRoot(
       listing = await root.list(listingDirectory, {
         order: options.order ?? "sorted",
         signal: options.signal,
+        snapshot: maxEntries === Number.POSITIVE_INFINITY,
+        admitEntry,
       });
     } catch (error) {
       yield onDirectoryError(directory, error);
@@ -146,30 +154,24 @@ export async function* walkRoot(
     {
       await using ownedListing = listing;
       while (true) {
-        let name: string | undefined;
+        let next: Awaited<ReturnType<RootDirectoryListing["next"]>>;
         try {
-          name = await listing.next();
+          next = await listing.next();
           options.signal?.throwIfAborted();
         } catch (error) {
           yield onDirectoryError(directory, error);
           return;
         }
-        if (name === undefined) return;
+        if (next === undefined) return;
+        const name = next.kind === "entry" ? next.entry.name : next.name;
         const child = directory
           ? path.posix.join(directory.split(path.sep).join(path.posix.sep), name)
           : name;
-        if (examined >= maxEntries) {
+        if (next.kind === "limit") {
           yield onLimit(child);
           return;
         }
-        examined += 1;
-        let entry: DirEntry;
-        try {
-          entry = await listing.readEntry(name);
-        } catch (error) {
-          yield onDirectoryError(directory, error);
-          return;
-        }
+        const entry = next.entry;
         let kind = entryKind(entry);
         let size = entry.size;
         if (kind === "symlink") {

--- a/src/root-walk.ts
+++ b/src/root-walk.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { FsSafeError } from "./errors.js";
 import { resolveRootPath } from "./root-path.js";
+import type { RootDirectoryListing } from "./root-directory-list.js";
 import type { DirEntry, PathStat } from "./types.js";
 
 export type RootWalkSymlinkPolicy = "skip" | "follow-within-root";
@@ -26,6 +27,7 @@ export type RootWalkEntryFilter = (entry: RootWalkDataEntry) => RootWalkEntryFil
 export type RootWalkOptions = {
   maxDepth?: number;
   maxEntries?: number;
+  order?: "sorted" | "filesystem";
   symlinkPolicy: RootWalkSymlinkPolicy;
   signal?: AbortSignal;
   limitBehavior?: RootWalkLimitBehavior;
@@ -36,7 +38,10 @@ export type RootWalkOptions = {
 type RootWalkCapability = {
   rootReal: string;
   stat(relativePath: string): Promise<PathStat>;
-  list(relativePath: string, options: { withFileTypes: true }): Promise<DirEntry[]>;
+  list(
+    relativePath: string,
+    options: { order: "sorted" | "filesystem"; signal?: AbortSignal },
+  ): Promise<RootDirectoryListing>;
 };
 
 function validateBudget(name: string, value: number | undefined): number {
@@ -66,6 +71,9 @@ export async function* walkRoot(
   if (!(["skip", "follow-within-root"] as const).includes(options.symlinkPolicy)) {
     throw new TypeError(`invalid root walk symlink policy: ${String(options.symlinkPolicy)}`);
   }
+  if (options.order !== undefined && !(["sorted", "filesystem"] as const).includes(options.order)) {
+    throw new TypeError(`invalid root walk order: ${String(options.order)}`);
+  }
   if (
     options.limitBehavior !== undefined &&
     !(["truncate", "throw"] as const).includes(options.limitBehavior)
@@ -94,9 +102,15 @@ export async function* walkRoot(
     return limitEntry(atPath);
   };
 
+  const onDirectoryError = (directory: string, error: unknown): RootWalkEntry => {
+    options.signal?.throwIfAborted();
+    if ((options.onDirectoryError ?? "throw") === "throw") throw error;
+    return { relativePath: directory, kind: "directory-error", size: 0, error };
+  };
+
   async function* visit(directory: string, depth: number): AsyncGenerator<RootWalkEntry> {
     options.signal?.throwIfAborted();
-    let entries: DirEntry[];
+    let listing: RootDirectoryListing;
     try {
       const resolvedDirectory = await resolveRootPath({
         absolutePath: path.resolve(root.rootReal, directory),
@@ -121,65 +135,83 @@ export async function* walkRoot(
         .relative(root.rootReal, resolvedDirectory.canonicalPath)
         .split(path.sep)
         .join(path.posix.sep);
-      entries = await root.list(listingDirectory, { withFileTypes: true });
+      listing = await root.list(listingDirectory, {
+        order: options.order ?? "sorted",
+        signal: options.signal,
+      });
     } catch (error) {
-      // Cancellation is never a recoverable directory read failure.
-      options.signal?.throwIfAborted();
-      if ((options.onDirectoryError ?? "throw") === "throw") throw error;
-      yield { relativePath: directory, kind: "directory-error", size: 0, error };
+      yield onDirectoryError(directory, error);
       return;
     }
-    options.signal?.throwIfAborted();
-    for (const entry of entries) {
-      options.signal?.throwIfAborted();
-      const child = directory
-        ? path.posix.join(directory.split(path.sep).join(path.posix.sep), entry.name)
-        : entry.name;
-      if (examined >= maxEntries) {
-        yield onLimit(child);
-        return;
-      }
-      examined += 1;
-      let kind = entryKind(entry);
-      let size = entry.size;
-      if (kind === "symlink") {
-        if (options.symlinkPolicy === "skip") {
-          continue;
+    try {
+      while (true) {
+        let name: string | undefined;
+        try {
+          name = await listing.next();
+          options.signal?.throwIfAborted();
+        } catch (error) {
+          yield onDirectoryError(directory, error);
+          return;
         }
-        const resolved = await resolveRootPath({
-          absolutePath: path.resolve(root.rootReal, child),
-          rootPath: root.rootReal,
-          rootCanonicalPath: root.rootReal,
-          boundaryLabel: "root walk",
-        });
-        if (!resolved.exists) {
-          continue;
+        if (name === undefined) return;
+        const child = directory
+          ? path.posix.join(directory.split(path.sep).join(path.posix.sep), name)
+          : name;
+        if (examined >= maxEntries) {
+          yield onLimit(child);
+          return;
         }
-        const target = await root.stat(path.relative(root.rootReal, resolved.canonicalPath));
-        kind = target.isDirectory ? "directory" : target.isFile ? "file" : "other";
-        size = target.size;
-      }
+        examined += 1;
+        let entry: DirEntry;
+        try {
+          entry = await listing.readEntry(name);
+        } catch (error) {
+          yield onDirectoryError(directory, error);
+          return;
+        }
+        let kind = entryKind(entry);
+        let size = entry.size;
+        if (kind === "symlink") {
+          if (options.symlinkPolicy === "skip") {
+            continue;
+          }
+          const resolved = await resolveRootPath({
+            absolutePath: path.resolve(root.rootReal, child),
+            rootPath: root.rootReal,
+            rootCanonicalPath: root.rootReal,
+            boundaryLabel: "root walk",
+          });
+          if (!resolved.exists) {
+            continue;
+          }
+          const target = await root.stat(path.relative(root.rootReal, resolved.canonicalPath));
+          kind = target.isDirectory ? "directory" : target.isFile ? "file" : "other";
+          size = target.size;
+        }
 
-      const walkEntry: RootWalkDataEntry = { relativePath: child, kind, size };
-      const filterResult = options.entryFilter?.(walkEntry) ?? "include";
-      if (!(["include", "skip", "skip-subtree"] as const).includes(filterResult)) {
-        throw new TypeError(`invalid root walk entryFilter result: ${String(filterResult)}`);
+        const walkEntry: RootWalkDataEntry = { relativePath: child, kind, size };
+        const filterResult = options.entryFilter?.(walkEntry) ?? "include";
+        if (!(["include", "skip", "skip-subtree"] as const).includes(filterResult)) {
+          throw new TypeError(`invalid root walk entryFilter result: ${String(filterResult)}`);
+        }
+        if (filterResult === "include") {
+          yield walkEntry;
+        }
+        if (kind !== "directory") {
+          continue;
+        }
+        if (filterResult === "skip-subtree") {
+          continue;
+        }
+        if (depth >= maxDepth) {
+          yield onLimit(child);
+          return;
+        }
+        yield* visit(child, depth + 1);
+        if (truncated) return;
       }
-      if (filterResult === "include") {
-        yield walkEntry;
-      }
-      if (kind !== "directory") {
-        continue;
-      }
-      if (filterResult === "skip-subtree") {
-        continue;
-      }
-      if (depth >= maxDepth) {
-        yield onLimit(child);
-        return;
-      }
-      yield* visit(child, depth + 1);
-      if (truncated) return;
+    } finally {
+      await listing.close();
     }
   }
 

--- a/src/root-walk.ts
+++ b/src/root-walk.ts
@@ -103,8 +103,8 @@ export async function* walkRoot(
   };
 
   const onDirectoryError = (directory: string, error: unknown): RootWalkEntry => {
-    options.signal?.throwIfAborted();
-    if ((options.onDirectoryError ?? "throw") === "throw") throw error;
+    // Rethrow cancellation with any disposal failure already attached.
+    if (options.signal?.aborted || (options.onDirectoryError ?? "throw") === "throw") throw error;
     return { relativePath: directory, kind: "directory-error", size: 0, error };
   };
 
@@ -143,7 +143,8 @@ export async function* walkRoot(
       yield onDirectoryError(directory, error);
       return;
     }
-    try {
+    {
+      await using ownedListing = listing;
       while (true) {
         let name: string | undefined;
         try {
@@ -210,8 +211,6 @@ export async function* walkRoot(
         yield* visit(child, depth + 1);
         if (truncated) return;
       }
-    } finally {
-      await listing.close();
     }
   }
 

--- a/test/root-walk-budget.test.ts
+++ b/test/root-walk-budget.test.ts
@@ -134,7 +134,7 @@ it("rejects a directory replaced across filesystem iterator yields", async () =>
   await expect(iterator.next()).rejects.toMatchObject({ code: "path-mismatch" });
 });
 
-it.each(["sorted", "filesystem"] as const)("preserves filesystem-supported case aliases in %s order", async (order, context) => {
+it.for(["sorted", "filesystem"] as const)("preserves filesystem-supported case aliases in %s order", async (order, context) => {
   const directory = await tempRoot("fs-safe-walk-case-");
   await fs.mkdir(path.join(directory, "nested"));
   await fs.writeFile(path.join(directory, "nested", "value"), "value");
@@ -242,6 +242,7 @@ it.each(["between-yields", "during-metadata", "symlink-root", "ancestor-alias"] 
     await fs.mkdir(directory, { recursive: true });
     await fs.writeFile(path.join(directory, "a"), "a");
     await fs.writeFile(path.join(directory, "b"), "b");
+    const original = await fs.stat(directory, { bigint: true });
     const capability = await root(directory);
     const replace = async () => {
       if (phase === "ancestor-alias") {
@@ -262,19 +263,40 @@ it.each(["between-yields", "during-metadata", "symlink-root", "ancestor-alias"] 
     const iterator = capability.walk("", {
       order: phase === "during-metadata" ? "sorted" : "filesystem", symlinkPolicy: "skip", maxEntries: 2,
     });
-    if (phase === "during-metadata") {
-      observeChildMetadata(directory, (name) => {
-        if (name === "a") {
-          fsSync.renameSync(directory, path.join(container, "moved"));
-          fsSync.mkdirSync(directory);
-          fsSync.writeFileSync(path.join(directory, "b"), "replacement");
+    try {
+      if (phase === "during-metadata") {
+        observeChildMetadata(directory, (name) => {
+          if (name === "a") {
+            fsSync.renameSync(directory, path.join(container, "moved"));
+            fsSync.mkdirSync(directory);
+            fsSync.writeFileSync(path.join(directory, "b"), "replacement");
+          }
+        });
+      } else {
+        const first = (await iterator.next()).value;
+        expect(first).toMatchObject({ kind: "file", size: 1 });
+        expect(["a", "b"]).toContain(first.relativePath);
+        try {
+          await replace();
+        } catch (error) {
+          const failure = error as NodeJS.ErrnoException;
+          if (phase !== "ancestor-alias" || process.platform !== "win32" ||
+            failure.syscall !== "rename" || !["EPERM", "EACCES"].includes(failure.code ?? "")) throw error;
+          expect(failure).toMatchObject({ code: expect.stringMatching(/^(?:EPERM|EACCES)$/), syscall: "rename" });
+          const unchanged = await fs.stat(directory, { bigint: true });
+          expect({ dev: unchanged.dev, ino: unchanged.ino }).toEqual({ dev: original.dev, ino: original.ino });
+          expect(await fs.readdir(container)).toEqual(["parent"]);
+          expect((await iterator.next()).value).toEqual({
+            relativePath: first.relativePath === "a" ? "b" : "a", kind: "file", size: 1,
+          });
+          expect((await iterator.next()).done).toBe(true);
+          return;
         }
-      });
-    } else {
-      expect((await iterator.next()).value).toEqual({ relativePath: "a", kind: "file", size: 1 });
-      await replace();
+      }
+      await expect(iterator.next()).rejects.toMatchObject({ code: "path-mismatch" });
+    } finally {
+      await iterator.return();
     }
-    await expect(iterator.next()).rejects.toMatchObject({ code: "path-mismatch" });
   },
 );
 

--- a/test/root-walk-budget.test.ts
+++ b/test/root-walk-budget.test.ts
@@ -1,0 +1,178 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { root } from "../src/root.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+function observeChildMetadata(directory: string): string[] {
+  const names: string[] = [];
+  const observe = (candidate: fsSync.PathLike) => {
+    if (path.dirname(String(candidate)) === directory) names.push(path.basename(String(candidate)));
+  };
+  const sync = fsSync.lstatSync.bind(fsSync);
+  vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
+    observe(args[0]);
+    return sync(...args);
+  });
+  const lstatAsync = fs.lstat.bind(fs);
+  vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+    observe(args[0]);
+    return await lstatAsync(...args);
+  });
+  return names;
+}
+
+function observeDirectoryStream(): { reads: number; closed: number } {
+  const calls = { reads: 0, closed: 0 };
+  const opendir = fs.opendir.bind(fs);
+  vi.spyOn(fs, "opendir").mockImplementation(async (...args) => {
+    const handle = await opendir(...args);
+    const read = handle.read.bind(handle);
+    vi.spyOn(handle, "read").mockImplementation(async () => {
+      calls.reads += 1;
+      return await read();
+    });
+    const close = handle.close.bind(handle);
+    vi.spyOn(handle, "close").mockImplementation(async () => {
+      calls.closed += 1;
+      await close();
+    });
+    return handle;
+  });
+  return calls;
+}
+
+it.each([0, 2, 5])("bounds metadata to %i examined entries without changing sorted truncation", async (maxEntries) => {
+  const directory = await tempRoot("fs-safe-walk-budget-");
+  const names = ["e", "d", "c", "b", "a"];
+  await Promise.all(names.map(name => fs.writeFile(path.join(directory, name), name)));
+  const capability = await root(directory);
+  const observed = observeChildMetadata(directory);
+  const entries = [];
+  for await (const entry of capability.walk("", { symlinkPolicy: "skip", maxEntries })) entries.push(entry);
+  const sorted = names.toSorted();
+  expect(entries).toEqual([
+    ...sorted.slice(0, maxEntries).map(relativePath => ({ relativePath, kind: "file", size: 1 })),
+    ...(maxEntries < names.length ? [{ relativePath: sorted[maxEntries], kind: "truncated", size: 0 }] : []),
+  ]);
+  expect(observed).toEqual(sorted.slice(0, maxEntries));
+});
+
+it.each([0, 2, 5])("reads only %i entries and one lookahead in filesystem order", async (maxEntries) => {
+  const directory = await tempRoot("fs-safe-walk-stream-budget-");
+  const names = ["a", "b", "c", "d", "e"];
+  await Promise.all(names.map(name => fs.writeFile(path.join(directory, name), name)));
+  const capability = await root(directory);
+  const observed = observeChildMetadata(directory);
+  const readdir = vi.spyOn(fs, "readdir");
+  const calls = observeDirectoryStream();
+  const entries = [];
+  for await (const entry of capability.walk("", { symlinkPolicy: "skip", order: "filesystem", maxEntries })) entries.push(entry);
+  expect(readdir).not.toHaveBeenCalled();
+  expect(calls.reads).toBe(maxEntries + 1);
+  expect(calls.closed).toBe(1);
+  expect(observed).toHaveLength(maxEntries);
+  expect(entries.filter(entry => entry.kind === "file").map(entry => entry.relativePath)).toEqual(observed);
+  expect(entries.filter(entry => entry.kind === "truncated")).toHaveLength(maxEntries < names.length ? 1 : 0);
+});
+
+it.each(["break", "abort", "limit-error", "filter-error"] as const)("closes directory streams on %s", async (outcome) => {
+  const directory = await tempRoot("fs-safe-walk-stream-close-");
+  await fs.writeFile(path.join(directory, "a"), "a");
+  await fs.writeFile(path.join(directory, "b"), "b");
+  const capability = await root(directory);
+  const calls = observeDirectoryStream();
+  const controller = new AbortController();
+  const observed: string[] = [];
+  const consume = async () => {
+    for await (const entry of capability.walk("", {
+      symlinkPolicy: "skip", order: "filesystem", signal: controller.signal,
+      maxEntries: outcome === "limit-error" ? 1 : undefined,
+      limitBehavior: "throw",
+      entryFilter: () => {
+        if (outcome === "filter-error") throw new Error("filter failed");
+        return "include";
+      },
+    })) {
+      observed.push(entry.relativePath);
+      if (outcome === "break") break;
+      if (outcome === "abort") controller.abort();
+    }
+  };
+  if (outcome === "break") await consume();
+  else await expect(consume()).rejects.toMatchObject(
+    outcome === "abort" ? { name: "AbortError" }
+      : outcome === "limit-error" ? { code: "too-large" }
+        : { message: "filter failed" },
+  );
+  expect(calls.closed).toBe(1);
+  expect(observed).toHaveLength(outcome === "filter-error" ? 0 : 1);
+  expect(calls.reads).toBe(outcome === "limit-error" ? 2 : 1);
+});
+
+it.each(["sorted", "filesystem"] as const)("rejects a directory replaced across %s iterator yields", async (order) => {
+  const directory = await tempRoot("fs-safe-walk-directory-swap-");
+  const nested = path.join(directory, "nested");
+  await fs.mkdir(nested);
+  await fs.writeFile(path.join(nested, "a"), "original");
+  await fs.writeFile(path.join(nested, "b"), "original");
+  const capability = await root(directory);
+  const iterator = capability.walk("nested", { order, symlinkPolicy: "skip" });
+  expect((await iterator.next()).value).toMatchObject({ kind: "file", size: 8 });
+  await fs.rename(nested, path.join(directory, "moved"));
+  await fs.mkdir(nested);
+  await fs.writeFile(path.join(nested, "a"), "replacement");
+  await fs.writeFile(path.join(nested, "b"), "replacement");
+  await expect(iterator.next()).rejects.toMatchObject({ code: "path-mismatch" });
+});
+
+it.each(["sorted", "filesystem"] as const)("preserves filesystem-supported case aliases in %s order", async (order, context) => {
+  const directory = await tempRoot("fs-safe-walk-case-");
+  await fs.mkdir(path.join(directory, "nested"));
+  await fs.writeFile(path.join(directory, "nested", "value"), "value");
+  try {
+    await fs.stat(path.join(directory, "NESTED"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    context.skip("fixture filesystem is case-sensitive");
+    return;
+  }
+  const capability = await root(directory);
+  const entries = [];
+  for await (const entry of capability.walk("NESTED", { order, symlinkPolicy: "skip" })) entries.push(entry);
+  expect(entries).toEqual([{ relativePath: "NESTED/value", kind: "file", size: 5 }]);
+});
+
+it("does not inspect a directory's unused suffix after the caller stops iteration", async () => {
+  const directory = await tempRoot("fs-safe-walk-break-");
+  await fs.writeFile(path.join(directory, "a"), "a");
+  await fs.writeFile(path.join(directory, "z"), "z");
+  const capability = await root(directory);
+  const observed = observeChildMetadata(directory);
+  for await (const entry of capability.walk("", { symlinkPolicy: "skip" })) {
+    expect(entry).toEqual({ relativePath: "a", kind: "file", size: 1 });
+    break;
+  }
+  expect(observed).toEqual(["a"]);
+});
+
+it("does not inspect a parent suffix after a child consumes the remaining budget", async () => {
+  const directory = await tempRoot("fs-safe-walk-nested-budget-");
+  await fs.mkdir(path.join(directory, "a"));
+  await fs.writeFile(path.join(directory, "a", "child"), "value");
+  await fs.writeFile(path.join(directory, "z"), "unused");
+  const capability = await root(directory);
+  const observed = observeChildMetadata(directory);
+  const entries = [];
+  for await (const entry of capability.walk("", { symlinkPolicy: "skip", maxEntries: 2 })) entries.push(entry);
+  expect(entries.map(({ relativePath, kind }) => ({ relativePath, kind }))).toEqual([
+    { relativePath: "a", kind: "directory" },
+    { relativePath: "a/child", kind: "file" },
+    { relativePath: "z", kind: "truncated" },
+  ]);
+  expect(observed).not.toContain("z");
+});

--- a/test/root-walk-budget.test.ts
+++ b/test/root-walk-budget.test.ts
@@ -8,7 +8,7 @@ import { useRealTempDirs } from "./helpers/vitest.js";
 const { tempRoot } = useRealTempDirs();
 afterEach(() => vi.restoreAllMocks());
 
-function observeChildMetadata(directory: string): string[] {
+function observeChildMetadata(directory: string, afterRead?: (name: string) => void): string[] {
   const names: string[] = [];
   const observe = (candidate: fsSync.PathLike) => {
     if (path.dirname(String(candidate)) === directory) names.push(path.basename(String(candidate)));
@@ -16,12 +16,16 @@ function observeChildMetadata(directory: string): string[] {
   const sync = fsSync.lstatSync.bind(fsSync);
   vi.spyOn(fsSync, "lstatSync").mockImplementation((...args) => {
     observe(args[0]);
-    return sync(...args);
+    const result = sync(...args);
+    if (path.dirname(String(args[0])) === directory) afterRead?.(path.basename(String(args[0])));
+    return result;
   });
   const lstatAsync = fs.lstat.bind(fs);
   vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
     observe(args[0]);
-    return await lstatAsync(...args);
+    const result = await lstatAsync(...args);
+    if (path.dirname(String(args[0])) === directory) afterRead?.(path.basename(String(args[0])));
+    return result;
   });
   return names;
 }
@@ -114,14 +118,14 @@ it.each(["break", "abort", "limit-error", "filter-error"] as const)("closes dire
   expect(calls.reads).toBe(outcome === "limit-error" ? 2 : 1);
 });
 
-it.each(["sorted", "filesystem"] as const)("rejects a directory replaced across %s iterator yields", async (order) => {
+it("rejects a directory replaced across filesystem iterator yields", async () => {
   const directory = await tempRoot("fs-safe-walk-directory-swap-");
   const nested = path.join(directory, "nested");
   await fs.mkdir(nested);
   await fs.writeFile(path.join(nested, "a"), "original");
   await fs.writeFile(path.join(nested, "b"), "original");
   const capability = await root(directory);
-  const iterator = capability.walk("nested", { order, symlinkPolicy: "skip" });
+  const iterator = capability.walk("nested", { order: "filesystem", symlinkPolicy: "skip", maxEntries: 2 });
   expect((await iterator.next()).value).toMatchObject({ kind: "file", size: 8 });
   await fs.rename(nested, path.join(directory, "moved"));
   await fs.mkdir(nested);
@@ -153,11 +157,14 @@ it("does not inspect a directory's unused suffix after the caller stops iteratio
   await fs.writeFile(path.join(directory, "z"), "z");
   const capability = await root(directory);
   const observed = observeChildMetadata(directory);
-  for await (const entry of capability.walk("", { symlinkPolicy: "skip" })) {
-    expect(entry).toEqual({ relativePath: "a", kind: "file", size: 1 });
+  let firstName: string | undefined;
+  for await (const entry of capability.walk("", { order: "filesystem", symlinkPolicy: "skip", maxEntries: 2 })) {
+    expect(entry).toMatchObject({ kind: "file", size: 1 });
+    expect(["a", "z"]).toContain(entry.relativePath);
+    firstName = entry.relativePath;
     break;
   }
-  expect(observed).toEqual(["a"]);
+  expect(observed).toEqual([firstName]);
 });
 
 it("does not inspect a parent suffix after a child consumes the remaining budget", async () => {
@@ -175,4 +182,150 @@ it("does not inspect a parent suffix after a child consumes the remaining budget
     { relativePath: "z", kind: "truncated" },
   ]);
   expect(observed).not.toContain("z");
+});
+
+it("stops metadata batches at followed directory symlinks before spending descendant budget", async () => {
+  const directory = await tempRoot("fs-safe-walk-link-budget-");
+  const target = path.join(directory, "target");
+  await fs.mkdir(target);
+  await fs.writeFile(path.join(target, "child"), "value");
+  await fs.symlink(target, path.join(directory, "a-alias"), process.platform === "win32" ? "junction" : "dir");
+  await fs.writeFile(path.join(directory, "m-sibling"), "unused");
+  const capability = await root(directory);
+  const observed = observeChildMetadata(directory);
+  const entries = [];
+  for await (const entry of capability.walk("", { symlinkPolicy: "follow-within-root", maxEntries: 2 })) entries.push(entry);
+  expect(entries.map(({ relativePath, kind }) => ({ relativePath, kind }))).toEqual([
+    { relativePath: "a-alias", kind: "directory" },
+    { relativePath: "a-alias/child", kind: "file" },
+    { relativePath: "m-sibling", kind: "truncated" },
+  ]);
+  expect(observed).not.toContain("m-sibling");
+});
+
+it("stops at skipped symlinks before observing the following batch", async () => {
+  const directory = await tempRoot("fs-safe-walk-skipped-link-batch-");
+  const target = path.join(directory, "target");
+  await fs.mkdir(target);
+  await fs.symlink(target, path.join(directory, "a-alias"), process.platform === "win32" ? "junction" : "dir");
+  const sibling = path.join(directory, "m-sibling");
+  await fs.writeFile(sibling, "old");
+  const capability = await root(directory);
+  observeChildMetadata(directory, (name) => {
+    if (name === "a-alias") queueMicrotask(() => fsSync.writeFileSync(sibling, "updated"));
+  });
+  const entries = [];
+  for await (const entry of capability.walk("", { symlinkPolicy: "skip", maxEntries: 2 })) entries.push(entry);
+  expect(entries).toEqual([
+    { relativePath: "m-sibling", kind: "file", size: 7 },
+    { relativePath: "target", kind: "truncated", size: 0 },
+  ]);
+});
+
+it.each([undefined, 2])("reuses prepared sorted metadata with an entry budget of %s", async (maxEntries) => {
+  const directory = await tempRoot("fs-safe-walk-snapshot-");
+  await fs.writeFile(path.join(directory, "a"), "a");
+  await fs.writeFile(path.join(directory, "b"), "before");
+  const capability = await root(directory);
+  const iterator = capability.walk("", { symlinkPolicy: "skip", maxEntries });
+  expect((await iterator.next()).value).toEqual({ relativePath: "a", kind: "file", size: 1 });
+  await fs.writeFile(path.join(directory, "b"), "changed after the listing");
+  expect((await iterator.next()).value).toEqual({ relativePath: "b", kind: "file", size: 6 });
+  expect((await iterator.next()).done).toBe(true);
+});
+
+it.each(["between-yields", "during-metadata", "symlink-root", "ancestor-alias"] as const)(
+  "retains root replacement rejection %s with an identical listing receipt",
+  async (phase) => {
+    const container = await tempRoot("fs-safe-walk-root-receipt-");
+    const directory = path.join(container, "parent", "root");
+    await fs.mkdir(directory, { recursive: true });
+    await fs.writeFile(path.join(directory, "a"), "a");
+    await fs.writeFile(path.join(directory, "b"), "b");
+    const capability = await root(directory);
+    const replace = async () => {
+      if (phase === "ancestor-alias") {
+        const parent = path.dirname(directory);
+        const moved = path.join(container, "moved-parent");
+        await fs.rename(parent, moved);
+        await fs.symlink(moved, parent, process.platform === "win32" ? "junction" : "dir");
+        return;
+      }
+      const moved = path.join(container, "moved");
+      await fs.rename(directory, moved);
+      if (phase === "symlink-root") {
+        await fs.symlink(moved, directory, process.platform === "win32" ? "junction" : "dir");
+      } else {
+        await fs.mkdir(directory);
+      }
+    };
+    const iterator = capability.walk("", {
+      order: phase === "during-metadata" ? "sorted" : "filesystem", symlinkPolicy: "skip", maxEntries: 2,
+    });
+    if (phase === "during-metadata") {
+      observeChildMetadata(directory, (name) => {
+        if (name === "a") {
+          fsSync.renameSync(directory, path.join(container, "moved"));
+          fsSync.mkdirSync(directory);
+          fsSync.writeFileSync(path.join(directory, "b"), "replacement");
+        }
+      });
+    } else {
+      expect((await iterator.next()).value).toEqual({ relativePath: "a", kind: "file", size: 1 });
+      await replace();
+    }
+    await expect(iterator.next()).rejects.toMatchObject({ code: "path-mismatch" });
+  },
+);
+
+it("counts failed metadata reads before reporting a skipped subtree", async () => {
+  const directory = await tempRoot("fs-safe-walk-failed-entry-budget-");
+  await fs.mkdir(path.join(directory, "a"));
+  await fs.writeFile(path.join(directory, "a", "a-good"), "value");
+  await fs.writeFile(path.join(directory, "a", "b-broken"), "value");
+  await fs.writeFile(path.join(directory, "z"), "unused");
+  const capability = await root(directory);
+  observeChildMetadata(path.join(directory, "a"), (name) => {
+    if (name === "b-broken") {
+      throw Object.assign(new Error("metadata unavailable"), { code: "EACCES" });
+    }
+  });
+  const entries = [];
+  for await (const entry of capability.walk("", {
+    symlinkPolicy: "skip", maxEntries: 3, onDirectoryError: "skip-and-report",
+  })) entries.push(entry);
+  expect(entries.map(({ relativePath, kind }) => ({ relativePath, kind }))).toEqual([
+    { relativePath: "a", kind: "directory" },
+    { relativePath: "a/a-good", kind: "file" },
+    { relativePath: "a", kind: "directory-error" },
+    { relativePath: "z", kind: "truncated" },
+  ]);
+});
+
+it("lets event-loop cancellation interrupt a complete budgeted scan before the unused suffix", async () => {
+  const directory = await tempRoot("fs-safe-walk-timer-");
+  const count = 256;
+  await Promise.all(Array.from({ length: count }, (_, index) =>
+    fs.writeFile(path.join(directory, String(index).padStart(3, "0")), "value")));
+  const capability = await root(directory);
+  const observed = observeChildMetadata(directory);
+  const controller = new AbortController();
+  const reason = new Error("cancelled from a timer");
+  let timer: ReturnType<typeof setImmediate> | undefined;
+  let yielded = 0;
+  const consume = async () => {
+    for await (const _entry of capability.walk("", {
+      symlinkPolicy: "skip", maxEntries: count, signal: controller.signal,
+    })) {
+      yielded += 1;
+      timer ??= setImmediate(() => controller.abort(reason));
+    }
+  };
+  try {
+    await expect(consume()).rejects.toBe(reason);
+    expect(yielded).toBeGreaterThan(0);
+    expect(observed.length).toBeLessThan(count);
+  } finally {
+    clearImmediate(timer);
+  }
 });

--- a/test/root-walk-cleanup.test.ts
+++ b/test/root-walk-cleanup.test.ts
@@ -8,14 +8,17 @@ import { useRealTempDirs } from "./helpers/vitest.js";
 const { tempRoot } = useRealTempDirs();
 afterEach(() => vi.restoreAllMocks());
 
-it.each(["setup-abort", "setup-error", "read-abort", "read-error", "filter-error", "close-only"] as const)(
+it.each([
+  "setup-abort", "setup-error", "read-abort", "read-error", "filter-error", "filter-undefined",
+  "close-only", "iterator-return", "iterator-throw", "iterator-throw-undefined",
+] as const)(
   "retains walk and close failures after %s",
   async (phase) => {
     const directory = await tempRoot("fs-safe-walk-close-failure-");
     await fs.writeFile(path.join(directory, "entry"), "value");
     const capability = await root(directory);
     const controller = new AbortController();
-    const primaryFailure = new Error(`${phase} failed`);
+    const primaryFailure = phase.endsWith("undefined") ? undefined : new Error(`${phase} failed`);
     const closeFailure = new Error("directory close failed");
     let closeAttempts = 0;
     const opendir = fs.opendir.bind(fs);
@@ -47,7 +50,7 @@ it.each(["setup-abort", "setup-error", "read-abort", "read-error", "filter-error
       signal: controller.signal,
       onDirectoryError: phase.endsWith("abort") ? "skip-and-report" : "throw",
       entryFilter: () => {
-        if (phase === "filter-error") throw primaryFailure;
+        if (phase === "filter-error" || phase === "filter-undefined") throw primaryFailure;
         return "include";
       },
     });
@@ -56,7 +59,16 @@ it.each(["setup-abort", "setup-error", "read-abort", "read-error", "filter-error
         // Complete the real walk so close-only failures occur at EOF.
       }
     };
-    if (phase === "close-only") {
+    if (phase.startsWith("iterator-")) {
+      expect((await iterator.next()).value).toMatchObject({ kind: "file", size: 5 });
+      if (phase === "iterator-return") {
+        await expect(iterator.return()).rejects.toBe(closeFailure);
+      } else {
+        await expect(iterator.throw(primaryFailure)).rejects.toMatchObject({
+          name: "SuppressedError", error: closeFailure, suppressed: primaryFailure,
+        });
+      }
+    } else if (phase === "close-only") {
       await expect(consume()).rejects.toBe(closeFailure);
     } else {
       await expect(consume()).rejects.toMatchObject({

--- a/test/root-walk-cleanup.test.ts
+++ b/test/root-walk-cleanup.test.ts
@@ -1,0 +1,71 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { root } from "../src/root.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+afterEach(() => vi.restoreAllMocks());
+
+it.each(["setup-abort", "setup-error", "read-abort", "read-error", "filter-error", "close-only"] as const)(
+  "retains walk and close failures after %s",
+  async (phase) => {
+    const directory = await tempRoot("fs-safe-walk-close-failure-");
+    await fs.writeFile(path.join(directory, "entry"), "value");
+    const capability = await root(directory);
+    const controller = new AbortController();
+    const primaryFailure = new Error(`${phase} failed`);
+    const closeFailure = new Error("directory close failed");
+    let closeAttempts = 0;
+    const opendir = fs.opendir.bind(fs);
+    vi.spyOn(fs, "opendir").mockImplementation(async (...args) => {
+      const handle = await opendir(...args);
+      const close = handle.close.bind(handle);
+      vi.spyOn(handle, "close").mockImplementation(async () => {
+        closeAttempts += 1;
+        await close();
+        throw closeFailure;
+      });
+      if (phase === "setup-abort") controller.abort(primaryFailure);
+      if (phase === "setup-error") {
+        vi.spyOn(fsSync, "lstatSync").mockImplementationOnce(() => { throw primaryFailure; });
+      }
+      const read = handle.read.bind(handle);
+      vi.spyOn(handle, "read").mockImplementation(async () => {
+        if (phase === "read-error") throw primaryFailure;
+        const entry = await read();
+        if (phase === "read-abort") controller.abort(primaryFailure);
+        return entry;
+      });
+      return handle;
+    });
+
+    const iterator = capability.walk("", {
+      order: "filesystem",
+      symlinkPolicy: "skip",
+      signal: controller.signal,
+      onDirectoryError: phase.endsWith("abort") ? "skip-and-report" : "throw",
+      entryFilter: () => {
+        if (phase === "filter-error") throw primaryFailure;
+        return "include";
+      },
+    });
+    const consume = async () => {
+      for await (const _entry of iterator) {
+        // Complete the real walk so close-only failures occur at EOF.
+      }
+    };
+    if (phase === "close-only") {
+      await expect(consume()).rejects.toBe(closeFailure);
+    } else {
+      await expect(consume()).rejects.toMatchObject({
+        name: "SuppressedError",
+        error: closeFailure,
+        suppressed: phase === "setup-error" ? { code: "path-mismatch", cause: primaryFailure } : primaryFailure,
+      });
+    }
+    await iterator.return();
+    expect(closeAttempts).toBe(1);
+  },
+);

--- a/test/root-walk-options.test.ts
+++ b/test/root-walk-options.test.ts
@@ -1,10 +1,9 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import { root } from "../src/root.js";
-import { walkRoot, type RootWalkEntry } from "../src/root-walk.js";
-import type { DirEntry } from "../src/types.js";
+import type { RootWalkEntry } from "../src/root-walk.js";
 
 const tempDirs: string[] = [];
 
@@ -15,6 +14,7 @@ async function tempRoot(): Promise<string> {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(
     tempDirs.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })),
   );
@@ -110,23 +110,16 @@ it("reports failed directory subtrees and continues when requested", async () =>
   await fs.mkdir(path.join(directory, "healthy"));
   await fs.writeFile(path.join(directory, "healthy", "value.txt"), "healthy");
   const capability = await root(directory);
-  const list = capability.list.bind(capability) as (
-    relativePath: string,
-    options: { withFileTypes: true },
-  ) => Promise<DirEntry[]>;
-  const walkingRoot = {
-    rootReal: capability.rootReal,
-    stat: capability.stat.bind(capability),
-    async list(relativePath: string, options: { withFileTypes: true }): Promise<DirEntry[]> {
-      if (relativePath === "broken") {
-        throw Object.assign(new Error("unreadable subtree"), { code: "EACCES" });
-      }
-      return await list(relativePath, options);
-    },
-  };
+  const readdir = fs.readdir.bind(fs);
+  vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {
+    if (String(args[0]) === path.join(capability.rootReal, "broken")) {
+      throw Object.assign(new Error("unreadable subtree"), { code: "EACCES" });
+    }
+    return await readdir(...args);
+  });
 
   const entries: RootWalkEntry[] = [];
-  for await (const entry of walkRoot(walkingRoot, "", {
+  for await (const entry of capability.walk("", {
     symlinkPolicy: "skip",
     onDirectoryError: "skip-and-report",
   })) {
@@ -145,7 +138,7 @@ it("reports failed directory subtrees and continues when requested", async () =>
   });
 
   await expect(async () => {
-    for await (const _entry of walkRoot(walkingRoot, "", { symlinkPolicy: "skip" })) {
+    for await (const _entry of capability.walk("", { symlinkPolicy: "skip" })) {
       // Consume the iterator to prove the default remains fail-fast.
     }
   }).rejects.toMatchObject({ code: "EACCES" });
@@ -155,17 +148,15 @@ it("observes an abort that occurs while an empty directory is being listed", asy
   const directory = await tempRoot();
   const controller = new AbortController();
   const capability = await root(directory);
-  const walkingRoot = {
-    rootReal: capability.rootReal,
-    stat: capability.stat.bind(capability),
-    async list(): Promise<DirEntry[]> {
-      controller.abort();
-      return [];
-    },
-  };
+  const readdir = fs.readdir.bind(fs);
+  vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {
+    const names = await readdir(...args);
+    controller.abort();
+    return names;
+  });
 
   await expect(async () => {
-    for await (const _entry of walkRoot(walkingRoot, "", {
+    for await (const _entry of capability.walk("", {
       signal: controller.signal,
       symlinkPolicy: "skip",
     })) {
@@ -178,6 +169,7 @@ it.each([
   { symlinkPolicy: "unexpected" },
   { symlinkPolicy: "skip", limitBehavior: "unexpected" },
   { symlinkPolicy: "skip", onDirectoryError: "unexpected" },
+  { symlinkPolicy: "skip", order: "unexpected" },
 ])("rejects invalid runtime walk policies: %j", async (options) => {
   const directory = await tempRoot();
   const capability = await root(directory);


### PR DESCRIPTION
## What Problem This Solves

A small `Root.walk` entry budget still reads metadata for every file in a wide directory before returning its first result.

## Why This Change Was Made

Sorted walks with finite budgets now prepare at most 32 admitted entries per batch, capped by the remaining global budget. Batches stop at directory or symlink boundaries so recursive traversal cannot overspend the budget through sibling prefetch. Identity checks bracket each batch, and event-loop handoffs permit cancellation. Unbounded sorted walks retain the existing full metadata snapshot path.

An optional `order: "filesystem"` streams directory names and metadata with one name of truncation lookahead. Explicit directory disposal preserves both operation and cleanup errors on supported Node versions, including early generator return or a thrown `undefined`. Windows tests also verify the unchanged traversal when the OS prevents an ancestor rename while its directory stream is open.

## User Impact

Bounded scans avoid inspecting unused entries. Sorted mode retains deterministic order and still enumerates all names; filesystem order also bounds enumeration. An early break in sorted mode may leave the current bounded batch prefetched. Finite complete scans pay some additional validation cost.

## Evidence

Three paired fresh-process samples of the bounded-walk implementation (`7a008fc`) over a synthetic 50,000-file directory with a 128-entry budget produced these medians on macOS arm64 / Node 24, native helpers disabled. Later compatibility corrections preserve the metadata batching algorithm:

| Mode | Time | Child metadata reads | Names read | Peak RSS |
| --- | ---: | ---: | ---: | ---: |
| Before | 252.46 ms | 50,000 | 50,000 | 104.4 MiB |
| Sorted | 52.43 ms | 128 | 50,000 | 60.6 MiB |
| Filesystem | 41.94 ms | 128 | 129 | 56.8 MiB |

All partial runs returned 128 entries and one truncation marker. Complete traversals retained identical output digests. Finite complete scans of 1,000 and 5,000 files added approximately 24 and 27 ms in the final repetition; a 16-file JS/CSS asset read added 2 ms. These timings vary with filesystem caches and host load; the call-count reduction is deterministic. On filesystems without directory-entry types, Node may stat the lookahead name.

- Combined walk, Root, parent-policy, mutation-authority, and dispatch proof passes 182 tests with two platform/native skips on each of Node 22 and Node 24. Coverage includes budget accounting, DFS boundaries, cancellation, directory replacement, case aliases, and double-failure cleanup.
- Budget, early-return, cleanup, and cancellation regressions reproduce on the corresponding original implementations.
- Build, docs, package, boundary, and whitespace checks pass. Fresh independent complete-candidate review is clean through P2.
- Final cross-platform CI, coverage, CodeQL, and benchmarks are green. No version change or release is included.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included

Final head `78c2da1d0e22d5632b66b647b52edabc8cdc6573` passed all 15 [CI jobs](https://github.com/openclaw/fs-safe/actions/runs/34735218801), [coverage](https://github.com/openclaw/fs-safe/actions/runs/34735218804), [CodeQL](https://github.com/openclaw/fs-safe/actions/runs/34735218803), and [benchmarks](https://github.com/openclaw/fs-safe/actions/runs/34735218821). The exact-head review has no remaining findings.
