### PR TITLE
feat(copy): unify tree copying and add XFS reflinks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,8 @@ jobs:
       - name: Build and stage host binding
         run: pnpm native:build
 
-      - name: Test native directory cloning
-        run: pnpm test test/clone.test.ts
+      - name: Test directory copying and native cloning
+        run: pnpm test test/clone.test.ts test/copy-tree.test.ts
 
       - name: Test native Btrfs snapshots
         if: runner.os == 'Linux'
@@ -153,6 +153,38 @@ jobs:
           trap 'sudo umount "$fixture/mount"' EXIT
           sudo chown "$(id -u):$(id -g)" "$fixture/mount"
           FS_SAFE_CLONE_TEST_ROOT="$fixture/mount" pnpm test test/clone.test.ts
+
+      - name: Test XFS cloning and unavailable-reflink fallback
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y xfsprogs e2fsprogs attr acl
+          fixture=$(mktemp -d "$RUNNER_TEMP/fs-safe-xfs.XXXXXX")
+          cleanup() {
+            for reflink in 1 0; do
+              if mountpoint -q "$fixture/mount-$reflink"; then
+                sudo umount "$fixture/mount-$reflink"
+              fi
+            done
+          }
+          trap cleanup EXIT
+          for reflink in 1 0; do
+            mount="$fixture/mount-$reflink"
+            mkdir "$mount"
+            truncate -s 1G "$fixture/volume-$reflink.img"
+            mkfs.xfs -q -m "reflink=$reflink" "$fixture/volume-$reflink.img"
+            sudo mount -o loop "$fixture/volume-$reflink.img" "$mount"
+            sudo chown "$(id -u):$(id -g)" "$mount"
+            if [[ "$reflink" == 1 ]]; then
+              node scripts/clone-xfs-proof.mjs "$mount"
+              TMPDIR="$mount" FS_SAFE_CLONE_TEST_ROOT="$mount" pnpm test test/clone.test.ts test/copy-tree.test.ts
+            else
+              node scripts/clone-xfs-proof.mjs "$mount" no-reflink
+              TMPDIR="$mount" pnpm test test/copy-tree.test.ts
+            fi
+            sudo umount "$mount"
+          done
 
       - name: Smoke method benchmarks with native binding
         run: pnpm benchmark:methods --mode require --iterations 1 --samples 1 --warmup 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Read native ZIP entries from the retained, admitted input buffer and reuse the parsed directory, eliminating temporary disk staging and archive handoff copies while preserving validation.
-- Add `@openclaw/fs-safe/clone` for native APFS directory clones, Btrfs subvolume preparation and snapshots, and parallel ReFS tree cloning, with exclusive destinations and cancellation that waits for native writes to settle. Document APFS descendant ACL preservation limits and caller-owned permission checks.
+- Add `copyTree` in `@openclaw/fs-safe/copy` with `clone: "auto"` (default), `"always"`, and `"never"` policies, combining portable byte copying with native APFS directory clones, Btrfs snapshots, and parallel ReFS and XFS reflinks. Destinations are exclusive and cancellation waits for admitted writes to settle. Preserve XFS file and directory xattrs and ACLs; document APFS descendant ACL limits and caller-owned permission checks.
 - Add async and sync positional reads that fill caller-owned buffers through short reads, stop at EOF, preserve descriptor offsets and ownership, and support cooperative async cancellation.
 - Add composed Root `assertBeforeMutation` callbacks that recheck live caller authority immediately before filesystem mutation dispatch, including each buffered-write chunk and direct file removal, preserving refusal errors and owned cleanup across native and JavaScript writers.
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ contract. Low-level helpers that OpenClaw needs to compose higher-level APIs are
 | `@openclaw/fs-safe/file-lock` | async/sync sidecar locks, root-bounded sidecars, ownership verification, and stale policy |
 | `@openclaw/fs-safe/permissions` | POSIX mode and Windows ACL inspection, raw owner/ACE facts, private-directory creation, and remediation helpers |
 | `@openclaw/fs-safe/walk` | budget-bounded directory walking with symlink policy, filters, and truncation accounting; not root-bounded |
-| `@openclaw/fs-safe/clone`       | native APFS directory clones and clone metadata, Btrfs subvolume snapshots, and parallel ReFS block cloning; see [directory cloning](docs/clone.md)                                                                                                                                            |
+| `@openclaw/fs-safe/copy` | directory copying with `clone: "auto"`, `"always"`, or `"never"`; native APFS, Btrfs, ReFS, and XFS cloning, portable byte copying, and clone metadata; see [directory copying](docs/copy.md) |
 | `@openclaw/fs-safe/archive` | policy-driven ZIP/TAR extraction, clamp/filter policy, metadata/path-depth limits, native gzip/zstd/bzip2, and bounded entry reads |
 | `@openclaw/fs-safe/advanced` | lower-level composition helpers such as path scopes, root-file open, bounded descriptor reads, install paths, filename sanitizing, temp-file targets, sibling-temp writes, local-root readers, regular-file helpers, `pathExists`, and `withTimeout`; less stable than focused public subpaths |
 | `@openclaw/fs-safe/errors` | `FsSafeError`, closed codes/categories, causes, and operation-specific details receipts |

