### PR TITLE
perf(archive): retain TAR buffers across member reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,13 +177,16 @@ jobs:
           FS_SAFE_NATIVE_MODE: require
         run: pnpm test test/file-hash-options.test.ts
 
-      - name: Test native ZIP buffer ownership and validation
+      - name: Test native archive buffer ownership and validation
         env:
           FS_SAFE_NATIVE_MODE: require
-        run: pnpm test test/native-zip-buffer.test.ts
+        run: pnpm test test/native-zip-buffer.test.ts test/native-tar-buffer.test.ts
 
       - name: Prove native ZIP buffer lifetime across garbage collection
         run: node --expose-gc scripts/native-zip-buffer-gc-proof.mjs
+
+      - name: Prove native TAR buffer lifetime across garbage collection
+        run: node --expose-gc scripts/native-tar-buffer-gc-proof.mjs
 
       - name: Prove sidecar contention with required native binding
         run: node scripts/sidecar-contention-proof.mjs require

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Performance: read TAR members from a retained private input buffer, removing temporary-file staging in native and JavaScript modes and redundant native admission/replay for plain TAR while preserving complete framing, trailer, and limit validation.
+
 - Read native ZIP entries from the retained, admitted input buffer and reuse the parsed directory, eliminating temporary disk staging and archive handoff copies while preserving validation.
 - Add `@openclaw/fs-safe/clone` for native APFS directory clones, Btrfs subvolume preparation and snapshots, and parallel ReFS tree cloning, with exclusive destinations and cancellation that waits for native writes to settle. Document APFS descendant ACL preservation limits and caller-owned permission checks.
 - Add async and sync positional reads that fill caller-owned buffers through short reads, stop at EOF, preserve descriptor offsets and ownership, and support cooperative async cancellation.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -571,12 +571,19 @@ limits. It does not apply payload budgets to unrequested members. ZIP
 inputs retain the archive subpath's 256 MiB compressed-input ceiling.
 With a native binding it uses the same Rust decoders as extraction, including
 zstd and bzip2 TAR. Without native it retains the JS ZIP/TAR/gzip implementation.
-Both ZIP readers consume the admitted buffer directly. The native ZIP reader
-retains the private allocation and parsed directory across worker-thread
-inspection and reading, without a disk snapshot or an extra archive-byte copy.
+Archive member reads retain their private in-memory input without a disk
+snapshot. The native ZIP reader retains the private allocation and parsed directory across worker-thread
+inspection and reading without an extra archive-byte copy.
 Decompression still allocates its bounded output; Node receives that native
 allocation without another copy where external buffers are supported.
-TAR decoders and replay retain their private disk snapshot.
+Native TAR retains the fully admitted member offsets alongside the same input
+allocation. Plain TAR copies only the selected payload range after full archive
+validation. Gzip, zstd, and bzip2 replay bounded decompression and still validate
+all framing, trailers, and physical padding before returning. The JavaScript
+TAR/gzip fallback streams views of the private input into the shared WASM parser
+for admission and replay; WASM transport and selected output still require copies.
+Returned buffers own their bytes, so changing a result cannot modify an archive
+reader or retain an unrelated part of the input through its backing ArrayBuffer.
 
 Requested paths and effective member names use extraction's canonical pre-strip
 identity: backslashes become `/`, and repeated separators and `.` components

--- a/docs/native.md
+++ b/docs/native.md
@@ -59,14 +59,18 @@ whether a path, archive entry, mode, owner, or cleanup policy is acceptable.
 
 ## Archives
 
-Native ZIP entry reads retain a private, unpooled input Buffer in the async
-reader and reuse the parsed ZIP directory after TypeScript admission and
-selection. The internal binding borrows that allocation: it must never be
+Native ZIP and TAR entry reads retain a private, unpooled input Buffer in
+the async reader. ZIP reuses its parsed directory; TAR retains admitted member
+offsets. TypeScript validates and selects the requested member before reading. The internal binding borrows that allocation: it must never be
 mutated or detached while the reader or a read task exists. The public API only
 accepts a pathname and owns this buffer exclusively. An N-API reference keeps
-the bytes alive; a mutex serializes access to the retained ZIP cursor. Output
-decompression allocates a new vector, which N-API transfers to Node without a
-second payload copy on runtimes supporting external buffers.
+the bytes alive; a mutex serializes access to the retained ZIP cursor. Plain
+TAR copies only the selected range after complete admission, while gzip, zstd,
+and bzip2 replay bounded decompression and validate the full physical stream.
+Concurrent TAR reads share immutable input and own separate decoder state.
+Each output owns a new vector, which N-API transfers to Node without a second
+payload copy on runtimes supporting external buffers. No entry-read path
+requires temporary-file staging. Extraction retains its private staged input.
 
 Rust streams ZIP and TAR payloads, including gzip, zstd, and bzip2. It first
 returns a bounded manifest. TypeScript applies the shared path, filter, strip,

