### PR TITLE
docs(clone): explain APFS descendant ACL loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Read native ZIP entries from the retained, admitted input buffer and reuse the parsed directory, eliminating temporary disk staging and archive handoff copies while preserving validation.
-- Add `@openclaw/fs-safe/clone` for native APFS directory clones, Btrfs subvolume preparation and snapshots, and parallel ReFS tree cloning, with exclusive destinations and cancellation that waits for native writes to settle.
+- Add `@openclaw/fs-safe/clone` for native APFS directory clones, Btrfs subvolume preparation and snapshots, and parallel ReFS tree cloning, with exclusive destinations and cancellation that waits for native writes to settle. Document APFS descendant ACL preservation limits and caller-owned permission checks.
 - Add async and sync positional reads that fill caller-owned buffers through short reads, stop at EOF, preserve descriptor offsets and ownership, and support cooperative async cancellation.
 - Add composed Root `assertBeforeMutation` callbacks that recheck live caller authority immediately before filesystem mutation dispatch, including each buffered-write chunk and direct file removal, preserving refusal errors and owned cleanup across native and JavaScript writers.
 

--- a/docs/clone.md
+++ b/docs/clone.md
@@ -27,6 +27,14 @@ Source and destination must be on a filesystem that supports cloning between the
 
 Btrfs preserves native subvolume snapshot semantics: nested subvolume contents are not included. Prepare source-only templates without nested subvolumes. This API does not recursively snapshot a hierarchy of subvolumes.
 