--- a/benchmarks/clone.mjs
+++ b/benchmarks/clone.mjs
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { cloneTree, probeTreeClone } from "../dist/clone.js";
+import { copyTree, probeTreeClone } from "../dist/copy.js";
 
 const [sourceArgument, parentArgument, samplesArgument = "3"] = process.argv.slice(2);
 assert(
@@ -55,7 +55,7 @@ for (let sample = 0; sample < samples; sample++) {
   for (const concurrency of sample % 2 ? [16, 1] : [1, 16]) {
     const destination = path.join(output, `workers-${concurrency}-sample-${sample + 1}`);
     const started = performance.now();
-    await cloneTree(source, destination, { concurrency });
+    await copyTree(source, destination, { clone: "always", concurrency });
     const seconds = (performance.now() - started) / 1000;
     assert.deepEqual(
       await inventory(destination),

--- a/benchmarks/lifecycle.mjs
+++ b/benchmarks/lifecycle.mjs
@@ -13,19 +13,20 @@ export async function registerLifecycle({ api: a, workspace: w, native, binding,
   const cloneTarget = path.join(w, "clone-target");
   const clonePreparation = path.join(w, "clone-preparation");
   const cloneSkip = !cloneBackend
-    ? "Native directory cloning requires APFS, Btrfs, or ReFS."
+    ? "Native directory cloning requires APFS, Btrfs, ReFS, or XFS."
     : undefined;
   if (cloneBackend) {
     await a.createCloneSource(cloneSource);
-    fs.writeFileSync(path.join(cloneSource, "payload"), "clone benchmark");
+  } else {
+    fs.mkdirSync(cloneSource);
   }
+  fs.writeFileSync(path.join(cloneSource, "payload"), "clone benchmark");
   add("createCloneSource", () => a.createCloneSource(clonePreparation), {
     skip: cloneSkip,
     verify: () => assert(fs.statSync(clonePreparation).isDirectory()),
     after: () => fs.rmSync(clonePreparation, { recursive: true, force: true }),
   });
-  add("cloneTree", () => a.cloneTree(cloneSource, cloneTarget), {
-    skip: cloneSkip,
+  add("copyTree", () => a.copyTree(cloneSource, cloneTarget), {
     verify: () =>
       assert.equal(fs.readFileSync(path.join(cloneTarget, "payload"), "utf8"), "clone benchmark"),
     after: () => fs.rmSync(cloneTarget, { recursive: true, force: true }),

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -22,7 +22,7 @@ if (backend) {
 
 | Backend | Operation                                                  | Source preparation                                                                                                          |
 | ------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `apfs`  | One native directory clone                                 | `createCloneSource` creates an empty directory.                                                                             |
+| `apfs`  | Native bulk clone, then directory timestamp repair         | `createCloneSource` creates an empty directory.                                                                             |
 | `btrfs` | One native writable subvolume snapshot                     | `createCloneSource` creates a subvolume; an ordinary directory is not a snapshot source. No `btrfs` executable is required. |
 | `refs`  | Native directory traversal with parallel file block clones | `createCloneSource` creates an empty directory on ReFS, including Dev Drive volumes.                                        |
 | `xfs`   | Native directory traversal with parallel file reflinks     | `createCloneSource` creates an empty directory. The XFS volume must support reflinks.                                       |
@@ -57,7 +57,7 @@ Apple [strongly discourages general directory cloning](https://github.com/apple-
 
 Automatic copying does not recover from permission errors, I/O errors, cancellation, or rejected source contents such as ReFS named streams. A failed clone must leave the destination absent before fallback can create it; otherwise copying fails rather than merging into a partial tree.
 
-ReFS and XFS cloning use 16 workers by default; `concurrency` accepts integers from 1 through 32 and bounds native file-clone workers. APFS and Btrfs use their bulk operation. Portable byte copying is sequential with one 128 KiB buffer.
+ReFS and XFS cloning use 16 workers by default; `concurrency` accepts integers from 1 through 32 and bounds native file-clone workers. Btrfs uses its bulk operation. APFS uses a bulk clone followed by native directory-entry enumeration to restore directory timestamps; known regular files and symbolic links need no additional stat or open. Portable byte copying is sequential with one 128 KiB buffer.
 
 Clones preserve file contents, empty directories, timestamps, executable modes where supported, and literal symbolic links. Editing a clone does not modify its source. Unsupported filesystem operations fail; callers may choose their own copy or checkout fallback after the failed operation has settled.
 

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -1,9 +1,9 @@
-# Native directory cloning
+# Directory copying and cloning
 
-`@openclaw/fs-safe/clone` materializes independent directory trees using filesystem copy-on-write primitives. It requires a native binding and a supported filesystem; it never substitutes an ordinary byte copy when cloning is unavailable.
+`@openclaw/fs-safe/copy` materializes independent, caller-owned directory trees. `copyTree` prefers native copy-on-write operations by default, can require cloning, or can copy regular file bytes without cloning or copy offload.
 
 ```ts
-import { cloneTree, createCloneSource, probeTreeClone } from "@openclaw/fs-safe/clone";
+import { copyTree, createCloneSource, probeTreeClone } from "@openclaw/fs-safe/copy";
 
 const parent = "/srv/worktrees";
 const backend = probeTreeClone(parent);
@@ -11,7 +11,10 @@ if (backend) {
   const template = `${parent}/template`;
   await createCloneSource(template);
   // Populate this caller-owned template, then keep its contents unchanged.
-  await cloneTree(template, `${parent}/checkout`, { signal: AbortSignal.timeout(60_000) });
+  await copyTree(template, `${parent}/checkout`, {
+    clone: "always",
+    signal: AbortSignal.timeout(60_000),
+  });
 }
 ```
 
@@ -22,14 +25,15 @@ if (backend) {
 | `apfs`  | One native directory clone                                 | `createCloneSource` creates an empty directory.                                                                             |
 | `btrfs` | One native writable subvolume snapshot                     | `createCloneSource` creates a subvolume; an ordinary directory is not a snapshot source. No `btrfs` executable is required. |
 | `refs`  | Native directory traversal with parallel file block clones | `createCloneSource` creates an empty directory on ReFS, including Dev Drive volumes.                                        |
+| `xfs`   | Native directory traversal with parallel file reflinks     | `createCloneSource` creates an empty directory. The XFS volume must support reflinks.                                       |
 
-Source and destination must be on a filesystem that supports cloning between them. The source repository used to populate a template can live elsewhere. ReFS shares file data rather than the whole directory metadata tree, so creating many small files still has a cost.
+Native cloning requires source and destination filesystems that support cloning between them. Automatic and ordinary copying can cross filesystems. The source repository used to populate a template can live elsewhere. ReFS and XFS share file data rather than the whole directory metadata tree, so creating many small files still has a cost.
 
 Btrfs preserves native subvolume snapshot semantics: nested subvolume contents are not included. Prepare source-only templates without nested subvolumes. This API does not recursively snapshot a hierarchy of subvolumes.
 
 ### APFS permissions
 
-APFS directory cloning does not guarantee descendant ACL preservation. With the `CLONE_ACL` flag used here, live macOS testing preserved the source root's ACL but dropped an explicit ACL on a source descendant. Destination ACL inheritance was also omitted below the cloned root. `probeTreeClone` checks filesystem support only; neither it nor `cloneTree` checks whether these ACL semantics meet the caller's permission policy. A successful clone is not proof of source ACL preservation or normal file-creation inheritance throughout the tree.
+APFS directory cloning does not guarantee descendant ACL preservation. With the `CLONE_ACL` flag used here, live macOS testing preserved the source root's ACL but dropped an explicit ACL on a source descendant. Destination ACL inheritance was also omitted below the cloned root. `probeTreeClone` checks filesystem support only; neither it nor `copyTree` checks whether these ACL semantics meet the caller's permission policy. A successful clone is not proof of source ACL preservation or normal file-creation inheritance throughout the tree.
 
 Callers that require source ACL preservation or destination ACL inheritance must use a creation path that preserves their permission policy. For example, a private Git template cache can prohibit custom descendant ACLs and decline cloning when the destination parent has inheritable ACL entries, the template root carries ACLs, or ACL inspection fails; it must also account for policy changes during cloning. Checking only the source root cannot establish that an arbitrary tree has no descendant ACLs. This library does not inspect or repair ACLs after a clone.
 
@@ -37,17 +41,29 @@ Apple [strongly discourages general directory cloning](https://github.com/apple-
 
 ## API
 
-`TreeCloneBackend` is the `"apfs" | "btrfs" | "refs"` union returned by the probe. `CloneTreeOptions` contains the optional `signal` and `concurrency` arguments.
+`TreeCloneBackend` is the `"apfs" | "btrfs" | "refs" | "xfs"` union returned by the probe. `CopyTreeOptions` contains the optional `clone`, `signal`, and `concurrency` arguments.
 
-`probeTreeClone(parentPath)` synchronously inspects an existing directory and returns `"apfs"`, `"btrfs"`, `"refs"`, or `undefined`. It creates no probe artifacts. An unavailable native binding produces `undefined` in automatic mode; the package's explicit native `require` mode still reports a missing binding as an error.
+`probeTreeClone(parentPath)` synchronously inspects an existing directory and returns its supported backend name or `undefined`. It creates no probe artifacts. A filesystem name identifies a candidate backend; for example, an older XFS volume may have reflinks disabled. The actual operation determines availability. An unavailable native binding produces `undefined` in automatic mode; the package's explicit native `require` mode still reports a missing binding as an error.
 
 `createCloneSource(destination, { signal? })` creates an empty cloneable source. Its parent must already exist and the destination must be absent.
 
-`cloneTree(source, destination, { signal?, concurrency? })` clones a directory into an absent destination. Existing destinations are never merged or overwritten. The destination must be outside the source tree. ReFS uses 16 workers by default; `concurrency` accepts integers from 1 through 32. APFS and Btrfs use their bulk operation and do not need worker parallelism.
+`copyTree(source, destination, { clone?, signal?, concurrency? })` copies a directory into an absent destination. Existing destinations are never merged or overwritten. The destination must be outside the source tree.
+
+| `clone` policy     | Behavior                                                                                                                                     |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"auto"` (default) | Prefer native cloning; copy bytes when the binding or filesystem capability is unavailable, or cloning cannot cross the filesystem boundary. |
+| `"always"`         | Require native cloning. Unsupported operations fail without a byte-copy fallback.                                                            |
+| `"never"`          | Copy regular file bytes using reads and writes. No native cloning or copy-offload calls. Works without a native binding.                     |
+
+Automatic copying does not recover from permission errors, I/O errors, cancellation, or rejected source contents such as ReFS named streams. A failed clone must leave the destination absent before fallback can create it; otherwise copying fails rather than merging into a partial tree.
+
+ReFS and XFS cloning use 16 workers by default; `concurrency` accepts integers from 1 through 32 and bounds native file-clone workers. APFS and Btrfs use their bulk operation. Portable byte copying is sequential with one 128 KiB buffer.
 
 Clones preserve file contents, empty directories, timestamps, executable modes where supported, and literal symbolic links. Editing a clone does not modify its source. Unsupported filesystem operations fail; callers may choose their own copy or checkout fallback after the failed operation has settled.
 
 The ReFS backend rejects files with alternate data streams and unsupported reparse-point types instead of silently losing their contents. Symbolic links and junctions are preserved.
+
+XFS preserves regular-file and directory modes, timestamps, extended attributes, and ACLs. It rejects special files, symlink extended attributes, non-UTF-8 names, and directory nesting deeper than 128 levels. Hardlinked source files become independent reflinked files. Portable byte copying preserves file contents, empty directories, modes where supported, file and directory timestamps, and literal symbolic links; it does not promise ownership, ACL, extended-attribute, alternate-stream, or sparse-layout preservation. On Windows, byte copying rejects unresolved symbolic links because Node does not expose their file/directory link type; resolved links keep their literal target and source type. POSIX dangling links are preserved. Choose a copying policy that meets the caller's metadata requirements; automatic copying can select either path.
 
 `readCloneFileMetadata(files)` asynchronously reads APFS data-stream identities and file metadata in one native batch. Results correspond to input order; missing or unsupported entries return `undefined`. The returned `CloneFileMetadata` includes clone ID, device/inode, size, mode, ownership, and timestamps. These are point-in-time observations, not authorization or proof that later reads remain unchanged. Consumers such as Git index adapters must validate their own content and timestamp invariants. The reader does not follow leaf symbolic links.
 
@@ -61,6 +77,8 @@ Completion is not a crash-durability guarantee. The API is suitable for reconstr
 
 ## Platform tests and benchmarks
 
-After building the host native binding, run `pnpm test test/clone.test.ts`. APFS tests can use the normal macOS temporary directory. For Btrfs or ReFS, set `FS_SAFE_CLONE_TEST_ROOT` to an existing writable directory on that filesystem. The test creates and cleans only its own temporary children. An explicitly configured unsupported directory fails the test rather than silently skipping platform proof.
+After building the host native binding, run `pnpm test test/clone.test.ts test/copy-tree.test.ts`. APFS tests can use the normal macOS temporary directory. For Btrfs, ReFS, or XFS, set `FS_SAFE_CLONE_TEST_ROOT` to an existing writable directory on that filesystem. The test creates and cleans only its own temporary children. An explicitly configured unsupported directory fails the test rather than silently skipping platform proof. XFS metadata tests require the `attr` and `acl` utilities.
+
+Run `node scripts/clone-xfs-proof.mjs MOUNT` on a real XFS volume to verify the public API, hashes, independent writes, and shared physical extents. It requires `filefrag` from `e2fsprogs`. Add `no-reflink` for an XFS fixture formatted with reflinks disabled; strict copying must fail and automatic copying must succeed through byte copying.
 
 Run `node benchmarks/clone.mjs SOURCE DESTINATION_PARENT` after `pnpm build` to compare one and 16 workers on the same immutable source. It records copying time separately from fixture preparation and full file-hash verification, and retains its uniquely named output directory for inspection. Prepare Btrfs sources with `createCloneSource` first.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -132,7 +132,7 @@ type FsSafeErrorCode =
 | `symlink` | Path component is a symlink, policy is `reject`. | Caller followed a symlink they shouldn't have, or `symlinks: "reject"` is set. |
 | `timeout` | An operation with a wall-clock budget overran. | Secure file read or timed operation exceeded `timeoutMs`. |
 | `too-large` | A read or bounded walk exceeded its configured budget. | Caller gave a too-permissive file or traversal limit. |
-| `unsupported-platform` | The destination filesystem cannot perform the requested operation. | `createCloneSource` and `cloneTree` emit this code when the native probe finds no supported cloning backend. Callers can select their own checkout or copy fallback after the operation settles. |
+| `unsupported-platform` | The platform or filesystem cannot perform the requested operation. | `createCloneSource` and `copyTree({ clone: "always" })` require native cloning support. The default `copyTree({ clone: "auto" })` selects portable byte copying when cloning is unavailable; unsupported source contents or metadata still fail. See [directory copying](copy.md) for backend limits and fallback behavior. |
 
 Secret writes reject invalid `mode` / `dirMode` values with `invalid-path` before directory creation. Existing secret directories with a mode different from the requested `dirMode` report `insecure-permissions` without chmod; a created directory whose descriptor ownership no longer matches its initializing effective user reports `not-owned`.
 

--- a/native/src/clone_linux.rs
+++ b/native/src/clone_linux.rs
@@ -1,0 +1,450 @@
+use std::ffi::CString;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex, mpsc};
+
+use rustix::fs::{AtFlags, Dir, FileType, Mode, OFlags, Stat, Timestamps, XattrFlags};
+
+use crate::unix::{
+    borrowed, create_exclusive_target, open_beneath, open_cleanup_directory, os_error,
+    remove_owned_tree,
+};
+use crate::{NativeResult, native_error};
+
+const MAX_DEPTH: usize = 128;
+
+fn stat(fd: i32) -> NativeResult<Stat> {
+    rustix::fs::fstat(borrowed(fd)).map_err(|error| os_error(error, "inspect XFS clone entry"))
+}
+
+fn same_identity(left: &Stat, right: &Stat) -> bool {
+    left.st_dev == right.st_dev && left.st_ino == right.st_ino
+}
+
+fn unchanged(before: &Stat, after: &Stat) -> NativeResult<()> {
+    if !same_identity(before, after)
+        || before.st_mode != after.st_mode
+        || before.st_size != after.st_size
+        || before.st_mtime != after.st_mtime
+        || before.st_mtime_nsec != after.st_mtime_nsec
+        || before.st_ctime != after.st_ctime
+        || before.st_ctime_nsec != after.st_ctime_nsec
+    {
+        return Err(native_error(
+            "path-mismatch",
+            "XFS clone source changed during cloning",
+        ));
+    }
+    Ok(())
+}
+
+fn timestamps(metadata: &Stat) -> Timestamps {
+    Timestamps {
+        last_access: rustix::fs::Timespec {
+            tv_sec: metadata.st_atime as _,
+            tv_nsec: metadata.st_atime_nsec as _,
+        },
+        last_modification: rustix::fs::Timespec {
+            tv_sec: metadata.st_mtime as _,
+            tv_nsec: metadata.st_mtime_nsec as _,
+        },
+    }
+}
+
+fn xattr_names(fd: i32) -> NativeResult<Vec<CString>> {
+    // Most entries have no attributes or a short ACL. Linux bounds the larger
+    // list at 64 KiB; only allocate that buffer when the small one is full.
+    let mut buffer = vec![0; 256];
+    let length = match rustix::fs::flistxattr(borrowed(fd), buffer.as_mut_slice()) {
+        Err(rustix::io::Errno::RANGE) => {
+            buffer.resize(65_536, 0);
+            rustix::fs::flistxattr(borrowed(fd), buffer.as_mut_slice())
+        }
+        result => result,
+    }
+    .map_err(|error| os_error(error, "list XFS clone extended attributes"))?;
+    buffer.truncate(length);
+    buffer
+        .split_inclusive(|&byte| byte == 0)
+        .map(|name| {
+            CString::from_vec_with_nul(name.to_vec())
+                .map_err(|_| native_error("EIO", "invalid extended attribute name list"))
+        })
+        .collect()
+}
+
+fn copy_metadata(source_fd: i32, target_fd: i32, metadata: &Stat) -> NativeResult<()> {
+    let names = xattr_names(source_fd)?;
+    for inherited in xattr_names(target_fd)? {
+        if !names.contains(&inherited) {
+            rustix::fs::fremovexattr(borrowed(target_fd), inherited.as_c_str())
+                .map_err(|error| os_error(error, "remove inherited clone extended attribute"))?;
+        }
+    }
+    // chmod can alter an access ACL's mask. Set the mode first, then install
+    // the source ACL along with its other xattrs; default ACLs arrive only
+    // after all children have been created.
+    rustix::fs::fchmod(borrowed(target_fd), Mode::from_raw_mode(metadata.st_mode))
+        .map_err(|error| os_error(error, "preserve XFS clone mode"))?;
+    let mut value = vec![0; if names.is_empty() { 0 } else { 65_536 }];
+    for name in names {
+        let length =
+            rustix::fs::fgetxattr(borrowed(source_fd), name.as_c_str(), value.as_mut_slice())
+                .map_err(|error| os_error(error, "read XFS clone extended attribute"))?;
+        rustix::fs::fsetxattr(
+            borrowed(target_fd),
+            name.as_c_str(),
+            &value[..length],
+            XattrFlags::empty(),
+        )
+        .map_err(|error| os_error(error, "preserve XFS clone extended attribute"))?;
+    }
+    rustix::fs::futimens(borrowed(target_fd), &timestamps(metadata))
+        .map_err(|error| os_error(error, "preserve XFS clone timestamps"))?;
+    unchanged(metadata, &stat(source_fd)?)
+}
+
+fn open_child(parent_fd: i32, name: &str, flags: OFlags) -> NativeResult<OwnedFd> {
+    let fd = open_beneath(
+        parent_fd,
+        name,
+        (flags | OFlags::CLOEXEC | OFlags::NOFOLLOW).bits() as i32,
+    )?;
+    // open_beneath transfers ownership of its newly opened descriptor.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+struct FileJob {
+    source_parent: Arc<OwnedFd>,
+    target_parent: Arc<OwnedFd>,
+    name: String,
+    metadata: Stat,
+}
+
+fn clone_file(job: FileJob) -> NativeResult<()> {
+    // NONBLOCK prevents an entry replaced by a FIFO from blocking admission.
+    let source = open_child(
+        job.source_parent.as_raw_fd(),
+        &job.name,
+        OFlags::RDONLY | OFlags::NONBLOCK,
+    )?;
+    let opened = stat(source.as_raw_fd())?;
+    unchanged(&job.metadata, &opened)?;
+    if !FileType::from_raw_mode(opened.st_mode).is_file() {
+        return Err(native_error("path-mismatch", "XFS clone file changed type"));
+    }
+    let target = create_exclusive_target(job.target_parent.as_raw_fd(), &job.name)?;
+    // This is deliberately the strict primitive: preserve its errno and never
+    // fall back to byte copying, normalize permissions, or fsync each file.
+    rustix::fs::ioctl_ficlone(&target, &source).map_err(|error| {
+        if error == rustix::io::Errno::OPNOTSUPP {
+            native_error(
+                "CLONE_UNAVAILABLE",
+                format!("clone XFS file extents: {error}"),
+            )
+        } else {
+            os_error(error, "clone XFS file extents")
+        }
+    })?;
+    copy_metadata(source.as_raw_fd(), target.as_raw_fd(), &job.metadata)
+}
+
+#[derive(Default)]
+struct WorkState {
+    pending: usize,
+    error: Option<napi::Error<String>>,
+}
+
+struct Work<'a> {
+    sender: mpsc::SyncSender<FileJob>,
+    state: Arc<(Mutex<WorkState>, Condvar)>,
+    cancelled: &'a AtomicBool,
+}
+
+impl Work<'_> {
+    fn check(&self) -> NativeResult<()> {
+        if let Some(error) = &self.state.0.lock().unwrap().error {
+            return Err(native_error(error.status.clone(), error.reason.clone()));
+        }
+        if self.cancelled.load(Ordering::Relaxed) {
+            return Err(native_error("Cancelled", "directory cloning aborted"));
+        }
+        Ok(())
+    }
+
+    fn submit(&self, job: FileJob) -> NativeResult<()> {
+        self.check()?;
+        self.state.0.lock().unwrap().pending += 1;
+        if self.sender.send(job).is_err() {
+            self.state.0.lock().unwrap().pending -= 1;
+            return Err(native_error("EIO", "XFS clone worker stopped"));
+        }
+        Ok(())
+    }
+
+    fn settle(&self) -> NativeResult<()> {
+        let mut state = self.state.0.lock().unwrap();
+        while state.pending != 0 {
+            state = self.state.1.wait(state).unwrap();
+        }
+        drop(state);
+        self.check()
+    }
+}
+
+fn clone_symlink(
+    source_parent: i32,
+    target_parent: i32,
+    name: &str,
+    metadata: &Stat,
+) -> NativeResult<()> {
+    let source = open_child(source_parent, name, OFlags::PATH)?;
+    unchanged(metadata, &stat(source.as_raw_fd())?)?;
+    // O_PATH pins the link itself, so readlinkat never resolves its target.
+    let target = rustix::fs::readlinkat(&source, "", Vec::new())
+        .map_err(|error| os_error(error, "read XFS clone symbolic link"))?;
+    // Linux does not provide f*xattr for O_PATH symlink descriptors. The only
+    // path lookup here uses a pinned parent and a validated literal child,
+    // with a no-follow operation and identity checks around it. Callers must
+    // keep the source namespace immutable, as for the other clone backends.
+    let proc_path = format!("/proc/self/fd/{source_parent}/{name}");
+    let mut attributes = [0u8; 1];
+    match rustix::fs::llistxattr(proc_path.as_str(), &mut attributes[..]) {
+        Ok(0) => {}
+        Ok(_) | Err(rustix::io::Errno::RANGE) => {
+            return Err(native_error(
+                "ENOTSUP",
+                "XFS cloning cannot preserve symbolic-link extended attributes",
+            ));
+        }
+        Err(error) => return Err(os_error(error, "inspect symbolic-link extended attributes")),
+    }
+    let current = rustix::fs::statat(borrowed(source_parent), name, AtFlags::SYMLINK_NOFOLLOW)
+        .map_err(|error| os_error(error, "reinspect XFS clone symbolic link"))?;
+    unchanged(metadata, &current)?;
+    rustix::fs::symlinkat(target.as_c_str(), borrowed(target_parent), name)
+        .map_err(|error| os_error(error, "create XFS clone symbolic link"))?;
+    rustix::fs::utimensat(
+        borrowed(target_parent),
+        name,
+        &timestamps(metadata),
+        AtFlags::SYMLINK_NOFOLLOW,
+    )
+    .map_err(|error| os_error(error, "preserve XFS clone symbolic-link timestamps"))?;
+    unchanged(metadata, &stat(source.as_raw_fd())?)
+}
+
+fn walk(
+    source: Arc<OwnedFd>,
+    target: Arc<OwnedFd>,
+    work: &Work<'_>,
+    depth: usize,
+) -> NativeResult<()> {
+    work.check()?;
+    if depth > MAX_DEPTH {
+        return Err(native_error(
+            "ENAMETOOLONG",
+            "XFS clone directory nesting exceeds 128 levels",
+        ));
+    }
+    let metadata = stat(source.as_raw_fd())?;
+    let mut directory = Dir::read_from(&source)
+        .map_err(|error| os_error(error, "open XFS clone directory stream"))?;
+    for entry in &mut directory {
+        work.check()?;
+        let entry = entry.map_err(|error| os_error(error, "read XFS clone directory entry"))?;
+        let name = entry.file_name();
+        if matches!(name.to_bytes(), b"." | b"..") {
+            continue;
+        }
+        let name_str = name
+            .to_str()
+            .map_err(|_| native_error("ENOTSUP", "XFS clone names must be valid UTF-8"))?;
+        let child = rustix::fs::statat(&source, name, AtFlags::SYMLINK_NOFOLLOW)
+            .map_err(|error| os_error(error, "inspect XFS clone child"))?;
+        if child.st_dev != metadata.st_dev {
+            return Err(native_error(
+                "EXDEV",
+                "XFS clone source contains another filesystem",
+            ));
+        }
+        if child.st_ino as u64 != entry.ino() {
+            return Err(native_error(
+                "path-mismatch",
+                "XFS clone entry changed after enumeration",
+            ));
+        }
+        match FileType::from_raw_mode(child.st_mode) {
+            FileType::Directory => {
+                let opened = open_cleanup_directory(source.as_raw_fd(), name)?;
+                unchanged(&child, &stat(opened.as_raw_fd())?)?;
+                rustix::fs::mkdirat(&target, name, Mode::from_bits_retain(0o700))
+                    .map_err(|error| os_error(error, "create XFS clone child directory"))?;
+                let created = open_cleanup_directory(target.as_raw_fd(), name)?;
+                walk(Arc::new(opened), Arc::new(created), work, depth + 1)?;
+            }
+            FileType::RegularFile => work.submit(FileJob {
+                source_parent: Arc::clone(&source),
+                target_parent: Arc::clone(&target),
+                name: name_str.to_owned(),
+                metadata: child,
+            })?,
+            FileType::Symlink => {
+                clone_symlink(source.as_raw_fd(), target.as_raw_fd(), name_str, &child)?
+            }
+            _ => {
+                return Err(native_error(
+                    "ENOTSUP",
+                    "XFS cloning supports regular files, directories, and symbolic links",
+                ));
+            }
+        }
+    }
+    // A directory's mtime and default ACL must be installed after its children
+    // settle. Holding only the traversal stack and bounded queue limits FDs.
+    work.settle()?;
+    copy_metadata(source.as_raw_fd(), target.as_raw_fd(), &metadata)
+}
+
+fn prepare_cleanup(directory_fd: i32, depth: usize) -> NativeResult<()> {
+    if depth > MAX_DEPTH + 1 {
+        return Err(native_error(
+            "ENAMETOOLONG",
+            "XFS clone cleanup nesting exceeded",
+        ));
+    }
+    rustix::fs::fchmod(borrowed(directory_fd), Mode::from_bits_retain(0o700))
+        .map_err(|error| os_error(error, "restore owned clone cleanup permissions"))?;
+    let mut directory = Dir::read_from(borrowed(directory_fd))
+        .map_err(|error| os_error(error, "open XFS clone cleanup directory"))?;
+    for entry in &mut directory {
+        let entry = entry.map_err(|error| os_error(error, "read XFS clone cleanup entry"))?;
+        let name = entry.file_name();
+        if matches!(name.to_bytes(), b"." | b"..") {
+            continue;
+        }
+        let current = rustix::fs::statat(borrowed(directory_fd), name, AtFlags::SYMLINK_NOFOLLOW)
+            .map_err(|error| os_error(error, "inspect XFS clone cleanup entry"))?;
+        if !FileType::from_raw_mode(current.st_mode).is_dir() {
+            continue;
+        }
+        if current.st_ino as u64 != entry.ino() {
+            return Err(native_error(
+                "path-mismatch",
+                "XFS clone cleanup entry changed",
+            ));
+        }
+        let child = open_cleanup_directory(directory_fd, name)?;
+        if !same_identity(&current, &stat(child.as_raw_fd())?) {
+            return Err(native_error(
+                "path-mismatch",
+                "XFS clone cleanup directory changed",
+            ));
+        }
+        prepare_cleanup(child.as_raw_fd(), depth + 1)?;
+    }
+    Ok(())
+}
+
+pub fn clone_tree(
+    source_fd: i32,
+    parent_fd: i32,
+    basename: &str,
+    cancelled: &AtomicBool,
+    concurrency: usize,
+) -> NativeResult<()> {
+    if stat(source_fd)?.st_dev != stat(parent_fd)?.st_dev {
+        return Err(native_error(
+            "EXDEV",
+            "XFS clone source and destination must share a filesystem",
+        ));
+    }
+    let source = Arc::new(open_cleanup_directory(source_fd, c".")?);
+    rustix::fs::mkdirat(borrowed(parent_fd), basename, Mode::from_bits_retain(0o700))
+        .map_err(|error| os_error(error, "create XFS clone destination"))?;
+    let name = CString::new(basename)
+        .map_err(|_| native_error("EINVAL", "clone destination contains a NUL byte"))?;
+    let target = Arc::new(open_cleanup_directory(parent_fd, name.as_c_str())?);
+    let concurrency = concurrency.clamp(1, 32);
+    let (sender, receiver) = mpsc::sync_channel::<FileJob>(concurrency * 2);
+    let receiver = Arc::new(Mutex::new(receiver));
+    let state = Arc::new((Mutex::new(WorkState::default()), Condvar::new()));
+    let result = std::thread::scope(|scope| {
+        let mut workers = Vec::new();
+        for _ in 0..concurrency {
+            let receiver = Arc::clone(&receiver);
+            let state = Arc::clone(&state);
+            let worker = std::thread::Builder::new().spawn_scoped(scope, move || {
+                loop {
+                    let Ok(job) = receiver.lock().unwrap().recv() else {
+                        break;
+                    };
+                    let skip = cancelled.load(Ordering::Relaxed)
+                        || state.0.lock().unwrap().error.is_some();
+                    let result = if skip {
+                        Ok(())
+                    } else {
+                        std::panic::catch_unwind(|| clone_file(job)).unwrap_or_else(|_| {
+                            Err(native_error("EIO", "XFS clone worker panicked"))
+                        })
+                    };
+                    let mut current = state.0.lock().unwrap();
+                    if current.error.is_none() {
+                        current.error = result.err();
+                    }
+                    current.pending -= 1;
+                    state.1.notify_all();
+                }
+            });
+            match worker {
+                Ok(worker) => workers.push(worker),
+                Err(error) => {
+                    drop(sender);
+                    for worker in workers {
+                        let _ = worker.join();
+                    }
+                    return Err(native_error(
+                        "EIO",
+                        format!("start XFS clone worker: {error}"),
+                    ));
+                }
+            }
+        }
+        let work = Work {
+            sender,
+            state,
+            cancelled,
+        };
+        let result = walk(source, Arc::clone(&target), &work, 0);
+        // Even an early traversal error must settle every admitted write before
+        // metadata recovery or removal touches the owned destination.
+        let settled = work.settle();
+        drop(work);
+        let mut joined = Ok(());
+        for worker in workers {
+            if worker.join().is_err() {
+                joined = Err(native_error("EIO", "XFS clone worker panicked"));
+            }
+        }
+        result.and(settled).and(joined)
+    });
+    if let Err(error) = result {
+        let cleanup = prepare_cleanup(target.as_raw_fd(), 0)
+            .and_then(|()| remove_owned_tree(parent_fd, basename, target.as_raw_fd()));
+        return match cleanup {
+            Ok(outcome) if outcome == "removed" => Err(error),
+            Ok(_) => Err(native_error(
+                error.status,
+                format!(
+                    "{}; clone destination changed and was preserved",
+                    error.reason
+                ),
+            )),
+            Err(cleanup) => Err(native_error(
+                error.status,
+                format!("{}; clone cleanup failed: {}", error.reason, cleanup.reason),
+            )),
+        };
+    }
+    Ok(())
+}

--- a/native/src/clone_unix.rs
+++ b/native/src/clone_unix.rs
@@ -7,7 +7,11 @@ pub fn probe(parent_fd: i32) -> NativeResult<Option<String>> {
     let stats = rustix::fs::fstatfs(borrowed(parent_fd))
         .map_err(|error| os_error(error, "inspect clone filesystem"))?;
     #[cfg(target_os = "linux")]
-    let supported = (stats.f_type as u64 == 0x9123_683e).then_some("btrfs");
+    let supported = match stats.f_type as u64 {
+        0x9123_683e => Some("btrfs"),
+        0x5846_5342 => Some("xfs"),
+        _ => None,
+    };
     #[cfg(target_os = "macos")]
     let supported = stats.f_fstypename[..5]
         .iter()
@@ -20,7 +24,7 @@ pub fn probe(parent_fd: i32) -> NativeResult<Option<String>> {
 fn require_supported(parent_fd: i32) -> NativeResult<()> {
     if probe(parent_fd)?.is_none() {
         return Err(native_error(
-            "ENOTSUP",
+            "CLONE_UNAVAILABLE",
             "directory cloning is unavailable on this filesystem",
         ));
     }
@@ -78,6 +82,14 @@ pub fn create_source(parent_fd: i32, basename: &str) -> NativeResult<()> {
     require_supported(parent_fd)?;
     #[cfg(target_os = "linux")]
     {
+        if probe(parent_fd)?.as_deref() == Some("xfs") {
+            return rustix::fs::mkdirat(
+                borrowed(parent_fd),
+                basename,
+                rustix::fs::Mode::from_bits_retain(0o700),
+            )
+            .map_err(|error| os_error(error, "create XFS clone source directory"));
+        }
         const CREATE: rustix::ioctl::Opcode =
             rustix::ioctl::opcode::write::<BtrfsVolumeArgs>(0x94, 14);
         btrfs_mutation::<CREATE>(parent_fd, basename, 0)
@@ -111,11 +123,20 @@ pub fn clone_tree(
     }
     #[cfg(target_os = "linux")]
     {
+        if probe(parent_fd)?.as_deref() == Some("xfs") {
+            return crate::clone_linux::clone_tree(
+                source_fd,
+                parent_fd,
+                basename,
+                cancelled,
+                _concurrency,
+            );
+        }
         // Btrfs assigns inode 256 to subvolume roots. Snapshotting an ordinary
         // directory must fail rather than silently changing the operation.
         if source.st_ino != 256 {
             return Err(native_error(
-                "ENOTSUP",
+                "CLONE_UNAVAILABLE",
                 "Btrfs directory cloning requires a subvolume source",
             ));
         }
@@ -130,7 +151,7 @@ pub fn clone_tree(
             .map_err(|_| native_error("EINVAL", "clone destination contains a NUL byte"))?;
         // CLONE_ACL can copy the root ACL, but directory clones can lose both
         // source and inherited descendant ACLs. Callers own eligibility; see
-        // docs/clone.md for Apple's directory-clone warning and XNU references.
+        // docs/copy.md for Apple's directory-clone warning and XNU references.
         // Both descriptors stay pinned until this bulk operation settles.
         const CLONE_NOFOLLOW: u32 = 0x0001;
         const CLONE_ACL: u32 = 0x0004;
@@ -149,7 +170,16 @@ pub fn clone_tree(
                     .raw_os_error()
                     .unwrap_or(libc::EIO),
             );
-            return Err(os_error(error, "clone APFS directory"));
+            return Err(
+                if error == rustix::io::Errno::NOTSUP || error == rustix::io::Errno::OPNOTSUPP {
+                    native_error(
+                        "CLONE_UNAVAILABLE",
+                        format!("clone APFS directory: {error}"),
+                    )
+                } else {
+                    os_error(error, "clone APFS directory")
+                },
+            );
         }
     }
     // These bulk operations cannot be interrupted once dispatched. Report

--- a/native/src/clone_unix.rs
+++ b/native/src/clone_unix.rs
@@ -38,6 +38,97 @@ fn check_cancelled(cancelled: &AtomicBool) -> NativeResult<()> {
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+fn restore_apfs_directory_timestamps(
+    source_fd: i32,
+    parent_fd: i32,
+    name: &std::ffi::CStr,
+    source_root: &rustix::fs::Stat,
+    cancelled: &AtomicBool,
+) -> NativeResult<()> {
+    use crate::unix::open_cleanup_directory;
+    use rustix::fs::{AtFlags, Dir, FileType, Stat, Timespec, Timestamps};
+    use std::os::fd::{AsRawFd, OwnedFd};
+
+    struct Directory {
+        entries: Dir,
+        target: OwnedFd,
+        times: Timestamps,
+    }
+
+    fn directory(source: OwnedFd, target: OwnedFd, metadata: &Stat) -> NativeResult<Directory> {
+        let times = Timestamps {
+            last_access: Timespec {
+                tv_sec: metadata.st_atime,
+                tv_nsec: metadata.st_atime_nsec,
+            },
+            last_modification: Timespec {
+                tv_sec: metadata.st_mtime,
+                tv_nsec: metadata.st_mtime_nsec,
+            },
+        };
+        // This stream owns the freshly opened source fd. Capture timestamps
+        // before reading it, since readdir can update source access time.
+        let entries = Dir::new(source)
+            .map_err(|error| os_error(error, "open APFS clone directory stream"))?;
+        Ok(Directory {
+            entries,
+            target,
+            times,
+        })
+    }
+
+    check_cancelled(cancelled)?;
+    let source = open_cleanup_directory(source_fd, c".")?;
+    let target = open_cleanup_directory(parent_fd, name)?;
+    let mut stack = vec![directory(source, target, source_root)?];
+    // APFS resets timestamps on nested directories as well as the clone root.
+    // Repair directories bottom-up; regular file data and metadata remain the
+    // bulk clone's responsibility. The stack retains only active ancestors.
+    while let Some(parent) = stack.last_mut() {
+        check_cancelled(cancelled)?;
+        if let Some(entry) = parent.entries.next() {
+            let entry =
+                entry.map_err(|error| os_error(error, "read APFS clone directory entry"))?;
+            let name = entry.file_name();
+            if matches!(name.to_bytes(), b"." | b"..") {
+                continue;
+            }
+            let source_parent = parent
+                .entries
+                .fd()
+                .map_err(|error| os_error(error, "inspect APFS source directory stream"))?;
+            let kind = if entry.file_type() == FileType::Unknown {
+                let metadata =
+                    rustix::fs::statat(source_parent, name, AtFlags::SYMLINK_NOFOLLOW)
+                        .map_err(|error| os_error(error, "classify APFS clone directory entry"))?;
+                FileType::from_raw_mode(metadata.st_mode)
+            } else {
+                entry.file_type()
+            };
+            if !kind.is_dir() {
+                continue;
+            }
+            let source = open_cleanup_directory(source_parent.as_raw_fd(), name)?;
+            let metadata = rustix::fs::fstat(&source)
+                .map_err(|error| os_error(error, "inspect APFS clone source directory"))?;
+            if metadata.st_ino != entry.ino() {
+                return Err(native_error(
+                    "path-mismatch",
+                    "APFS source directory changed after enumeration",
+                ));
+            }
+            let target = open_cleanup_directory(parent.target.as_raw_fd(), name)?;
+            stack.push(directory(source, target, &metadata)?);
+        } else {
+            let completed = stack.pop().unwrap();
+            rustix::fs::futimens(&completed.target, &completed.times)
+                .map_err(|error| os_error(error, "preserve APFS clone directory timestamps"))?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(target_os = "linux")]
 #[repr(C)]
 struct BtrfsVolumeArgs {
@@ -147,9 +238,6 @@ pub fn clone_tree(
     }
     #[cfg(target_os = "macos")]
     {
-        use rustix::fs::{OFlags, Timespec, Timestamps};
-        use std::os::fd::{FromRawFd, OwnedFd};
-
         let name = std::ffi::CString::new(basename)
             .map_err(|_| native_error("EINVAL", "clone destination contains a NUL byte"))?;
         // CLONE_ACL can copy the root ACL, but directory clones can lose both
@@ -184,30 +272,13 @@ pub fn clone_tree(
                 },
             );
         }
-        // APFS can stamp the cloned root with its creation time. Restore the
-        // captured source times through a pinned, no-follow directory handle;
-        // the bulk clone still handles descendants without a userspace walk.
-        let cloned_fd = crate::unix::open_beneath(
+        restore_apfs_directory_timestamps(
+            source_fd,
             parent_fd,
-            basename,
-            (OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC).bits() as i32,
+            name.as_c_str(),
+            &source,
+            cancelled,
         )?;
-        // SAFETY: open_beneath transfers ownership of a newly opened descriptor.
-        let cloned = unsafe { OwnedFd::from_raw_fd(cloned_fd) };
-        rustix::fs::futimens(
-            &cloned,
-            &Timestamps {
-                last_access: Timespec {
-                    tv_sec: source.st_atime,
-                    tv_nsec: source.st_atime_nsec,
-                },
-                last_modification: Timespec {
-                    tv_sec: source.st_mtime,
-                    tv_nsec: source.st_mtime_nsec,
-                },
-            },
-        )
-        .map_err(|error| os_error(error, "preserve APFS clone root timestamps"))?;
     }
     // These bulk operations cannot be interrupted once dispatched. Report
     // cancellation only after their writes settle; recovery may then proceed.

--- a/native/src/clone_unix.rs
+++ b/native/src/clone_unix.rs
@@ -147,6 +147,9 @@ pub fn clone_tree(
     }
     #[cfg(target_os = "macos")]
     {
+        use rustix::fs::{OFlags, Timespec, Timestamps};
+        use std::os::fd::{FromRawFd, OwnedFd};
+
         let name = std::ffi::CString::new(basename)
             .map_err(|_| native_error("EINVAL", "clone destination contains a NUL byte"))?;
         // CLONE_ACL can copy the root ACL, but directory clones can lose both
@@ -181,6 +184,30 @@ pub fn clone_tree(
                 },
             );
         }
+        // APFS can stamp the cloned root with its creation time. Restore the
+        // captured source times through a pinned, no-follow directory handle;
+        // the bulk clone still handles descendants without a userspace walk.
+        let cloned_fd = crate::unix::open_beneath(
+            parent_fd,
+            basename,
+            (OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC).bits() as i32,
+        )?;
+        // SAFETY: open_beneath transfers ownership of a newly opened descriptor.
+        let cloned = unsafe { OwnedFd::from_raw_fd(cloned_fd) };
+        rustix::fs::futimens(
+            &cloned,
+            &Timestamps {
+                last_access: Timespec {
+                    tv_sec: source.st_atime,
+                    tv_nsec: source.st_atime_nsec,
+                },
+                last_modification: Timespec {
+                    tv_sec: source.st_mtime,
+                    tv_nsec: source.st_mtime_nsec,
+                },
+            },
+        )
+        .map_err(|error| os_error(error, "preserve APFS clone root timestamps"))?;
     }
     // These bulk operations cannot be interrupted once dispatched. Report
     // cancellation only after their writes settle; recovery may then proceed.

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -8,6 +8,8 @@ mod archive_gzip;
 mod fast_file;
 mod clone_tree;
 mod clone_metadata;
+#[cfg(target_os = "linux")]
+mod clone_linux;
 #[cfg(unix)]
 mod clone_unix;
 #[cfg(windows)]

--- a/native/src/unix.rs
+++ b/native/src/unix.rs
@@ -256,7 +256,7 @@ pub fn read_at(reader: &IndependentReader, buffer: &mut [u8], offset: u64) -> Na
 }
 
 #[cfg(target_os = "linux")]
-fn create_exclusive_target(root_fd: i32, rel_path: &str) -> NativeResult<OwnedFd> {
+pub(crate) fn create_exclusive_target(root_fd: i32, rel_path: &str) -> NativeResult<OwnedFd> {
     let flags = OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::CLOEXEC;
     let fd = open_beneath(root_fd, rel_path, flags.bits() as i32)?;
     // SAFETY: open_beneath returned a fresh descriptor owned by this call.
@@ -370,7 +370,7 @@ pub fn owned_tree_removal_available(parent_fd: i32) -> bool {
 }
 
 #[cfg(target_os = "linux")]
-fn open_cleanup_directory(parent_fd: i32, name: &CStr) -> NativeResult<OwnedFd> {
+pub(crate) fn open_cleanup_directory(parent_fd: i32, name: &CStr) -> NativeResult<OwnedFd> {
     use rustix::fs::{ResolveFlags, openat2};
 
     openat2(

--- a/native/src/unix.rs
+++ b/native/src/unix.rs
@@ -384,7 +384,7 @@ pub(crate) fn open_cleanup_directory(parent_fd: i32, name: &CStr) -> NativeResul
 }
 
 #[cfg(target_os = "macos")]
-fn open_cleanup_directory(parent_fd: i32, name: &CStr) -> NativeResult<OwnedFd> {
+pub(crate) fn open_cleanup_directory(parent_fd: i32, name: &CStr) -> NativeResult<OwnedFd> {
     let child = rustix::fs::openat(
         borrowed(parent_fd),
         name,

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
       "types": "./dist/root.d.ts",
       "default": "./dist/root.js"
     },
-    "./clone": {
-      "types": "./dist/clone.d.ts",
-      "default": "./dist/clone.js"
+    "./copy": {
+      "types": "./dist/copy.d.ts",
+      "default": "./dist/copy.js"
     },
     "./config": {
       "types": "./dist/config.d.ts",

--- a/scripts/clone-xfs-proof.mjs
+++ b/scripts/clone-xfs-proof.mjs
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { copyTree, createCloneSource, probeTreeClone } from "../dist/copy.js";
+
+const [mountArgument, mode = "reflink", ...extra] = process.argv.slice(2);
+assert(
+  mountArgument && ["reflink", "no-reflink"].includes(mode) && extra.length === 0,
+  "Usage: node scripts/clone-xfs-proof.mjs MOUNT [no-reflink]",
+);
+assert.equal(process.platform, "linux", "XFS proof requires Linux");
+const mount = await fs.realpath(mountArgument);
+assert.equal(probeTreeClone(mount), "xfs", "Mount must have native XFS support");
+
+function hash(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function extents(filename) {
+  // filefrag -b1 reports FIEMAP offsets in bytes; -s requests FIEMAP_FLAG_SYNC.
+  // https://github.com/tytso/e2fsprogs/blob/master/misc/filefrag.c
+  // https://www.kernel.org/doc/html/latest/filesystems/fiemap.html
+  const output = execFileSync("filefrag", ["-b1", "-e", "-s", filename], {
+    encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C" },
+    timeout: 10_000,
+  });
+  const mapped = [];
+  for (const line of output.split("\n")) {
+    if (!/^\s*\d+:/.test(line)) continue;
+    const match = /^\s*\d+:\s*(\d+)\.\.\s*(\d+):\s*(\d+)\.\.\s*(\d+):\s*(\d+):\s*(.*)$/.exec(line);
+    assert(match, "Unrecognized filefrag extent format");
+    const [, logicalStart, logicalLast, physicalStart, physicalLast, length, flags] = match;
+    const logical = BigInt(logicalStart);
+    const physical = BigInt(physicalStart);
+    const bytes = BigInt(length);
+    assert.equal(BigInt(logicalLast) + 1n - logical, bytes, "Invalid logical extent length");
+    assert.equal(BigInt(physicalLast) + 1n - physical, bytes, "Invalid physical extent length");
+    assert(
+      !/unknown_loc|delalloc|unwritten|not_aligned|inline|encoded|hole/.test(flags),
+      "Proof requires initialized, physically mapped file data",
+    );
+    mapped.push({ logical, end: logical + bytes, physical, shared: /\bshared\b/.test(flags) });
+  }
+  assert(mapped.length > 0, "No physical extents reported");
+  return mapped;
+}
+
+function assertSharedData(source, destination, size) {
+  const original = extents(source);
+  const copied = extents(destination);
+  let sourceIndex = 0;
+  let copyIndex = 0;
+  let offset = 0n;
+  const end = BigInt(size);
+  while (offset < end) {
+    const left = original[sourceIndex];
+    const right = copied[copyIndex];
+    assert(left && right, "Extent maps do not cover the entire file");
+    assert(left.logical <= offset && left.end > offset, "Source extent map has a gap");
+    assert(right.logical <= offset && right.end > offset, "Copy extent map has a gap");
+    assert(left.shared && right.shared, "FIEMAP_EXTENT_SHARED is missing");
+    assert.equal(
+      left.physical + offset - left.logical,
+      right.physical + offset - right.logical,
+      "Source and copy data occupy different physical bytes",
+    );
+    offset = left.end < right.end ? left.end : right.end;
+    if (offset >= left.end) sourceIndex++;
+    if (offset >= right.end) copyIndex++;
+  }
+  return size;
+}
+
+function assertSeparateData(source, destination, size) {
+  const original = extents(source);
+  const copied = extents(destination);
+  let covered = 0n;
+  for (const right of copied) {
+    assert.equal(right.logical, covered, "Byte-copy extent map has a gap");
+    assert(!right.shared, "Byte copy unexpectedly reports shared storage");
+    covered = right.end;
+    const rightEnd = right.physical + right.end - right.logical;
+    for (const left of original) {
+      const leftEnd = left.physical + left.end - left.logical;
+      assert(
+        rightEnd <= left.physical || leftEnd <= right.physical,
+        "Byte copy overlaps the source's physical storage",
+      );
+    }
+  }
+  assert(covered >= BigInt(size), "Byte-copy extent map does not cover the file");
+  return size;
+}
+
+const owned = await fs.mkdtemp(path.join(mount, "fs-safe-xfs-proof-"));
+try {
+  const source = path.join(owned, "source");
+  await createCloneSource(source);
+  await fs.mkdir(path.join(source, "nested"));
+  await fs.mkdir(path.join(source, "empty-directory"));
+  const files = new Map([
+    ["payload", Buffer.alloc(1024 * 1024, 0x5a)],
+    [
+      "nested/unaligned",
+      Buffer.from(Array.from({ length: 4097 }, (_, index) => (index % 251) + 1)),
+    ],
+    ["empty-file", Buffer.alloc(0)],
+  ]);
+  for (const [name, bytes] of files) await fs.writeFile(path.join(source, name), bytes);
+  await fs.symlink("nested/unaligned", path.join(source, "literal-link"));
+
+  async function verify(directory) {
+    assert.deepEqual((await fs.readdir(directory)).sort(), [
+      "empty-directory",
+      "empty-file",
+      "literal-link",
+      "nested",
+      "payload",
+    ]);
+    assert.deepEqual(await fs.readdir(path.join(directory, "nested")), ["unaligned"]);
+    assert.deepEqual(await fs.readdir(path.join(directory, "empty-directory")), []);
+    assert.equal(await fs.readlink(path.join(directory, "literal-link")), "nested/unaligned");
+    for (const [name, bytes] of files) {
+      assert.equal(
+        hash(await fs.readFile(path.join(directory, name))),
+        hash(bytes),
+        `SHA-256 mismatch for ${name}`,
+      );
+    }
+  }
+
+  const results = [];
+  if (mode === "no-reflink") {
+    const rejected = path.join(owned, "strict-unavailable");
+    await assert.rejects(copyTree(source, rejected, { clone: "always" }), {
+      code: "unsupported-platform",
+    });
+    await assert.rejects(fs.access(rejected), { code: "ENOENT" });
+    results.push({ policy: "always", unsupported: true, destinationAbsent: true });
+  }
+  const cases =
+    mode === "reflink"
+      ? [
+          { label: "always-one-worker", clone: "always", concurrency: 1 },
+          { label: "always-default-workers", clone: "always" },
+          { label: "auto", clone: "auto" },
+          { label: "never", clone: "never" },
+        ]
+      : [
+          { label: "auto", clone: "auto" },
+          { label: "never", clone: "never" },
+        ];
+  for (const { label, ...options } of cases) {
+    const destination = path.join(owned, label);
+    const started = performance.now();
+    await copyTree(source, destination, options);
+    const milliseconds = performance.now() - started;
+    await verify(destination);
+    let sharedBytes = 0;
+    let separateBytes = 0;
+    for (const [name, bytes] of files) {
+      if (bytes.length === 0) continue;
+      const [original, copied] = await Promise.all([
+        fs.stat(path.join(source, name), { bigint: true }),
+        fs.stat(path.join(destination, name), { bigint: true }),
+      ]);
+      assert.equal(original.dev, copied.dev, "Extent comparison requires the same device");
+      assert.notEqual(original.ino, copied.ino, "Copy must have an independent inode");
+      if (mode === "reflink" && options.clone !== "never") {
+        sharedBytes += assertSharedData(
+          path.join(source, name),
+          path.join(destination, name),
+          bytes.length,
+        );
+      } else {
+        separateBytes += assertSeparateData(
+          path.join(source, name),
+          path.join(destination, name),
+          bytes.length,
+        );
+      }
+    }
+    const edited = Buffer.alloc(4096, 0x31);
+    const handle = await fs.open(path.join(destination, "payload"), "r+");
+    try {
+      await handle.write(edited, 0, edited.length, 0);
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    const expectedEdit = Buffer.from(files.get("payload"));
+    edited.copy(expectedEdit);
+    assert.equal(hash(await fs.readFile(path.join(destination, "payload"))), hash(expectedEdit));
+    await verify(source);
+    results.push({
+      policy: label,
+      milliseconds,
+      sharedBytes,
+      separateBytes,
+      hashesMatch: true,
+      independentWrite: true,
+    });
+  }
+  console.log(JSON.stringify({ backend: "xfs", mode, results }));
+} finally {
+  assert.equal(
+    path.dirname(owned),
+    mount,
+    "Cleanup target must remain a direct child of the mount",
+  );
+  assert(path.basename(owned).startsWith("fs-safe-xfs-proof-"), "Unexpected cleanup target");
+  await fs.rm(owned, { recursive: true, force: true });
+}

--- a/scripts/docs-site-navigation.mjs
+++ b/scripts/docs-site-navigation.mjs
@@ -6,7 +6,7 @@ export const sections = [
   ["Root API", ["root.md", "reading.md", "writing.md", "walk.md", "path-scope.md"]],
   ["Atomic & temp", ["atomic.md", "staged-file.md", "durability.md", "output.md", "json.md", "temp.md", "archive.md"]],
   ["Stores", ["store.md", "json-store.md", "file-store.md", "private-file-store.md"]],
-  ["Specialized", ["clone.md", "secret-file.md", "secure-file.md", "permissions.md", "regular-file.md", "positional-read.md", "sidecar-lock.md", "local-roots.md"]],
+  ["Specialized", ["copy.md", "secret-file.md", "secure-file.md", "permissions.md", "regular-file.md", "positional-read.md", "sidecar-lock.md", "local-roots.md"]],
   ["Path & filename", ["path.md", "filename.md", "install-path.md"]],
   ["Reference", ["errors.md", "types.md", "public-api.md", "testing.md", "timing.md", "advanced.md", "test-hooks.md", "migrating-to-0.5.md", "migrating-to-0.6.md", "contributing.md"]],
 ];

--- a/src/copy-tree-portable.ts
+++ b/src/copy-tree-portable.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { FsSafeError } from "./errors.js";
+import {
+  assertStagedDirectoryCurrent,
+  exactIdentityMatches,
+  openStagedDirectory,
+} from "./staged-directory.js";
+
+/** Byte-copy adapter for the shared immutable-source, caller-owned namespace contract. */
+export async function copyOwnedTree(
+  source: ReturnType<typeof openStagedDirectory>,
+  destination: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  signal?.throwIfAborted();
+  const buffer = Buffer.allocUnsafe(128 * 1024);
+  async function copyFile(from: string, to: string, stat: fs.BigIntStats): Promise<void> {
+    const input = await fsp.open(
+      from,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK,
+    );
+    try {
+      const opened = await input.stat({ bigint: true });
+      if (!opened.isFile() || !exactIdentityMatches(stat, opened)) {
+        throw new FsSafeError("path-mismatch", "copy source changed while opening");
+      }
+      const output = await fsp.open(to, "wx", 0o600);
+      try {
+        let position = 0;
+        while (true) {
+          signal?.throwIfAborted();
+          const { bytesRead } = await input.read(buffer, 0, buffer.length, position);
+          if (bytesRead === 0) break;
+          let written = 0;
+          while (written < bytesRead) {
+            signal?.throwIfAborted();
+            const { bytesWritten } = await output.write(
+              buffer,
+              written,
+              bytesRead - written,
+              position + written,
+            );
+            if (bytesWritten === 0) throw new Error("copy write made no progress");
+            written += bytesWritten;
+          }
+          position += bytesRead;
+        }
+        if (process.platform !== "win32") await output.chmod(Number(stat.mode & 0o7777n));
+        await output.utimes(stat.atime, stat.mtime);
+      } finally {
+        await output.close();
+      }
+    } finally {
+      await input.close();
+    }
+  }
+  async function copyDirectory(from: string, to: string): Promise<void> {
+    signal?.throwIfAborted();
+    const stat = await fsp.lstat(from, { bigint: true });
+    // Exclusive admission prevents merging a pre-existing directory, including
+    // any destination left by an unsuccessful native clone.
+    await fsp.mkdir(to, { mode: 0o700 });
+    const target = openStagedDirectory(to);
+    let original: ReturnType<typeof openStagedDirectory> | undefined;
+    try {
+      original = openStagedDirectory(from);
+      if (!exactIdentityMatches(stat, original.receipt.identity)) {
+        throw new FsSafeError("path-mismatch", "copy source directory changed while opening");
+      }
+      for (const entry of await fsp.readdir(from, { withFileTypes: true })) {
+        signal?.throwIfAborted();
+        assertStagedDirectoryCurrent(target.receipt);
+        assertStagedDirectoryCurrent(original.receipt);
+        const childSource = path.join(from, entry.name);
+        const childTarget = path.join(to, entry.name);
+        const child = await fsp.lstat(childSource, { bigint: true });
+        if (child.isDirectory()) {
+          await copyDirectory(childSource, childTarget);
+        } else if (child.isFile()) {
+          await copyFile(childSource, childTarget, child);
+        } else if (child.isSymbolicLink()) {
+          const link = await fsp.readlink(childSource);
+          let type: "dir" | "file" | undefined;
+          if (process.platform === "win32") {
+            // Older Node releases infer link type from the destination, where a
+            // relative directory target may not exist yet. Inspect the source.
+            // lstat does not expose the Windows link's directory attribute, so
+            // an unresolved source cannot be recreated with a proven type.
+            try {
+              type = (await fsp.stat(childSource)).isDirectory() ? "dir" : "file";
+            } catch (error) {
+              if (
+                error instanceof Error &&
+                "code" in error &&
+                (error.code === "ENOENT" || error.code === "ENOTDIR" || error.code === "ELOOP")
+              ) {
+                throw new FsSafeError(
+                  "unsupported-platform",
+                  "byte copying cannot determine the type of an unresolved Windows symbolic link",
+                  { cause: error },
+                );
+              }
+              throw error;
+            }
+          }
+          signal?.throwIfAborted();
+          await fsp.symlink(link, childTarget, type);
+        } else {
+          throw new FsSafeError("not-file", "tree copying does not support special files");
+        }
+      }
+      assertStagedDirectoryCurrent(original.receipt);
+      assertStagedDirectoryCurrent(target.receipt);
+      if (process.platform !== "win32") fs.fchmodSync(target.fd, Number(stat.mode & 0o7777n));
+      await fsp.utimes(to, stat.atime, stat.mtime);
+      assertStagedDirectoryCurrent(target.receipt);
+    } finally {
+      try {
+        if (original) fs.closeSync(original.fd);
+      } finally {
+        fs.closeSync(target.fd);
+      }
+    }
+  }
+  try {
+    await copyDirectory(source.receipt.realPath, destination);
+  } catch (error) {
+    signal?.throwIfAborted();
+    throw error;
+  }
+}

--- a/src/copy-tree-portable.ts
+++ b/src/copy-tree-portable.ts
@@ -81,7 +81,10 @@ export async function copyOwnedTree(
         } else if (child.isFile()) {
           await copyFile(childSource, childTarget, child);
         } else if (child.isSymbolicLink()) {
-          const link = await fsp.readlink(childSource);
+          const link =
+            process.platform === "win32"
+              ? await fsp.readlink(childSource)
+              : await fsp.readlink(childSource, { encoding: "buffer" });
           let type: "dir" | "file" | undefined;
           if (process.platform === "win32") {
             // Older Node releases infer link type from the destination, where a

--- a/src/copy.ts
+++ b/src/copy.ts
@@ -1,13 +1,18 @@
 import fs from "node:fs";
 import path from "node:path";
 import { assertAbsolutePathInput } from "./absolute-path.js";
+import { copyOwnedTree } from "./copy-tree-portable.js";
 import { FsSafeError } from "./errors.js";
 import { getNativeBinding, requireNativeBinding } from "./native.js";
 import { assertStagedDirectoryCurrent, openStagedDirectory } from "./staged-directory.js";
 export { readCloneFileMetadata, type CloneFileMetadata } from "./clone-metadata.js";
 
-export type TreeCloneBackend = "apfs" | "btrfs" | "refs";
-export type CloneTreeOptions = { signal?: AbortSignal; concurrency?: number };
+export type TreeCloneBackend = "apfs" | "btrfs" | "refs" | "xfs";
+export type CopyTreeOptions = {
+  clone?: "auto" | "always" | "never";
+  signal?: AbortSignal;
+  concurrency?: number;
+};
 
 /** Inspect an existing real directory without creating probe files. */
 export function probeTreeClone(parentPath: string): TreeCloneBackend | undefined {
@@ -21,41 +26,61 @@ export function probeTreeClone(parentPath: string): TreeCloneBackend | undefined
   }
 }
 
-/** Create an empty clone source: a Btrfs subvolume or an ordinary APFS/ReFS directory. */
+/** Create an empty clone source: a Btrfs subvolume or an ordinary supported directory. */
 export async function createCloneSource(
   destination: string,
-  options: Pick<CloneTreeOptions, "signal"> = {},
+  options: Pick<CopyTreeOptions, "signal"> = {},
 ): Promise<void> {
-  await clone(undefined, destination, options);
+  await materializeTree(undefined, destination, options, "always");
 }
 
-/** Clone an immutable, caller-owned tree into an absent destination, without byte-copy fallback. */
-export async function cloneTree(
+/** Copy an immutable, caller-owned tree, preferring native cloning unless configured otherwise. */
+export async function copyTree(
   source: string,
   destination: string,
-  options: CloneTreeOptions = {},
+  options: CopyTreeOptions = {},
 ): Promise<void> {
-  await clone(source, destination, options);
+  options.signal?.throwIfAborted();
+  const policy = options.clone ?? "auto";
+  if (policy !== "auto" && policy !== "always" && policy !== "never") {
+    throw new FsSafeError("invalid-path", "copy clone policy must be auto, always, or never");
+  }
+  await materializeTree(source, destination, options, policy);
 }
 
-async function clone(
+function cloneUnavailable(error: unknown): boolean {
+  if (error instanceof FsSafeError && error.code === "unsupported-platform") return true;
+  if (!(error instanceof Error) || !("code" in error)) return false;
+  // ENOTSUP also describes unsupported contents (for example named streams).
+  // Only capability failures may select a byte copy, never lossy source errors.
+  return error.code === "CLONE_UNAVAILABLE" || error.code === "EXDEV" || error.code === "ENOSYS";
+}
+
+async function materializeTree(
   source: string | undefined,
   destination: string,
-  options: CloneTreeOptions,
+  options: CopyTreeOptions,
+  policy: NonNullable<CopyTreeOptions["clone"]>,
 ): Promise<void> {
   options.signal?.throwIfAborted();
   const concurrency = options.concurrency ?? 16;
   if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 32) {
     throw new FsSafeError("invalid-path", "clone concurrency must be an integer between 1 and 32");
   }
-  const native = requireNativeBinding();
+  const native =
+    policy === "always"
+      ? requireNativeBinding()
+      : policy === "auto"
+        ? getNativeBinding()
+        : undefined;
   const target = assertAbsolutePathInput(destination);
   const name = path.basename(target);
   if (!name) throw new FsSafeError("invalid-path", "clone destination must name a child directory");
   const parent = openStagedDirectory(path.dirname(target));
   let original: ReturnType<typeof openStagedDirectory> | undefined;
   try {
-    if (!native.probeTreeClone(parent.fd)) {
+    const supported = native?.probeTreeClone(parent.fd);
+    if (!supported && policy === "always") {
       throw new FsSafeError(
         "unsupported-platform",
         "destination filesystem does not support tree cloning",
@@ -77,28 +102,43 @@ async function clone(
     }
     assertStagedDirectoryCurrent(parent.receipt);
     options.signal?.throwIfAborted();
+    let cloned = false;
     // napi-rs uses the supplied signal's onabort property. Give it a private
     // signal so caller handlers and other admitted native operations stay intact.
-    const cancellation = options.signal ? new AbortController() : undefined;
+    const cancellation = options.signal && supported ? new AbortController() : undefined;
     const abort = () => cancellation?.abort();
     options.signal?.addEventListener("abort", abort, { once: true });
     try {
-      await native.cloneTree(
-        original?.fd ?? null,
-        parent.fd,
-        name,
-        concurrency,
-        cancellation?.signal,
-      );
+      if (native && supported) {
+        await native.cloneTree(
+          original?.fd ?? null,
+          parent.fd,
+          name,
+          concurrency,
+          cancellation?.signal,
+        );
+        cloned = true;
+      }
     } catch (error) {
       options.signal?.throwIfAborted();
-      throw error;
+      if (policy !== "auto" || !cloneUnavailable(error)) {
+        if (error instanceof Error && "code" in error && error.code === "CLONE_UNAVAILABLE") {
+          throw new FsSafeError("unsupported-platform", error.message, { cause: error });
+        }
+        throw error;
+      }
     } finally {
       options.signal?.removeEventListener("abort", abort);
     }
     options.signal?.throwIfAborted();
     assertStagedDirectoryCurrent(parent.receipt);
     if (original) assertStagedDirectoryCurrent(original.receipt);
+    if (!cloned && original) {
+      await copyOwnedTree(original, target, options.signal);
+      options.signal?.throwIfAborted();
+      assertStagedDirectoryCurrent(parent.receipt);
+      assertStagedDirectoryCurrent(original.receipt);
+    }
   } finally {
     try {
       if (original) fs.closeSync(original.fd);

--- a/src/native-binding.ts
+++ b/src/native-binding.ts
@@ -84,7 +84,7 @@ export interface NativeBinding {
     readEntry(index: number, maxBytes: number, signal?: AbortSignal): Promise<Buffer>;
   }>;
   readCloneFileMetadata(paths: string[]): Promise<(Buffer | null)[]>;
-  probeTreeClone(parentFd: number): "apfs" | "btrfs" | "refs" | null;
+  probeTreeClone(parentFd: number): "apfs" | "btrfs" | "refs" | "xfs" | null;
   cloneTree(
     sourceFd: number | null,
     parentFd: number,

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -233,9 +233,23 @@ describe("native directory cloning", () => {
       throw error;
     }
     await fs.symlink("missing-target", path.join(source, "dangling"), "file");
+    const outside = path.join(directory, "outside");
+    const outsideTarget = path.join("..", "outside");
+    await fs.mkdir(outside);
+    await fs.writeFile(path.join(outside, "payload"), "outside contents");
+    await fs.utimes(outside, 1_600_000_000, 1_600_000_000);
+    await fs.symlink(outsideTarget, path.join(source, "directory-link"), "dir");
+    const outsideBefore = await fs.stat(outside, { bigint: true });
     await copyTree(source, destination, { clone: "always" });
     expect(await fs.readlink(path.join(destination, "link"))).toBe("payload");
     expect(await fs.readlink(path.join(destination, "dangling"))).toBe("missing-target");
+    expect(await fs.readlink(path.join(destination, "directory-link"))).toBe(outsideTarget);
+    const outsideAfter = await fs.stat(outside, { bigint: true });
+    expect(outsideAfter.mtimeNs).toBe(1_600_000_000_000_000_000n);
+    // Reapplying an equal mtime still changes ctime if traversal follows this link.
+    expect(outsideAfter.ctimeNs).toBe(outsideBefore.ctimeNs);
+    expect(await fs.readdir(outside)).toEqual(["payload"]);
+    expect(await fs.readFile(path.join(outside, "payload"), "utf8")).toBe("outside contents");
     await fs.writeFile(path.join(destination, "payload"), "clone edit");
     expect(await fs.readFile(path.join(destination, "link"), "utf8")).toBe("clone edit");
     expect(await fs.readFile(path.join(source, "payload"), "utf8")).toBe("original");

--- a/test/clone.test.ts
+++ b/test/clone.test.ts
@@ -1,15 +1,11 @@
+import { execFileSync } from "node:child_process";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, assert, describe, expect, it, type TestContext } from "vitest";
-import {
-  cloneTree,
-  createCloneSource,
-  probeTreeClone,
-  readCloneFileMetadata,
-} from "../src/clone.js";
 import { configureFsSafeNative } from "../src/config.js";
+import { copyTree, createCloneSource, probeTreeClone, readCloneFileMetadata } from "../src/copy.js";
 import {
   __resetNativeLoaderForTest,
   __setNativeLoaderForTest,
@@ -29,7 +25,7 @@ async function cloneFixture(context: TestContext) {
   const backend = probeTreeClone(parent);
   if (!backend) {
     if (explicitParent) throw new Error("FS_SAFE_CLONE_TEST_ROOT requires native clone support");
-    context.skip("native APFS, Btrfs, or ReFS volume unavailable");
+    context.skip("native APFS, Btrfs, ReFS, or XFS volume unavailable");
     throw new Error("unreachable");
   }
   const directory = await fs.mkdtemp(path.join(parent, "fs-safe-clone-"));
@@ -50,7 +46,7 @@ describe("native directory cloning", () => {
     configureFsSafeNative({ mode: "off" });
     expect(probeTreeClone(directory)).toBeUndefined();
     await expect(createCloneSource(destination)).rejects.toThrow();
-    await expect(cloneTree(source, destination)).rejects.toThrow();
+    await expect(copyTree(source, destination, { clone: "always" })).rejects.toThrow();
     expect(await fs.readdir(directory)).toEqual(["source"]);
     expect(await fs.readFile(path.join(source, "payload"), "utf8")).toBe("original");
   });
@@ -62,7 +58,9 @@ describe("native directory cloning", () => {
     await fs.mkdir(source);
     const signal = AbortSignal.abort(new Error("caller canceled cloning"));
     await expect(createCloneSource(destination, { signal })).rejects.toThrow("caller canceled");
-    await expect(cloneTree(source, destination, { signal })).rejects.toThrow("caller canceled");
+    await expect(copyTree(source, destination, { clone: "always", signal })).rejects.toThrow(
+      "caller canceled",
+    );
     expect(await fs.readdir(directory)).toEqual(["source"]);
   });
 
@@ -76,7 +74,7 @@ describe("native directory cloning", () => {
     const destination = path.join(directory, "destination");
     await fs.mkdir(source);
     await fs.writeFile(path.join(source, "payload"), "original");
-    await expect(cloneTree(source, destination)).rejects.toThrow();
+    await expect(copyTree(source, destination, { clone: "always" })).rejects.toThrow();
     await expect(createCloneSource(destination)).rejects.toThrow();
     expect(await fs.readdir(directory)).toEqual(["source"]);
   });
@@ -88,7 +86,9 @@ describe("native directory cloning", () => {
       const source = path.join(directory, "source");
       const destination = path.join(directory, "destination");
       await fs.mkdir(source);
-      await expect(cloneTree(source, destination, { concurrency })).rejects.toThrow();
+      await expect(
+        copyTree(source, destination, { clone: "always", concurrency }),
+      ).rejects.toThrow();
       expect(await fs.readdir(directory)).toEqual(["source"]);
     },
   );
@@ -120,7 +120,10 @@ describe("native directory cloning", () => {
     }));
     const controller = new AbortController();
     let settled = false;
-    const pending = cloneTree(source, destination, { signal: controller.signal }).then(
+    const pending = copyTree(source, destination, {
+      clone: "always",
+      signal: controller.signal,
+    }).then(
       () => {
         settled = true;
         return undefined;
@@ -150,9 +153,12 @@ describe("native directory cloning", () => {
     }
   });
 
-  it.for([1, 8])(
-    "preserves tree data and metadata with concurrency %s and independent writes",
-    async (concurrency, context) => {
+  it.for([
+    { label: "one worker", concurrency: 1 },
+    { label: "default workers", concurrency: undefined },
+  ])(
+    "preserves tree data and metadata with $label and independent writes",
+    async ({ concurrency }, context) => {
       const { source, destination } = await cloneFixture(context);
       await fs.mkdir(path.join(source, "nested"));
       await fs.mkdir(path.join(source, "empty-directory"));
@@ -173,17 +179,28 @@ describe("native directory cloning", () => {
         await fs.chmod(original, 0o751);
         await fs.chmod(path.join(source, "nested"), 0o750);
       }
+      const directories = ["", "nested", "empty-directory"];
+      for (const name of directories) {
+        await fs.utimes(path.join(source, name), 1_600_000_000, 1_600_000_000);
+      }
       const controller = new AbortController();
       let callerAborts = 0;
       controller.signal.onabort = () => {
         callerAborts++;
       };
-      await cloneTree(source, destination, { concurrency, signal: controller.signal });
+      await copyTree(source, destination, {
+        clone: "always",
+        concurrency,
+        signal: controller.signal,
+      });
       controller.abort();
       expect(callerAborts).toBe(1);
       for (const [name, bytes] of contents) {
         expect((await fs.readFile(path.join(destination, name))).equals(bytes), name).toBe(true);
         expect((await fs.stat(path.join(destination, name))).mtimeMs).toBe(1_600_000_000_000);
+      }
+      for (const name of directories) {
+        expect((await fs.stat(path.join(destination, name))).mtimeMs, name).toBe(1_600_000_000_000);
       }
       expect(await fs.readdir(path.join(destination, "empty-directory"))).toEqual([]);
       if (process.platform !== "win32") {
@@ -192,7 +209,7 @@ describe("native directory cloning", () => {
       }
       await fs.writeFile(cloned, "independent edit");
       expect((await fs.readFile(original)).equals(payload)).toBe(true);
-      await expect(cloneTree(source, destination)).rejects.toThrow();
+      await expect(copyTree(source, destination, { clone: "always" })).rejects.toThrow();
       await expect(createCloneSource(destination)).rejects.toThrow();
       expect(await fs.readFile(cloned, "utf8")).toBe("independent edit");
       expect(await fs.readdir(destination)).not.toContain("source");
@@ -216,7 +233,7 @@ describe("native directory cloning", () => {
       throw error;
     }
     await fs.symlink("missing-target", path.join(source, "dangling"), "file");
-    await cloneTree(source, destination);
+    await copyTree(source, destination, { clone: "always" });
     expect(await fs.readlink(path.join(destination, "link"))).toBe("payload");
     expect(await fs.readlink(path.join(destination, "dangling"))).toBe("missing-target");
     await fs.writeFile(path.join(destination, "payload"), "clone edit");
@@ -224,7 +241,9 @@ describe("native directory cloning", () => {
     expect(await fs.readFile(path.join(source, "payload"), "utf8")).toBe("original");
     const alias = path.join(directory, "source-alias");
     await fs.symlink(source, alias, process.platform === "win32" ? "junction" : "dir");
-    await expect(cloneTree(alias, path.join(directory, "alias-clone"))).rejects.toThrow();
+    await expect(
+      copyTree(alias, path.join(directory, "alias-clone"), { clone: "always" }),
+    ).rejects.toThrow();
     await expect(fs.access(path.join(directory, "alias-clone"))).rejects.toMatchObject({
       code: "ENOENT",
     });
@@ -236,7 +255,7 @@ describe("native directory cloning", () => {
     const ordinary = path.join(directory, "ordinary");
     await fs.mkdir(ordinary);
     await fs.writeFile(path.join(ordinary, "payload"), "original");
-    await expect(cloneTree(ordinary, destination)).rejects.toThrow();
+    await expect(copyTree(ordinary, destination, { clone: "always" })).rejects.toThrow();
     await expect(fs.access(destination)).rejects.toMatchObject({ code: "ENOENT" });
     expect(await fs.readFile(path.join(ordinary, "payload"), "utf8")).toBe("original");
   });
@@ -247,17 +266,87 @@ describe("native directory cloning", () => {
     const original = path.join(source, "payload");
     await fs.writeFile(original, "main data");
     await fs.writeFile(`${original}:metadata`, "named stream data");
-    await expect(cloneTree(source, destination)).rejects.toThrow();
+    await expect(copyTree(source, destination, { clone: "always" })).rejects.toThrow();
     expect(await fs.readFile(original, "utf8")).toBe("main data");
     expect(await fs.readFile(`${original}:metadata`, "utf8")).toBe("named stream data");
     await expect(fs.access(destination)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("removes a failed XFS clone without altering its source and permits retry", async (context) => {
+    const { source, destination, backend } = await cloneFixture(context);
+    if (backend !== "xfs") context.skip("XFS-specific partial clone cleanup");
+    const readonly = path.join(source, "readonly");
+    const copiedReadonly = path.join(destination, "readonly");
+    await fs.mkdir(readonly);
+    await fs.writeFile(path.join(readonly, "payload"), "read-only directory contents");
+    const nested = path.join(source, "nested");
+    const fifo = path.join(nested, "unsupported-fifo");
+    await fs.mkdir(nested);
+    await fs.writeFile(path.join(source, "payload"), "original");
+    execFileSync("mkfifo", [fifo]);
+    await fs.chmod(readonly, 0o555);
+    try {
+      await expect(copyTree(source, destination, { clone: "always" })).rejects.toThrow();
+      expect((await fs.lstat(fifo)).isFIFO()).toBe(true);
+      expect(await fs.readFile(path.join(source, "payload"), "utf8")).toBe("original");
+      expect((await fs.stat(readonly)).mode & 0o777).toBe(0o555);
+      await expect(fs.access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+
+      await fs.unlink(fifo);
+      await copyTree(source, destination, { clone: "always" });
+      expect(await fs.readFile(path.join(destination, "payload"), "utf8")).toBe("original");
+      expect(await fs.readdir(path.join(destination, "nested"))).toEqual([]);
+      expect(await fs.readFile(path.join(copiedReadonly, "payload"), "utf8")).toBe(
+        "read-only directory contents",
+      );
+      expect((await fs.stat(copiedReadonly)).mode & 0o777).toBe(0o555);
+    } finally {
+      await fs.chmod(readonly, 0o755);
+      await fs.chmod(copiedReadonly, 0o755).catch((error: unknown) => {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+      });
+    }
+  });
+
+  it("preserves XFS file and directory extended attributes and ACLs", async (context) => {
+    const { source, destination, backend } = await cloneFixture(context);
+    if (backend !== "xfs") context.skip("XFS-specific extended metadata");
+    await fs.mkdir(path.join(source, "nested"));
+    await fs.writeFile(path.join(source, "nested", "payload"), "original");
+    const entries = ["", "nested", path.join("nested", "payload")];
+    for (const name of entries) {
+      const original = path.join(source, name);
+      execFileSync("setfattr", ["-n", "user.fs-safe-clone", "-v", `metadata:${name}`, original]);
+      execFileSync("setfacl", [
+        "-m",
+        name === path.join("nested", "payload") ? "u:65534:r--" : "u:65534:r-x,d:u:65534:r-x",
+        original,
+      ]);
+    }
+
+    await copyTree(source, destination, { clone: "always" });
+    for (const name of entries) {
+      const cloned = path.join(destination, name);
+      expect(
+        execFileSync("getfattr", ["--only-values", "-n", "user.fs-safe-clone", cloned], {
+          encoding: "utf8",
+        }),
+      ).toBe(`metadata:${name}`);
+      const aclOptions = ["--omit-header", "--numeric", "--absolute-names"];
+      expect(execFileSync("getfacl", [...aclOptions, cloned], { encoding: "utf8" })).toBe(
+        execFileSync("getfacl", [...aclOptions, path.join(source, name)], { encoding: "utf8" }),
+      );
+    }
+    expect(await fs.readFile(path.join(destination, "nested", "payload"), "utf8")).toBe("original");
+  });
+
   it("rejects cloning a tree into itself or its descendants", async (context) => {
     const { source } = await cloneFixture(context);
     await fs.writeFile(path.join(source, "payload"), "original");
-    await expect(cloneTree(source, source)).rejects.toThrow();
-    await expect(cloneTree(source, path.join(source, "child"))).rejects.toThrow();
+    await expect(copyTree(source, source, { clone: "always" })).rejects.toThrow();
+    await expect(
+      copyTree(source, path.join(source, "child"), { clone: "always" }),
+    ).rejects.toThrow();
     expect(await fs.readdir(source)).toEqual(["payload"]);
   });
 
@@ -268,7 +357,7 @@ describe("native directory cloning", () => {
     const cloned = path.join(destination, "payload");
     await fs.writeFile(original, Buffer.alloc(1024 * 1024, 0x5a));
     await fs.symlink("payload", path.join(source, "link"));
-    await cloneTree(source, destination);
+    await copyTree(source, destination, { clone: "always" });
     const [originalMetadata, clonedMetadata, linkMetadata, missingMetadata] =
       await readCloneFileMetadata([
         original,

--- a/test/copy-tree.test.ts
+++ b/test/copy-tree.test.ts
@@ -158,11 +158,18 @@ describe("directory copying", () => {
     async () => {
       const { source, destination } = await copyFixture();
       await fs.symlink("missing-target", path.join(source, "dangling"));
+      const rawTarget = Buffer.from([0xff]);
+      await fs.symlink(rawTarget, path.join(source, "raw-link"));
       await copyTree(source, destination);
       const copied = path.join(destination, "dangling");
       expect(await fs.readlink(copied)).toBe("missing-target");
       expect((await fs.lstat(copied)).isSymbolicLink()).toBe(true);
       await expect(fs.stat(copied)).rejects.toMatchObject({ code: "ENOENT" });
+      for (const directory of [source, destination]) {
+        expect(await fs.readlink(path.join(directory, "raw-link"), { encoding: "buffer" })).toEqual(
+          rawTarget,
+        );
+      }
     },
   );
 

--- a/test/copy-tree.test.ts
+++ b/test/copy-tree.test.ts
@@ -1,0 +1,252 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { configureFsSafeNative } from "../src/config.js";
+import { copyTree } from "../src/copy.js";
+import {
+  __resetNativeLoaderForTest,
+  __setNativeLoaderForTest,
+  getNativeBinding,
+} from "../src/native.js";
+import { useRealTempDirs } from "./helpers/vitest.js";
+
+const { tempRoot } = useRealTempDirs();
+beforeEach(() => configureFsSafeNative({ mode: "off" }));
+afterEach(() => {
+  configureFsSafeNative({ mode: "auto" });
+  __resetNativeLoaderForTest();
+});
+
+async function copyFixture() {
+  const directory = await tempRoot("fs-safe-copy-tree-");
+  const source = path.join(directory, "source");
+  const destination = path.join(directory, "destination-é space");
+  await fs.mkdir(source);
+  await fs.mkdir(path.join(source, "empty"));
+  await fs.writeFile(path.join(source, "payload"), "original");
+  return { directory, source, destination };
+}
+
+describe("directory copying", () => {
+  it.for([
+    { label: "automatic cloning by default", clone: undefined },
+    { label: "cloning disabled", clone: "never" as const },
+  ])("copies without a native binding with $label", async ({ clone }) => {
+    const { source, destination } = await copyFixture();
+    const original = path.join(source, "payload");
+    const copied = path.join(destination, "payload");
+    await fs.utimes(original, 1_600_000_000, 1_600_000_000);
+    if (process.platform !== "win32") await fs.chmod(original, 0o751);
+
+    await copyTree(source, destination, { clone });
+    expect(await fs.readFile(copied, "utf8")).toBe("original");
+    expect(await fs.readdir(path.join(destination, "empty"))).toEqual([]);
+    expect((await fs.stat(copied)).mtimeMs).toBe(1_600_000_000_000);
+    if (process.platform !== "win32") expect((await fs.stat(copied)).mode & 0o777).toBe(0o751);
+    await fs.writeFile(copied, "independent edit");
+    expect(await fs.readFile(original, "utf8")).toBe("original");
+  });
+
+  it("requires native cloning when the policy is always", async () => {
+    const { source, destination } = await copyFixture();
+    await expect(copyTree(source, destination, { clone: "always" })).rejects.toThrow();
+    await expect(fs.access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await fs.readFile(path.join(source, "payload"), "utf8")).toBe("original");
+  });
+
+  it.for([
+    { code: "CLONE_UNAVAILABLE", fallback: true },
+    { code: "EXDEV", fallback: true },
+    { code: "ENOSYS", fallback: true },
+    { code: "ENOTSUP", fallback: false },
+    { code: "EACCES", fallback: false },
+    { code: "EIO", fallback: false },
+  ])(
+    "handles native $code without confusing capability failures with source errors",
+    async ({ code, fallback }, context) => {
+      configureFsSafeNative({ mode: "auto" });
+      const binding = getNativeBinding();
+      if (!binding) {
+        context.skip("native binding unavailable");
+        return;
+      }
+      const { source, destination } = await copyFixture();
+      const failure = Object.assign(new Error(`native copy failed: ${code}`), { code });
+      __setNativeLoaderForTest(() => ({
+        ...binding,
+        probeTreeClone: () => "xfs",
+        async cloneTree() {
+          throw failure;
+        },
+      }));
+      if (fallback) {
+        await copyTree(source, destination);
+        expect(await fs.readFile(path.join(destination, "payload"), "utf8")).toBe("original");
+      } else {
+        await expect(copyTree(source, destination)).rejects.toBe(failure);
+        await expect(fs.access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      expect(await fs.readFile(path.join(source, "payload"), "utf8")).toBe("original");
+    },
+  );
+
+  it("never invokes the native clone operation when cloning is disabled", async (context) => {
+    configureFsSafeNative({ mode: "auto" });
+    const binding = getNativeBinding();
+    if (!binding) {
+      context.skip("native binding unavailable");
+      return;
+    }
+    const { source, destination } = await copyFixture();
+    let nativeCalls = 0;
+    __setNativeLoaderForTest(() => ({
+      ...binding,
+      probeTreeClone: () => "xfs",
+      async cloneTree() {
+        nativeCalls++;
+        throw new Error("native cloning must not run");
+      },
+    }));
+    await copyTree(source, destination, { clone: "never" });
+    expect(nativeCalls).toBe(0);
+    expect(await fs.readFile(path.join(destination, "payload"), "utf8")).toBe("original");
+  });
+
+  it("refuses an existing destination without merging or replacing its contents", async () => {
+    const { source, destination } = await copyFixture();
+    await fs.mkdir(destination);
+    await fs.writeFile(path.join(destination, "payload"), "keep this destination");
+    await expect(copyTree(source, destination)).rejects.toThrow();
+    expect(await fs.readFile(path.join(destination, "payload"), "utf8")).toBe(
+      "keep this destination",
+    );
+    expect(await fs.readdir(destination)).toEqual(["payload"]);
+  });
+
+  it("preserves relative file and directory symlinks before their copied targets exist", async (context) => {
+    const { source, destination } = await copyFixture();
+    await fs.mkdir(path.join(source, "z-directory"));
+    await fs.writeFile(path.join(source, "z-directory", "child"), "directory contents");
+    try {
+      await fs.symlink("payload", path.join(source, "link"), "file");
+    } catch (error) {
+      if (
+        process.platform === "win32" &&
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "EPERM"
+      ) {
+        context.skip("Windows symlink creation requires Developer Mode or privilege");
+      }
+      throw error;
+    }
+    await fs.symlink("z-directory", path.join(source, "a-directory-link"), "dir");
+    await copyTree(source, destination);
+    expect(await fs.readlink(path.join(destination, "link"))).toBe("payload");
+    expect(await fs.readlink(path.join(destination, "a-directory-link"))).toBe("z-directory");
+    expect(await fs.readdir(path.join(destination, "a-directory-link"))).toEqual(["child"]);
+    expect(await fs.readFile(path.join(destination, "a-directory-link", "child"), "utf8")).toBe(
+      "directory contents",
+    );
+    await fs.writeFile(path.join(destination, "payload"), "copy edit");
+    expect(await fs.readFile(path.join(destination, "link"), "utf8")).toBe("copy edit");
+    expect(await fs.readFile(path.join(source, "payload"), "utf8")).toBe("original");
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "preserves dangling POSIX symlinks literally",
+    async () => {
+      const { source, destination } = await copyFixture();
+      await fs.symlink("missing-target", path.join(source, "dangling"));
+      await copyTree(source, destination);
+      const copied = path.join(destination, "dangling");
+      expect(await fs.readlink(copied)).toBe("missing-target");
+      expect((await fs.lstat(copied)).isSymbolicLink()).toBe(true);
+      await expect(fs.stat(copied)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects an unresolved Windows link instead of guessing its type",
+    async () => {
+      const { source, destination } = await copyFixture();
+      const missing = path.join(source, "missing-target");
+      const dangling = path.join(source, "dangling");
+      await fs.symlink(missing, dangling, "junction");
+      await expect(copyTree(source, destination)).rejects.toMatchObject({
+        code: "unsupported-platform",
+      });
+      expect(await fs.readlink(dangling)).toBe(missing);
+      await expect(fs.lstat(path.join(destination, "dangling"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
+
+  it("honors pre-abort without creating a destination", async () => {
+    const { source, destination } = await copyFixture();
+    const reason = new Error("copy canceled by caller");
+    await expect(copyTree(source, destination, { signal: AbortSignal.abort(reason) })).rejects.toBe(
+      reason,
+    );
+    await expect(fs.access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("settles a byte copy aborted after visible progress before the destination is reused", async () => {
+    const { source, destination } = await copyFixture();
+    const original = path.join(source, "payload");
+    const copied = path.join(destination, "payload");
+    const bytes = Buffer.alloc(8 * 1024 * 1024, 0x5a);
+    await fs.writeFile(original, bytes);
+    const controller = new AbortController();
+    const reason = new Error("cancel after partial byte copy");
+    let settled = false;
+    const pending = copyTree(source, destination, {
+      clone: "never",
+      signal: controller.signal,
+    }).then(
+      () => {
+        settled = true;
+        return undefined;
+      },
+      (error: unknown) => {
+        settled = true;
+        return error;
+      },
+    );
+    let observedPartialWrite = false;
+    const deadline = performance.now() + 2000;
+    try {
+      while (!settled && performance.now() < deadline) {
+        const stat = await fs.stat(copied).catch((error: unknown) => {
+          if (error instanceof Error && "code" in error && error.code === "ENOENT")
+            return undefined;
+          throw error;
+        });
+        if (stat && stat.size > 0 && stat.size < bytes.length / 2) {
+          observedPartialWrite = true;
+          controller.abort(reason);
+          break;
+        }
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      expect(observedPartialWrite).toBe(true);
+      expect(await pending).toBe(reason);
+      expect((await fs.stat(copied)).size).toBeLessThan(bytes.length);
+      await fs.rm(destination, { recursive: true });
+      await copyTree(source, destination, { clone: "never" });
+      expect((await fs.readFile(copied)).equals(bytes)).toBe(true);
+      expect((await fs.readFile(original)).equals(bytes)).toBe(true);
+    } finally {
+      controller.abort(reason);
+      await pending;
+    }
+  });
+
+  it("rejects an invalid clone policy before creating a destination", async () => {
+    const { source, destination } = await copyFixture();
+    // @ts-expect-error JavaScript callers can supply an invalid policy.
+    await expect(copyTree(source, destination, { clone: "sometimes" })).rejects.toThrow();
+    await expect(fs.access(destination)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/test/public-api.json
+++ b/test/public-api.json
@@ -134,16 +134,16 @@
       ],
       "errorCodes": {}
     },
-    "./clone": {
+    "./copy": {
       "runtime": [
-        "cloneTree",
+        "copyTree",
         "createCloneSource",
         "probeTreeClone",
         "readCloneFileMetadata"
       ],
       "types": [
         "CloneFileMetadata",
-        "CloneTreeOptions",
+        "CopyTreeOptions",
         "TreeCloneBackend"
       ],
       "errorCodes": {}


### PR DESCRIPTION
## What Problem This Solves

Directory copying and filesystem cloning need one consumer API. The unreleased clone-only API also rejects XFS volumes that support file reflinks.

## Why This Change Was Made

Replace the unreleased `/clone` subpath with `@openclaw/fs-safe/copy` and `copyTree(source, destination, { clone })`. The default `"auto"` tries cloning and falls back to byte copying for unavailable capabilities; `"always"` requires cloning and `"never"` uses explicit reads and writes. Permission, I/O, cancellation, and rejected-content errors do not trigger fallback.

Add XFS traversal using strict FICLONE operations, bounded native workers, pinned directories, source identity checks, and joined cancellation. XFS preserves regular-file/directory modes, timestamps, xattrs, and ACLs. The existing APFS/Btrfs/ReFS backends remain behind the same API.

## User Impact

Consumers choose one copy policy instead of maintaining separate copy and clone calls. The destination must be absent and outside the immutable caller-owned source. Existing destinations are never merged or overwritten. `createCloneSource` still prepares Btrfs subvolumes and ordinary directories for other clone backends.

This changes an unreleased API only; the v0.9.0 package does not export `/clone`. APFS descendant ACL limits remain documented. Byte copying does not promise ACL/xattr/ownership/alternate-stream/sparse-layout preservation. Failed or canceled calls can leave caller-owned output after all writes settle.

## Evidence

- Final head `238e813` passed [CI](https://github.com/openclaw/fs-safe/actions/runs/34735985507), [coverage](https://github.com/openclaw/fs-safe/actions/runs/34735985527), [CodeQL](https://github.com/openclaw/fs-safe/actions/runs/34735985560), and [benchmarks](https://github.com/openclaw/fs-safe/actions/runs/34735985497). Native CI lanes cover macOS, Windows, Linux/Btrfs/XFS, and Linux musl; real ReFS proof ran locally as recorded below. Fresh exact-head [review](https://github.com/openclaw/fs-safe/pull/301#issuecomment-5650776570) found no actionable issues and confirmed both prior findings resolved.

- Fresh Windows native build, real ReFS/copy/navigation tests: 41 passed, 7 platform/privilege skips.
- OpenClaw consumer against the built candidate: 15 backend and real ReFS tests passed, including shared extents and independent writes.
- Linux Rust workspace check and clippy with warnings denied passed.
- Package public API contract regenerated; package/import checks, documentation examples, and docs site passed.
- Real WSL2 XFS volumes: shared physical extents, independent inodes, SHA-256 equality, and independent writes verified through the built public API. A reflink-disabled volume rejects strict cloning and passes auto/never copies with physically separate extents.
- Actual native cancellation: observed a created destination file before abort; rejection at 203.67 ms, destination absent, all 8,456 source hashes unchanged, and immediate same-path reuse succeeded.
- XFS synthetic 8,456-file / 160 MiB benchmark, one warmup plus three rotated samples: median 1.111 s with one worker, 0.439 s with 16 workers, and 10.314 s with byte copying. Hash verification ran outside timers. These measurements describe this WSL2 fixture, not universal throughput.
- Independent P0-P2 review found one older Node 22 Windows symlink issue. Fixed by deriving link type from the source; unresolved Windows links fail explicitly because Node does not expose their link type. Added directory traversal and unresolved-link regression coverage. Other reviewed changes had no actionable findings.
- Full Linux `pnpm check` passed before the final APFS/raw-link repairs: 8,755 tests, zero failures, 95 platform skips; lint, build, docs, and package checks passed. OpenClaw core typecheck and 79 focused tests passed with the candidate alias; its real XFS backend flow verified 1 MiB shared extents and independent edits.
- macOS CI exposed timestamp loss on the root and nested APFS directories. An iterative native pass now restores directory timestamps after bulk cloning, retaining only active ancestor descriptors and skipping known files and symlinks without stat/open. Independent review found no actionable issues. Root/nested/empty-directory assertions remain unchanged, and a directory-link regression checks that outside metadata is untouched; final macOS native and coverage CI passed on 238e813, including the unchanged timestamp assertions and outside-directory-link regression.
- ClawSweeper found raw POSIX symlink targets were UTF-8 decoded. Portable copying now preserves their Buffer bytes. The exact regression fails on 304a01b (ff becomes efbfbd) and passes on the repaired source (ff stays ff); the final source was restored and its hash verified. Windows behavior is unchanged.

- [x] Tests added or updated when behavior changed
- [x] Security and compatibility impact considered
- [x] `CHANGELOG.md` updated when release-relevant
- [x] No credentials, private paths, private hosts, or sensitive contents included

### Captured XFS VM proof

Verified in a WSL2 Linux VM (not a Crabbox lease): kernel `6.18.33.2-microsoft-standard-WSL2`, x86_64, Node 26.8.2. Two disposable 1 GiB XFS loopback volumes used 4 KiB blocks, one with `reflink=1` and one with `reflink=0`. Baseline `cc10fd89ac8581a96e041330156ae07042c62e54` rejected XFS cloning through the public API with `unsupported-platform` and left the destination absent.

The XFS candidate's repository-owned proof runs:

```sh
node scripts/clone-xfs-proof.mjs "$FIXTURE"
node scripts/clone-xfs-proof.mjs "$NO_REFLINK_FIXTURE" no-reflink
```

Captured stdout, respectively:

```json
{"backend":"xfs","mode":"reflink","results":[{"policy":"always-one-worker","milliseconds":3.0876379999999983,"sharedBytes":1052673,"separateBytes":0,"hashesMatch":true,"independentWrite":true},{"policy":"always-default-workers","milliseconds":4.083631999999994,"sharedBytes":1052673,"separateBytes":0,"hashesMatch":true,"independentWrite":true},{"policy":"auto","milliseconds":3.776452000000006,"sharedBytes":1052673,"separateBytes":0,"hashesMatch":true,"independentWrite":true},{"policy":"never","milliseconds":15.818287999999995,"sharedBytes":0,"separateBytes":1052673,"hashesMatch":true,"independentWrite":true}]}
```

```json
{"backend":"xfs","mode":"no-reflink","results":[{"policy":"always","unsupported":true,"destinationAbsent":true},{"policy":"auto","milliseconds":19.012953999999993,"sharedBytes":0,"separateBytes":1052673,"hashesMatch":true,"independentWrite":true},{"policy":"never","milliseconds":14.668910000000011,"sharedBytes":0,"separateBytes":1052673,"hashesMatch":true,"independentWrite":true}]}
```

The proof checks complete SHA-256 content, distinct inodes, FIEMAP physical extent offsets and shared flags, and independent writes. `always` and `auto` share all file data on reflink-enabled XFS; `never` has disjoint extents. On reflink-disabled XFS, strict cloning refuses without creating a destination while `auto` and `never` copy normally.

A separate public-API cancellation probe aborted after observing the first real destination file event, 140.65 ms after starting a one-worker clone. The promise rejected with the caller's exact abort reason at 203.67 ms total; the destination was absent after rejection, every source hash matched, and retrying the same destination succeeded with matching hashes.

The same synthetic 160 MiB tree (8,456 files, 65 directories) was measured with one warmup per mode and three measured rounds in rotating order. All source and destination hashes were verified outside timed regions. Median times:

| Mode | Median |
| --- | ---: |
| Strict clone, 1 worker | 1.111 s |
| Strict clone, 16 workers | 0.439 s |
| Normal copy (`clone: "never"`) | 10.314 s |

For this local WSL2 workload, 16 workers were 2.53x faster than one worker and 23.47x faster than normal copying. These are synthetic workload measurements, not an OpenClaw worktree benchmark or a general performance guarantee. The cancellation and timing fixture contains only regular files and is unaffected by the final portable symlink repair.

Focused tests before the final raw-link/macOS repair: reflink-enabled XFS 32 passed / 4 platform skips; reflink-disabled XFS portable copy 16 passed / 1 Windows skip. Full `pnpm check` passed before the final raw-link/macOS repair: 271 test files passed, 8,755 tests passed, 95 platform skips, zero failures. `git diff --check` also passed. The first full run exposed two package-lifecycle tests that require the JavaScript pnpm CLI; using the official same-version pnpm 11.25.0 JavaScript distribution resolved them without changing dependencies or sources. Native `cargo check --workspace --locked` and `cargo clippy --workspace --locked -- -D warnings` passed.

A subsequent public-API regression probe confirmed and then verified the POSIX raw-target fix: an ASCII symlink name pointing to raw byte `ff` copied to `efbfbd` before the fix and preserves `ff` after it. The final package build and focused copy/clone suites on ordinary Linux storage passed: 26 tests passed, 10 platform/filesystem skips, zero failures. The final diff check passed. The complete local suite and mounted XFS proofs were not repeated for that narrow repair; final CI covers the mounted filesystem and macOS lanes.