--- a/native/src/archive.rs
+++ b/native/src/archive.rs
@@ -123,8 +123,14 @@ fn open_tar_reader(
     cancelled: Arc<AtomicBool>,
     limits: TarMeterLimits,
 ) -> Result<TarMetadataMeter<Box<dyn Read + Send>>> {
-    let mut file = File::open(path).map_err(|error| io_error("open archive", error))?;
-    let decoded: Box<dyn Read + Send> = match format {
+    let file = File::open(path).map_err(|error| io_error("open archive", error))?;
+    open_tar_source(file, format, cancelled, limits)
+}
+
+fn open_tar_source<'a, R: Read + Seek + Send + 'a>(
+    mut file: R, format: ArchiveFormat, cancelled: Arc<AtomicBool>, limits: TarMeterLimits,
+) -> Result<TarMetadataMeter<Box<dyn Read + Send + 'a>>> {
+    let decoded: Box<dyn Read + Send + 'a> = match format {
         ArchiveFormat::TarZstd => Box::new(CancellationReader {
             inner: zstd::stream::read::Decoder::new(file)
                 .map_err(|error| io_error("open zstd archive", error))?,
@@ -178,7 +184,11 @@ fn inspect_tar(
     limits: InspectLimits,
     cancelled: Arc<AtomicBool>,
 ) -> Result<Vec<ArchiveEntryData>> {
-    let mut reader = open_tar_reader(path, format, cancelled, limits.tar)?;
+    let reader = open_tar_reader(path, format, cancelled, limits.tar)?;
+    inspect_tar_reader(reader)
+}
+
+fn inspect_tar_reader<R: Read>(mut reader: TarMetadataMeter<R>) -> Result<Vec<ArchiveEntryData>> {
     let mut result = Vec::new();
     let mut buffer = [0; 65536];
     while reader.read(&mut buffer).map_err(|error| io_error("admit tar", error))? != 0 {
@@ -837,6 +847,128 @@ impl Task for ReadZipBufferTask {
     }
 }
 
+struct TarBufferData {
+    input: Buffer,
+    format: ArchiveFormat,
+    limits: TarMeterLimits,
+    members: Vec<ArchiveEntryData>,
+}
+
+#[napi]
+pub struct NativeTarBufferReader {
+    data: Arc<TarBufferData>,
+}
+
+#[napi]
+impl NativeTarBufferReader {
+    #[napi(getter)]
+    pub fn entries(&self) -> Vec<NativeArchiveEntry> {
+        self.data.members.iter().map(|entry| NativeArchiveEntry {
+            index: entry.index, path: entry.path.clone(), kind: entry.kind.clone(),
+            size: entry.size as f64, mode: entry.mode,
+        }).collect()
+    }
+
+    #[napi]
+    pub fn read_entry(&self, index: u32, max_bytes: f64, signal: Option<AbortSignal>) -> Result<AsyncTask<ReadTarBufferTask>> {
+        if !max_bytes.is_finite() || !(0.0..=MAX_SAFE_INTEGER as f64).contains(&max_bytes)
+            || max_bytes.fract() != 0.0 {
+            return Err(Error::new(Status::InvalidArg, "maxBytes must be a non-negative safe integer"));
+        }
+        let cancelled = signal.as_ref().map(cancellation).unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+        Ok(AsyncTask::with_optional_signal(ReadTarBufferTask {
+            data: Arc::clone(&self.data), index: index as usize, max_bytes: max_bytes as u64, cancelled,
+        }, signal))
+    }
+}
+
+pub struct OpenTarBufferTask {
+    buffer: Option<Buffer>,
+    format: ArchiveFormat,
+    limits: TarMeterLimits,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl Task for OpenTarBufferTask {
+    type Output = NativeTarBufferReader;
+    type JsValue = NativeTarBufferReader;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        check_cancelled(&self.cancelled)?;
+        let input = self.buffer.take().ok_or_else(|| Error::new(Status::GenericFailure, "TAR buffer already consumed"))?;
+        let reader = open_tar_source(Cursor::new(input.as_ref()), self.format, Arc::clone(&self.cancelled), self.limits)?;
+        let members = inspect_tar_reader(reader)?;
+        Ok(NativeTarBufferReader { data: Arc::new(TarBufferData { input, format: self.format, limits: self.limits, members }) })
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        check_cancelled(&self.cancelled)?;
+        Ok(output)
+    }
+}
+
+// Same private, immutable, unpooled borrowing contract as the ZIP buffer reader.
+#[napi(js_name = "openTarBufferNative")]
+pub fn open_tar_buffer_native(buffer: Buffer, kind: String, limits: NativeTarLimits, signal: Option<AbortSignal>) -> Result<AsyncTask<OpenTarBufferTask>> {
+    let format = parse_format(&kind).map_err(|error| Error::new(Status::InvalidArg, error.reason))?;
+    if matches!(format, ArchiveFormat::Zip) {
+        return Err(Error::new(Status::InvalidArg, "zip is not a tar stream"));
+    }
+    let limits = limits.checked()?;
+    let cancelled = signal.as_ref().map(cancellation).unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+    Ok(AsyncTask::with_optional_signal(OpenTarBufferTask { buffer: Some(buffer), format, limits, cancelled }, signal))
+}
+
+pub struct ReadTarBufferTask {
+    data: Arc<TarBufferData>,
+    index: usize,
+    max_bytes: u64,
+    cancelled: Arc<AtomicBool>,
+}
+
+impl Task for ReadTarBufferTask {
+    type Output = Vec<u8>;
+    type JsValue = Buffer;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        check_cancelled(&self.cancelled)?;
+        let member = self.data.members.get(self.index)
+            .ok_or_else(|| Error::new(Status::InvalidArg, "archive entry not found"))?;
+        if member.kind != "file" {
+            return Err(Error::new(Status::InvalidArg, "archive entry is not a file"));
+        }
+        if member.size > self.max_bytes { return Err(limit_error("archive-entry-extracted-size-exceeds-limit")); }
+        let input = self.data.input.as_ref();
+        if matches!(self.data.format, ArchiveFormat::Tar) && !input.starts_with(&[0x1f, 0x8b]) {
+            // Complete admission already checked this immutable raw TAR, including
+            // unselected members and EOF. Its retained payload range needs no replay.
+            let range = member.offset.checked_add(member.size)
+                .and_then(|end| Some((usize::try_from(member.offset).ok()?, usize::try_from(end).ok()?)))
+                .and_then(|(start, end)| input.get(start..end))
+                .ok_or_else(|| Error::new(Status::InvalidArg, "archive-header-invalid: truncated TAR payload"))?;
+            let mut output = Vec::with_capacity(range.len());
+            for chunk in range.chunks(65536) {
+                check_cancelled(&self.cancelled)?;
+                output.extend_from_slice(chunk);
+            }
+            return Ok(output);
+        }
+        let mut reader = open_tar_source(Cursor::new(input), self.data.format, Arc::clone(&self.cancelled), self.data.limits)?;
+        skip_tar_to(&mut reader, &mut 0, member.offset)?;
+        let output = read_bounded(&mut (&mut reader).take(member.size), self.max_bytes, Arc::clone(&self.cancelled))?;
+        if output.len() as u64 != member.size {
+            return Err(Error::new(Status::InvalidArg, "archive-header-invalid: truncated TAR payload"));
+        }
+        drain_tar_metadata(&mut reader).map_err(|error| io_error("finish tar", error))?;
+        Ok(output)
+    }
+
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        check_cancelled(&self.cancelled)?;
+        Ok(output.into())
+    }
+}
+
 pub struct ReadEntryTask {
     path: String,
     format: ArchiveFormat,
@@ -932,6 +1064,27 @@ mod tests {
         drop(task);
         let original = Arc::try_unwrap(archive).ok().unwrap().into_inner().unwrap().into_inner().into_inner();
         assert_eq!(original.as_ptr(), input_pointer, "input bytes must not be copied");
+    }
+
+    #[test]
+    fn buffered_tar_retains_the_input_allocation_across_reader_and_tasks() {
+        let raw = fixture_tar();
+        for (format, bytes) in [
+            (ArchiveFormat::Tar, raw.clone()), (ArchiveFormat::Tar, gzip(&raw)),
+            (ArchiveFormat::TarZstd, zstd::stream::encode_all(raw.as_slice(), 1).unwrap()),
+            (ArchiveFormat::TarBzip2, bzip(&raw)),
+        ] {
+            let input = Buffer::from(bytes);
+            let pointer = input.as_ptr();
+            let mut open = OpenTarBufferTask { buffer: Some(input), format, limits: limits(10).tar, cancelled: Arc::new(AtomicBool::new(false)) };
+            let reader = open.compute().unwrap();
+            let mut task = ReadTarBufferTask { data: Arc::clone(&reader.data), index: 1, max_bytes: 3, cancelled: Arc::new(AtomicBool::new(false)) };
+            drop(reader);
+            assert_eq!(task.data.input.as_ptr(), pointer, "input bytes must not be copied");
+            assert_eq!(task.compute().unwrap(), b"two");
+            task.index = 0;
+            assert_eq!(task.compute().unwrap(), b"one");
+        }
     }
 
     fn fixture_tar() -> Vec<u8> {

--- a/scripts/native-tar-buffer-gc-proof.mjs
+++ b/scripts/native-tar-buffer-gc-proof.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { gzipSync } from "node:zlib";
+import { configureFsSafeNative } from "../dist/native-config.js";
+import { getNativeBinding } from "../dist/native.js";
+import { resolveTarMeterLimits } from "../dist/archive-limits.js";
+
+assert.equal(typeof globalThis.gc, "function", "run with --expose-gc");
+configureFsSafeNative({ mode: "require" });
+const native = getNativeBinding();
+const payload = Buffer.alloc(1024 * 1024, 42);
+const header = Buffer.alloc(512);
+header.write("payload");
+header.write("0000644\0", 100);
+header.write(`${payload.length.toString(8).padStart(11, "0")}\0`, 124);
+header.fill(32, 148, 156);
+header[156] = 48;
+header.write(`${header.reduce((sum, byte) => sum + byte, 0).toString(8).padStart(6, "0")}\0 `, 148);
+const raw = Buffer.concat([header, payload, Buffer.alloc(1024)]);
+
+for (const fixture of [raw, gzipSync(raw)]) {
+  for (let round = 0; round < 3; round++) {
+    let input = Buffer.allocUnsafeSlow(fixture.length);
+    fixture.copy(input);
+    let opening = native.openTarBufferNative(input, "tar", resolveTarMeterLimits());
+    input = undefined;
+    globalThis.gc();
+    let reader = await opening;
+    opening = undefined;
+    await new Promise(resolve => setImmediate(resolve));
+    globalThis.gc();
+    const pending = Array.from({ length: 8 }, () => reader.readEntry(0, payload.length));
+    reader = undefined;
+    globalThis.gc();
+    const results = await Promise.all(pending);
+    for (const result of results) assert.ok(result.equals(payload));
+    await new Promise(resolve => setImmediate(resolve));
+    globalThis.gc();
+  }
+}
+console.log(JSON.stringify({ proof: "native-tar-buffer-gc", reads: 48, outcome: "passed" }));

--- a/src/archive-gzip-tail.ts
+++ b/src/archive-gzip-tail.ts
@@ -4,6 +4,26 @@ import { Writable } from "node:stream";
 import type { Gunzip } from "node:zlib";
 import { ArchiveFormatError } from "./archive-errors.js";
 
+function assertConsumedBoundary(consumed: number, size: number): void {
+  if (!Number.isSafeInteger(consumed) || consumed <= 0 || consumed > size) {
+    throw new ArchiveFormatError("invalid gzip consumed-input boundary");
+  }
+}
+
+/** Validate the same physical suffix when admission owns an in-memory input. */
+export async function validateGzipBufferTail(input: Buffer, consumed: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  assertConsumedBoundary(consumed, input.length);
+  for (let position = consumed; position < input.length; position += 65536) {
+    signal?.throwIfAborted();
+    if (input.subarray(position, position + 65536).some(byte => byte !== 0)) {
+      throw new ArchiveFormatError("nonzero gzip container padding");
+    }
+    if (position + 65536 < input.length) await new Promise<void>(resolve => setImmediate(resolve));
+  }
+  signal?.throwIfAborted();
+}
+
 /** Track physical input, not the sum of bytes consumed across separate writes:
  * gunzip can resume on a later chunk after leaving an earlier padding gap. */
 export class GzipInput extends Writable {
@@ -51,9 +71,7 @@ export async function validateGzipContainerTail(filePath: string, consumed: numb
   const handle = await fs.open(filePath, "r");
   try {
     const { size } = fsSync.fstatSync(handle.fd);
-    if (!Number.isSafeInteger(consumed) || consumed <= 0 || consumed > size) {
-      throw new ArchiveFormatError("invalid gzip consumed-input boundary");
-    }
+    assertConsumedBoundary(consumed, size);
     if (consumed === size) return;
     const buffer = Buffer.allocUnsafe(65536);
     let position = consumed;

--- a/src/archive-read.ts
+++ b/src/archive-read.ts
@@ -34,7 +34,6 @@ import { getNativeBinding, type NativeBinding } from "./native.js";
 import type { NativeArchiveEntry } from "./native-binding.js";
 import { admitZipBuffer } from "./archive-zip-admission.js";
 import { resolveExtractLimits, resolveTarMeterLimits } from "./archive-limits.js";
-import { tempFile } from "./temp-target.js";
 
 const ZIP_UNIX_FILE_TYPE_MASK = 0o170000;
 const ZIP_UNIX_SYMLINK_TYPE = 0o120000;
@@ -114,7 +113,7 @@ async function readArchiveInput(archivePath: string): Promise<Buffer> {
       return stat;
     }, opened);
 
-    // Native ZIP workers borrow this private buffer. A pooled allocation could
+    // Native archive workers borrow this private buffer. A pooled allocation could
     // share its ArrayBuffer with unrelated JS buffers while the worker runs.
     return await readBoundedAsync(DEFAULT_MAX_ARCHIVE_BYTES_ZIP,
       async (buffer, length) => (await handle.read(buffer, 0, length, null)).bytesRead,
@@ -167,11 +166,11 @@ async function readZipEntry(buffer: Buffer, entryPath: string, maxBytes: number)
   return await readStreamBounded(stream.pipe(integrity), maxBytes);
 }
 
-async function readTarEntry(archivePath: string, entryPath: string, maxBytes: number): Promise<Buffer> {
+async function readTarEntry(archiveBuffer: Buffer, entryPath: string, maxBytes: number): Promise<Buffer> {
   const seenPaths = new Set<string>();
   let selected: AdmittedTarMember | undefined;
   const limits = resolveTarMeterLimits();
-  await inspectTar({ archivePath, limits, onMember(info) {
+  await inspectTar({ archiveBuffer, limits, onMember(info) {
     const normalized = canonicalEntryPath(info.path);
     if (seenPaths.has(normalized)) {
       throw new ArchiveSecurityError("entry-path", `archive contains duplicate entry path: ${formatErrorDetail(normalized)}`);
@@ -185,7 +184,7 @@ async function readTarEntry(archivePath: string, entryPath: string, maxBytes: nu
   }
   if (selected.size > maxBytes) throw new ArchiveLimitError(ARCHIVE_LIMIT_ERROR_CODE.ENTRY_EXTRACTED_SIZE_EXCEEDS_LIMIT);
   let result: Buffer | undefined;
-  await replayTar({ archivePath, limits, members: [selected], async consume(_member, payload) {
+  await replayTar({ archiveBuffer, limits, members: [selected], async consume(_member, payload) {
     result = await readStreamBounded(payload, maxBytes);
   } });
   return result!;
@@ -223,12 +222,15 @@ function throwNativeReadError(error: unknown): never {
   throw error;
 }
 
-async function readNativeZipEntry(
-  native: NativeBinding, buffer: Buffer, requested: string, displayPath: string, maxBytes: number, physicalCount: number,
+async function readNativeBufferEntry(
+  native: NativeBinding, buffer: Buffer, kind: ArchiveKind, requested: string, displayPath: string, maxBytes: number, physicalCount?: number,
 ): Promise<Buffer> {
   try {
     const signal = new AbortController().signal;
-    const reader = await native.openZipBufferNative(buffer, resolveTarMeterLimits(), AbortSignal.any([signal]));
+    const limits = resolveTarMeterLimits();
+    const reader = kind === "zip"
+      ? await native.openZipBufferNative(buffer, limits, AbortSignal.any([signal]))
+      : await native.openTarBufferNative(buffer, kind, limits, AbortSignal.any([signal]));
     const selected = selectNativeEntry(reader.entries, requested, displayPath, physicalCount);
     return await reader.readEntry(selected.index, maxBytes, AbortSignal.any([signal]));
   } catch (error) {
@@ -254,41 +256,8 @@ export async function readArchiveEntry(
     ? admitZipBuffer(buffer, resolveExtractLimits())
     : undefined;
   const native = getNativeBinding();
-  if (kind === "zip" && native) {
-    return await readNativeZipEntry(native, buffer, requestedEntry, entryPath, options.maxBytes, physicalCount!);
-  }
-  if (!native) {
-    assertPortableArchiveKind(kind);
-    if (kind === "zip") return await readZipEntry(buffer, requestedEntry, options.maxBytes);
-  }
-  const staged = await tempFile({ prefix: "fs-safe-archive-read", fileName: "archive.bin" });
-  try {
-    await fs.writeFile(staged.path, buffer, { flag: "wx", mode: 0o600 });
-    if (native) {
-      try {
-        const signal = new AbortController().signal;
-        const limits = resolveTarMeterLimits();
-        const manifest = await native.inspectArchiveNative(
-          staged.path,
-          kind,
-          limits,
-          signal,
-        );
-        const selected = selectNativeEntry(manifest, requestedEntry, entryPath);
-        return await native.readArchiveEntryNative(
-          staged.path,
-          kind,
-          selected.path,
-          options.maxBytes,
-          limits,
-          signal,
-        );
-      } catch (error) {
-        throwNativeReadError(error);
-      }
-    }
-    return await readTarEntry(staged.path, requestedEntry, options.maxBytes);
-  } finally {
-    await staged.cleanup();
-  }
+  if (native) return await readNativeBufferEntry(native, buffer, kind, requestedEntry, entryPath, options.maxBytes, physicalCount);
+  assertPortableArchiveKind(kind);
+  return kind === "zip" ? await readZipEntry(buffer, requestedEntry, options.maxBytes)
+    : await readTarEntry(buffer, requestedEntry, options.maxBytes);
 }

--- a/src/archive-tar-stream.ts
+++ b/src/archive-tar-stream.ts
@@ -1,11 +1,18 @@
 import fs from "node:fs";
-import { Writable } from "node:stream";
+import { Readable, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createGunzip } from "node:zlib";
-import { GzipInput, validateGzipContainerTail } from "./archive-gzip-tail.js";
+import { GzipInput, validateGzipBufferTail, validateGzipContainerTail } from "./archive-gzip-tail.js";
 import { ArchiveFormatError } from "./archive-errors.js";
 import type { TarMeterLimits } from "./archive-limits.js";
 import { TarParserStream, type AdmittedTarMember } from "./archive-tar-wasm.js";
+
+/** Buffers are private immutable snapshots, just like the staged file route. */
+type TarInput = { archivePath: string; archiveBuffer?: never } | { archiveBuffer: Buffer; archivePath?: never };
+
+function* bufferChunks(buffer: Buffer): Generator<Buffer> {
+  for (let offset = 0; offset < buffer.length; offset += 65536) yield buffer.subarray(offset, offset + 65536);
+}
 
 async function gzipFile(filePath: string): Promise<boolean> {
   const handle = await fs.promises.open(filePath, "r");
@@ -16,14 +23,18 @@ async function gzipFile(filePath: string): Promise<boolean> {
   } finally { await handle.close(); }
 }
 
-async function withTarStream<T>(params: {
-  archivePath: string; limits: TarMeterLimits; signal?: AbortSignal;
+async function withTarStream<T>(params: TarInput & {
+  limits: TarMeterLimits; signal?: AbortSignal;
   onMember?: (entry: AdmittedTarMember) => void;
 }, consume: (parser: TarParserStream) => Promise<T>): Promise<T> {
-  const gzip = await gzipFile(params.archivePath);
+  const buffer = params.archiveBuffer;
+  const gzip = buffer !== undefined ? buffer[0] === 31 && buffer[1] === 139 : await gzipFile(params.archivePath!);
   const parser = new TarParserStream(params.limits, params.onMember);
-  const input = fs.createReadStream(params.archivePath, { highWaterMark: 65536 });
-  const decoder = gzip ? createGunzip() : undefined;
+  const input = buffer !== undefined
+    ? Readable.from(bufferChunks(buffer), { objectMode: false, highWaterMark: 65536 })
+    : fs.createReadStream(params.archivePath!, { highWaterMark: 65536 });
+  // Match the WASM input window for buffered reads instead of emitting 16 KiB chunks.
+  const decoder = gzip ? createGunzip(buffer === undefined ? undefined : { chunkSize: 65536 }) : undefined;
   const gzipInput = decoder ? new GzipInput(decoder) : undefined;
   const destroy = (error?: Error) => {
     input.destroy(error); gzipInput?.destroy(error); decoder?.destroy(error); parser.destroy(error);
@@ -41,7 +52,10 @@ async function withTarStream<T>(params: {
     const result = await consume(parser);
     const error = await settled;
     if (error) throw error;
-    if (gzipInput) await validateGzipContainerTail(params.archivePath, gzipInput.tailOffset, params.signal);
+    if (gzipInput) {
+      if (buffer !== undefined) await validateGzipBufferTail(buffer, gzipInput.tailOffset, params.signal);
+      else await validateGzipContainerTail(params.archivePath!, gzipInput.tailOffset, params.signal);
+    }
     return result;
   } finally {
     destroy();
@@ -49,8 +63,8 @@ async function withTarStream<T>(params: {
   }
 }
 
-export async function inspectTar(params: {
-  archivePath: string; limits: TarMeterLimits; signal?: AbortSignal;
+export async function inspectTar(params: TarInput & {
+  limits: TarMeterLimits; signal?: AbortSignal;
   onMember?: (entry: AdmittedTarMember) => void;
 }): Promise<void> {
   await withTarStream(params, async (parser) => {
@@ -59,9 +73,9 @@ export async function inspectTar(params: {
 }
 
 /** Replay in physical order, retaining at most one decoded chunk. Every range
- * comes from complete admission of the immutable staged input. */
-export async function replayTar<T extends AdmittedTarMember>(params: {
-  archivePath: string; limits: TarMeterLimits; signal?: AbortSignal;
+ * comes from complete admission of the immutable input. */
+export async function replayTar<T extends AdmittedTarMember>(params: TarInput & {
+  limits: TarMeterLimits; signal?: AbortSignal;
   members: readonly T[];
   consume(member: T, payload: AsyncIterable<Buffer>): Promise<void>;
 }): Promise<void> {

--- a/src/native-binding.ts
+++ b/src/native-binding.ts
@@ -78,6 +78,11 @@ export interface NativeWindowsSecurityFacts {
 }
 
 export interface NativeBinding {
+  /** Internal: same private, immutable input ownership as the ZIP buffer reader. */
+  openTarBufferNative(buffer: Buffer, kind: string, limits: TarMeterLimits, signal?: AbortSignal): Promise<{
+    readonly entries: NativeArchiveEntry[];
+    readEntry(index: number, maxBytes: number, signal?: AbortSignal): Promise<Buffer>;
+  }>;
   /** Internal: input remains private, unpooled and immutable until the reader is released. */
   openZipBufferNative(buffer: Buffer, limits: TarMeterLimits, signal?: AbortSignal): Promise<{
     readonly entries: NativeArchiveEntry[];

--- a/test/archive-pax.test.ts
+++ b/test/archive-pax.test.ts
@@ -29,8 +29,8 @@ for (const mode of ["off", "require"] as const) {
         const native = paxNative!;
         inspectNative = vi.fn(native.inspectArchiveNative.bind(native));
         extractNative = vi.fn(native.extractArchiveNative.bind(native));
-        readNative = vi.fn(native.readArchiveEntryNative.bind(native));
-        __setNativeLoaderForTest(() => ({ ...native, inspectArchiveNative: inspectNative, extractArchiveNative: extractNative, readArchiveEntryNative: readNative }));
+        readNative = vi.fn(native.openTarBufferNative.bind(native));
+        __setNativeLoaderForTest(() => ({ ...native, inspectArchiveNative: inspectNative, extractArchiveNative: extractNative, openTarBufferNative: readNative }));
       }
     });
 
@@ -46,7 +46,7 @@ for (const mode of ["off", "require"] as const) {
       expect(await readArchiveEntry(archivePath, name, { maxBytes: expected.length })).toEqual(expected);
       expect(await readArchiveEntry(archivePath, "sentinel", { maxBytes: 3 })).toEqual(Buffer.from("end"));
       if (mode === "require") {
-        expect(inspectNative).toHaveBeenCalledTimes(3);
+        expect(inspectNative).toHaveBeenCalledTimes(1);
         expect(extractNative).toHaveBeenCalledTimes(1);
         expect(readNative).toHaveBeenCalledTimes(2);
       }

--- a/test/archive-read-boundaries.test.ts
+++ b/test/archive-read-boundaries.test.ts
@@ -236,7 +236,7 @@ describe("bounded archive reads", () => {
   });
 
   it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
-    "closes the selected archive when private staging allocation fails",
+    "reads TAR without staging and closes the descriptor when temporary storage is blocked",
     async () => {
       const root = await tempRoot("fs-safe-archive-read-staging-failure-");
       const archivePath = path.join(root, "fixture.tar");
@@ -253,7 +253,7 @@ describe("bounded archive reads", () => {
         expect(descriptorsForFile(archivePath)).toEqual([]);
         for (let attempt = 0; attempt < 3; attempt += 1) {
           await expect(readArchiveEntry(archivePath, "value", { maxBytes: 2 }))
-            .rejects.toThrow("Unsafe fallback secure temp dir");
+            .resolves.toEqual(Buffer.from("ok"));
           expect(descriptorsForFile(archivePath)).toEqual([]);
         }
       } finally {

--- a/test/archive-read-canonical.test.ts
+++ b/test/archive-read-canonical.test.ts
@@ -32,13 +32,18 @@ for (const { mode, format } of routes) {
       configureFsSafeNative({ mode });
       if (mode === "require") {
         const native = paxNative!;
-        inspectNative = vi.fn(format === "zip" ? native.openZipBufferNative.bind(native) : native.inspectArchiveNative.bind(native));
+        inspectNative = vi.fn(format === "zip" ? native.openZipBufferNative.bind(native) : native.openTarBufferNative.bind(native));
         readNative = vi.fn(native.readArchiveEntryNative.bind(native));
         extractNative = vi.fn(native.extractArchiveNative.bind(native));
         __setNativeLoaderForTest(() => ({ ...native,
-          inspectArchiveNative: format === "zip" ? native.inspectArchiveNative.bind(native) : inspectNative,
+          inspectArchiveNative: native.inspectArchiveNative.bind(native),
           readArchiveEntryNative: readNative, extractArchiveNative: extractNative,
           openZipBufferNative: async (...args) => {
+            const reader = await inspectNative(...args);
+            readNative = vi.fn(reader.readEntry.bind(reader));
+            return { entries: reader.entries, readEntry: readNative };
+          },
+          openTarBufferNative: async (...args) => {
             const reader = await inspectNative(...args);
             readNative = vi.fn(reader.readEntry.bind(reader));
             return { entries: reader.entries, readEntry: readNative };
@@ -95,12 +100,8 @@ for (const { mode, format } of routes) {
       nativeRead(true);
       if (mode === "require") {
         const inspected = await inspectNative.mock.results[0]!.value;
-        // ZIP selects the retained manifest index; TAR retains its raw spelling.
-        if (format === "zip") {
-          expect(inspected.entries.some((entry: { index: number }) => entry.index === readNative.mock.calls[0]![0])).toBe(true);
-        } else {
-          expect(inspected.some((entry: { path: string }) => entry.path === readNative.mock.calls[0]![2])).toBe(true);
-        }
+        // Both native readers select the retained manifest index.
+        expect(inspected.entries.some((entry: { index: number }) => entry.index === readNative.mock.calls[0]![0])).toBe(true);
       }
     });
 

--- a/test/archive-tar-framing.test.ts
+++ b/test/archive-tar-framing.test.ts
@@ -41,8 +41,8 @@ for (const backend of ["off", "auto-missing", "auto", "require"] as const) {
         const native = paxNative!;
         inspect = vi.fn(native.inspectArchiveNative.bind(native));
         extract = vi.fn(native.extractArchiveNative.bind(native));
-        read = vi.fn(native.readArchiveEntryNative.bind(native));
-        __setNativeLoaderForTest(() => ({ ...native, inspectArchiveNative: inspect, extractArchiveNative: extract, readArchiveEntryNative: read }));
+        read = vi.fn(native.openTarBufferNative.bind(native));
+        __setNativeLoaderForTest(() => ({ ...native, inspectArchiveNative: inspect, extractArchiveNative: extract, openTarBufferNative: read }));
       }
     });
 
@@ -197,10 +197,10 @@ for (const backend of ["off", "auto-missing", "auto", "require"] as const) {
         await expect(fs.stat(stagedPath!)).rejects.toMatchObject({ code: "ENOENT" });
         expect((await fs.readdir(path.dirname(fixture.destDir))).sort()).toEqual([path.basename(fixture.archivePath), "out"]);
 
-        read.mockImplementationOnce(async (...args: Parameters<NonNullable<typeof paxNative>["readArchiveEntryNative"]>) => {
-          await fs.writeFile(args[0], gzip ? gzipSync(bytes) : bytes);
-          args[4] = { ...args[4], maxDecodedBytes: canonical.length };
-          return paxNative!.readArchiveEntryNative(...args);
+        await fs.writeFile(fixture.archivePath, gzip ? gzipSync(bytes) : bytes);
+        read.mockImplementationOnce(async (...args: Parameters<NonNullable<typeof paxNative>["openTarBufferNative"]>) => {
+          args[2] = { ...args[2], maxDecodedBytes: canonical.length };
+          return paxNative!.openTarBufferNative(...args);
         });
         await expect(readArchiveEntry(fixture.archivePath, "value", { maxBytes: 7 })).rejects.toMatchObject({
           name: code === "archive-header-invalid" ? "ArchiveFormatError" : "ArchiveLimitError", code,
@@ -285,8 +285,8 @@ for (const backend of ["off", "auto-missing", "auto", "require"] as const) {
         });
         expect(await readArchiveEntry(fixture.archivePath, "raw", { maxBytes: 700 })).toEqual(Buffer.alloc(700, 0x61));
         if (backend === "auto" || backend === "require") {
-          expect(inspect).toHaveBeenLastCalledWith(expect.any(String), "tar", resolveTarMeterLimits(), expect.any(AbortSignal));
-          expect(read).toHaveBeenLastCalledWith(expect.any(String), "tar", "raw", 700, resolveTarMeterLimits(), expect.any(AbortSignal));
+          expect(inspect).not.toHaveBeenCalled();
+          expect(read).toHaveBeenLastCalledWith(expect.any(Buffer), "tar", resolveTarMeterLimits(), expect.any(AbortSignal));
         }
         const smallFirst = await setup(tarFixture([member, { path: "large", body: Buffer.alloc(1000) }]), gzip);
         expect(await readArchiveEntry(smallFirst.archivePath, "value", { maxBytes: 7 })).toEqual(Buffer.from("payload"));
@@ -322,9 +322,9 @@ for (const backend of ["off", "auto-missing", "auto", "require"] as const) {
         expect(await fs.readFile(path.join(fixture.destDir, "sentinel"), "utf8")).toBe("unchanged");
         await expect(readArchiveEntry(fixture.archivePath, "value", { maxBytes: 7 })).rejects.toMatchObject(invalid);
         if (backend === "auto" || backend === "require") {
-          expect(inspect).toHaveBeenCalledTimes(2);
+          expect(inspect).toHaveBeenCalledTimes(1);
           expect(extract).not.toHaveBeenCalled();
-          expect(read).not.toHaveBeenCalled();
+          expect(read).toHaveBeenCalledTimes(1);
         }
       });
 

--- a/test/archive-tar-gzip-ratio.test.ts
+++ b/test/archive-tar-gzip-ratio.test.ts
@@ -37,6 +37,7 @@ for (const backend of ["off", "auto-missing", "auto", "require"] as const) {
     () => {
       let inspect: ReturnType<typeof vi.fn> | undefined;
       let extract: ReturnType<typeof vi.fn> | undefined;
+      let open: ReturnType<typeof vi.fn> | undefined;
       let read: ReturnType<typeof vi.fn> | undefined;
 
       beforeEach(() => {
@@ -50,12 +51,16 @@ for (const backend of ["off", "auto-missing", "auto", "require"] as const) {
           const native = paxNative!;
           inspect = vi.fn(native.inspectArchiveNative.bind(native));
           extract = vi.fn(native.extractArchiveNative.bind(native));
-          read = vi.fn(native.readArchiveEntryNative.bind(native));
+          open = vi.fn(async (...args: Parameters<typeof native.openTarBufferNative>) => {
+            const reader = await native.openTarBufferNative(...args);
+            read = vi.fn(reader.readEntry.bind(reader));
+            return { entries: reader.entries, readEntry: read };
+          });
           __setNativeLoaderForTest(() => ({
             ...native,
             inspectArchiveNative: inspect!,
             extractArchiveNative: extract!,
-            readArchiveEntryNative: read!,
+            openTarBufferNative: open!,
           }));
         }
       });
@@ -96,7 +101,8 @@ for (const backend of ["off", "auto-missing", "auto", "require"] as const) {
         expect(selected.equals(payload)).toBe(true);
 
         if (backend === "auto" || backend === "require") {
-          expect(inspect).toHaveBeenCalledTimes(2);
+          expect(inspect).toHaveBeenCalledTimes(1);
+          expect(open).toHaveBeenCalledTimes(1);
           expect(extract).toHaveBeenCalledTimes(1);
           expect(read).toHaveBeenCalledTimes(1);
         }

--- a/test/native-tar-buffer.test.ts
+++ b/test/native-tar-buffer.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readArchiveEntry } from "../src/archive-read.js";
+import { resolveTarMeterLimits } from "../src/archive-limits.js";
+import { validateGzipBufferTail } from "../src/archive-gzip-tail.js";
+import { configureFsSafeNative, __resetFsSafeNativeConfigForTest } from "../src/native-config.js";
+import { __resetNativeLoaderForTest, __setNativeLoaderForTest, type NativeBinding } from "../src/native.js";
+import * as temp from "../src/temp-target.js";
+import { tarFixture } from "./helpers/archive-fuzz.js";
+import { paxNative as native } from "./helpers/archive-pax-native.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+const payload = Buffer.alloc(128 * 1024, 42);
+const fixture = tarFixture([{ path: "earlier", body: "skip" }, { path: "payload", body: payload }, { path: "directory", type: "5" }]);
+function own(bytes: Buffer): Buffer {
+  const input = Buffer.allocUnsafeSlow(bytes.length);
+  bytes.copy(input);
+  return input;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  __resetFsSafeNativeConfigForTest();
+  __resetNativeLoaderForTest();
+});
+
+for (const mode of ["off", "require"] as const) {
+  describe.skipIf(mode === "require" && !native)(`buffered TAR mode=${mode}`, () => {
+    it.each([false, true])("reads without temporary storage (gzip=%s)", async gzip => {
+      configureFsSafeNative({ mode });
+      const dir = await tempRoot("fs-safe-tar-buffer-");
+      const archivePath = path.join(dir, gzip ? "input.tar.gz" : "input.tar");
+      await fs.writeFile(archivePath, gzip ? gzipSync(fixture) : fixture);
+      const staging = vi.spyOn(temp, "tempFile").mockRejectedValue(new Error("temporary storage unavailable"));
+      const open = vi.fn(async (...args: Parameters<NativeBinding["openTarBufferNative"]>) => {
+        expect(args[0].byteOffset).toBe(0);
+        expect(args[0].buffer.byteLength).toBeLessThanOrEqual(args[0].length + 1);
+        const reader = await native!.openTarBufferNative(...args);
+        await fs.writeFile(archivePath, "replaced after admission");
+        return reader;
+      });
+      if (mode === "require") __setNativeLoaderForTest(() => ({ ...native!, openTarBufferNative: open }));
+      await expect(readArchiveEntry(archivePath, "payload", { maxBytes: payload.length })).resolves.toEqual(payload);
+      expect(staging).not.toHaveBeenCalled();
+      if (mode === "require") expect(open).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([false, true])("admits unselected members and framing before returning a range (gzip=%s)", async gzip => {
+      configureFsSafeNative({ mode });
+      const dir = await tempRoot("fs-safe-tar-buffer-invalid-");
+      const archivePath = path.join(dir, gzip ? "input.tar.gz" : "input.tar");
+      const checksum = Buffer.from(fixture); checksum[148]! ^= 1;
+      for (const [bytes, code] of [
+        [checksum, "archive-header-invalid"],
+        [fixture.subarray(0, fixture.length - 512), "archive-header-invalid"],
+        [Buffer.concat([fixture, Buffer.from([1])]), "archive-header-invalid"],
+        [tarFixture([{ path: "payload", body: payload }, { path: "../escape" }]), "entry-path"],
+        [tarFixture([{ path: "payload", body: payload }, { path: "./payload" }]), "entry-path"],
+      ] as const) {
+        await fs.writeFile(archivePath, gzip ? gzipSync(bytes) : bytes);
+        await expect(readArchiveEntry(archivePath, "payload", { maxBytes: payload.length })).rejects.toMatchObject({ code });
+      }
+      await fs.writeFile(archivePath, gzip ? gzipSync(fixture) : fixture);
+      await expect(readArchiveEntry(archivePath, "payload", { maxBytes: payload.length - 1 })).rejects.toMatchObject({ code: "archive-entry-extracted-size-exceeds-limit" });
+    });
+  });
+}
+
+describe.skipIf(!native)("native retained TAR reader", () => {
+  it.each([false, true])("retains independent outputs during concurrent reads and cancellation (gzip=%s)", async gzip => {
+    const input = own(gzip ? gzipSync(fixture) : fixture);
+    const reader = await native!.openTarBufferNative(input, "tar", resolveTarMeterLimits());
+    expect(reader.entries[1]).toMatchObject({ path: "payload", size: payload.length, index: 1 });
+    const results = await Promise.all(Array.from({ length: 8 }, () => reader.readEntry(1, payload.length)));
+    for (const result of results) expect(result).toEqual(payload);
+    results[0]!.fill(0);
+    expect(await reader.readEntry(1, payload.length)).toEqual(payload);
+    expect(results[1]).toEqual(payload);
+    await expect(reader.readEntry(3, payload.length)).rejects.toThrow("not found");
+    await expect(reader.readEntry(2, payload.length)).rejects.toThrow("not a file");
+    for (const max of [-1, NaN, Infinity, 0.5, Number.MAX_SAFE_INTEGER + 1]) expect(() => reader.readEntry(1, max)).toThrow();
+    const readAbort = new AbortController();
+    const reading = reader.readEntry(1, payload.length, readAbort.signal);
+    readAbort.abort();
+    await expect(reading).rejects.toThrow();
+    const openAbort = new AbortController();
+    const opening = native!.openTarBufferNative(input, "tar", resolveTarMeterLimits(), openAbort.signal);
+    openAbort.abort();
+    await expect(opening).rejects.toThrow();
+    await expect(native!.openTarBufferNative(input, "tar", { ...resolveTarMeterLimits(), maxDecodedBytes: fixture.length - 1 })).rejects.toThrow("archive-decoded-size-exceeds-limit");
+  });
+});
+
+it("validates every physical gzip padding byte and joins cancellation", async () => {
+  const input = Buffer.alloc(256 * 1024);
+  await expect(validateGzipBufferTail(input, 1)).resolves.toBeUndefined();
+  input[input.length - 1] = 1;
+  await expect(validateGzipBufferTail(input, 1)).rejects.toThrow("nonzero gzip container padding");
+  for (const consumed of [0, -1, NaN, 0.5, input.length + 1]) await expect(validateGzipBufferTail(input, consumed)).rejects.toThrow("consumed-input boundary");
+  const abort = new AbortController();
+  const pending = validateGzipBufferTail(input, 1, abort.signal);
+  abort.abort();
+  await expect(pending).rejects.toThrow();
+});

--- a/test/native-tar-buffer.test.ts
+++ b/test/native-tar-buffer.test.ts
@@ -43,7 +43,7 @@ for (const mode of ["off", "require"] as const) {
         return reader;
       });
       if (mode === "require") __setNativeLoaderForTest(() => ({ ...native!, openTarBufferNative: open }));
-      await expect(readArchiveEntry(archivePath, "payload", { maxBytes: payload.length })).resolves.toEqual(payload);
+      expect((await readArchiveEntry(archivePath, "payload", { maxBytes: payload.length })).equals(payload)).toBe(true);
       expect(staging).not.toHaveBeenCalled();
       if (mode === "require") expect(open).toHaveBeenCalledTimes(1);
     });
@@ -75,10 +75,10 @@ describe.skipIf(!native)("native retained TAR reader", () => {
     const reader = await native!.openTarBufferNative(input, "tar", resolveTarMeterLimits());
     expect(reader.entries[1]).toMatchObject({ path: "payload", size: payload.length, index: 1 });
     const results = await Promise.all(Array.from({ length: 8 }, () => reader.readEntry(1, payload.length)));
-    for (const result of results) expect(result).toEqual(payload);
+    for (const result of results) expect(result.equals(payload)).toBe(true);
     results[0]!.fill(0);
-    expect(await reader.readEntry(1, payload.length)).toEqual(payload);
-    expect(results[1]).toEqual(payload);
+    expect((await reader.readEntry(1, payload.length)).equals(payload)).toBe(true);
+    expect(results[1]!.equals(payload)).toBe(true);
     await expect(reader.readEntry(3, payload.length)).rejects.toThrow("not found");
     await expect(reader.readEntry(2, payload.length)).rejects.toThrow("not a file");
     for (const max of [-1, NaN, Infinity, 0.5, Number.MAX_SAFE_INTEGER + 1]) expect(() => reader.readEntry(1, max)).toThrow();


### PR DESCRIPTION
TAR member reads previously copied an already admitted input Buffer into a temporary file. Native reads also repeated full admission before replaying the selected entry. Retain the private, unpooled input across native tasks and use its admitted member index: plain TAR copies only the selected range; gzip/zstd/bzip2 use bounded replay and still drain the complete stream. TypeScript continues to own path/collision/type selection. Each returned member owns its bytes.

The JS TAR/gzip fallback also streams the retained input without disk staging. Buffered gzip emits 64 KiB chunks matching the WASM input window; this avoids a measured large-gzip slowdown from using Node’s default 16 KiB output chunks. Extraction keeps its existing staged-file path.

Measured end-to-end medians in milliseconds on one AWS c7a.2xlarge / AMD EPYC 9R14, Linux x64, Node 24.18.1. Two runs, 24 interleaved samples per variant per run after warmup; synthetic repeated-byte payloads and warm filesystem cache. The baseline coordinator uses the same addon and dependencies, isolating this change.

| Member | Previous native | Buffered native | Previous JS | Buffered JS |
| --- | ---: | ---: | ---: | ---: |
| TAR 64 B | 0.522 | 0.244 | 1.456 | 0.864 |
| GZIP 64 B | 0.528 | 0.240 | 1.651 | 1.038 |
| TAR 1 MiB | 1.825 | 0.843 | 2.933 | 1.252 |
| GZIP 1 MiB | 1.311 | 0.917 | 4.122 | 2.124 |
| TAR 16 MiB | 36.688 | 17.141 | 43.416 | 26.170 |
| GZIP 16 MiB | 14.151 | 11.773 | 44.394 | 27.380 |

Validation: 8,744 tests and package/documentation checks passed with `FS_SAFE_PAX_REQUIRE_NATIVE=1 pnpm check` on AWS Crabbox `cbx_96451998a7b5`; 73 Rust tests passed. The full 352-workload method inventory ran in both modes (functional coverage smoke, not a broad performance claim). Focused macOS archive tests and forced-GC ownership proof passed; Rust confirms input pointer identity for all four TAR codecs. Coverage includes source replacement, concurrent independent outputs, cancellation, limits, unselected unsafe/colliding members, PAX offsets, malformed EOF, CRC/trailers, and physical padding. CI now runs the TAR buffer and forced-GC tests in every native lane. Independent review is clean through P2. The initial coverage run exposed slow element-wise assertions in the new concurrency test; `Buffer.equals` preserves byte-for-byte checks and output-independence proof while reducing focused test execution from roughly 7.5 seconds to 0.6 seconds locally. All 11 focused coverage cases pass without increasing timeouts.

One existing test expected temporary-storage failure; it now verifies that reads succeed with that storage blocked and all source descriptors close. No public API or safety policy change, and no release/version publication.