+### APFS permissions
+
+APFS directory cloning does not guarantee descendant ACL preservation. With the `CLONE_ACL` flag used here, live macOS testing preserved the source root's ACL but dropped an explicit ACL on a source descendant. Destination ACL inheritance was also omitted below the cloned root. `probeTreeClone` checks filesystem support only; neither it nor `cloneTree` checks whether these ACL semantics meet the caller's permission policy. A successful clone is not proof of source ACL preservation or normal file-creation inheritance throughout the tree.
+
+Callers that require source ACL preservation or destination ACL inheritance must use a creation path that preserves their permission policy. For example, a private Git template cache can prohibit custom descendant ACLs and decline cloning when the destination parent has inheritable ACL entries, the template root carries ACLs, or ACL inspection fails; it must also account for policy changes during cloning. Checking only the source root cannot establish that an arbitrary tree has no descendant ACLs. This library does not inspect or repair ACLs after a clone.
+
+Apple [strongly discourages general directory cloning](https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/man/man2/clonefile.2). The [XNU directory-clone authorizer notes unfinished descendant ACL inheritance](https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/vfs/vfs_subr.c#L8879); this is one verified limitation, not Apple's stated complete rationale. The bulk operation remains useful for controlled, immutable templates whose callers accept its metadata semantics.
+
 ## API
 
 `TreeCloneBackend` is the `"apfs" | "btrfs" | "refs"` union returned by the probe. `CloneTreeOptions` contains the optional `signal` and `concurrency` arguments.

--- a/native/src/clone_unix.rs
+++ b/native/src/clone_unix.rs
@@ -128,8 +128,10 @@ pub fn clone_tree(
     {
         let name = std::ffi::CString::new(basename)
             .map_err(|_| native_error("EINVAL", "clone destination contains a NUL byte"))?;
-        // sys/clonefile.h: preserve literal symlinks and source ACLs. Both
-        // descriptors remain pinned by the caller until this operation settles.
+        // CLONE_ACL can copy the root ACL, but directory clones can lose both
+        // source and inherited descendant ACLs. Callers own eligibility; see
+        // docs/clone.md for Apple's directory-clone warning and XNU references.
+        // Both descriptors stay pinned until this bulk operation settles.
         const CLONE_NOFOLLOW: u32 = 0x0001;
         const CLONE_ACL: u32 = 0x0004;
         check_cancelled(cancelled)?;


### PR DESCRIPTION
Related: #293.

## What Problem This Solves

Consumers could mistake a successful APFS directory clone for preservation of source ACLs or normal destination ACL inheritance throughout the tree.

## Why This Change Was Made

Document the observed descendant ACL loss, distinguish filesystem support from permission-policy eligibility, and point callers to their own permission-preserving creation path. Correct the Rust comment and link Apple's warning and XNU's unfinished inheritance note without claiming these explain Apple's complete rationale.

## User Impact

Documentation and comments only; no runtime or API change. Callers can see why a controlled source-only template is appropriate and why checking only an arbitrary source tree's root is insufficient.

## Evidence

- Built native macOS binding and package; documentation examples passed.
- 23 focused documentation and clone tests passed, with 3 platform-specific skips.
- Live APFS checks confirmed shared blocks, distinct inodes and independent writes. Explicit source-root ACLs survived, while an explicit descendant-file ACL was omitted. A separate Git checkout control received inherited descendant ACLs that the directory clone omitted.
- A live 12,000-file bulk clone settled before returning the exact cancellation reason; immediate destination cleanup/reuse remained intact.
- Full `pnpm check`: 8,663 tests passed, 97 skipped, and 2 pnpm lifecycle tests failed. Both failures reproduced on unchanged main because the local pnpm executable path does not match the tests' expected JavaScript CLI path. The failure prevented the final package-check step from running in that invocation.
- Independent P0–P2 review found no actionable issue. `git diff --check` passed.

- [x] Tests added or updated when behavior changed (no runtime behavior change)
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included

### Captured native APFS proof

The following captured output comes from the built `dist/clone.js` public facade and real macOS APFS fixtures. It uses no binding substitution or mocks. The clone implementation tested at `0b40e52d058cdee1299f85e78fc0b223d9a65377` is unchanged by this PR apart from the comment.

Explicit source ACL and in-flight cancellation output:

```json
{
  "sourceRootAclPreserved": true,
  "sourceDescendantAclOmitted": {
    "source": [
      "0: group:everyone allow read"
    ],
    "clone": []
  },
  "cow": true,
  "distinctInodes": true,
  "cancellationAfterBulkClone": {
    "files": 12000,
    "exactReason": true,
    "settledMs": 177,
    "immediateDestinationReuseStable": true
  }
}
```

The fixture added `everyone allow read` separately to the source root and `nested/payload`. `sourceRootAclPreserved` was emitted only after asserting the cloned root's `ls -lde` ACL entries equal the source root's entries. The captured descendant entries show the loss directly.

Destination inheritance versus normal Git checkout:

```json
{
  "backend": "apfs",
  "cow": true,
  "independentWrites": true,
  "aclCloneCallSucceeded": true,
  "git": [
    [
      "0: group:everyone inherited allow list,file_inherit,directory_inherit"
    ],
    [
      "0: group:everyone inherited allow list,file_inherit,directory_inherit"
    ],
    [
      "0: group:everyone inherited allow read"
    ],
    []
  ],
  "clone": [
    [
      "0: group:everyone inherited allow list,file_inherit,directory_inherit"
    ],
    [],
    [],
    []
  ]
}
```

Each ACL array is ordered as root, `nested`, `nested/payload`, and `link`. Before creating either destination, the fixture ran `chmod +a 'everyone allow read,file_inherit,directory_inherit'` on their shared parent. The control used `git worktree add --detach`; the clone used `await cloneTree(template, destination)`. ACL entries were read with `/bin/ls -lde`. The source-only template was kept immutable and its contents matched the Git fixture. Both calls completed successfully, but only Git applied inheritance below the root.

The cancellation fixture created 12,000 source files, called `cloneTree` with an AbortSignal, and aborted after 5 ms. After rejection with the exact caller-supplied reason, the destination contained all 12,000 files, proving the admitted bulk call completed. The fixture then removed and immediately reused that destination; its replacement sentinel remained the sole entry after 250 ms. Every fixture was task-owned and removed after observation.
